### PR TITLE
✨ allow for existing cluster to be brought 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ cython_debug/
 #.idea/
 
 **/.DS_Store
+
+.vscode

--- a/deployments/ui/kagenti-ui.yaml
+++ b/deployments/ui/kagenti-ui.yaml
@@ -23,9 +23,8 @@ spec:
       serviceAccountName: kagenti-ui-service-account
       containers:
         - name: kagenti-ui-container
-#          image: ghcr.io/kagenti/kagenti/ui:latest
-          image: kagenti-demo-ui:latest
-          imagePullPolicy: Never
+          image: ghcr.io/kagenti/kagenti/ui:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: UV_CACHE_DIR
               value: "/app/.cache/uv"

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -18,11 +18,11 @@ Before running the demo setup script, ensure you have the following prerequisite
 
 - **Python:** Python version >=3.9
 - **uv:** [uv](https://docs.astral.sh/uv/getting-started/installation) must be installed (e.g. `pip install uv`)
-- **Docker:** Docker Desktop, Rancher Desktop or Podman Machine. You must alias it to `docker` (e.g. `sudo ln -s /opt/homebrew/bin/podman /usr/local/bin/docker`). On MacOS, you will need also to do `brew install docker-credential-helper`
+- **Docker:** Docker Desktop, Rancher Desktop or Podman Machine. You must alias it to `docker` (e.g. `sudo ln -s /opt/homebrew/bin/podman /usr/local/bin/docker`). On MacOS, you will need also to do `brew install docker-credential-helper`. *Not required if using `--use-existing-cluster`*.
   - On Rancher or Podman Desktop, configure VM size to at least 12 GB of memory and 4 cores
   - On Podman Desktop, make sure you use a machine with [rootful connection](https://podman-desktop.io/docs/podman/setting-podman-machine-default-connection)
   - Make sure to increase your resource limits (for [rancher](https://docs.rancherdesktop.io/how-to-guides/increasing-open-file-limit/), for podman you may need to edit inside the machine the file `/etc/security/limits.conf` and restart the machine)
-- **Kind:** A [tool](https://kind.sigs.k8s.io) to run a Kubernetes cluster in docker (e.g. `brew install kind`).
+- **Kind:** A [tool](https://kind.sigs.k8s.io) to run a Kubernetes cluster in docker (e.g. `brew install kind`). *Not required if using `--use-existing-cluster`*.
 - **kubectl:** The Kubernetes command-line tool (installs with **kind**).
 - **Helm:** A package manager for Kubernetes (e.g. `brew install helm`).
 - **[ollama](https://ollama.com/download)** to run LLMs locally (e.g. `brew install ollama`). Then start the **ollama* service in the background (e.g.`ollama serve`).
@@ -71,6 +71,28 @@ Using `--silent` flag removes the interactive install mode.
 
 ```shell
 uv run kagenti-installer --silent
+```
+
+### Using an Existing Kubernetes Cluster
+
+If you already have a Kubernetes cluster configured and want to skip the kind cluster creation, you can use the `--use-existing-cluster` flag:
+
+```shell
+uv run kagenti-installer --use-existing-cluster
+```
+
+This option will:
+- Skip the kind and Docker dependency checks
+- Use the cluster defined in your `KUBECONFIG` environment variable
+- Skip kind-specific operations like image preloading
+- Deploy all platform components to your existing cluster
+
+Make sure your `KUBECONFIG` is properly set and points to a cluster where you have admin privileges before using this option.
+
+**Note:** When using an existing cluster, you may want to skip the registry component as it's primarily designed for kind clusters:
+
+```shell
+uv run kagenti-installer --use-existing-cluster --skip-install registry
 ```
 
 To skip installation of the specific component e.g. keycloak and SPIRE, issue:

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -89,11 +89,7 @@ This option will:
 
 Make sure your `KUBECONFIG` is properly set and points to a cluster where you have admin privileges before using this option.
 
-**Note:** When using an existing cluster, you may want to skip the registry component as it's primarily designed for kind clusters:
-
-```shell
-uv run kagenti-installer --use-existing-cluster --skip-install registry
-```
+**Note:** When using an existing cluster, the registry component is automatically skipped as it's primarily designed for kind clusters that have been initialized with a specific configuration.
 
 To skip installation of the specific component e.g. keycloak and SPIRE, issue:
 

--- a/kagenti/installer/app/checker.py
+++ b/kagenti/installer/app/checker.py
@@ -27,7 +27,7 @@ from .config import ContainerEngine
 from .utils import console, get_command_version
 
 
-def check_dependencies():
+def check_dependencies(use_existing_cluster: bool = False):
     """Checks if required command-line tools are installed and meet version requirements."""
     console.print(
         Panel(Text("1. Checking Dependencies", justify="center", style="bold yellow"))
@@ -38,7 +38,16 @@ def check_dependencies():
     except ValueError:
         console.log(f"[bold red]✗ Container engine must be either 'docker' or 'podman'[/bold red]")
         raise typer.Exit(1)
-    for tool, versions in config.REQ_VERSIONS.items():
+    
+    # Filter out tools not needed for existing clusters
+    required_tools = config.REQ_VERSIONS.copy()
+    if use_existing_cluster:
+        # Remove kind and docker requirements when using existing cluster
+        required_tools.pop('kind', None)
+        required_tools.pop('docker', None)
+        console.log("[yellow]Using existing cluster - skipping kind and docker checks.[/yellow]")
+    
+    for tool, versions in required_tools.items():
         if tool == "docker" and tool != container_engine.value:
             continue
         if tool == "podman" and tool != container_engine.value:

--- a/kagenti/installer/app/cli.py
+++ b/kagenti/installer/app/cli.py
@@ -130,7 +130,8 @@ def main(
         checker.check_env_vars()
 
         should_install_registry = InstallableComponent.REGISTRY not in skip_install
-        cluster.setup_cluster(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster)
+        cluster.create_kind_cluster(install_registry=should_install_registry)
+        cluster.check_kube_connection(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster)
 
         if preload_images and not use_existing_cluster:
             cluster.preload_images_in_kind(config.PRELOADABLE_IMAGES)

--- a/kagenti/installer/app/cli.py
+++ b/kagenti/installer/app/cli.py
@@ -130,8 +130,10 @@ def main(
         checker.check_env_vars()
 
         should_install_registry = InstallableComponent.REGISTRY not in skip_install
-        cluster.create_kind_cluster(install_registry=should_install_registry)
-        cluster.check_kube_connection(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster)
+        using_kind_cluster = cluster.create_kind_cluster(install_registry=should_install_registry)
+        # If create_kind_cluster returns None/False, we're not using a kind cluster
+        using_kind_cluster = bool(using_kind_cluster)
+        cluster.check_kube_connection(install_registry=should_install_registry, use_existing_cluster=use_existing_cluster, using_kind_cluster=using_kind_cluster)
 
         if preload_images and not use_existing_cluster:
             cluster.preload_images_in_kind(config.PRELOADABLE_IMAGES)

--- a/kagenti/installer/app/cluster.py
+++ b/kagenti/installer/app/cluster.py
@@ -64,32 +64,41 @@ def kind_cluster_running():
         raise typer.Exit(1)
 
 
-def check_kube_connection(install_registry: bool, use_existing_cluster: bool):
+def check_kube_connection(install_registry: bool, use_existing_cluster: bool, using_kind_cluster: bool):
     """Sets up the Kubernetes cluster - either creates a kind cluster or uses existing cluster."""
-    if use_existing_cluster:
+    # Check if KUBECONFIG is set or if a cluster is accessible from the default kubeconfig location ~/.kube/config
+    kubeconfig_path = os.getenv("KUBECONFIG") or os.path.expanduser("~/.kube/config")
+    if not kubeconfig_path:
         console.print(
-            Panel(
-                Text("3. Using Kubernetes Cluster", justify="center", style="bold yellow")
-            )
+            "[bold red]Unable to find an existing KUBECONFIG. Please set it to your cluster's kubeconfig file.[/bold red]"
         )
-        try:
-            kube_config.load_kube_config()
-            v1_api = client.CoreV1Api()
-            # Test connection by getting cluster info
-            v1_api.list_namespace(limit=1)
-            console.log(
-                "[bold green]✓[/bold green] Successfully connected the Kubernetes cluster."
-            )
-        except Exception as e:
-            console.log(
-                f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
-            )
-            console.print(
-                "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
-            )
+        raise typer.Exit(1)
+
+    # Ask for confirmation so we don't add to an existing cluster by mistake
+    if not use_existing_cluster and not using_kind_cluster:
+        console.print(f"[yellow]Found Kubernetes cluster configuration in KUBECONFIG: {kubeconfig_path}[/yellow]")
+        if not Confirm.ask(
+            "[bold yellow]?[/bold yellow] Do you want to proceed with this Kubernetes cluster?",
+            default=True,
+        ):
+            console.print("[bold red]Installation cancelled by user.[/bold red]")
             raise typer.Exit(1)
 
-        console.print()
+    try:
+        kube_config.load_kube_config()
+        v1_api = client.CoreV1Api()
+        # Test connection by getting cluster info
+        v1_api.list_namespace(limit=1)
+        console.log(
+            "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
+        )
+
+    except Exception as e:
+        console.log(
+            f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
+            )
+        raise typer.Exit(1)
+    console.print()
 
 
 def confirm_ask(prompt: str, default: bool, silent: bool):
@@ -112,7 +121,7 @@ def create_kind_cluster(install_registry: bool, silent: bool):
             console.log(
                 f"[bold green]✓[/bold green] Kind cluster '{config.CLUSTER_NAME}' already running. Skipping creation."
             )
-            return
+            return True
         else:
             console.log(
                 f"[bold red]x Kind cluster '{config.CLUSTER_NAME}' exists but is not running."
@@ -125,43 +134,7 @@ def create_kind_cluster(install_registry: bool, silent: bool):
         default=True,
         silent=silent,
     ):
-        # Ask if they want to use an existing cluster instead
-        if Confirm.ask(
-            "[bold yellow]?[/bold yellow] Would you like to use an existing Kubernetes cluster defined in your KUBECONFIG?",
-            default=True,
-        ):
-            console.print(
-                "[bold green]Switching to existing cluster mode...[/bold green]"
-            )
-            # Test connection to existing cluster
-            try:
-                kube_config.load_kube_config()
-                v1_api = client.CoreV1Api()
-                # Test connection by getting cluster info
-                v1_api.list_namespace(limit=1)
-                console.log(
-                    "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
-                )
-
-                if install_registry:
-                    console.print(
-                        "[yellow]Warning: Registry installation is not recommended for existing clusters. "
-                        "Consider using --skip-install registry if you encounter issues.[/yellow]\n"
-                    )
-                console.print()
-                return  # Exit without creating kind cluster
-
-            except Exception as e:
-                console.log(
-                    f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"
-                )
-                console.print(
-                    "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
-                )
-                raise typer.Exit(1)
-        else:
-            console.print("[bold red]Cannot proceed without a cluster. Exiting.[/bold red]")
-            raise typer.Exit()
+        return False
 
     base_config = """
 kind: Cluster
@@ -210,6 +183,7 @@ containerdConfigPatches:
             console.log(f"[red]{e.stderr.strip()}[/red]")
             raise typer.Exit(1)
     console.print()
+    return True
 
 
 def preload_images_in_kind(images: list[str]):

--- a/kagenti/installer/app/cluster.py
+++ b/kagenti/installer/app/cluster.py
@@ -64,12 +64,12 @@ def kind_cluster_running():
         raise typer.Exit(1)
 
 
-def setup_cluster(install_registry: bool, use_existing_cluster: bool):
+def check_kube_connection(install_registry: bool, use_existing_cluster: bool):
     """Sets up the Kubernetes cluster - either creates a kind cluster or uses existing cluster."""
     if use_existing_cluster:
         console.print(
             Panel(
-                Text("3. Using Existing Kubernetes Cluster", justify="center", style="bold yellow")
+                Text("3. Using Kubernetes Cluster", justify="center", style="bold yellow")
             )
         )
         try:
@@ -78,7 +78,7 @@ def setup_cluster(install_registry: bool, use_existing_cluster: bool):
             # Test connection by getting cluster info
             v1_api.list_namespace(limit=1)
             console.log(
-                "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
+                "[bold green]✓[/bold green] Successfully connected the Kubernetes cluster."
             )
         except Exception as e:
             console.log(
@@ -88,15 +88,8 @@ def setup_cluster(install_registry: bool, use_existing_cluster: bool):
                 "[red]Please ensure KUBECONFIG is set and points to a valid cluster.[/red]"
             )
             raise typer.Exit(1)
-        
-        if install_registry:
-            console.print(
-                "[yellow]Warning: Registry installation is not recommended for existing clusters. "
-                "Consider using --skip-install registry if you encounter issues.[/yellow]\n"
-            )
+
         console.print()
-    else:
-        create_kind_cluster(install_registry)
 
 
 def confirm_ask(prompt: str, default: bool, silent: bool):
@@ -149,7 +142,7 @@ def create_kind_cluster(install_registry: bool, silent: bool):
                 console.log(
                     "[bold green]✓[/bold green] Successfully connected to existing Kubernetes cluster."
                 )
-                
+
                 if install_registry:
                     console.print(
                         "[yellow]Warning: Registry installation is not recommended for existing clusters. "
@@ -157,7 +150,7 @@ def create_kind_cluster(install_registry: bool, silent: bool):
                     )
                 console.print()
                 return  # Exit without creating kind cluster
-                
+
             except Exception as e:
                 console.log(
                     f"[bold red]✗ Failed to connect to existing Kubernetes cluster: {e}[/bold red]"

--- a/kagenti/installer/app/components/addons.py
+++ b/kagenti/installer/app/components/addons.py
@@ -16,7 +16,7 @@
 from .. import config
 from ..utils import run_command
 
-def install():
+def install(**kwargs):
     """Installs Prometheus, Kiali, Phoenix, and the OpenTelemetry Collector."""
     # Prometheus
     run_command(

--- a/kagenti/installer/app/components/agents.py
+++ b/kagenti/installer/app/components/agents.py
@@ -24,7 +24,7 @@ from .. import config
 from ..utils import console, run_command, create_or_update_secret
 
 
-def install():
+def install(**kwargs):
     """Applies required secrets and labels to the agent namespaces defined in .env."""
     namespaces_str = os.getenv("AGENT_NAMESPACES")
     if not namespaces_str:

--- a/kagenti/installer/app/components/cert_manager.py
+++ b/kagenti/installer/app/components/cert_manager.py
@@ -17,7 +17,7 @@ from .. import config
 from ..utils import run_command
 
 
-def install():
+def install(**kwargs):
     """Installs cert-manager into the Kubernetes cluster."""
     # Install cert-manager
     run_command(

--- a/kagenti/installer/app/components/gateway.py
+++ b/kagenti/installer/app/components/gateway.py
@@ -18,7 +18,7 @@ from ..utils import run_command, wait_for_deployment
 
 # TODO - configure namespace(s) where this should be deployed - currently is in default
 
-def install():
+def install(**kwargs):
     """Installs the Istio ingress and egress gateways."""
     run_command(
         ["kubectl", "apply", "-f", str(config.RESOURCES_DIR / "http-gateway.yaml")],

--- a/kagenti/installer/app/components/inspector.py
+++ b/kagenti/installer/app/components/inspector.py
@@ -19,7 +19,7 @@ from .. import config
 from ..utils import console, run_command
 
 
-def install():
+def install(**kwargs):
     """Installs the MCP inspector """
     deploy_path = str(config.RESOURCES_DIR /  "mcp-inspector.yaml")
     run_command(["kubectl", "apply", "-f", str(deploy_path)], "Installing MCP Inspector")

--- a/kagenti/installer/app/components/istio.py
+++ b/kagenti/installer/app/components/istio.py
@@ -16,7 +16,7 @@
 from ..utils import run_command
 
 
-def install():
+def install(**kwargs):
     """Installs all Istio components using the official Helm charts."""
     run_command(
         [

--- a/kagenti/installer/app/components/keycloak.py
+++ b/kagenti/installer/app/components/keycloak.py
@@ -152,7 +152,7 @@ def setup_keycloak() -> str:
     return (setup.get_client_secret(kagenti_keycloak_client_id))
 
 
-def install():
+def install(use_existing_cluster: bool = False, **kwargs):
     """Installs Keycloak, patches it for proxy headers, and runs initial setup."""
     run_command(
         [
@@ -209,23 +209,24 @@ def install():
         "Adding Keycloak to Istio ambient mesh",
     )
 
-    # Setup Keycloak demo realm, user, and agent client
-    (kagenti_keycloak_client_secret) = setup_keycloak()
+    if not use_existing_cluster:
+        # Setup Keycloak demo realm, user, and agent client
+        (slack_agent_client_secret, slack_tool_client_secret) = setup_keycloak()
 
-    # Distribute client secret to agent namespaces
-    namespaces_str = os.getenv("AGENT_NAMESPACES", "")
-    if not namespaces_str:
-        return
+        # Distribute client secret to agent namespaces
+        namespaces_str = os.getenv("AGENT_NAMESPACES", "")
+        if not namespaces_str:
+            return
 
-    agent_namespaces = [ns.strip() for ns in namespaces_str.split(",") if ns.strip()]
-    try:
-        kube_config.load_kube_config()
-        v1_api = client.CoreV1Api()
-    except Exception as e:
-        console.log(
-            f"[bold red]✗ Could not connect to Kubernetes to create secrets: {e}[/bold red]"
-        )
-        raise typer.Exit(1)
+        agent_namespaces = [ns.strip() for ns in namespaces_str.split(",") if ns.strip()]
+        try:
+            kube_config.load_kube_config()
+            v1_api = client.CoreV1Api()
+        except Exception as e:
+            console.log(
+                f"[bold red]✗ Could not connect to Kubernetes to create secrets: {e}[/bold red]"
+            )
+            raise typer.Exit(1)
 
     for ns in agent_namespaces:
         if not secret_exists(v1_api, "kagenti-keycloak-client-secret", ns):

--- a/kagenti/installer/app/components/keycloak.py
+++ b/kagenti/installer/app/components/keycloak.py
@@ -211,7 +211,7 @@ def install(use_existing_cluster: bool = False, **kwargs):
 
     if not use_existing_cluster:
         # Setup Keycloak demo realm, user, and agent client
-        (kagenti_keycloak_client_secret, slack_tool_client_secret) = setup_keycloak()
+        kagenti_keycloak_client_secret = setup_keycloak()
 
         # Distribute client secret to agent namespaces
         namespaces_str = os.getenv("AGENT_NAMESPACES", "")

--- a/kagenti/installer/app/components/keycloak.py
+++ b/kagenti/installer/app/components/keycloak.py
@@ -211,7 +211,7 @@ def install(use_existing_cluster: bool = False, **kwargs):
 
     if not use_existing_cluster:
         # Setup Keycloak demo realm, user, and agent client
-        (slack_agent_client_secret, slack_tool_client_secret) = setup_keycloak()
+        (kagenti_keycloak_client_secret, slack_tool_client_secret) = setup_keycloak()
 
         # Distribute client secret to agent namespaces
         namespaces_str = os.getenv("AGENT_NAMESPACES", "")

--- a/kagenti/installer/app/components/mcp_gateway.py
+++ b/kagenti/installer/app/components/mcp_gateway.py
@@ -17,7 +17,7 @@ from .. import config
 from ..utils import run_command
 
 
-def install():
+def install(**kwargs):
 
     """Install K8s Gateway CRDs."""
     # This command installs K8s Gateway CRDs

--- a/kagenti/installer/app/components/metrics_server.py
+++ b/kagenti/installer/app/components/metrics_server.py
@@ -16,7 +16,7 @@
 from .. import config
 from ..utils import run_command
 
-def install():
+def install(**kwargs):
     """Installs the Kubernetes metrics server."""
     # Install metrics server
     run_command(

--- a/kagenti/installer/app/components/operator.py
+++ b/kagenti/installer/app/components/operator.py
@@ -55,7 +55,7 @@ def get_latest_operator_version(fallback="0.2.0-alpha.4") -> str:
         return fallback
     
 
-def install():
+def install(**kwargs):
     """Installs the Platform Operator using its Helm chart."""
 
     operator_version = get_latest_operator_version()

--- a/kagenti/installer/app/components/registry.py
+++ b/kagenti/installer/app/components/registry.py
@@ -23,7 +23,7 @@ from ..config import ContainerEngine
 from ..utils import console, run_command
 
 
-def install():
+def install(**kwargs):
     """Deploys the internal container registry and configures its DNS."""
     run_command(
         ["kubectl", "apply", "-f", str(config.RESOURCES_DIR / "registry.yaml")],

--- a/kagenti/installer/app/components/spire.py
+++ b/kagenti/installer/app/components/spire.py
@@ -17,7 +17,7 @@ from .. import config
 from ..utils import run_command
 
 
-def install():
+def install(**kwargs):
     """Installs all SPIRE components using the official Helm charts."""
     # This command sets up SPIRE CRDs
     run_command(

--- a/kagenti/installer/app/components/tekton.py
+++ b/kagenti/installer/app/components/tekton.py
@@ -17,7 +17,7 @@ from .. import config
 from ..utils import run_command
 
 
-def install():
+def install(**kwargs):
     """Installs Tekton Pipelines from its official release YAML."""
     tekton_url = f"https://storage.googleapis.com/tekton-releases/pipeline/previous/{config.TEKTON_VERSION}/release.yaml"
     run_command(

--- a/kagenti/installer/app/components/ui.py
+++ b/kagenti/installer/app/components/ui.py
@@ -19,7 +19,7 @@ from .. import config
 from ..utils import console, run_command
 
 
-def install():
+def install(**kwargs):
     """Installs the Kagenti UI from its deployment YAML."""
     run_command(
         [


### PR DESCRIPTION
## Summary

Allow for existing cluster to be used. This is for a larger idea to allow for an easy way to install on OpenShift.

This PR is based on #128 by @cooktheryan - it has been rebased and extended to skip registry install and automatic kyecloak setup (which requires a functioning ingress). This PR is also preparing for future PRs targeting OpenShift enablement.

## Related issue(s)
#127 

Fixes #127 


Existing functionality
```
➜  installer git:(main) ✗ uv run kagenti-installer
╭──────────────────────────╮
│ Agent Platform Installer │
╰──────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                             1. Checking Dependencies                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[15:05:21] ✓ kind version 0.24.0 is compatible.                                                        checker.py:60
           ✓ docker version 5.4.1 is compatible.                                                       checker.py:60
[15:05:22] ✓ kubectl version 1.33.0 is compatible.                                                     checker.py:60
[15:05:23] ✓ helm version 3.18.6 is compatible.                                                        checker.py:60
All dependency checks passed.

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                        2. Checking Environment Variables                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
           ✓ All required environment variables are set.                                              checker.py:100

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           3. Kubernetes Cluster Setup                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
? Kind cluster 'agent-platform' not found. Create it now? [y/n] (y): n
Cannot proceed without a cluster. Exiting.
```

New functionality
```
➜  installer git:(main) ✗ uv run kagenti-installer
╭──────────────────────────╮
│ Agent Platform Installer │
╰──────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                             1. Checking Dependencies                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[15:06:47] ✓ kind version 0.24.0 is compatible.                                                        checker.py:60
[15:06:48] ✓ docker version 5.4.1 is compatible.                                                       checker.py:60
[15:06:49] ✓ kubectl version 1.33.0 is compatible.                                                     checker.py:60
           ✓ helm version 3.18.6 is compatible.                                                        checker.py:60
All dependency checks passed.

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                        2. Checking Environment Variables                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[15:06:50] ✓ All required environment variables are set.                                              checker.py:100

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           3. Kubernetes Cluster Setup                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
? Kind cluster 'agent-platform' not found. Create it now? [y/n] (y): n
? Would you like to use an existing Kubernetes cluster defined in your KUBECONFIG? [y/n] (y): y
Switching to existing cluster mode...
[15:06:56] ✓ Successfully connected to existing Kubernetes cluster.                                   cluster.py:135
Warning: Registry installation is not recommended for existing clusters. Consider using --skip-install registry if
you encounter issues.


╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                           4. Checking Agent Namespaces                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
The following required agent namespaces do not exist: team1
Do you want to create them now? [y/n] (y):
[15:06:59] ✓ Creating namespace 'team1' done.                                                            utils.py:88

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                             5. Installing Components                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─────────────────────╮
│ Installing Registry │
╰─────────────────────╯
           ✓ Deploying container registry manifest done.                                                 utils.py:88
[15:07:04] ✓ Waiting for registry deployment done.                                                       utils.py:88
⠋ Configuring registry DNS...Error: no container with name or ID "agent-platform-control-plane" found: no such container
           ✓ Registry DNS configured in Kind container.                                               registry.py:50

╭───────────────────╮
│ Installing Tekton │
╰───────────────────╯
[15:07:06] ✓ Installing Tekton Pipelines done.                                                           utils.py:88

╭─────────────────────────╮
│ Installing Cert_manager │
╰─────────────────────────╯
[15:07:07] ✓ Installing Cert Manager done.                                                               utils.py:88
[15:07:34] ✓ Waiting for deployment/cert-manager in namespace cert-manager done.                         utils.py:88
           ✓ Waiting for deployment/cert-manager-cainjector in namespace cert-manager done.              utils.py:88
[15:07:37] ✓ Waiting for deployment/cert-manager-webhook in namespace cert-manager done.                 utils.py:88

╭─────────────────────╮
│ Installing Operator │
╰─────────────────────╯
[15:07:38] ✓ Installing the Platform Operator done.                                                      utils.py:88

╭──────────────────╮
│ Installing Istio │
╰──────────────────╯
           ✓ Adding Istio Helm repo done.                                                                utils.py:88
[15:07:43] ✓ Updating Helm repos done.                                                                   utils.py:88
[15:07:46] ✓ Installing Istio base done.                                                                 utils.py:88
[15:07:47] ✓ Installing Kubernetes Gateway API done.                                                     utils.py:88
[15:07:56] ✓ Installing Istiod (ambient profile) done.                                                   utils.py:88
[15:07:58] ✓ Installing Istio CNI done.                                                                  utils.py:88
[15:08:11] ✓ Installing Ztunnel done.                                                                    utils.py:88
           ✓ Waiting for ztunnel rollout done.                                                           utils.py:88
           ✓ Waiting for Istio CNI rollout done.                                                         utils.py:88
           ✓ Waiting for Istiod rollout done.                                                            utils.py:88

╭───────────────────────────╮
│ Installing Metrics_server │
╰───────────────────────────╯
[15:08:12] ✓ Installing Kubernetes metrics server done.                                                  utils.py:88
           ✓ Patching metrics server to allow insecure TLS for kubelet communication done.               utils.py:88
[15:08:42] ✓ Waiting for metrics server deployment to be ready done.                                     utils.py:88

╭────────────────────╮
│ Installing Gateway │
╰────────────────────╯
           ✓ Creating Istio ingress gateway done.                                                        utils.py:88
[15:08:43] ✓ Adding NodePort service for gateway done.                                                   utils.py:88
           ✓ Annotating gateway service type done.                                                       utils.py:88
           ✓ Adding egress waypoint gateway done.                                                        utils.py:88
[15:09:04] ✓ Waiting for waypoint gateway rollout done.                                                  utils.py:88

╭───────────────────╮
│ Installing Addons │
╰───────────────────╯
[15:09:05] ✓ Installing Prometheus done.                                                                 utils.py:88
[15:09:20] ✓ Waiting for Prometheus rollout done.                                                        utils.py:88
[15:09:21] ✓ Installing Kiali done.                                                                      utils.py:88
           ✓ Adding Kiali Route done.                                                                    utils.py:88
           ✓ Enabling istio-system for kiali routing done.                                               utils.py:88
[15:10:01] ✓ Waiting for Kiali rollout done.                                                             utils.py:88
           ✓ Installing Phoenix done.                                                                    utils.py:88
[15:10:26] ✓ Waiting for Postgres rollout done.                                                          utils.py:88
[15:11:06] ✓ Waiting for Phoenix rollout done.                                                           utils.py:88
           ✓ Installing Otel Collector done.                                                             utils.py:88
[15:11:16] ✓ Waiting for otel collector rollout done.                                                    utils.py:88

╭─────────────────────╮
│ Installing Keycloak │
╰─────────────────────╯
           ✓ Creating Keycloak namespace done.                                                           utils.py:88
           ✓ Deploying Keycloak statefulset done.                                                        utils.py:88
           ✓ Scaling Keycloak to 1 replica done.                                                         utils.py:88
           ✓ Patching Keycloak for proxy headers done.                                                   utils.py:88
⠏ Waiting for Keycloak rollout...
```

