### PR TITLE
added metrics-server to the installer

### DIFF
--- a/kagenti/installer/app/cli.py
+++ b/kagenti/installer/app/cli.py
@@ -30,6 +30,7 @@ from .components import (
     registry,
     tekton,
     ui,
+    metrics_server,
 )
 from .config import InstallableComponent
 from .utils import console
@@ -49,6 +50,7 @@ INSTALLERS = {
     InstallableComponent.GATEWAY: gateway.install,
     InstallableComponent.KEYCLOAK: keycloak.install,
     InstallableComponent.AGENTS: agents.install,
+    InstallableComponent.METRICS_SERVER: metrics_server.install,    
 }
 
 
@@ -133,6 +135,7 @@ def main(
         deploy_component(InstallableComponent.TEKTON, skip_install)
         deploy_component(InstallableComponent.OPERATOR, skip_install)
         deploy_component(InstallableComponent.ISTIO, skip_install)
+        deploy_component(InstallableComponent.METRICS_SERVER, skip_install)        
 
         # Components that depend on Istio
         if InstallableComponent.ISTIO not in skip_install:

--- a/kagenti/installer/app/components/__init__.py
+++ b/kagenti/installer/app/components/__init__.py
@@ -22,5 +22,6 @@ from . import (
     operator,
     registry,
     tekton,
-    ui
+    ui,
+    metrics_server
 )

--- a/kagenti/installer/app/components/metrics_server.py
+++ b/kagenti/installer/app/components/metrics_server.py
@@ -1,0 +1,61 @@
+# Assisted by watsonx Code Assistant
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import config
+from ..utils import run_command
+
+def install():
+    """Installs the Kubernetes metrics server."""
+    # Install metrics server
+    run_command(
+        [
+            "kubectl",
+            "apply",
+            "-f",
+            "https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml"
+        ],
+        "Installing Kubernetes metrics server",
+    )
+    
+    # Patch metrics server to allow insecure TLS (needed for local development)
+    run_command(
+        [
+            "kubectl",
+            "patch",
+            "-n",
+            "kube-system",
+            "deployment",
+            "metrics-server",
+            "--type=json",
+            "-p",
+            '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+        ],
+        "Patching metrics server to allow insecure TLS for kubelet communication",
+    )
+    
+    # Wait for metrics server deployment to be ready
+    run_command(
+        [
+            "kubectl",
+            "wait",
+            "--for=condition=Available",
+            "deployment/metrics-server",
+            "-n",
+            "kube-system",
+            "--timeout=300s"
+        ],
+        "Waiting for metrics server deployment to be ready",
+    )
+    

--- a/kagenti/installer/app/config.py
+++ b/kagenti/installer/app/config.py
@@ -33,7 +33,7 @@ KEYCLOAK_URL = "http://keycloak.localtest.me:8080/realms/master"
 # Defines the minimum (inclusive) and maximum (exclusive) required versions for tools.
 REQ_VERSIONS = {
     "kind": {"min": "0.20.0", "max": "0.99.0"},
-    "docker": {"min": "5.0.0", "max": "28.0.0"},
+    "docker": {"min": "5.0.0", "max": "29.0.0"},
     "kubectl": {"min": "1.29.0", "max": "1.34.0"},
     "helm": {"min": "3.14.0", "max": "3.19.0"},
 }
@@ -48,6 +48,7 @@ PRELOADABLE_IMAGES = [
     "arizephoenix/phoenix:version-8.32.1",
     "postgres:12",
     "prom/prometheus:v3.1.0",
+    "registry.k8s.io/metrics-server/metrics-server:v0.7.2",    
 ]
 
 
@@ -64,3 +65,4 @@ class InstallableComponent(str, Enum):
     GATEWAY = "gateway"
     KEYCLOAK = "keycloak"
     AGENTS = "agents"
+    METRICS_SERVER= "metrics_server"    


### PR DESCRIPTION
## Summary
Install Kubernetes Metrics Server to enable real-time resource monitoring and debugging capabilities.

## Changes
- Add metrics_server.py installation module
- Configure metrics server with insecure TLS for local development
- Add wait logic for deployment readiness
- Changed max Docker version to 29.0.0

- Fixes #41 