### PR TITLE
🐛 Modify deployment imagePullPolicy to use Always

### DIFF
--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -342,7 +342,7 @@ def _construct_agent_resource_body(
                         "image": image_name,
                         "imageTag": image_tag,
                         "imageRegistry": image_registry_prefix,
-                        "imagePullPolicy": "IfNotPresent",
+                        "imagePullPolicy": constants.DEFAULT_IMAGE_POLICY,
                     },
                     "containerPorts": [
                         {

--- a/kagenti/ui/lib/constants.py
+++ b/kagenti/ui/lib/constants.py
@@ -45,6 +45,7 @@ MCP_INSPECTOR_URL = "http://mcp-inspector.localtest.me:8080"
 DEFAULT_REPO_URL = "https://github.com/kagenti/agent-examples"
 DEFAULT_REPO_BRANCH = "main"
 DEFAULT_IMAGE_TAG = "v0.0.1"
+DEFAULT_IMAGE_POLICY = "Always"
 
 # --- Kubernetes Secret for Git User ---
 GIT_USER_SECRET_NAME = "github-token-secret"


### PR DESCRIPTION
## Summary
Updates the container imagePullPolicy from `IfNotPresent` to `Always` to ensure the latest image versions are pulled during deployments of Agents and Tools.

**Motivation**
The previous IfNotPresent policy could cause issues where:

- Cached images with the same tag but different content were used
- Development/staging environments didn't reflect the most recent image builds

Using Always ensures that Kubernetes will pull the latest version of the image on every deployment, providing more predictable and up-to-date deployments.

## Related issue(s)

Fixes #89 
