### PR TITLE
:sparkles: Update client registration with a new client name

### DIFF
--- a/kagenti/auth/client-registration/README.md
+++ b/kagenti/auth/client-registration/README.md
@@ -9,6 +9,7 @@
 ```sh
 cd kagenti/auth/client-registration
 docker build -t client-registration .
+docker tag client-registration ghcr.io/kagenti/kagenti/client-registration:latest
 ```
 
 ### Install Kagenti
@@ -21,7 +22,7 @@ uv run kagenti-installer
 ### Load the image into the cluster
 
 ```sh
-kind load docker-image client-registration --name agent-platform
+kind load docker-image ghcr.io/kagenti/kagenti/client-registration:latest --name agent-platform
 ```
 
 ### Import a new agent
@@ -44,4 +45,4 @@ The default username and password are `admin`.
 
 Go to `Clients` tab on the sidebar.
 
-After a while, a new client `team1/weather-service` should appear.
+After a while, a new client should appear.

--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -6,6 +6,7 @@ KEYCLOAK_REALM = os.environ.get('KEYCLOAK_REALM')
 KEYCLOAK_ADMIN_USERNAME = os.environ.get('KEYCLOAK_ADMIN_USERNAME')
 KEYCLOAK_ADMIN_PASSWORD = os.environ.get('KEYCLOAK_ADMIN_PASSWORD')
 CLIENT_NAME = os.environ.get('CLIENT_NAME')
+CLIENT_ID = os.environ.get('CLIENT_ID')
 NAMESPACE = os.environ.get('NAMESPACE')
 
 def register_client(
@@ -14,12 +15,13 @@ def register_client(
     keycloak_admin_username: str,
     keycloak_admin_password: str,
     client_name: str,
+    client_id: str,
     namespace: str
 ):
-    clientId = f'{namespace}/{client_name}'
+    # clientId = f'{namespace}/{client_name}'
 
     if keycloak_url is None:
-        print(f'Expected environment variable "KEYCLOAK_URL". Skipping client registration of {clientId}.')
+        print(f'Expected environment variable "KEYCLOAK_URL". Skipping client registration of {client_id}.')
         return
     if keycloak_realm is None:
         raise Exception('Expected environment variable "KEYCLOAK_REALM"')
@@ -29,6 +31,8 @@ def register_client(
         raise Exception('Expected environment variable "KEYCLOAK_ADMIN_PASSWORD"')
     if client_name is None:
         raise Exception('Expected environment variable "CLIENT_NAME"')
+    if client_id is None:
+        raise Exception('Expected environment variable "CLIENT_ID"')
     if namespace is None:
         raise Exception('Expected environment variable "NAMESPACE"')
 
@@ -45,7 +49,7 @@ def register_client(
         internal_client_id = keycloak_admin.create_client(
             {
                 "name": client_name,
-                "clientId": clientId,
+                "clientId": client_id,
                 "standardFlowEnabled": True,
                 "directAccessGrantsEnabled": True,
                 "fullScopeAllowed": False,
@@ -53,9 +57,9 @@ def register_client(
             }
         )
 
-        print(f'Created Keycloak client "{clientId}": {internal_client_id}')
+        print(f'Created Keycloak client "{client_id}": {internal_client_id}')
     except KeycloakPostError as e:
-        print(f'Could not create Keycloak client "{clientId}": {e}')
+        print(f'Could not create Keycloak client "{client_id}": {e}')
 
 register_client(
     KEYCLOAK_URL,
@@ -63,5 +67,6 @@ register_client(
     KEYCLOAK_ADMIN_USERNAME,
     KEYCLOAK_ADMIN_PASSWORD,
     CLIENT_NAME,
+    CLIENT_ID,
     NAMESPACE
 )


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Current client registration executed in containerId before creating the components (agents and tools) uses old naming convention `namespaces/comp-name`. This update makes the registration consistent. 

It will still fail, since the default agent and tool are already registered as part of the Kagenti Keyloack install.

## Related issue(s)

Fixes #
