### PR TITLE
:sparkles: Expose Gateway following mcp-gateway pattern

### DIFF
--- a/kagenti/installer/app/resources/gateway.yaml
+++ b/kagenti/installer/app/resources/gateway.yaml
@@ -24,3 +24,10 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: mcp-mcp # gateway listener
+      hostname: 'mcp.127-0-0-1.sslip.io' #public accessibly MCP host one used by client
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All


### PR DESCRIPTION
## Summary

Exposes the MCP server outside the Kind cluster at MCP=http://mcp.127-0-0-1.sslip.io:8888/mcp

This allows Kagenti to use the same endpoint address as the MCP-Gateway's dev environment.

Config based on https://github.com/kagenti/mcp-gateway/blob/377e7e8ebbdf6c5d904bf72b6ad48ea9f7a58001/config/istio/gateway/gateway.yaml#L11
