### PR TITLE
Fix helm detection on Fedora with dnf packaged helm

### DIFF
--- a/kagenti/installer/app/utils.py
+++ b/kagenti/installer/app/utils.py
@@ -48,7 +48,7 @@ def get_command_version(command: str) -> Optional[Version]:
             result = subprocess.run(
                 [executable_path, "version"], capture_output=True, text=True, check=True
             )
-            match = re.search(r'Version:"v([^"]+)"', result.stdout)
+            match = re.search(r'Version:"v?([^"]+)"', result.stdout)
             version_str = match.group(1) if match else ""
         else:
             result = subprocess.run(


### PR DESCRIPTION
The dnf packaged helm on Fedora 42 displays a version string that does not include a 'v'.

$ helm version
version.BuildInfo{Version:"3.18.1",
GitCommit:"f6f8700a539c18101509434f3b59e6a21402a1b2", GitTreeState:"clean", GoVersion:"go1.24.3"}

The updated regex fixes helm detection on Fedora.

Note however that the logic in get_command_version does not differentiate between a missing helm binary and a failure to parse the version string, which resulted in a misleading error message.

[09:58:31] ✗ helm is not installed or not in PATH.   checker.py:42

Please install or update the required tools before proceeding.