### PR TITLE
:sparkles: add configuration for running ollama on linux

### DIFF
--- a/kagenti/installer/app/components/agents.py
+++ b/kagenti/installer/app/components/agents.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import platform
 import typer
 from kubernetes import client, config as kube_config
 
@@ -75,6 +76,15 @@ def install():
                     ns,
                 ],
                 f"Creating 'openai-secret' in '{ns}'",
+            )
+        # if user operating system is linux, do some special config to enable ollama
+        if platform.system() == "Linux":
+            run_command(
+                [
+                    "sh",
+                    "linux/ollama-config.sh"
+                ],
+                "Customizing ollama environment for Linux",
             )
 
         run_command(

--- a/kagenti/installer/app/linux/ollama-config.sh
+++ b/kagenti/installer/app/linux/ollama-config.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+set -ex
+
+# This script is used to addply a headless service to a kind cluster so that local services (i.e. ollama)
+# can be accessed via http://dockerhost:<port>
+
+cat <<EOF | kubectl apply -f -
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: dockerhost
+  labels:
+    kubernetes.io/service-name: dockerhost
+addressType: IPv4
+endpoints:
+- addresses:
+  - $(docker network inspect kind | jq .[0].IPAM.Config[0].Gateway | sed s/\"//g)
+  conditions:
+    ready: true
+ports:
+- name: all-ports
+  protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dockerhost
+spec:
+  clusterIP: None
+EOF
+
+## We also need to update the ollama environment to use dockerhost instead of host.docker.internal
+
+sed -i 's/host\.docker\.internal/dockerhost/g' resources/environments.yaml


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR allows Linux users to use kagenti with ollama. 

It does so by using a headless service to reach ollama on the host system, mapping the service to the kind docker network and then updating the ollama hostname in environment configmap.

The linux configuration is done via a script as that seemed like the easiest approach, but happy to try another way if folks think that makes more sense.

Used the weather agent demo to validate that this works on Fedora 41. 

## Related issue(s)

Fixes #79 
