### PR TITLE
✨ Update installer to allow for docker or podman as container engine options

### DIFF
--- a/kagenti/installer/app/checker.py
+++ b/kagenti/installer/app/checker.py
@@ -23,6 +23,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from . import config
+from .config import ContainerEngine
 from .utils import console, get_command_version
 
 
@@ -32,7 +33,16 @@ def check_dependencies():
         Panel(Text("1. Checking Dependencies", justify="center", style="bold yellow"))
     )
     all_ok = True
+    try:
+        container_engine = ContainerEngine(config.CONTAINER_ENGINE)
+    except ValueError:
+        console.log(f"[bold red]✗ Container engine must be either 'docker' or 'podman'[/bold red]")
+        raise typer.Exit(1)
     for tool, versions in config.REQ_VERSIONS.items():
+        if tool == "docker" and tool != container_engine.value:
+            continue
+        if tool == "podman" and tool != container_engine.value:
+            continue
         with console.status(f"[cyan]Checking for {tool}..."):
             time.sleep(0.5)
             version = get_command_version(tool)

--- a/kagenti/installer/app/config.py
+++ b/kagenti/installer/app/config.py
@@ -29,11 +29,19 @@ TEKTON_VERSION = "v0.66.0"
 LATEST_TAG = "0.2.0-alpha.5"
 KEYCLOAK_URL = "http://keycloak.localtest.me:8080/realms/master"
 
+# --- Container Engine Options ---
+class ContainerEngine(str, Enum):
+    PODMAN = "podman"
+    DOCKER = "docker"
+
+CONTAINER_ENGINE =  "docker"
+
 # --- Dependency Version Requirements ---
 # Defines the minimum (inclusive) and maximum (exclusive) required versions for tools.
 REQ_VERSIONS = {
     "kind": {"min": "0.20.0", "max": "0.99.0"},
     "docker": {"min": "5.0.0", "max": "29.0.0"},
+    "podman": {"min":"5.0.0", "max":"5.6.0"},
     "kubectl": {"min": "1.29.0", "max": "1.35.0"},
     "helm": {"min": "3.14.0", "max": "3.19.0"},
 }


### PR DESCRIPTION
## Summary
This PR allows users to choose whether they want to use docker or podman as their container engine during kagenti installation without the need for using any symbolic links as is suggested in the [docs](https://github.com/kagenti/kagenti/blob/a293d21664dfd8fa701df4d5ebfd7ba6530d07f3/docs/demos.md?plain=1#L14).



This PR adds a `CONTAINER_ENGINE` variable to `kagenti/installer/app/config.py`. By default this variable is set to `"docker"`, leaving the default behavior unchanged. It also adds an Enum class `ContainerEngine()` to ensure that only the strings `"podman"` or `"docker"` can be  passed to the relevant `subprocess.run()`.  

During the dependency check in `check_dependencies()` only the selected container engine's version will be evaluated.

This has been tested on a Mac M2 with podman. 

## Related issue(s)

Fixes #179