### PR TITLE
:wrench: Update broker-router flag

### DIFF
--- a/kagenti/installer/app/resources/gateway-deployment.yaml
+++ b/kagenti/installer/app/resources/gateway-deployment.yaml
@@ -128,7 +128,7 @@ spec:
           command:
             - ./mcp_gateway
             - --mcp-gateway-config=/config/config.yaml
-            - --mcp-broker-address=0.0.0.0:8080
+            - --mcp-broker-public-address=0.0.0.0:8080
             - --mcp-router-address=0.0.0.0:50051
             - --log-level=-4  # info level
           volumeMounts:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

With the recent updated `v0.1` tag I was seeing
```
oc logs -f pod/mcp-broker-router-6bbbb5b577-6hp6n -n mcp-system
flag provided but not defined: -mcp-broker-address
```

## Related issue(s)
