### PR TITLE
:bug: Add missing CLIENT_SECRET to Weather Agent

### DIFF
--- a/kagenti/installer/app/resources/environments.yaml
+++ b/kagenti/installer/app/resources/environments.yaml
@@ -24,7 +24,11 @@ data:
     ]
   mcp-weather: |
     [
-      {"name": "MCP_URL", "value": "http://weather-tool:8000/mcp"}
+      {"name": "MCP_URL", "value": "http://weather-tool:8000/mcp"},
+      {
+        "name": "CLIENT_SECRET",
+        "valueFrom": {"secretKeyRef": {"name": "kagenti-keycloak-client-secret", "key": "client-secret"}}
+      }
     ]
   mcp-slack: |
     [


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Weather Agent does not set CLIENT_SECRET that is needed to obtain the Keycloak secret

## Related issue(s)

Fixes #
