### PR TITLE
Added environment variables for openai weather demo

### DIFF
--- a/kagenti/installer/src/resources/environments.yaml
+++ b/kagenti/installer/src/resources/environments.yaml
@@ -14,7 +14,13 @@ data:
       {
         "name": "OPENAI_API_KEY",
         "valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}
-      }
+      },
+      {
+        "name": "LLM_API_KEY",
+        "valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}
+      },
+      {"name": "LLM_API_BASE", "value": "https://api.openai.com/v1"},
+      {"name": "LLM_MODEL", "value": "gpt-4o-mini-2024-07-18"}
     ]
   mcp-weather: |
     [


### PR DESCRIPTION
This is to make the weather agent and tool work with openai configuration. 

Has been tested with weather demo, but may need to test other relevant demos. 