### PR TITLE
✨ allow for existing cluster to be brought

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -11,9 +11,9 @@ Before running the demo setup script, ensure you have the following prerequisite
 
 * **Python:** Python versionn >=3.9
 * **uv:** [uv](https://docs.astral.sh/uv/getting-started/installation) must be installed (e.g. `pip install uv`)
-* **Docker:** Docker Desktop, Rancher Desktop or Podman Machine. You must alias it to `docker` (e.g. `sudo ln -s /opt/homebrew/bin/podman /usr/local/bin/docker`). On MacOS, you will need also to do `brew install docker-credential-helper`
+* **Docker:** Docker Desktop, Rancher Desktop or Podman Machine. You must alias it to `docker` (e.g. `sudo ln -s /opt/homebrew/bin/podman /usr/local/bin/docker`). On MacOS, you will need also to do `brew install docker-credential-helper`. *Not required if using `--use-existing-cluster`*.
   * In Rancher Decktop, configure VM size to at least 8GB of memory and 4 cores
-* **Kind:** A [tool](https://kind.sigs.k8s.io) to run a Kubernetes cluster in docker (e.g. `brew install kind`).
+* **Kind:** A [tool](https://kind.sigs.k8s.io) to run a Kubernetes cluster in docker (e.g. `brew install kind`). *Not required if using `--use-existing-cluster`*.
 * **kubectl:** The Kubernetes command-line tool (installs with **kind**).
 * **Helm:** A package manager for Kubernetes (e.g. `brew install helm`).
 * **[ollama](https://ollama.com/download)** to run LLMs locally (e.g. `brew install ollama`). Then start the **ollama* service in the background (e.g.`ollama serve`).
@@ -56,6 +56,28 @@ uv run kagenti-installer
 ```
 
 The installer creates a kind cluster named `agent-platform` and then deploys all platform components.
+
+### Using an Existing Kubernetes Cluster
+
+If you already have a Kubernetes cluster configured and want to skip the kind cluster creation, you can use the `--use-existing-cluster` flag:
+
+```shell
+uv run kagenti-installer --use-existing-cluster
+```
+
+This option will:
+- Skip the kind and Docker dependency checks
+- Use the cluster defined in your `KUBECONFIG` environment variable
+- Skip kind-specific operations like image preloading
+- Deploy all platform components to your existing cluster
+
+Make sure your `KUBECONFIG` is properly set and points to a cluster where you have admin privileges before using this option.
+
+**Note:** When using an existing cluster, you may want to skip the registry component as it's primarily designed for kind clusters:
+
+```shell
+uv run kagenti-installer --use-existing-cluster --skip-install registry
+```
 
 To skip installation of the specific component e.g. keycloak and SPIRE, issue:
 

--- a/kagenti/installer/app/checker.py
+++ b/kagenti/installer/app/checker.py
@@ -26,13 +26,22 @@ from . import config
 from .utils import console, get_command_version
 
 
-def check_dependencies():
+def check_dependencies(use_existing_cluster: bool = False):
     """Checks if required command-line tools are installed and meet version requirements."""
     console.print(
         Panel(Text("1. Checking Dependencies", justify="center", style="bold yellow"))
     )
     all_ok = True
-    for tool, versions in config.REQ_VERSIONS.items():
+    
+    # Filter out tools not needed for existing clusters
+    required_tools = config.REQ_VERSIONS.copy()
+    if use_existing_cluster:
+        # Remove kind and docker requirements when using existing cluster
+        required_tools.pop('kind', None)
+        required_tools.pop('docker', None)
+        console.log("[yellow]Using existing cluster - skipping kind and docker checks.[/yellow]")
+    
+    for tool, versions in required_tools.items():
         with console.status(f"[cyan]Checking for {tool}..."):
             time.sleep(0.5)
             version = get_command_version(tool)

--- a/kagenti/installer/app/cli.py
+++ b/kagenti/installer/app/cli.py
@@ -47,7 +47,7 @@ app = typer.Typer(
 INSTALLERS = {
     InstallableComponent.REGISTRY: registry.install,
     InstallableComponent.TEKTON: tekton.install,
-    InstallableComponent.CERT_MANAGER: cert_manager.install, 
+    InstallableComponent.CERT_MANAGER: cert_manager.install,
     InstallableComponent.OPERATOR: operator.install,
     InstallableComponent.ISTIO: istio.install,
     InstallableComponent.SPIRE: spire.install,
@@ -58,7 +58,7 @@ INSTALLERS = {
     InstallableComponent.KEYCLOAK: keycloak.install,
     InstallableComponent.AGENTS: agents.install,
     InstallableComponent.METRICS_SERVER: metrics_server.install,
-    InstallableComponent.INSPECTOR: inspector.install,  
+    InstallableComponent.INSPECTOR: inspector.install,
 }
 
 
@@ -125,7 +125,8 @@ def main(
         checker.check_env_vars()
 
         should_install_registry = InstallableComponent.REGISTRY not in skip_install
-        cluster.setup_cluster(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster)
+        cluster.create_kind_cluster(install_registry=should_install_registry)
+        cluster.check_kube_connection(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster)
 
         if preload_images and not use_existing_cluster:
             cluster.preload_images_in_kind(config.PRELOADABLE_IMAGES)
@@ -148,11 +149,11 @@ def main(
 
         deploy_component(InstallableComponent.REGISTRY, skip_install)
         deploy_component(InstallableComponent.TEKTON, skip_install)
-        deploy_component(InstallableComponent.CERT_MANAGER, skip_install)          
+        deploy_component(InstallableComponent.CERT_MANAGER, skip_install)
         deploy_component(InstallableComponent.OPERATOR, skip_install)
         deploy_component(InstallableComponent.ISTIO, skip_install)
-        deploy_component(InstallableComponent.METRICS_SERVER, skip_install)        
-            
+        deploy_component(InstallableComponent.METRICS_SERVER, skip_install)
+
 
         # Components that depend on Istio
         if InstallableComponent.ISTIO not in skip_install:

--- a/kagenti/installer/app/cli.py
+++ b/kagenti/installer/app/cli.py
@@ -125,8 +125,10 @@ def main(
         checker.check_env_vars()
 
         should_install_registry = InstallableComponent.REGISTRY not in skip_install
-        cluster.create_kind_cluster(install_registry=should_install_registry)
-        cluster.check_kube_connection(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster)
+        using_kind_cluster = cluster.create_kind_cluster(install_registry=should_install_registry)
+        # If create_kind_cluster returns None/False, we're not using a kind cluster
+        using_kind_cluster = bool(using_kind_cluster)
+        cluster.check_kube_connection(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster, using_kind_cluster=using_kind_cluster)
 
         if preload_images and not use_existing_cluster:
             cluster.preload_images_in_kind(config.PRELOADABLE_IMAGES)

--- a/kagenti/installer/app/cli.py
+++ b/kagenti/installer/app/cli.py
@@ -40,7 +40,7 @@ from .config import InstallableComponent
 from .utils import console
 
 app = typer.Typer(
-    help="A CLI tool to install the Agent Platform on a local Kind cluster.",
+    help="A CLI tool to install the Agent Platform on a Kubernetes cluster (Kind or existing).",
     add_completion=False,
 )
 
@@ -103,9 +103,14 @@ def main(
         "--preload-images",
         help="Flag to enable preloading of images in kind.",
     ),
+    use_existing_cluster: bool = typer.Option(
+        False,
+        "--use-existing-cluster",
+        help="Use existing Kubernetes cluster defined in KUBECONFIG instead of creating a kind cluster.",
+    ),
 ):
     """
-    Installer for the Agent Platform. Checks dependencies and sets up a Kind cluster with optional components.
+    Installer for the Agent Platform. Checks dependencies and sets up a Kubernetes cluster (either Kind or existing) with optional components.
     """
     try:
         console.print(
@@ -116,14 +121,16 @@ def main(
         )
 
         # --- Setup and Pre-flight Checks ---
-        checker.check_dependencies()
+        checker.check_dependencies(use_existing_cluster=use_existing_cluster)
         checker.check_env_vars()
 
         should_install_registry = InstallableComponent.REGISTRY not in skip_install
-        cluster.create_kind_cluster(install_registry=should_install_registry)
+        cluster.setup_cluster(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster)
 
-        if preload_images:
+        if preload_images and not use_existing_cluster:
             cluster.preload_images_in_kind(config.PRELOADABLE_IMAGES)
+        elif preload_images and use_existing_cluster:
+            console.print("[yellow]Warning: --preload-images flag is only supported with kind clusters. Skipping image preloading.[/yellow]\n")
 
         if InstallableComponent.AGENTS not in skip_install:
             cluster.check_and_create_agent_namespaces()
@@ -168,10 +175,16 @@ def main(
             "\n",
         )
 
-        console.print(
-            "To open Kagenti UI in your browser: open http://kagenti-ui.localtest.me:8080",
-            "\n",
-        )
+        if use_existing_cluster:
+            console.print(
+                "To open Kagenti UI in your browser, you may need to set up port forwarding or ingress depending on your cluster configuration.",
+                "\n",
+            )
+        else:
+            console.print(
+                "To open Kagenti UI in your browser: open http://kagenti-ui.localtest.me:8080",
+                "\n",
+            )
 
     except typer.Exit:
         console.print("\n[bold yellow]Installation aborted.[/bold yellow]")

--- a/kagenti/installer/app/cluster.py
+++ b/kagenti/installer/app/cluster.py
@@ -59,32 +59,41 @@ def kind_cluster_running():
         raise typer.Exit(1)
 
 
-def check_kube_connection(install_registry: bool, use_existing_cluster: bool):
+def check_kube_connection(install_registry: bool, use_existing_cluster: bool, using_kind_cluster: bool):
     """Sets up the Kubernetes cluster - either creates a kind cluster or uses existing cluster."""
-    if use_existing_cluster:
+    # Check if KUBECONFIG is set or if a cluster is accessible from the default kubeconfig location ~/.kube/config
+    kubeconfig_path = os.getenv("KUBECONFIG") or os.path.expanduser("~/.kube/config")
+    if not kubeconfig_path:
         console.print(
-            Panel(
-                Text("3. Using Kubernetes Cluster", justify="center", style="bold yellow")
-            )
+            "[bold red]Unable to find an existing KUBECONFIG. Please set it to your cluster's kubeconfig file.[/bold red]"
         )
-        try:
-            kube_config.load_kube_config()
-            v1_api = client.CoreV1Api()
-            # Test connection by getting cluster info
-            v1_api.list_namespace(limit=1)
-            console.log(
-                "[bold green]✓[/bold green] Successfully connected the Kubernetes cluster."
-            )
-        except Exception as e:
-            console.log(
-                f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
-            )
-            console.print(
-                "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
-            )
+        raise typer.Exit(1)
+
+    # Ask for confirmation so we don't add to an existing cluster by mistake
+    if not use_existing_cluster and not using_kind_cluster:
+        console.print(f"[yellow]Found Kubernetes cluster configuration in KUBECONFIG: {kubeconfig_path}[/yellow]")
+        if not Confirm.ask(
+            "[bold yellow]?[/bold yellow] Do you want to proceed with this Kubernetes cluster?",
+            default=True,
+        ):
+            console.print("[bold red]Installation cancelled by user.[/bold red]")
             raise typer.Exit(1)
 
-        console.print()
+    try:
+        kube_config.load_kube_config()
+        v1_api = client.CoreV1Api()
+        # Test connection by getting cluster info
+        v1_api.list_namespace(limit=1)
+        console.log(
+            "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
+        )
+
+    except Exception as e:
+        console.log(
+            f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
+            )
+        raise typer.Exit(1)
+    console.print()
 
 
 def create_kind_cluster(install_registry: bool):
@@ -99,7 +108,7 @@ def create_kind_cluster(install_registry: bool):
             console.log(
                 f"[bold green]✓[/bold green] Kind cluster '{config.CLUSTER_NAME}' already running. Skipping creation."
             )
-            return
+            return True
         else:
             console.log(
                 f"[bold red]x Kind cluster '{config.CLUSTER_NAME}' exists but is not running."
@@ -111,43 +120,7 @@ def create_kind_cluster(install_registry: bool):
         f"[bold yellow]?[/bold yellow] Kind cluster '{config.CLUSTER_NAME}' not found. Create it now?",
         default=True,
     ):
-        # Ask if they want to use an existing cluster instead
-        if Confirm.ask(
-            "[bold yellow]?[/bold yellow] Would you like to use an existing Kubernetes cluster defined in your KUBECONFIG?",
-            default=True,
-        ):
-            console.print(
-                "[bold green]Switching to existing cluster mode...[/bold green]"
-            )
-            # Test connection to existing cluster
-            try:
-                kube_config.load_kube_config()
-                v1_api = client.CoreV1Api()
-                # Test connection by getting cluster info
-                v1_api.list_namespace(limit=1)
-                console.log(
-                    "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
-                )
-
-                if install_registry:
-                    console.print(
-                        "[yellow]Warning: Registry installation is not recommended for existing clusters. "
-                        "Consider using --skip-install registry if you encounter issues.[/yellow]\n"
-                    )
-                console.print()
-                return  # Exit without creating kind cluster
-
-            except Exception as e:
-                console.log(
-                    f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
-                )
-                console.print(
-                    "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
-                )
-                raise typer.Exit(1)
-        else:
-            console.print("[bold red]Cannot proceed without a cluster. Exiting.[/bold red]")
-            raise typer.Exit()
+        return False
 
     base_config = """
 kind: Cluster
@@ -196,6 +169,7 @@ containerdConfigPatches:
             console.log(f"[red]{e.stderr.strip()}[/red]")
             raise typer.Exit(1)
     console.print()
+    return True
 
 
 def preload_images_in_kind(images: list[str]):

--- a/kagenti/installer/app/cluster.py
+++ b/kagenti/installer/app/cluster.py
@@ -59,6 +59,41 @@ def kind_cluster_running():
         raise typer.Exit(1)
 
 
+def setup_cluster(install_registry: bool, use_existing_cluster: bool):
+    """Sets up the Kubernetes cluster - either creates a kind cluster or uses existing cluster."""
+    if use_existing_cluster:
+        console.print(
+            Panel(
+                Text("3. Using Existing Kubernetes Cluster", justify="center", style="bold yellow")
+            )
+        )
+        try:
+            kube_config.load_kube_config()
+            v1_api = client.CoreV1Api()
+            # Test connection by getting cluster info
+            v1_api.list_namespace(limit=1)
+            console.log(
+                "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
+            )
+        except Exception as e:
+            console.log(
+                f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
+            )
+            console.print(
+                "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
+            )
+            raise typer.Exit(1)
+        
+        if install_registry:
+            console.print(
+                "[yellow]Warning: Registry installation is not recommended for existing clusters. "
+                "Consider using --skip-install registry if you encounter issues.[/yellow]\n"
+            )
+        console.print()
+    else:
+        create_kind_cluster(install_registry)
+
+
 def create_kind_cluster(install_registry: bool):
     """Creates a Kind cluster if it doesn't already exist."""
     console.print(
@@ -83,8 +118,43 @@ def create_kind_cluster(install_registry: bool):
         f"[bold yellow]?[/bold yellow] Kind cluster '{config.CLUSTER_NAME}' not found. Create it now?",
         default=True,
     ):
-        console.print("[bold red]Cannot proceed without a cluster. Exiting.[/bold red]")
-        raise typer.Exit()
+        # Ask if they want to use an existing cluster instead
+        if Confirm.ask(
+            "[bold yellow]?[/bold yellow] Would you like to use an existing Kubernetes cluster defined in your KUBECONFIG?",
+            default=True,
+        ):
+            console.print(
+                "[bold green]Switching to existing cluster mode...[/bold green]"
+            )
+            # Test connection to existing cluster
+            try:
+                kube_config.load_kube_config()
+                v1_api = client.CoreV1Api()
+                # Test connection by getting cluster info
+                v1_api.list_namespace(limit=1)
+                console.log(
+                    "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
+                )
+                
+                if install_registry:
+                    console.print(
+                        "[yellow]Warning: Registry installation is not recommended for existing clusters. "
+                        "Consider using --skip-install registry if you encounter issues.[/yellow]\n"
+                    )
+                console.print()
+                return  # Exit without creating kind cluster
+                
+            except Exception as e:
+                console.log(
+                    f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
+                )
+                console.print(
+                    "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
+                )
+                raise typer.Exit(1)
+        else:
+            console.print("[bold red]Cannot proceed without a cluster. Exiting.[/bold red]")
+            raise typer.Exit()
 
     base_config = """
 kind: Cluster

--- a/kagenti/installer/app/cluster.py
+++ b/kagenti/installer/app/cluster.py
@@ -59,12 +59,12 @@ def kind_cluster_running():
         raise typer.Exit(1)
 
 
-def setup_cluster(install_registry: bool, use_existing_cluster: bool):
+def check_kube_connection(install_registry: bool, use_existing_cluster: bool):
     """Sets up the Kubernetes cluster - either creates a kind cluster or uses existing cluster."""
     if use_existing_cluster:
         console.print(
             Panel(
-                Text("3. Using Existing Kubernetes Cluster", justify="center", style="bold yellow")
+                Text("3. Using Kubernetes Cluster", justify="center", style="bold yellow")
             )
         )
         try:
@@ -73,7 +73,7 @@ def setup_cluster(install_registry: bool, use_existing_cluster: bool):
             # Test connection by getting cluster info
             v1_api.list_namespace(limit=1)
             console.log(
-                "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
+                "[bold green]✓[/bold green] Successfully connected the Kubernetes cluster."
             )
         except Exception as e:
             console.log(
@@ -83,15 +83,8 @@ def setup_cluster(install_registry: bool, use_existing_cluster: bool):
                 "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
             )
             raise typer.Exit(1)
-        
-        if install_registry:
-            console.print(
-                "[yellow]Warning: Registry installation is not recommended for existing clusters. "
-                "Consider using --skip-install registry if you encounter issues.[/yellow]\n"
-            )
+
         console.print()
-    else:
-        create_kind_cluster(install_registry)
 
 
 def create_kind_cluster(install_registry: bool):
@@ -135,7 +128,7 @@ def create_kind_cluster(install_registry: bool):
                 console.log(
                     "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
                 )
-                
+
                 if install_registry:
                     console.print(
                         "[yellow]Warning: Registry installation is not recommended for existing clusters. "
@@ -143,7 +136,7 @@ def create_kind_cluster(install_registry: bool):
                     )
                 console.print()
                 return  # Exit without creating kind cluster
-                
+
             except Exception as e:
                 console.log(
                     f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"


### PR DESCRIPTION
## Summary
Allow for existing cluster to be used. This is for a larger idea to allow for an easy way to install on OpenShift.

## Related issue(s)
#127 

Fixes #127 


Existing functionality
```
➜  installer git:(main) ✗ uv run kagenti-installer
╭──────────────────────────╮
│ Agent Platform Installer │
╰──────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                             1. Checking Dependencies                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[15:05:21] ✓ kind version 0.24.0 is compatible.                                                        checker.py:60
           ✓ docker version 5.4.1 is compatible.                                                       checker.py:60
[15:05:22] ✓ kubectl version 1.33.0 is compatible.                                                     checker.py:60
[15:05:23] ✓ helm version 3.18.6 is compatible.                                                        checker.py:60
All dependency checks passed.

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                        2. Checking Environment Variables                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
           ✓ All required environment variables are set.                                              checker.py:100

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           3. Kubernetes Cluster Setup                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
? Kind cluster 'agent-platform' not found. Create it now? [y/n] (y): n
Cannot proceed without a cluster. Exiting.
```

New functionality
```
➜  installer git:(main) ✗ uv run kagenti-installer
╭──────────────────────────╮
│ Agent Platform Installer │
╰──────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                             1. Checking Dependencies                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[15:06:47] ✓ kind version 0.24.0 is compatible.                                                        checker.py:60
[15:06:48] ✓ docker version 5.4.1 is compatible.                                                       checker.py:60
[15:06:49] ✓ kubectl version 1.33.0 is compatible.                                                     checker.py:60
           ✓ helm version 3.18.6 is compatible.                                                        checker.py:60
All dependency checks passed.

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                        2. Checking Environment Variables                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[15:06:50] ✓ All required environment variables are set.                                              checker.py:100

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           3. Kubernetes Cluster Setup                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
? Kind cluster 'agent-platform' not found. Create it now? [y/n] (y): n
? Would you like to use an existing Kubernetes cluster defined in your KUBECONFIG? [y/n] (y): y
Switching to existing cluster mode...
[15:06:56] ✓ Successfully connected to existing Kubernetes cluster.                                   cluster.py:135
Warning: Registry installation is not recommended for existing clusters. Consider using --skip-install registry if
you encounter issues.


╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           4. Checking Agent Namespaces                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
The following required agent namespaces do not exist: team1
Do you want to create them now? [y/n] (y):
[15:06:59] ✓ Creating namespace 'team1' done.                                                            utils.py:88

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                             5. Installing Components                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─────────────────────╮
│ Installing Registry │
╰─────────────────────╯
           ✓ Deploying container registry manifest done.                                                 utils.py:88
[15:07:04] ✓ Waiting for registry deployment done.                                                       utils.py:88
⠋ Configuring registry DNS...Error: no container with name or ID "agent-platform-control-plane" found: no such container
           ✓ Registry DNS configured in Kind container.                                               registry.py:50

╭───────────────────╮
│ Installing Tekton │
╰───────────────────╯
[15:07:06] ✓ Installing Tekton Pipelines done.                                                           utils.py:88

╭─────────────────────────╮
│ Installing Cert_manager │
╰─────────────────────────╯
[15:07:07] ✓ Installing Cert Manager done.                                                               utils.py:88
[15:07:34] ✓ Waiting for deployment/cert-manager in namespace cert-manager done.                         utils.py:88
           ✓ Waiting for deployment/cert-manager-cainjector in namespace cert-manager done.              utils.py:88
[15:07:37] ✓ Waiting for deployment/cert-manager-webhook in namespace cert-manager done.                 utils.py:88

╭─────────────────────╮
│ Installing Operator │
╰─────────────────────╯
[15:07:38] ✓ Installing the Platform Operator done.                                                      utils.py:88

╭──────────────────╮
│ Installing Istio │
╰──────────────────╯
           ✓ Adding Istio Helm repo done.                                                                utils.py:88
[15:07:43] ✓ Updating Helm repos done.                                                                   utils.py:88
[15:07:46] ✓ Installing Istio base done.                                                                 utils.py:88
[15:07:47] ✓ Installing Kubernetes Gateway API done.                                                     utils.py:88
[15:07:56] ✓ Installing Istiod (ambient profile) done.                                                   utils.py:88
[15:07:58] ✓ Installing Istio CNI done.                                                                  utils.py:88
[15:08:11] ✓ Installing Ztunnel done.                                                                    utils.py:88
           ✓ Waiting for ztunnel rollout done.                                                           utils.py:88
           ✓ Waiting for Istio CNI rollout done.                                                         utils.py:88
           ✓ Waiting for Istiod rollout done.                                                            utils.py:88

╭───────────────────────────╮
│ Installing Metrics_server │
╰───────────────────────────╯
[15:08:12] ✓ Installing Kubernetes metrics server done.                                                  utils.py:88
           ✓ Patching metrics server to allow insecure TLS for kubelet communication done.               utils.py:88
[15:08:42] ✓ Waiting for metrics server deployment to be ready done.                                     utils.py:88

╭────────────────────╮
│ Installing Gateway │
╰────────────────────╯
           ✓ Creating Istio ingress gateway done.                                                        utils.py:88
[15:08:43] ✓ Adding NodePort service for gateway done.                                                   utils.py:88
           ✓ Annotating gateway service type done.                                                       utils.py:88
           ✓ Adding egress waypoint gateway done.                                                        utils.py:88
[15:09:04] ✓ Waiting for waypoint gateway rollout done.                                                  utils.py:88

╭───────────────────╮
│ Installing Addons │
╰───────────────────╯
[15:09:05] ✓ Installing Prometheus done.                                                                 utils.py:88
[15:09:20] ✓ Waiting for Prometheus rollout done.                                                        utils.py:88
[15:09:21] ✓ Installing Kiali done.                                                                      utils.py:88
           ✓ Adding Kiali Route done.                                                                    utils.py:88
           ✓ Enabling istio-system for kiali routing done.                                               utils.py:88
[15:10:01] ✓ Waiting for Kiali rollout done.                                                             utils.py:88
           ✓ Installing Phoenix done.                                                                    utils.py:88
[15:10:26] ✓ Waiting for Postgres rollout done.                                                          utils.py:88
[15:11:06] ✓ Waiting for Phoenix rollout done.                                                           utils.py:88
           ✓ Installing Otel Collector done.                                                             utils.py:88
[15:11:16] ✓ Waiting for otel collector rollout done.                                                    utils.py:88

╭─────────────────────╮
│ Installing Keycloak │
╰─────────────────────╯
           ✓ Creating Keycloak namespace done.                                                           utils.py:88
           ✓ Deploying Keycloak statefulset done.                                                        utils.py:88
           ✓ Scaling Keycloak to 1 replica done.                                                         utils.py:88
           ✓ Patching Keycloak for proxy headers done.                                                   utils.py:88
⠏ Waiting for Keycloak rollout...
```

