### PR TITLE
🐛  disable SSL mode for keycloak-postgres connection

### DIFF
--- a/kagenti/installer/app/resources/keycloak.yaml
+++ b/kagenti/installer/app/resources/keycloak.yaml
@@ -93,6 +93,8 @@ spec:
               value: 'keycloak'
             - name: 'KC_DB_USERNAME'
               value: 'keycloak'
+            - name: KC_DB_URL_PROPERTIES
+              value: ?sslmode=disable  
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Seems that after some time Keycloak forgets that it is not using a SSL connection to the Postgres DB and tries to open new connection using SSL mode and the pod crash loop. This should address https://github.com/kagenti/kagenti/issues/115


