### PR TITLE
:book: Fix kind setup docs

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -16,7 +16,7 @@ cd kagenti
 3. Add the upstream repository as a remote (adjust the URL if you prefer SSH)
 
 ```shell
-git remote add upstream https://github.com/kubestellar/kubeflex.git
+git remote add upstream https://github.com/kagenti/kagenti.git
 ```
 
 4. Fetch all tags from upstream

--- a/kagenti/installer/app/checker.py
+++ b/kagenti/installer/app/checker.py
@@ -95,7 +95,6 @@ def check_env_vars():
         required_vars = [
             "GITHUB_USER",
             "GITHUB_TOKEN",
-            "OPENAI_API_KEY",
             "AGENT_NAMESPACES",
         ]
         missing = [v for v in required_vars if not os.getenv(v)]

--- a/kagenti/installer/app/config.py
+++ b/kagenti/installer/app/config.py
@@ -63,11 +63,6 @@ PRELOADABLE_IMAGES = [
     "ghcr.io/kagenti/mcp-gateway:v0.1",
     "ghcr.io/modelcontextprotocol/inspector:0.15.0",
     "public.ecr.aws/docker/library/registry:3.0.0-rc.4",
-    # Preloads images for versions matching the yaml file/URL
-    # for run command in cert_manager.py
-    "quay.io/jetstack/cert-manager-webhook:v1.17.2",
-    "quay.io/jetstack/cert-manager-cainjector:v1.17.2",
-    "quay.io/jetstack/cert-manager-controller:v1.17.2"
 ]
 
 # --- Git Repos and fallback tag versions ---

--- a/kagenti/installer/app/config.py
+++ b/kagenti/installer/app/config.py
@@ -61,7 +61,13 @@ PRELOADABLE_IMAGES = [
     "docker.io/nginxinc/nginx-unprivileged:1.29.0-alpine",
     "docker.io/nginx/nginx-prometheus-exporter:1.4.2",
     "ghcr.io/kagenti/mcp-gateway:v0.1",
-    "ghcr.io/modelcontextprotocol/inspector:0.15.0"
+    "ghcr.io/modelcontextprotocol/inspector:0.15.0",
+    "public.ecr.aws/docker/library/registry:3.0.0-rc.4",
+    # Preloads images for versions matching the yaml file/URL
+    # for run command in cert_manager.py
+    "quay.io/jetstack/cert-manager-webhook:v1.17.2",
+    "quay.io/jetstack/cert-manager-cainjector:v1.17.2",
+    "quay.io/jetstack/cert-manager-controller:v1.17.2"
 ]
 
 # --- Git Repos and fallback tag versions ---


### PR DESCRIPTION
## Summary
The main point is to remove the OpenAI API key enforcement  in the checker script. Along the way, I also:

-  (1) added to the list of images for the --preload-images option
- (2) fixed minor URL pointers for the dev guide.

Point 1 above enables a non `--silent` installer to advance in its container creation (but not necessarily complete, more details in [this commit](https://github.com/kagenti/kagenti/commit/e0ecc9f50701eef72ba8516ebf5ca70edd2dc4d3)).

## Related issue(s)
None

Fixes #
None
