### PR TITLE
:seedling::wrench: Override with .env vars

### DIFF
--- a/kagenti/installer/app/checker.py
+++ b/kagenti/installer/app/checker.py
@@ -72,7 +72,7 @@ def check_env_vars():
     )
     with console.status("[cyan]Checking for .env file and variables..."):
         time.sleep(0.5)
-        load_dotenv(dotenv_path=config.ENV_FILE)
+        load_dotenv(dotenv_path=config.ENV_FILE, override=True)
         required_vars = [
             "GITHUB_USER",
             "GITHUB_TOKEN",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This may depend on the "role" of `.env` in this project but [based on the demo documentation here](https://github.com/kagenti/kagenti/blob/8d7a4607454283b5ed054c1e509723501989b660/docs/demos.md?plain=1#L36-L49) I had understood that kagenti intends to take `.env` variables for this project. The `override=True` gives precedence to the `.env` file over other existing environment variables , for example other Github credentials that may exist in a user's environment. 

## Related issue(s)

Fixes #116 - without the `ghcr-secret` before #95, Github public packages could be pulled without issue, but once the secret was present, it becomes more necessary to ensure that the expected credentials are present.
