### PR TITLE
:book: Add instructions and logging around failing install

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -196,7 +196,7 @@ password: admin
 
 ### kagenti-installer reports "exceeded its progress deadline"
 
-Sometimes it can take a long time to pull container images.  Try re-running the installer.
+Sometimes it can take a long time to pull container images.  Try re-running the installer.  Use `oc get deployments --all-namespaces` to see pinpoint a failing deployment.
 
 ### Service stops responding through gateway
 
@@ -239,6 +239,8 @@ Error text:
 
 Check your [personal access token (classic)](https://github.com/settings/personal-access-tokens/).
 Make sure to grant scopes `all:repo`, `write:packages`, and `read:packages`.
+
+You may also get "ghcr.io: 403 Forbidden" errors installing Helm charts during Kagenti installation.  You may have cached credentials that are no longer valid.  The fix is `docker logout ghcr.io`.
 
 ### Agent log shows communication errors
 

--- a/kagenti/installer/app/utils.py
+++ b/kagenti/installer/app/utils.py
@@ -134,6 +134,8 @@ def run_command(command: list[str], description: str):
                 f"[bold red]✗[/bold red] {description} [bold red]failed[/bold red]."
             )
             console.log(f"[red]Error: {e.stderr.strip()}[/red]")
+            console.log("[red]Failed command[/red]")
+            console.log(" ".join(command))
             raise typer.Exit(1)
 
 


### PR DESCRIPTION
## Summary

Kagenti installs fail mysteriously if old credentials are being held by the container environment.

This PR adds doc with a new troubleshooting step.

This PR also adds code to log the failing command.  This makes troubleshooting easier.
NOTE: Logging commands is a good idea unless there are commands that do `kubectl create secret` with explicit passwords being run by pipelines where users might not have the secret.  I don't know if that is a typical Kagenti install flow; please don't approve this PR with the added logging if this might be a concern.

Fixes #
Resolves #223
