### PR TITLE
:sparkles: Add pre commit for linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+- repo: local
+  hooks:
+    # Run the linter
+    - id: make-lint
+      name: Run make lint
+      entry: make lint
+      language: system
+      pass_filenames: false
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.7
+  hooks:
+    # Run the formatter.
+    - id: ruff-format

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -25,6 +25,24 @@ git remote add upstream https://github.com/kubestellar/kubeflex.git
 git fetch upstream --tags
 ```
 
+### Pre-commit
+
+This project leverages [pre-commit](https://pre-commit.com/) to enforce consistency in code style and run checks prior to commits with linters and formatters.
+
+Installation can be done via [directions here](https://pre-commit.com/#installation) or `brew install pre-commit` on MacOS.
+
+From the project base, this will install the Git hook:
+```sh
+pre-commit install
+```
+
+To run against all files manually:
+```sh
+pre-commit run --all-files
+```
+
+VSCode extensions such as this [pre-commit-helper](https://marketplace.visualstudio.com/items?itemName=elagil.pre-commit-helper) can be configured to run directly when files are saved in VSCode.
+
 ### Making a PR
 
 Work on your local repo cloned from your fork. Create a branch:
@@ -33,7 +51,7 @@ Work on your local repo cloned from your fork. Create a branch:
 git checkout -b <name-of-your-branch>
 ```
 
-When ready to make your PR, make sure first to rebase from upstream 
+When ready to make your PR, make sure first to rebase from upstream
 (things may have changed while you have been working on the PR):
 
 ```shell
@@ -48,7 +66,7 @@ Resolve any conflict if needed, then you can make your PR by doing:
 git commit -am "<your commit message>" -s
 ```
 
-Note that commits must be all signed off to pass DCO checks. 
+Note that commits must be all signed off to pass DCO checks.
 It is reccomended (but not enforced) to follow best practices
 for commits comments such as [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
@@ -108,8 +126,8 @@ git push upstream v0.0.4-alpha.10
 
 ### Running locally
 
-To run the UI locally, ensure you have Python version 3.12 or above installed. 
-If Kagenti is not already running, execute the installer to set up Kagenti first. 
+To run the UI locally, ensure you have Python version 3.12 or above installed.
+If Kagenti is not already running, execute the installer to set up Kagenti first.
 Follow these steps to run the UI:
 
 1. Navigate to the kagenti/ui directory:
@@ -130,7 +148,7 @@ Note: Running locally allows you to explore various UI features except for conne
 
 Example: Connecting to `a2a-currency-converter`
 
-To test connectivity with the `a2a-currency-converter` agent within 
+To test connectivity with the `a2a-currency-converter` agent within
 the team1 namespace, apply the following HTTPRoute configuration:
 
 ```shell
@@ -149,14 +167,14 @@ spec:
     - "a2a-currency-converter.localtest.me"
   rules:
     - backendRefs:
-        - name: a2a-currency-converter 
-          port: 8000 
+        - name: a2a-currency-converter
+          port: 8000
 EOF
 ```
 
 ### Running Your Image in Kubernetes
 
-Before proceeding, ensure there is an existing Kagenti instance 
+Before proceeding, ensure there is an existing Kagenti instance
 running. To test your build on Kubernetes, execute the following script:
 
 ```shell

--- a/kagenti/ui/lib/agent_details_page.py
+++ b/kagenti/ui/lib/agent_details_page.py
@@ -40,10 +40,12 @@ from . import constants
 
 logger = logging.getLogger(__name__)
 
+
 # pylint: disable=too-many-arguments, too-many-positional-arguments
 def _handle_chat_interaction(
     st_object,
     agent_k8s_name: str,
+    # pylint: disable=unused-argument
     agent_chat_name: str,
     agent_url: str,
     session_key_prefix: str,

--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -140,6 +140,7 @@ def _get_keycloak_client_secret(st_object, client_name: str) -> str:
         )
         return ""
 
+
 # pylint: disable=too-many-arguments, too-many-positional-arguments, too-many-locals
 def _construct_tool_resource_body(
     st_object,
@@ -153,7 +154,7 @@ def _construct_tool_resource_body(
     protocol: str,
     framework: str,
     description: str,
-    build_from_source: bool ,
+    build_from_source: bool,
     registry_config: Optional[dict] = None,
     additional_env_vars: Optional[list] = None,
     image_tag: str = constants.DEFAULT_IMAGE_TAG,
@@ -181,7 +182,7 @@ def _construct_tool_resource_body(
         Optional[dict]: The constructed Kubernetes resource body, or None if an error occurred.
     """
     k8s_resource_name = sanitize_for_k8s_name(resource_name)
- #   image_name = k8s_resource_name
+    #   image_name = k8s_resource_name
     repo_user = get_secret_data(
         core_v1_api,
         build_namespace,
@@ -195,7 +196,7 @@ def _construct_tool_resource_body(
         )
         return None
     st_object.info(f"Using GitHub username '{repo_user}' from secret for build.")
-    #image_registry_prefix = f"ghcr.io/{repo_user}"
+    # image_registry_prefix = f"ghcr.io/{repo_user}"
     image_name = k8s_resource_name
     if build_from_source:
         # Use configured registry or fall back to local
@@ -204,7 +205,7 @@ def _construct_tool_resource_body(
         else:
             image_registry_prefix = "registry.cr-system.svc.cluster.local:5000"
     else:
-        image_registry_prefix,image_name,_tag =  parse_image_url(repo_url)
+        image_registry_prefix, image_name, _tag = parse_image_url(repo_url)
 
     client_secret_for_env = _get_keycloak_client_secret(
         st_object, f"{k8s_resource_name}-client"
@@ -257,7 +258,11 @@ def _construct_tool_resource_body(
         },
     }
     if build_from_source:
-        selected_mode = DEV_EXTERNAL_MODE if (registry_config and registry_config.get("requires_auth")) else DEV_LOCAL_MODE
+        selected_mode = (
+            DEV_EXTERNAL_MODE
+            if (registry_config and registry_config.get("requires_auth"))
+            else DEV_LOCAL_MODE
+        )
         pipeline_steps = get_pipeline_steps_for_mode(selected_mode)
 
         build_params = [
@@ -271,7 +276,7 @@ def _construct_tool_resource_body(
             },
             {
                 "name": "revision",
-                "value":  repo_branch,
+                "value": repo_branch,
             },
             {
                 "name": "subfolder-path",
@@ -279,16 +284,22 @@ def _construct_tool_resource_body(
             },
             {
                 "name": "image",
-                "value":  f"{image_registry_prefix}/{image_name}:{image_tag}"
+                "value": f"{image_registry_prefix}/{image_name}:{image_tag}",
             },
         ]
 
         # Add registry credentials for external registries
-        if registry_config and registry_config.get("requires_auth") and registry_config.get("credentials_secret"):
-            build_params.append({
-                "name": "registry-secret",  # Use the parameter name expected by kaniko task
-                "value": registry_config["credentials_secret"],
-            })
+        if (
+            registry_config
+            and registry_config.get("requires_auth")
+            and registry_config.get("credentials_secret")
+        ):
+            build_params.append(
+                {
+                    "name": "registry-secret",  # Use the parameter name expected by kaniko task
+                    "value": registry_config["credentials_secret"],
+                }
+            )
 
         spec["tool"] = {
             "toolType": "MCP",
@@ -320,28 +331,30 @@ def _construct_tool_resource_body(
     }
     return body
 
+
 def is_valid_image_url(url: str) -> bool:
     """Is URL valid?"""
-    pattern = re.compile(
-        r'^[\w\.-]+(?:/[\w\-]+)+:[\w\.\-]+$'
-    )
+    pattern = re.compile(r"^[\w\.-]+(?:/[\w\-]+)+:[\w\.\-]+$")
     return bool(pattern.match(url))
+
 
 def extract_repo_name(url):
     """Given a URL, extract the repo name"""
-    pattern = r'^([^\/:]+)\/([^\/:]+):([^\/:]+)$'
+    pattern = r"^([^\/:]+)\/([^\/:]+):([^\/:]+)$"
     match = re.match(pattern, url)
     if match:
         return match.group(1)  # repo name is the first group
     return None
 
+
 def extract_image_name(url):
     """Given a URL, extract the image name"""
-    pattern = r'^([^\/:]+)\/([^\/:]+):([^\/:]+)$'
+    pattern = r"^([^\/:]+)\/([^\/:]+):([^\/:]+)$"
     match = re.match(pattern, url)
     if match:
         return match.group(2)  # image name is the second group
     return None
+
 
 def _construct_agent_resource_body(
     st_object,
@@ -355,11 +368,10 @@ def _construct_agent_resource_body(
     protocol: str,
     framework: str,
     description: str,
-    build_from_source: bool ,
+    build_from_source: bool,
     registry_config: Optional[dict] = None,
     additional_env_vars: Optional[list] = None,
     image_tag: str = constants.DEFAULT_IMAGE_TAG,
-
 ) -> Optional[dict]:
     """
     Constructs the Kubernetes resource body for a new build.
@@ -384,7 +396,6 @@ def _construct_agent_resource_body(
         Optional[dict]: The constructed Kubernetes resource body, or None if an error occurred.
     """
 
-
     k8s_resource_name = sanitize_for_k8s_name(resource_name)
     repo_user = get_secret_data(
         core_v1_api,
@@ -408,7 +419,7 @@ def _construct_agent_resource_body(
         else:
             image_registry_prefix = "registry.cr-system.svc.cluster.local:5000"
     else:
-        image_registry_prefix,image_name,_tag =  parse_image_url(repo_url)
+        image_registry_prefix, image_name, _tag = parse_image_url(repo_url)
         if _tag:
             image_tag = _tag
 
@@ -420,7 +431,9 @@ def _construct_agent_resource_body(
         final_env_vars.extend(additional_env_vars)
     if client_secret_for_env:
         final_env_vars.append({"name": "CLIENT_SECRET", "value": client_secret_for_env})
-    final_env_vars.append({"name": "GITHUB_SECRET_NAME", "value": constants.GIT_USER_SECRET_NAME})
+    final_env_vars.append(
+        {"name": "GITHUB_SECRET_NAME", "value": constants.GIT_USER_SECRET_NAME}
+    )
     body = {
         "apiVersion": f"{constants.CRD_GROUP}/{constants.CRD_VERSION}",
         "kind": "Component",
@@ -438,8 +451,7 @@ def _construct_agent_resource_body(
         "spec": {
             "description": description,
             "suspend": False,
-            "agent": {
-            },
+            "agent": {},
             "deployer": {
                 "name": k8s_resource_name,
                 "namespace": build_namespace,
@@ -470,7 +482,6 @@ def _construct_agent_resource_body(
                         "limits": constants.DEFAULT_RESOURCE_LIMITS,
                         "requests": constants.DEFAULT_RESOURCE_REQUESTS,
                     },
-
                 },
                 "env": final_env_vars,
             },
@@ -488,7 +499,7 @@ def _construct_agent_resource_body(
             },
             {
                 "name": "revision",
-                "value":  repo_branch,
+                "value": repo_branch,
             },
             {
                 "name": "subfolder-path",
@@ -496,28 +507,37 @@ def _construct_agent_resource_body(
             },
             {
                 "name": "image",
-                "value":  f"{image_registry_prefix}/{image_name}:{image_tag}"
+                "value": f"{image_registry_prefix}/{image_name}:{image_tag}",
             },
         ]
 
         # Add registry credentials for external registries
-        if registry_config and registry_config.get("requires_auth") and registry_config.get("credentials_secret"):
-            build_params.append({
-                "name": "registry-secret",  # Use the parameter name expected by kaniko task
-                "value": registry_config["credentials_secret"],
-            })
+        if (
+            registry_config
+            and registry_config.get("requires_auth")
+            and registry_config.get("credentials_secret")
+        ):
+            build_params.append(
+                {
+                    "name": "registry-secret",  # Use the parameter name expected by kaniko task
+                    "value": registry_config["credentials_secret"],
+                }
+            )
 
         body["spec"]["agent"] = {
             "build": {
-                "mode": DEV_EXTERNAL_MODE if (registry_config and registry_config.get("requires_auth")) else DEV_LOCAL_MODE,
+                "mode": DEV_EXTERNAL_MODE
+                if (registry_config and registry_config.get("requires_auth"))
+                else DEV_LOCAL_MODE,
                 "pipeline": {
                     "parameters": build_params,
-                "cleanupAfterBuild": True,
+                    "cleanupAfterBuild": True,
                 },
             },
         }
 
     return body
+
 
 # pylint: disable=too-many-return-statements, too-many-branches, too-many-statements
 def trigger_and_monitor_build(
@@ -577,37 +597,37 @@ def trigger_and_monitor_build(
     build_cr_body = None
     if resource_type.lower() == "agent":
         build_cr_body = _construct_agent_resource_body(
-           st_object=st_object,
-           core_v1_api=core_v1_api,
-           build_namespace=build_namespace,
-           resource_name=k8s_resource_name,
-           resource_type=resource_type,
-           repo_url=repo_url,
-           repo_branch=repo_branch,
-           source_subfolder=source_subfolder,
-           protocol=protocol,
-           framework=framework,
-           description=description,
-           build_from_source=True,
-           registry_config=registry_config,
-           additional_env_vars=additional_env_vars,
+            st_object=st_object,
+            core_v1_api=core_v1_api,
+            build_namespace=build_namespace,
+            resource_name=k8s_resource_name,
+            resource_type=resource_type,
+            repo_url=repo_url,
+            repo_branch=repo_branch,
+            source_subfolder=source_subfolder,
+            protocol=protocol,
+            framework=framework,
+            description=description,
+            build_from_source=True,
+            registry_config=registry_config,
+            additional_env_vars=additional_env_vars,
         )
     elif resource_type.lower() == "tool":
         build_cr_body = _construct_tool_resource_body(
-           st_object=st_object,
-           core_v1_api=core_v1_api,
-           build_namespace=build_namespace,
-           resource_name=k8s_resource_name,
-           resource_type=resource_type,
-           repo_url=repo_url,
-           repo_branch=repo_branch,
-           source_subfolder=source_subfolder,
-           protocol=protocol,
-           framework=framework,
-           description=description,
-           build_from_source=True,
-           registry_config=registry_config,
-           additional_env_vars=additional_env_vars,
+            st_object=st_object,
+            core_v1_api=core_v1_api,
+            build_namespace=build_namespace,
+            resource_name=k8s_resource_name,
+            resource_type=resource_type,
+            repo_url=repo_url,
+            repo_branch=repo_branch,
+            source_subfolder=source_subfolder,
+            protocol=protocol,
+            framework=framework,
+            description=description,
+            build_from_source=True,
+            registry_config=registry_config,
+            additional_env_vars=additional_env_vars,
         )
     if not build_cr_body:
         st_object.error(
@@ -618,8 +638,9 @@ def trigger_and_monitor_build(
         f"Submitting build for {resource_type} '{k8s_resource_name}' in namespace '{build_namespace}'..."
     ):
         try:
-
-            logger.info("Generated Component manifest:\n%s", json.dumps(build_cr_body, indent=2))
+            logger.info(
+                "Generated Component manifest:\n%s", json.dumps(build_cr_body, indent=2)
+            )
             custom_obj_api.create_namespaced_custom_object(
                 group=constants.CRD_GROUP,
                 version=constants.CRD_VERSION,
@@ -664,12 +685,12 @@ def trigger_and_monitor_build(
                     name=k8s_resource_name,
                 )
                 status_data = build_obj.get("status", {})
-                #current_build_status = status_data.get("buildStatus", "Unknown")
+                # current_build_status = status_data.get("buildStatus", "Unknown")
                 build_status_data = status_data.get("buildStatus", {})
                 current_build_status = build_status_data.get("phase", "Unknown")
 
                 status_message = build_status_data.get("message", "")
-                #deployment_status = status_data.get("deploymentStatus", "")
+                # deployment_status = status_data.get("deploymentStatus", "")
                 deployment_status_data = status_data.get("deploymentStatus", {})
                 deployment_phase = deployment_status_data.get("phase", "Unknown")
 
@@ -717,30 +738,34 @@ def trigger_and_monitor_build(
             f"Build succeeded. Waiting for {resource_type} '{k8s_resource_name}' to deploy..."
         ):
             while (
-              final_deployment_phase not in ["Ready", "Failed", "Error"]
-              and deployment_retries < max_deployment_retries
+                final_deployment_phase not in ["Ready", "Failed", "Error"]
+                and deployment_retries < max_deployment_retries
             ):
                 deployment_retries += 1
                 try:
-                   # Re-fetch the object to get latest deployment status
+                    # Re-fetch the object to get latest deployment status
                     build_obj = custom_obj_api.get_namespaced_custom_object(
-                      group=constants.CRD_GROUP,
-                      version=constants.CRD_VERSION,
-                      namespace=build_namespace,
-                      plural=constants.COMPONENTS_PLURAL,
-                      name=k8s_resource_name,
+                        group=constants.CRD_GROUP,
+                        version=constants.CRD_VERSION,
+                        namespace=build_namespace,
+                        plural=constants.COMPONENTS_PLURAL,
+                        name=k8s_resource_name,
                     )
 
                     final_deployment_status = build_obj.get("status", {}).get(
-                       "deploymentStatus", {}
+                        "deploymentStatus", {}
                     )
-                    final_deployment_phase = final_deployment_status.get("phase", "Unknown")
-                    deployment_message = final_deployment_status.get("deploymentMessage", "")
+                    final_deployment_phase = final_deployment_status.get(
+                        "phase", "Unknown"
+                    )
+                    deployment_message = final_deployment_status.get(
+                        "deploymentMessage", ""
+                    )
 
                     # Update status display
                     status_placeholder.info(
-                       f"Deployment Status for '{k8s_resource_name}': **{final_deployment_phase}**\n"
-                       f"Message: {deployment_message}"
+                        f"Deployment Status for '{k8s_resource_name}': **{final_deployment_phase}**\n"
+                        f"Message: {deployment_message}"
                     )
 
                     if final_deployment_phase in ["Ready", "Failed", "Error"]:
@@ -761,8 +786,8 @@ def trigger_and_monitor_build(
             return True
         if final_deployment_phase in ["Failed", "Error"]:
             st_object.error(
-              # pylint: disable=line-too-long
-              f"{resource_type.capitalize()} '{k8s_resource_name}' deployment failed with status: {final_deployment_phase}. Check operator logs."
+                # pylint: disable=line-too-long
+                f"{resource_type.capitalize()} '{k8s_resource_name}' deployment failed with status: {final_deployment_phase}. Check operator logs."
             )
             return False
 
@@ -774,12 +799,12 @@ def trigger_and_monitor_build(
         )
         return False
 
-
     st_object.error(
         # pylint: disable=line-too-long
         f"{resource_type.capitalize()} build for '{k8s_resource_name}' in '{build_namespace}' finished with status: {current_build_status}. Check operator logs."
     )
     return False
+
 
 # pylint: disable=too-many-return-statements, too-many-branches
 def trigger_and_monitor_deployment_from_image(
@@ -832,35 +857,35 @@ def trigger_and_monitor_deployment_from_image(
     cr_body = None
     if resource_type.lower() == "agent":
         cr_body = _construct_agent_resource_body(
-           st_object=st_object,
-           core_v1_api=core_v1_api,
-           build_namespace=deployment_namespace,
-           resource_name=k8s_resource_name,
-           resource_type=resource_type,
-           repo_url=repo_url,
-           repo_branch="",
-           source_subfolder="",
-           protocol=protocol,
-           framework=framework,
-           description=description,
-           build_from_source=False,
-           additional_env_vars=additional_env_vars,
+            st_object=st_object,
+            core_v1_api=core_v1_api,
+            build_namespace=deployment_namespace,
+            resource_name=k8s_resource_name,
+            resource_type=resource_type,
+            repo_url=repo_url,
+            repo_branch="",
+            source_subfolder="",
+            protocol=protocol,
+            framework=framework,
+            description=description,
+            build_from_source=False,
+            additional_env_vars=additional_env_vars,
         )
     elif resource_type.lower() == "tool":
         cr_body = _construct_tool_resource_body(
-           st_object=st_object,
-           core_v1_api=core_v1_api,
-           build_namespace=deployment_namespace,
-           resource_name=k8s_resource_name,
-           resource_type=resource_type,
-           repo_url=repo_url,
-           repo_branch="",
-           source_subfolder="",
-           protocol=protocol,
-           framework=framework,
-           description=description,
-           build_from_source=False,
-           additional_env_vars=additional_env_vars,
+            st_object=st_object,
+            core_v1_api=core_v1_api,
+            build_namespace=deployment_namespace,
+            resource_name=k8s_resource_name,
+            resource_type=resource_type,
+            repo_url=repo_url,
+            repo_branch="",
+            source_subfolder="",
+            protocol=protocol,
+            framework=framework,
+            description=description,
+            build_from_source=False,
+            additional_env_vars=additional_env_vars,
         )
     if not cr_body:
         st_object.error(
@@ -871,8 +896,9 @@ def trigger_and_monitor_deployment_from_image(
         f"Submitting deployment for {resource_type} '{k8s_resource_name}' in namespace '{deployment_namespace}'..."
     ):
         try:
-
-            logger.info("Generated Component manifest:\n%s", json.dumps(cr_body, indent=2))
+            logger.info(
+                "Generated Component manifest:\n%s", json.dumps(cr_body, indent=2)
+            )
             custom_obj_api.create_namespaced_custom_object(
                 group=constants.CRD_GROUP,
                 version=constants.CRD_VERSION,
@@ -923,7 +949,9 @@ def trigger_and_monitor_deployment_from_image(
                     "deploymentStatus", {}
                 )
                 final_deployment_phase = final_deployment_status.get("phase", "Unknown")
-                deployment_message = final_deployment_status.get("deploymentMessage", "")
+                deployment_message = final_deployment_status.get(
+                    "deploymentMessage", ""
+                )
                 # Update status display
                 status_placeholder.info(
                     f"Deployment Status for '{k8s_resource_name}': **{final_deployment_phase}**\n"
@@ -958,6 +986,7 @@ def trigger_and_monitor_deployment_from_image(
         f"Last status: {final_deployment_phase}. Manual check might be needed."
     )
     return False
+
 
 # pylint: disable=too-many-branches
 def render_import_form(
@@ -1012,8 +1041,6 @@ def render_import_form(
         "selected_build_k8s_namespace", default_build_ns
     )
 
-
-
     if initial_selected_build_ns not in available_build_namespaces:
         initial_selected_build_ns = (
             default_build_ns
@@ -1028,7 +1055,7 @@ def render_import_form(
         options=available_build_namespaces,
         index=build_ns_index,
         key=f"{resource_type.lower()}_build_namespace_selector",
-            # pylint: disable=line-too-long
+        # pylint: disable=line-too-long
         help=f"The Component resource, the {resource_type}, and the '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap will be in this namespace.",
     )
 
@@ -1078,7 +1105,9 @@ def render_import_form(
 
         # --- Custom Environment Variables Editor ---
         st_object.subheader("Environment Variables")
-        st_object.caption(f"Define environment variables specific to this {resource_type}")
+        st_object.caption(
+            f"Define environment variables specific to this {resource_type}"
+        )
 
         custom_env_key = f"{resource_type.lower()}_custom_env_vars"
 
@@ -1095,26 +1124,35 @@ def render_import_form(
         def load_all_configmap_vars():
             """load original configmap vars, keeping user-added custom vars"""
             if not env_options:
-                st_object.warning(f"No configMap data available to load in namespace '{build_namespace_to_use}'")
+                st_object.warning(
+                    f"No configMap data available to load in namespace '{build_namespace_to_use}'"
+                )
                 return
             # First, remove any previously loaded configmap vars
-            user_custom_vars = [var for var in st.session_state.get(custom_env_key,[]) if not var.get('configmap_origin', False)]
+            user_custom_vars = [
+                var
+                for var in st.session_state.get(custom_env_key, [])
+                if not var.get("configmap_origin", False)
+            ]
             # Then, add all configmap vars
             config_map_data = get_config_map_data(
-                core_v1_api, build_namespace_to_use, constants.ENV_CONFIG_MAP_NAME)
+                core_v1_api, build_namespace_to_use, constants.ENV_CONFIG_MAP_NAME
+            )
 
             if config_map_data:
                 # Parse configmap data into env vars
                 all_configmap_vars = parse_configmap_data_to_env_vars(config_map_data)
                 configmap = []
                 for var in all_configmap_vars:
-                    configmap.append({
-                        "name": var["name"],
-                        "value": var["value"],
-                        'configmap_origin': True,
-                        'configmap_section': var.get('section', ''),
-                        'configmap_type': var.get('type', 'configmap')
-                        })
+                    configmap.append(
+                        {
+                            "name": var["name"],
+                            "value": var["value"],
+                            "configmap_origin": True,
+                            "configmap_section": var.get("section", ""),
+                            "configmap_type": var.get("type", "configmap"),
+                        }
+                    )
                 st.session_state[custom_env_key] = configmap + user_custom_vars
                 st.session_state[configmap_loaded_key] = True
                 return
@@ -1124,16 +1162,18 @@ def render_import_form(
         # a list
         def parse_env_file(content):
             env_vars = []
-            lines = content.strip().split('\n')
+            lines = content.strip().split("\n")
 
             for line_num, line in enumerate(lines, 1):
                 line = line.strip()
                 if not line or line.startswith("#"):
                     continue
-                if '=' not in line:
-                    st_object.warning(f"⚠️ Line {line_num}: Invalid format (missing '='): {line}")
+                if "=" not in line:
+                    st_object.warning(
+                        f"⚠️ Line {line_num}: Invalid format (missing '='): {line}"
+                    )
                     continue
-                name, value = line.split('=', 1)
+                name, value = line.split("=", 1)
                 name = name.strip()
                 value = value.strip()
 
@@ -1148,52 +1188,77 @@ def render_import_form(
                     st_object.warning(f"⚠️ Line {line_num}: Empty variable name")
             return env_vars
 
-
-        configmap_col1, configmap_col2, configmap_col3 = st_object.columns([2, 2, 2])
+        configmap_col1, configmap_col2, _ = st_object.columns([2, 2, 2])
         with configmap_col1:
-            if st_object.button("📄 Load Global Environment Vars",
-                           key=f"{resource_type.lower()}_load_configmap",
-                            help=f"Load all environment variables from the '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap in '{build_namespace_to_use}' namespace"):
+            if st_object.button(
+                "📄 Load Global Environment Vars",
+                key=f"{resource_type.lower()}_load_configmap",
+                # pylint: disable=line-too-long
+                help=f"Load all environment variables from the '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap in '{build_namespace_to_use}' namespace",
+            ):
                 load_all_configmap_vars()
                 if st.session_state[configmap_loaded_key]:
-                    configmap_var_count = len([var for var in st.session_state[custom_env_key] if var.get('configmap_origin', False)])
-                    st_object.success(f"Loaded {configmap_var_count} environment variables from ConfigMap")
+                    configmap_var_count = len(
+                        [
+                            var
+                            for var in st.session_state[custom_env_key]
+                            if var.get("configmap_origin", False)
+                        ]
+                    )
+                    st_object.success(
+                        f"Loaded {configmap_var_count} environment variables from ConfigMap"
+                    )
                 st.rerun()
         with configmap_col2:
             if st.session_state[configmap_loaded_key]:
-                if st_object.button("🔄 Reload Global Environment Vars",
-                               key=f"{resource_type.lower()}_reload_configmap",
-                                help=f"Restore original environment variables from the '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap in '{build_namespace_to_use}' namespace"):
+                if st_object.button(
+                    "🔄 Reload Global Environment Vars",
+                    key=f"{resource_type.lower()}_reload_configmap",
+                    # pylint: disable=line-too-long
+                    help=f"Restore original environment variables from the '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap in '{build_namespace_to_use}' namespace",
+                ):
                     load_all_configmap_vars()
-                    st_object.success(f"Restored environment variables from a '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap")
+                    st_object.success(
+                        f"Restored environment variables from a '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap"
+                    )
                     st.rerun()
 
         if st.session_state[configmap_loaded_key]:
-            configmap_vars_count = len([var for var in st.session_state[custom_env_key] if var.get('configmap_origin', False)])
-            user_vars_count = len([var for var in st.session_state[custom_env_key] if not var.get('configmap_origin', False)])
-
-            st_object.caption(f"Loaded {configmap_vars_count} environment variables from ConfigMap ")
+            configmap_vars_count = len(
+                [
+                    var
+                    for var in st.session_state[custom_env_key]
+                    if var.get("configmap_origin", False)
+                ]
+            )
+            st_object.caption(
+                f"Loaded {configmap_vars_count} environment variables from ConfigMap "
+            )
 
         custom_env_vars = st.session_state[custom_env_key]
         if custom_env_vars:
             # --------- Render each env var
             for i, env_var in enumerate(custom_env_vars):
                 col1, col2, col3, col4 = st_object.columns([3, 3, 2, 1])
-                """Determine if this env var originated from configmap or custom added"""
-                is_configmap_var = env_var.get('configmap_origin', False)
+                # Determine if this env var originated from configmap or custom added
+                is_configmap_var = env_var.get("configmap_origin", False)
 
                 with col1:
-                    env_var["name"] = st.text_input("Name",
-                                                    value=env_var["name"],
-                                                    key=f"{resource_type.lower()}_env_name_{i}",
-                                                    placeholder="example: API_KEY",
-                                                    label_visibility="collapsed" if i > 0 else "visible")
+                    env_var["name"] = st.text_input(
+                        "Name",
+                        value=env_var["name"],
+                        key=f"{resource_type.lower()}_env_name_{i}",
+                        placeholder="example: API_KEY",
+                        label_visibility="collapsed" if i > 0 else "visible",
+                    )
                 with col2:
-                    env_var["value"] = st.text_input("Value",
-                                                    value=env_var["value"],
-                                                    key=f"{resource_type.lower()}_env_value_{i}",
-                                                    placeholder="example: AAAA_BBBB_CCCC",
-                                                    label_visibility="collapsed" if i > 0 else "visible")
+                    env_var["value"] = st.text_input(
+                        "Value",
+                        value=env_var["value"],
+                        key=f"{resource_type.lower()}_env_value_{i}",
+                        placeholder="example: AAAA_BBBB_CCCC",
+                        label_visibility="collapsed" if i > 0 else "visible",
+                    )
 
                 with col3:
                     if i == 0:
@@ -1201,39 +1266,57 @@ def render_import_form(
                         st_object.write("")
 
                     if is_configmap_var:
-                        var_type = env_var.get('configmap_type', 'configmap')
-                        if var_type == 'secret':
-                            st_object.markdown("<span style='font-size: 10px; color: blue; '>🔒 **Custom Secret**</span>", unsafe_allow_html=True)
-                        elif var_type == 'configmap-secret':
-                            st_object.markdown("<span style='font-size: 10px; color: green; '>🔒 **ConfigMap Secret**</span>", unsafe_allow_html=True)
+                        var_type = env_var.get("configmap_type", "configmap")
+                        if var_type == "secret":
+                            st_object.markdown(
+                                "<span style='font-size: 10px; color: blue; '>🔒 **Custom Secret**</span>",
+                                unsafe_allow_html=True,
+                            )
+                        elif var_type == "configmap-secret":
+                            st_object.markdown(
+                                "<span style='font-size: 10px; color: green; '>🔒 **ConfigMap Secret**</span>",
+                                unsafe_allow_html=True,
+                            )
                         else:
-                            st_object.markdown("<span style='font-size: 10px; color: green'>🗂️ **ConfigMap**</span>", unsafe_allow_html=True)
+                            st_object.markdown(
+                                "<span style='font-size: 10px; color: green'>🗂️ **ConfigMap**</span>",
+                                unsafe_allow_html=True,
+                            )
                     else:
-                        st_object.markdown("<span style='font-size: 10px; color: blue; '>✏️ **Custom**</span>", unsafe_allow_html=True)
+                        st_object.markdown(
+                            "<span style='font-size: 10px; color: blue; '>✏️ **Custom**</span>",
+                            unsafe_allow_html=True,
+                        )
 
                 with col4:
                     if i == 0:
                         st_object.write("")
                         st_object.write("")
 
-                    if st.button( "🗑️",
-                                 key=f"{resource_type}.lower()-remove_env_{i}",
-                                 help="Remove this environment variable"):
+                    if st.button(
+                        "🗑️",
+                        key=f"{resource_type}.lower()-remove_env_{i}",
+                        help="Remove this environment variable",
+                    ):
                         remove_env_var(i)
                         st.rerun()
 
-        button_col1, button_col2, button_col3 = st_object.columns([1, 1, 1])
+        button_col1, button_col2, _ = st_object.columns([1, 1, 1])
         with button_col1:
-            if st_object.button("✚ Add Environment Variable",
-                           key=f"{resource_type.lower()}_add_env_var",
-                            help="Add a new custom environment variable"):
+            if st_object.button(
+                "✚ Add Environment Variable",
+                key=f"{resource_type.lower()}_add_env_var",
+                help="Add a new custom environment variable",
+            ):
                 add_env_var()
                 st.rerun()
 
         with button_col2:
-            if st_object.button("📥 Import .env File",
-                           key=f"{resource_type.lower()}_import_env_var",
-                            help="Import environment variables from .env file"):
+            if st_object.button(
+                "📥 Import .env File",
+                key=f"{resource_type.lower()}_import_env_var",
+                help="Import environment variables from .env file",
+            ):
                 st.session_state[import_dialog_key] = True
                 st.rerun()
 
@@ -1242,36 +1325,42 @@ def render_import_form(
         st_object.markdown("---")
         st_object.subheader("Import Environment Variables from .env file")
 
-        repo_url = st_object.text_input("Github Repository URL:",
-                                        placeholder="http://github.com/username/repository",
-                                        key=f"{resource_type.lower()}_repo_url",
-                                        help="Enter the Github repository URL")
-        file_path = st_object.text_input("Path to .env file:",
-                                        placeholder=". env or config/.env or path/to/your/.env",
-                                        key=f"{resource_type.lower()}_env_file_path",
-                                        help="Enter the path to .env file within the repository")
+        repo_url = st_object.text_input(
+            "Github Repository URL:",
+            placeholder="http://github.com/username/repository",
+            key=f"{resource_type.lower()}_repo_url",
+            help="Enter the Github repository URL",
+        )
+        file_path = st_object.text_input(
+            "Path to .env file:",
+            placeholder=". env or config/.env or path/to/your/.env",
+            key=f"{resource_type.lower()}_env_file_path",
+            help="Enter the path to .env file within the repository",
+        )
 
         import_col1, import_col2, _import_col3 = st_object.columns([1, 1, 2])
         with import_col1:
-            if st_object.button(" 🔄 Import",
-                                key=f"{resource_type.lower()}_do_import",
-                                disabled=not (repo_url and file_path)):
+            if st_object.button(
+                " 🔄 Import",
+                key=f"{resource_type.lower()}_do_import",
+                disabled=not (repo_url and file_path),
+            ):
                 try:
                     with st_object.spinner("Fetching .env file from repository ..."):
-
                         # Need to convert Github repo URL to raw file URL
                         if "github.com" in repo_url:
-
-                            if repo_url.endswith('.git'):
+                            if repo_url.endswith(".git"):
                                 repo_url = repo_url[:-4]
 
-                            repo_path = repo_url.replace("https://github.com/",'').replace("http://github.com/",'')
-                            if '/tree/' in repo_path:
-                                parts = repo_path.split('/tree/')
+                            repo_path = repo_url.replace(
+                                "https://github.com/", ""
+                            ).replace("http://github.com/", "")
+                            if "/tree/" in repo_path:
+                                parts = repo_path.split("/tree/")
                                 repo_path = parts[0]
-                                branch = parts[1].split('/')[0]
+                                branch = parts[1].split("/")[0]
                             else:
-                                branch = 'main'
+                                branch = "main"
                             raw_url = f"https://raw.githubusercontent.com/{repo_path}/{branch}/{file_path.lstrip('/')}"
                         else:
                             raw_url = f"{repo_url.rstrip('/')}/{file_path.lstrip('/')}"
@@ -1281,25 +1370,43 @@ def render_import_form(
 
                         imported_vars = parse_env_file(env_content)
                         if imported_vars:
-                            existing_names = {var["name"] for var in st.session_state[custom_env_key]}
-                            new_vars = [var for var in imported_vars if var["name"] not in existing_names]
-                            duplicate_vars = [var for var in imported_vars if var["name"] in existing_names]
+                            existing_names = {
+                                var["name"] for var in st.session_state[custom_env_key]
+                            }
+                            new_vars = [
+                                var
+                                for var in imported_vars
+                                if var["name"] not in existing_names
+                            ]
+                            duplicate_vars = [
+                                var
+                                for var in imported_vars
+                                if var["name"] in existing_names
+                            ]
                             st.session_state[custom_env_key].extend(new_vars)
-                            st_object.success("Successfully imported env vars from the .env file")
+                            st_object.success(
+                                "Successfully imported env vars from the .env file"
+                            )
                             if duplicate_vars:
                                 # pylint: disable=line-too-long
-                                st_object.warning(f"⚠️ Skipped {len(duplicate_vars)} duplicate variables {', '.join([var['name'] for var in duplicate_vars])}")
+                                st_object.warning(
+                                    f"⚠️ Skipped {len(duplicate_vars)} duplicate variables {', '.join([var['name'] for var in duplicate_vars])}"
+                                )
                             st.session_state[import_dialog_key] = False
                             st.rerun()
                         else:
-                            st_object.error("❌ No valid environment variables found in the file")
+                            st_object.error(
+                                "❌ No valid environment variables found in the file"
+                            )
                 except requests.RequestException as e:
                     st_object.error(f"❌ Failed to fetch file: {str(e)}")
                 except Exception as e:
                     st_object.error(f"❌ Import error: {str(e)}")
 
         with import_col2:
-            if st_object.button("❌ Cancel", key=f"{resource_type.lower()}_cancel_import"):
+            if st_object.button(
+                "❌ Cancel", key=f"{resource_type.lower()}_cancel_import"
+            ):
                 st.session_state[import_dialog_key] = False
                 st.rerun()
 
@@ -1310,21 +1417,22 @@ def render_import_form(
 
         for env_var in custom_env_vars:
             if env_var["name"].strip() and env_var["value"].strip():
-                valid_custom_env_vars.append({"name": env_var["name"].strip(),
-                                              "value": env_var["value"].strip()})
+                valid_custom_env_vars.append(
+                    {"name": env_var["name"].strip(), "value": env_var["value"].strip()}
+                )
             elif env_var["name".strip() or env_var["value"].strip()]:
                 invalid_custom_env_vars.append(env_var)
 
         if invalid_custom_env_vars:
             # pylint: disable=line-too-long
-            st_object.warning(f"{len(invalid_custom_env_vars)} environment variable(s) have missing name or value and will be ignored")
+            st_object.warning(
+                f"{len(invalid_custom_env_vars)} environment variable(s) have missing name or value and will be ignored"
+            )
 
     st_object.markdown("---")
 
     if not k8s_api_client:
-        st_object.error(
-            "Kubernetes client not available. Cannot proceed with build."
-        )
+        st_object.error("Kubernetes client not available. Cannot proceed with build.")
         return
 
     final_additional_envs = []
@@ -1336,8 +1444,9 @@ def render_import_form(
     if custom_env_vars:
         for env_var in custom_env_vars:
             if env_var["name"].strip() and env_var["value"].strip():
-                final_additional_envs.append({"name": env_var["name"].strip(),
-                                             "value": env_var["value"].strip()})
+                final_additional_envs.append(
+                    {"name": env_var["name"].strip(), "value": env_var["value"].strip()}
+                )
 
     custom_obj_api = get_custom_objects_api()
     if not custom_obj_api or not core_v1_api:
@@ -1347,9 +1456,10 @@ def render_import_form(
         return
 
     deployment_method = st_object.radio(
-       "Deployment Method",
-       ("Build from Source", "Deploy from Existing Image"),
-        key=f"{resource_type.lower()}_deployment_method",)
+        "Deployment Method",
+        ("Build from Source", "Deploy from Existing Image"),
+        key=f"{resource_type.lower()}_deployment_method",
+    )
 
     if example_subfolders is None:
         example_subfolders = []
@@ -1411,7 +1521,9 @@ def render_import_form(
                     st_object.info("No example subfolders.")
             manual_subfolder_input = st_object.text_input(
                 "Source Subfolder Path (relative to root)",
-                value=final_source_subfolder_path if final_source_subfolder_path else "",
+                value=final_source_subfolder_path
+                if final_source_subfolder_path
+                else "",
                 placeholder=f"e.g., {resource_type.lower()}s/my-new-{resource_type.lower()}",
                 key=f"manual_{resource_type.lower()}_source_subfolder_path",
             )
@@ -1419,7 +1531,8 @@ def render_import_form(
                 final_source_subfolder_path = manual_subfolder_input
 
         if st_object.button(
-            f"Build & Deploy New {resource_type}", key=f"build_new_{resource_type.lower()}_btn"
+            f"Build & Deploy New {resource_type}",
+            key=f"build_new_{resource_type.lower()}_btn",
         ):
             resource_name_suggestion = get_resource_name_from_path(
                 final_source_subfolder_path
@@ -1439,12 +1552,15 @@ def render_import_form(
                 return
 
             # Validate registry configuration for external registries
-            if registry_config and registry_config.get("requires_auth") and not registry_config.get("credentials_secret"):
+            if (
+                registry_config
+                and registry_config.get("requires_auth")
+                and not registry_config.get("credentials_secret")
+            ):
                 st_object.warning(
                     "Please specify a registry secret name for external registry authentication."
                 )
                 return
-
 
             trigger_and_monitor_build(
                 st_object=st,
@@ -1485,20 +1601,26 @@ def render_import_form(
 
         if st_object.button(
             f"Deploy {resource_type} from Image",
-            key=f"deploy_{resource_type.lower()}_from_image_btn"
+            key=f"deploy_{resource_type.lower()}_from_image_btn",
         ):
             if not docker_image_url or not build_namespace_to_use:
-                st_object.warning("Please provide the Docker image and select a namespace.")
+                st_object.warning(
+                    "Please provide the Docker image and select a namespace."
+                )
                 return
             if not k8s_api_client:
-                st_object.error("Kubernetes client not available. Cannot proceed with deployment.")
+                st_object.error(
+                    "Kubernetes client not available. Cannot proceed with deployment."
+                )
                 return
             _repo, resource_name, _tag = parse_image_url(docker_image_url)
 
             # Trigger deployment using the image
             custom_obj_api = get_custom_objects_api()
             if not custom_obj_api or not core_v1_api:
-                st_object.error("K8s API clients not initialized correctly. Cannot trigger deployment.")
+                st_object.error(
+                    "K8s API clients not initialized correctly. Cannot trigger deployment."
+                )
                 return
 
             resource_name_suggestion = extract_image_name(docker_image_url)
@@ -1519,20 +1641,21 @@ def render_import_form(
 
     st_object.markdown("---")
 
+
 def parse_image_url(url: str):
     """Parse an Image URL"""
     # Split off the tag
-    if ':' not in url:
+    if ":" not in url:
         raise ValueError("URL must contain a tag (e.g., :latest)")
 
-    base, tag = url.rsplit(':', 1)
-    parts = base.strip('/').split('/')
+    base, tag = url.rsplit(":", 1)
+    parts = base.strip("/").split("/")
 
     if len(parts) < 2:
         raise ValueError("URL must contain at least a repo and image name")
 
     image_name = parts[-1]
-    repo = '/'.join(parts[:-1])
+    repo = "/".join(parts[:-1])
 
     return repo, image_name, tag
 
@@ -1542,7 +1665,7 @@ DEFAULT_REGISTRY_OPTIONS = {
     LOCAL_REGISTRY: "registry.cr-system.svc.cluster.local:5000",
     QUAY_REGISTRY: "quay.io",
     DOCKER_HUB_REGISTRY: "docker.io",
-    GITHUB_REGISTRY: "ghcr.io"
+    GITHUB_REGISTRY: "ghcr.io",
 }
 
 
@@ -1570,7 +1693,7 @@ def get_registry_config_from_ui(st_object, resource_type, build_from_source):
         options=registry_options,
         index=0,  # Default to Local Registry
         key=f"{resource_type.lower()}_registry_selector",
-        help="Choose the container registry where the built image will be pushed"
+        help="Choose the container registry where the built image will be pushed",
     )
 
     registry_url = DEFAULT_REGISTRY_OPTIONS[selected_registry_key]
@@ -1581,7 +1704,7 @@ def get_registry_config_from_ui(st_object, resource_type, build_from_source):
             f"{selected_registry_key} Organization/Namespace:",
             placeholder="your-org-name",
             key=f"{resource_type.lower()}_registry_namespace",
-            help=f"Your organization or namespace in {selected_registry_key}"
+            help=f"Your organization or namespace in {selected_registry_key}",
         )
 
         # Show authentication requirements
@@ -1598,18 +1721,20 @@ def get_registry_config_from_ui(st_object, resource_type, build_from_source):
                 "Registry Secret Name:",
                 value="quay-registry-secret",
                 key=f"{resource_type.lower()}_registry_secret",
-                help="Name of the Kubernetes secret containing Quay.io credentials"
+                help="Name of the Kubernetes secret containing Quay.io credentials",
             )
         else:
             secret_name = st_object.text_input(
                 f"{selected_registry_key} Secret Name:",
                 value=f"{selected_registry_key.lower().replace(' ', '-').replace('.', '-')}-registry-secret",
                 key=f"{resource_type.lower()}_registry_secret",
-                help=f"Name of the Kubernetes secret containing {selected_registry_key} credentials"
+                help=f"Name of the Kubernetes secret containing {selected_registry_key} credentials",
             )
 
         if not namespace_or_org:
-            st_object.warning(f"Please specify your {selected_registry_key} organization/namespace")
+            st_object.warning(
+                f"Please specify your {selected_registry_key} organization/namespace"
+            )
             return None
 
         full_registry_url = f"{registry_url}/{namespace_or_org}"
@@ -1622,7 +1747,7 @@ def get_registry_config_from_ui(st_object, resource_type, build_from_source):
         "registry_url": full_registry_url,
         "registry_type": selected_registry_key,
         "credentials_secret": secret_name,
-        "requires_auth": selected_registry_key != LOCAL_REGISTRY
+        "requires_auth": selected_registry_key != LOCAL_REGISTRY,
     }
 
 
@@ -1633,8 +1758,12 @@ def validate_registry_config(registry_config, st_object):
     if not registry_config:
         return False
 
-    if registry_config["requires_auth"] and not registry_config.get("credentials_secret"):
-        st_object.error("External registries require authentication. Please specify a secret name.")
+    if registry_config["requires_auth"] and not registry_config.get(
+        "credentials_secret"
+    ):
+        st_object.error(
+            "External registries require authentication. Please specify a secret name."
+        )
         return False
 
     if registry_config["registry_type"] == QUAY_REGISTRY:
@@ -1644,7 +1773,10 @@ def validate_registry_config(registry_config, st_object):
 
     return True
 
-def parse_configmap_data_to_env_vars(env_options: Dict[str, Any]) -> List[Dict[str, Any]]:
+
+def parse_configmap_data_to_env_vars(
+    env_options: Dict[str, Any],
+) -> List[Dict[str, Any]]:
     """
     Parses ConfigMap data and return all environment variables as a flat list.
 
@@ -1657,105 +1789,115 @@ def parse_configmap_data_to_env_vars(env_options: Dict[str, Any]) -> List[Dict[s
 
     env_vars = []
 
+    # pylint: disable=too-many-nested-blocks
     for section_name, section_content in env_options.items():
         if isinstance(section_content, list):
-            for i, var in enumerate(section_content):
-                if isinstance(var, dict) and 'name' in var:
+            for _, var in enumerate(section_content):
+                if isinstance(var, dict) and "name" in var:
                     parsed_var = {
-                        'name': var['name'],
-                        'section': section_name,
-                        'configmap_origin': True
+                        "name": var["name"],
+                        "section": section_name,
+                        "configmap_origin": True,
                     }
 
-                    if 'valueFrom' in var and isinstance(var['valueFrom'], dict):
-                        secret_ref = var['valueFrom'].get('secretKeyRef', {})
+                    if "valueFrom" in var and isinstance(var["valueFrom"], dict):
+                        secret_ref = var["valueFrom"].get("secretKeyRef", {})
                         if secret_ref:
-                            secret_name = secret_ref.get('name', '')
-                            secret_key = secret_ref.get('key', '')
-                            parsed_var['value'] = f"<{secret_name}:{secret_key}>"
-                            parsed_var['type'] = 'configmap-secret'
+                            secret_name = secret_ref.get("name", "")
+                            secret_key = secret_ref.get("key", "")
+                            parsed_var["value"] = f"<{secret_name}:{secret_key}>"
+                            parsed_var["type"] = "configmap-secret"
                         else:
-                            parsed_var['value'] = str(var.get('valueFrom',''))
-                            parsed_var['type'] = 'configmap'
-                    elif 'value' in var:
-                        parsed_var['value'] = var['value']
-                        parsed_var['type'] = 'configmap'
+                            parsed_var["value"] = str(var.get("valueFrom", ""))
+                            parsed_var["type"] = "configmap"
+                    elif "value" in var:
+                        parsed_var["value"] = var["value"]
+                        parsed_var["type"] = "configmap"
                     else:
-                        parsed_var['value'] = str(var)
-                        parsed_var['type'] = 'configmap'
+                        parsed_var["value"] = str(var)
+                        parsed_var["type"] = "configmap"
 
                     env_vars.append(parsed_var)
 
         elif isinstance(section_content, str):
-           try:
-               parsed_content = json.loads(section_content)
-               if isinstance(parsed_content, list):
-                   for var in parsed_content:
-                       if isinstance(var, dict) and 'name' in var:
+            try:
+                parsed_content = json.loads(section_content)
+                if isinstance(parsed_content, list):
+                    for var in parsed_content:
+                        if isinstance(var, dict) and "name" in var:
                             parsed_var = {
-                               'name': var['name'],
-                               'section': section_name,
-                               'configmap_origin': True,
+                                "name": var["name"],
+                                "section": section_name,
+                                "configmap_origin": True,
                             }
-                            if 'valueFrom' in var and isinstance(var['valueFrom'], dict):
-                                secret_ref = var['valueFrom'].get('secretKeyRef', {})
+                            if "valueFrom" in var and isinstance(
+                                var["valueFrom"], dict
+                            ):
+                                secret_ref = var["valueFrom"].get("secretKeyRef", {})
                                 if secret_ref:
-                                    secret_name = secret_ref.get('name', '')
-                                    secret_key = secret_ref.get('key', '')
-                                    parsed_var['value'] = f"<{secret_name}:{secret_key}>"
-                                    parsed_var['type'] = 'configmap-secret'
+                                    secret_name = secret_ref.get("name", "")
+                                    secret_key = secret_ref.get("key", "")
+                                    parsed_var["value"] = (
+                                        f"<{secret_name}:{secret_key}>"
+                                    )
+                                    parsed_var["type"] = "configmap-secret"
                                 else:
-                                    parsed_var['value'] = str(var.get('valueFrom',''))
-                                    parsed_var['type'] = 'configmap'
-                            elif 'value' in var:
-                                parsed_var['value'] = var['value']
-                                parsed_var['type'] = 'configmap'
+                                    parsed_var["value"] = str(var.get("valueFrom", ""))
+                                    parsed_var["type"] = "configmap"
+                            elif "value" in var:
+                                parsed_var["value"] = var["value"]
+                                parsed_var["type"] = "configmap"
                             else:
-                                parsed_var['value'] = str(var)
-                                parsed_var['type'] = 'configmap'
+                                parsed_var["value"] = str(var)
+                                parsed_var["type"] = "configmap"
                             env_vars.append(parsed_var)
-           except json.JSONDecodeError:
-               # If not JSON, treat as single env var with section name as prefix
-               env_vars.append({
-                   'name': section_name.upper(),
-                   'value': str(section_content),
-                   'section': section_name,
-                   'configmap_origin': True,
-                   'type': 'configmap'
-               })
+            except json.JSONDecodeError:
+                # If not JSON, treat as single env var with section name as prefix
+                env_vars.append(
+                    {
+                        "name": section_name.upper(),
+                        "value": str(section_content),
+                        "section": section_name,
+                        "configmap_origin": True,
+                        "type": "configmap",
+                    }
+                )
         elif isinstance(section_content, dict):
-            if 'name' in section_content:
+            if "name" in section_content:
                 parsed_var = {
-                    'name': section_content['name'],
-                    'section': section_name,
-                    'configmap_origin': True,
+                    "name": section_content["name"],
+                    "section": section_name,
+                    "configmap_origin": True,
                 }
-                if 'valueFrom' in section_content and isinstance(section_content['valueFrom'], dict):
-                    secret_ref = section_content['valueFrom'].get('secretKeyRef', {})
+                if "valueFrom" in section_content and isinstance(
+                    section_content["valueFrom"], dict
+                ):
+                    secret_ref = section_content["valueFrom"].get("secretKeyRef", {})
                     if secret_ref:
-                        secret_name = secret_ref.get('name', '')
-                        secret_key = secret_ref.get('key', '')
-                        parsed_var['value'] = f"<{secret_name}:{secret_key}>"
-                        parsed_var['type'] = 'configmap-secret'
+                        secret_name = secret_ref.get("name", "")
+                        secret_key = secret_ref.get("key", "")
+                        parsed_var["value"] = f"<{secret_name}:{secret_key}>"
+                        parsed_var["type"] = "configmap-secret"
                     else:
-                        parsed_var['value'] = str(section_content.get('valueFrom',''))
-                        parsed_var['type'] = 'configmap'
-                elif 'value' in section_content:
-                    parsed_var['value'] = section_content['value']
-                    parsed_var['type'] = 'configmap'
+                        parsed_var["value"] = str(section_content.get("valueFrom", ""))
+                        parsed_var["type"] = "configmap"
+                elif "value" in section_content:
+                    parsed_var["value"] = section_content["value"]
+                    parsed_var["type"] = "configmap"
                 else:
-                    parsed_var['value'] = str(section_content)
-                    parsed_var['type'] = 'configmap'
+                    parsed_var["value"] = str(section_content)
+                    parsed_var["type"] = "configmap"
                 env_vars.append(parsed_var)
         else:
             # Treat as single env var with section name as prefix
-            env_vars.append({
-                'name': section_name.upper(),
-                'value': str(section_content),
-                'section': section_name,
-                'configmap_origin': True,
-                'type': 'configmap'
-            })
+            env_vars.append(
+                {
+                    "name": section_name.upper(),
+                    "value": str(section_content),
+                    "section": section_name,
+                    "configmap_origin": True,
+                    "type": "configmap",
+                }
+            )
 
     return env_vars
-

--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -1102,14 +1102,14 @@ def render_import_form(
             # Then, add all configmap vars
             config_map_data = get_config_map_data(
                 core_v1_api, build_namespace_to_use, constants.ENV_CONFIG_MAP_NAME)
-            
-            if config_map_data:       
+
+            if config_map_data:
                 # Parse configmap data into env vars
                 all_configmap_vars = parse_configmap_data_to_env_vars(config_map_data)
                 configmap = []
                 for var in all_configmap_vars:
                     configmap.append({
-                        "name": var["name"], 
+                        "name": var["name"],
                         "value": var["value"],
                         'configmap_origin': True,
                         'configmap_section': var.get('section', ''),
@@ -1157,7 +1157,7 @@ def render_import_form(
                 load_all_configmap_vars()
                 if st.session_state[configmap_loaded_key]:
                     configmap_var_count = len([var for var in st.session_state[custom_env_key] if var.get('configmap_origin', False)])
-                    st_object.success(f"Loaded {configmap_var_count} environment variables from ConfigMap") 
+                    st_object.success(f"Loaded {configmap_var_count} environment variables from ConfigMap")
                 st.rerun()
         with configmap_col2:
             if st.session_state[configmap_loaded_key]:
@@ -1165,7 +1165,7 @@ def render_import_form(
                                key=f"{resource_type.lower()}_reload_configmap",
                                 help=f"Restore original environment variables from the '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap in '{build_namespace_to_use}' namespace"):
                     load_all_configmap_vars()
-                    st_object.success(f"Restored environment variables from a '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap") 
+                    st_object.success(f"Restored environment variables from a '{constants.ENV_CONFIG_MAP_NAME}' ConfigMap")
                     st.rerun()
 
         if st.session_state[configmap_loaded_key]:
@@ -1173,10 +1173,10 @@ def render_import_form(
             user_vars_count = len([var for var in st.session_state[custom_env_key] if not var.get('configmap_origin', False)])
 
             st_object.caption(f"Loaded {configmap_vars_count} environment variables from ConfigMap ")
-           
+
         custom_env_vars = st.session_state[custom_env_key]
         if custom_env_vars:
-            # --------- Render each env var 
+            # --------- Render each env var
             for i, env_var in enumerate(custom_env_vars):
                 col1, col2, col3, col4 = st_object.columns([3, 3, 2, 1])
                 """Determine if this env var originated from configmap or custom added"""
@@ -1203,13 +1203,13 @@ def render_import_form(
                     if is_configmap_var:
                         var_type = env_var.get('configmap_type', 'configmap')
                         if var_type == 'secret':
-                            st_object.markdown(f"<span style='font-size: 10px; color: blue; '>🔒 **Custom Secret**</span>", unsafe_allow_html=True) 
+                            st_object.markdown("<span style='font-size: 10px; color: blue; '>🔒 **Custom Secret**</span>", unsafe_allow_html=True)
                         elif var_type == 'configmap-secret':
-                            st_object.markdown(f"<span style='font-size: 10px; color: green; '>🔒 **ConfigMap Secret**</span>", unsafe_allow_html=True) 
+                            st_object.markdown("<span style='font-size: 10px; color: green; '>🔒 **ConfigMap Secret**</span>", unsafe_allow_html=True)
                         else:
-                            st_object.markdown(f"<span style='font-size: 10px; color: green'>🗂️ **ConfigMap**</span>", unsafe_allow_html=True)
+                            st_object.markdown("<span style='font-size: 10px; color: green'>🗂️ **ConfigMap**</span>", unsafe_allow_html=True)
                     else:
-                        st_object.markdown(f"<span style='font-size: 10px; color: blue; '>✏️ **Custom**</span>", unsafe_allow_html=True)       
+                        st_object.markdown("<span style='font-size: 10px; color: blue; '>✏️ **Custom**</span>", unsafe_allow_html=True)
 
                 with col4:
                     if i == 0:
@@ -1664,7 +1664,7 @@ def parse_configmap_data_to_env_vars(env_options: Dict[str, Any]) -> List[Dict[s
                     parsed_var = {
                         'name': var['name'],
                         'section': section_name,
-                        'configmap_origin': True                      
+                        'configmap_origin': True
                     }
 
                     if 'valueFrom' in var and isinstance(var['valueFrom'], dict):
@@ -1695,7 +1695,7 @@ def parse_configmap_data_to_env_vars(env_options: Dict[str, Any]) -> List[Dict[s
                             parsed_var = {
                                'name': var['name'],
                                'section': section_name,
-                               'configmap_origin': True,                        
+                               'configmap_origin': True,
                             }
                             if 'valueFrom' in var and isinstance(var['valueFrom'], dict):
                                 secret_ref = var['valueFrom'].get('secretKeyRef', {})
@@ -1722,13 +1722,13 @@ def parse_configmap_data_to_env_vars(env_options: Dict[str, Any]) -> List[Dict[s
                    'section': section_name,
                    'configmap_origin': True,
                    'type': 'configmap'
-               })   
+               })
         elif isinstance(section_content, dict):
             if 'name' in section_content:
                 parsed_var = {
                     'name': section_content['name'],
                     'section': section_name,
-                    'configmap_origin': True,                    
+                    'configmap_origin': True,
                 }
                 if 'valueFrom' in section_content and isinstance(section_content['valueFrom'], dict):
                     secret_ref = section_content['valueFrom'].get('secretKeyRef', {})
@@ -1746,7 +1746,7 @@ def parse_configmap_data_to_env_vars(env_options: Dict[str, Any]) -> List[Dict[s
                 else:
                     parsed_var['value'] = str(section_content)
                     parsed_var['type'] = 'configmap'
-                env_vars.append(parsed_var)       
+                env_vars.append(parsed_var)
         else:
             # Treat as single env var with section name as prefix
             env_vars.append({
@@ -1756,6 +1756,6 @@ def parse_configmap_data_to_env_vars(env_options: Dict[str, Any]) -> List[Dict[s
                 'configmap_origin': True,
                 'type': 'configmap'
             })
-    
+
     return env_vars
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I noticed that the linting via `make lint` started to raise errors, so this is a proposal to leverage `pre-commit` to make this more automatic and consistent. For now, `make lint `only runs on some UI files. This is kept for now but can be expanded to the other files in this repo [but may require many updates for other files] and/or changed to leverage another linter like ruff. This mainly adds ruff-format which will format whitespace and other pep-8 violations.

Most of the changes to the `build_utils.py` are aesthetic - making spacing more consistent and standardizing on double quotes

Pre-commit only runs on the staged commits 

To install: `pip install pre-commit && pre-commit install` to set up Git hooks
To run manually: `pre-commit run --all-files`
