### PR TITLE
:sparkles: Add volume and VolumeMount to Component CustomResource

### DIFF
--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -252,6 +252,26 @@ def _construct_tool_resource_body(
                     "limits": constants.DEFAULT_RESOURCE_LIMITS,
                     "requests": constants.DEFAULT_RESOURCE_REQUESTS,
                 },
+                "volumes": [
+                    {
+                        "name": "cache",
+                        "emptyDir": {},
+                    },
+                    {
+                        "name": "venv",
+                        "emptyDir": {},
+                    },
+                ],
+                "volumeMounts": [
+                    {
+                        "name": "cache",
+                        "mountPath": "/app/.cache",
+                    },
+                    {
+                        "name": "venv",
+                        "mountPath": "/app/.venv",
+                    },
+                ],
             },
             "env": final_env_vars,
         },

--- a/kagenti/ui/lib/constants.py
+++ b/kagenti/ui/lib/constants.py
@@ -69,7 +69,13 @@ DEFAULT_ENV_VARS = [
         "name": "KEYCLOAK_URL",
         "value": "http://keycloak.keycloak.svc.cluster.local:8080",
     },
+    {   "name": "UV_CACHE_DIR", 
+        "value": "/app/.cache/uv"
+    },
+        
 ]
+
+
 
 # --- Resource Limits and Requests ---
 DEFAULT_RESOURCE_LIMITS = {"cpu": "500m", "memory": "1Gi"}


### PR DESCRIPTION

## Summary
This PR modifies Kagenti UI to support deployment of Component CustomResource with Volumes and VolumeMounts as well as adds new global env variable UV_CACHE_DIR.

Fixes #235 
