### PR TITLE
Weather agent fix

### DIFF
--- a/kagenti/examples/identity/kagenti_client_registration/client_registration.py
+++ b/kagenti/examples/identity/kagenti_client_registration/client_registration.py
@@ -1,6 +1,4 @@
 import os
-import logging
-
 from keycloak import KeycloakAdmin, KeycloakPostError
 
 KEYCLOAK_URL = os.environ.get('KEYCLOAK_URL')
@@ -9,9 +7,6 @@ KEYCLOAK_ADMIN_USERNAME = os.environ.get('KEYCLOAK_ADMIN_USERNAME')
 KEYCLOAK_ADMIN_PASSWORD = os.environ.get('KEYCLOAK_ADMIN_PASSWORD')
 CLIENT_NAME = os.environ.get('CLIENT_NAME')
 NAMESPACE = os.environ.get('NAMESPACE')
-
-print("test print")
-logging.info("test log")
 
 def register_client(
     keycloak_url: str,
@@ -24,7 +19,7 @@ def register_client(
     clientId = f'{namespace}/{client_name}'
 
     if keycloak_url is None:
-        print(f'Expected environment variable "KEYCLOAK_URL". Skipping client registration of {clientID}.')
+        print(f'Expected environment variable "KEYCLOAK_URL". Skipping client registration of {clientId}.')
         return
     if keycloak_realm is None:
         raise Exception('Expected environment variable "KEYCLOAK_REALM"')
@@ -58,9 +53,9 @@ def register_client(
             }
         )
 
-        logging.info(f'Created Keycloak client "{clientId}": {llama_stack_client_id}')
+        print(f'Created Keycloak client "{clientId}": {llama_stack_client_id}')
     except KeycloakPostError as e:
-        logging.error(f'Could not create Keycloak client "{clientId}": {e}')
+        print(f'Could not create Keycloak client "{clientId}": {e}')
 
 register_client(
     KEYCLOAK_URL,

--- a/kagenti/examples/identity/kagenti_client_registration/client_registration.py
+++ b/kagenti/examples/identity/kagenti_client_registration/client_registration.py
@@ -10,42 +10,63 @@ KEYCLOAK_ADMIN_PASSWORD = os.environ.get('KEYCLOAK_ADMIN_PASSWORD')
 CLIENT_NAME = os.environ.get('CLIENT_NAME')
 NAMESPACE = os.environ.get('NAMESPACE')
 
-if KEYCLOAK_URL is None:
-    raise Exception('Expected environment variable "KEYCLOAK_URL"')
-if KEYCLOAK_REALM is None:
-    raise Exception('Expected environment variable "KEYCLOAK_REALM"')
-if KEYCLOAK_ADMIN_USERNAME is None:
-    raise Exception('Expected environment variable "KEYCLOAK_ADMIN_USERNAME"')
-if KEYCLOAK_ADMIN_PASSWORD is None:
-    raise Exception('Expected environment variable "KEYCLOAK_ADMIN_PASSWORD"')
-if CLIENT_NAME is None:
-    raise Exception('Expected environment variable "CLIENT_NAME"')
-if NAMESPACE is None:
-    raise Exception('Expected environment variable "NAMESPACE"')
+print("test print")
+logging.info("test log")
 
-keycloak_admin = KeycloakAdmin(
-    server_url=KEYCLOAK_URL,
-    username=KEYCLOAK_ADMIN_USERNAME,
-    password=KEYCLOAK_ADMIN_PASSWORD,
-    realm_name=KEYCLOAK_REALM,
-    user_realm_name='master'
-)
+def register_client(
+    keycloak_url: str,
+    keycloak_realm: str,
+    keycloak_admin_username: str,
+    keycloak_admin_password: str,
+    client_name: str,
+    namespace: str
+):
+    clientId = f'{namespace}/{client_name}'
 
-clientId = f'{NAMESPACE}/{CLIENT_NAME}'
+    if keycloak_url is None:
+        print(f'Expected environment variable "KEYCLOAK_URL". Skipping client registration of {clientID}.')
+        return
+    if keycloak_realm is None:
+        raise Exception('Expected environment variable "KEYCLOAK_REALM"')
+    if keycloak_admin_username is None:
+        raise Exception('Expected environment variable "KEYCLOAK_ADMIN_USERNAME"')
+    if keycloak_admin_password is None:
+        raise Exception('Expected environment variable "KEYCLOAK_ADMIN_PASSWORD"')
+    if client_name is None:
+        raise Exception('Expected environment variable "CLIENT_NAME"')
+    if namespace is None:
+        raise Exception('Expected environment variable "NAMESPACE"')
 
-# Create client
-try:
-    llama_stack_client_id = keycloak_admin.create_client(
-        {
-            "name": CLIENT_NAME,
-            "clientId": clientId,
-            "standardFlowEnabled": True,
-            "directAccessGrantsEnabled": True,
-            "fullScopeAllowed": False,
-            "publicClient": True # Disable client authentication
-        }
+    keycloak_admin = KeycloakAdmin(
+        server_url=keycloak_url,
+        username=keycloak_admin_username,
+        password=keycloak_admin_password,
+        realm_name=keycloak_realm,
+        user_realm_name='master'
     )
 
-    logging.info(f'Created Keycloak client "{clientId}"')
-except KeycloakPostError as e:
-    logging.error(f'Could not create Keycloak client "{clientId}": {e}')
+    # Create client
+    try:
+        llama_stack_client_id = keycloak_admin.create_client(
+            {
+                "name": client_name,
+                "clientId": clientId,
+                "standardFlowEnabled": True,
+                "directAccessGrantsEnabled": True,
+                "fullScopeAllowed": False,
+                "publicClient": True # Disable client authentication
+            }
+        )
+
+        logging.info(f'Created Keycloak client "{clientId}": {llama_stack_client_id}')
+    except KeycloakPostError as e:
+        logging.error(f'Could not create Keycloak client "{clientId}": {e}')
+
+register_client(
+    KEYCLOAK_URL,
+    KEYCLOAK_REALM,
+    KEYCLOAK_ADMIN_USERNAME,
+    KEYCLOAK_ADMIN_PASSWORD,
+    CLIENT_NAME,
+    NAMESPACE
+)

--- a/kagenti/examples/identity/kagenti_client_registration/client_registration.py
+++ b/kagenti/examples/identity/kagenti_client_registration/client_registration.py
@@ -8,6 +8,7 @@ KEYCLOAK_REALM = os.environ.get('KEYCLOAK_REALM')
 KEYCLOAK_ADMIN_USERNAME = os.environ.get('KEYCLOAK_ADMIN_USERNAME')
 KEYCLOAK_ADMIN_PASSWORD = os.environ.get('KEYCLOAK_ADMIN_PASSWORD')
 CLIENT_NAME = os.environ.get('CLIENT_NAME')
+NAMESPACE = os.environ.get('NAMESPACE')
 
 if KEYCLOAK_URL is None:
     raise Exception('Expected environment variable "KEYCLOAK_URL"')
@@ -19,24 +20,32 @@ if KEYCLOAK_ADMIN_PASSWORD is None:
     raise Exception('Expected environment variable "KEYCLOAK_ADMIN_PASSWORD"')
 if CLIENT_NAME is None:
     raise Exception('Expected environment variable "CLIENT_NAME"')
+if NAMESPACE is None:
+    raise Exception('Expected environment variable "NAMESPACE"')
 
 keycloak_admin = KeycloakAdmin(
-            server_url=KEYCLOAK_URL,
-            username=KEYCLOAK_ADMIN_USERNAME,
-            password=KEYCLOAK_ADMIN_PASSWORD,
-            realm_name=KEYCLOAK_REALM,
-            user_realm_name='master')
+    server_url=KEYCLOAK_URL,
+    username=KEYCLOAK_ADMIN_USERNAME,
+    password=KEYCLOAK_ADMIN_PASSWORD,
+    realm_name=KEYCLOAK_REALM,
+    user_realm_name='master'
+)
+
+clientId = f'{NAMESPACE}/{CLIENT_NAME}'
 
 # Create client
 try:
-    llama_stack_client_id = keycloak_admin.create_client({
-        "clientId": CLIENT_NAME,
-        "standardFlowEnabled": True,
-        "directAccessGrantsEnabled": True,
-        "fullScopeAllowed": False,
-        "publicClient": True # Disable client authentication
-    })
+    llama_stack_client_id = keycloak_admin.create_client(
+        {
+            "name": CLIENT_NAME,
+            "clientId": clientId,
+            "standardFlowEnabled": True,
+            "directAccessGrantsEnabled": True,
+            "fullScopeAllowed": False,
+            "publicClient": True # Disable client authentication
+        }
+    )
 
-    logging.info("Created Keycloak client")
+    logging.info(f'Created Keycloak client "{clientId}"')
 except KeycloakPostError as e:
-    logging.error(f'Could not create Keycloak client "{CLIENT_NAME}": {e}')
+    logging.error(f'Could not create Keycloak client "{clientId}": {e}')


### PR DESCRIPTION
* Make `KEYCLOAK_URL` optional for client registration (simply does not attempt registration with Keycloak)
* Add client name during Keycloak registration
* Ensure logging is working (print shows up with `kubectl logs... -c kagenti-client-registration` but not logging module)