### PR TITLE
:sparkles: Create kagenti keycloak client

### DIFF
--- a/kagenti/installer/app/resources/environments.yaml
+++ b/kagenti/installer/app/resources/environments.yaml
@@ -56,7 +56,7 @@ data:
     [
       {
         "name": "CLIENT_SECRET",
-        "valueFrom": {"secretKeyRef": {"name": "slack-tool-client-secret", "key": "client-secret"}}
+        "valueFrom": {"secretKeyRef": {"name": "kagenti-keycloak-client-secret", "key": "client-secret"}}
       }, 
       {
         "name": "ISSUER",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Remove the hardcoded Keycloak Client creation. Instead create a Kagenti Keycloak client to contain a Keycloak secret. 
 
## Related issue(s)

Fixes #
