### PR TITLE
Make kagenti-installer work with podman

### DIFF
--- a/kagenti/installer/app/checker.py
+++ b/kagenti/installer/app/checker.py
@@ -16,7 +16,6 @@
 import os
 import time
 
-import docker
 import typer
 from dotenv import load_dotenv
 from packaging.version import parse
@@ -93,17 +92,3 @@ def check_env_vars():
             "[bold green]✓[/bold green] All required environment variables are set."
         )
     console.print()
-
-
-def kind_cluster_exists() -> bool:
-    """Checks if the Kind cluster is already running via the Docker daemon."""
-    try:
-        docker_client = docker.from_env()
-        return any(
-            config.CLUSTER_NAME in c.name for c in docker_client.containers.list()
-        )
-    except docker.errors.DockerException:
-        console.log(
-            "[bold red]✗ Docker is not running. Please start the Docker daemon.[/bold red]"
-        )
-        raise typer.Exit(1)

--- a/kagenti/installer/app/components/registry.py
+++ b/kagenti/installer/app/components/registry.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import docker
+import subprocess
+
 from kubernetes import client, config as kube_config
 import typer
 
@@ -41,13 +42,10 @@ def install():
             )
             registry_ip = service.spec.cluster_ip
 
-            docker_client = docker.from_env()
-            container = docker_client.containers.get(
-                f"{config.CLUSTER_NAME}-control-plane"
-            )
-            container.exec_run(
-                f"sh -c 'echo {registry_ip} registry.cr-system.svc.cluster.local >> /etc/hosts'"
-            )
+            container = f"{config.CLUSTER_NAME}-control-plane"
+            subprocess.run(
+                ["docker", "exec", container, "sh", "-c",
+                 f"echo {registry_ip} registry.cr-system.svc.cluster.local >> /etc/hosts"])
 
             console.log(
                 "[bold green]✓[/bold green] Registry DNS configured in Kind container."


### PR DESCRIPTION
The 'docker' python library does not work with podman so replace all usage with subprocess commands.

This has been tested with podman on macOS and Fedora 42. Not that it has not been tested with docker.