### PR TITLE
:bug: Don't insist on repulling Postgres container image

### DIFF
--- a/kagenti/installer/app/resources/phoenix.yaml
+++ b/kagenti/installer/app/resources/phoenix.yaml
@@ -105,7 +105,7 @@ spec:
               apiVersion: v1
               fieldPath: status.podIP
         image: postgres:12
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: postgres
         ports:
         - containerPort: 5432


### PR DESCRIPTION
## Summary
Sometimes Kubernetes isn't able to verify if a container image is the latest.

## Related issue(s)
#118

Fixes #
#118