### PR TITLE
weather agent/tool uses streamable-http transport by default

### DIFF
--- a/kagenti/installer/app/resources/environments.yaml
+++ b/kagenti/installer/app/resources/environments.yaml
@@ -24,7 +24,7 @@ data:
     ]
   mcp-weather: |
     [
-      {"name": "MCP_URL", "value": "http://weather-tool:8000/sse"}
+      {"name": "MCP_URL", "value": "http://weather-tool:8000/mcp"}
     ]
   KEYCLOAK_URL: "http://keycloak.keycloak:8080"
   KEYCLOAK_REALM: "master"


### PR DESCRIPTION
DO NOT MERGE yet. There is an inter-dependency on another PR in another repo (https://github.com/kagenti/agent-examples/pull/38).

We need to *modernize* our weather application so it makes use of streamable-http transport instead of sse