### PR TITLE
:sparkles: Retrieve the secret for a client

### DIFF
--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -55,7 +55,7 @@ def get_secret(
     keycloak_admin: KeycloakAdmin,
     internal_client_id: str,
     client_name: str,
-    secret_file: str = "secret.txt",
+    secret_file_path: str = "secret.txt",
 ) -> None:
     """
     Retrieve the secret for a Keycloak client and write it to a file.

--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -65,16 +65,10 @@ def register_client(
 
     # Always try to get the secret
     try:
-        info = keycloak_admin.get_server_info()
-        # print(f'Server info: {info}')
-        clients = keycloak_admin.get_clients()
-        client_ids = [client['clientId'] for client in clients]
-        print(client_ids)
-        
-        internal_client_id = keycloak_admin.get_client_id("{client_name}")
-        print(f'Retrieving client_id for client "{client_name}", id: {internal_client_id}.')
+        internal_client_id = keycloak_admin.get_client_id(f"{client_id}")
+        print(f'Retrieving client_id for client "{client_id}", id: {internal_client_id}.')
         secret = keycloak_admin.get_client_secrets(internal_client_id)["value"]
-        print(f'Successfully retrieved secret for client "{client_name}": {secret}.')
+        print(f'Successfully retrieved secret for client "{client_name}".')
     except KeycloakPostError as e:
         print(f"Could not retrieve secret for client '{client_name}': {e}")
         return

--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -9,6 +9,8 @@ CLIENT_NAME = os.environ.get('CLIENT_NAME')
 CLIENT_ID = os.environ.get('CLIENT_ID')
 NAMESPACE = os.environ.get('NAMESPACE')
 
+secret_file = "secret.txt"
+
 def register_client(
     keycloak_url: str,
     keycloak_realm: str,
@@ -60,6 +62,30 @@ def register_client(
         print(f'Created Keycloak client "{client_id}": {internal_client_id}')
     except KeycloakPostError as e:
         print(f'Could not create Keycloak client "{client_id}": {e}')
+
+    # Always try to get the secret
+    try:
+        info = keycloak_admin.get_server_info()
+        # print(f'Server info: {info}')
+        clients = keycloak_admin.get_clients()
+        client_ids = [client['clientId'] for client in clients]
+        print(client_ids)
+        
+        cl_id = keycloak_admin.get_client_id("{client_name}")
+        print(f'Retrieving client_id for client "{client_name}", id: {cl_id}.')
+        secret = keycloak_admin.get_client_secrets(cl_id)["value"]
+        print(f'Successfully retrieved secret for client "{client_name}".')
+    except KeycloakPostError as e:
+        print(f"Could not retrieve secret for client '{client_name}': {e}")
+        return
+
+    # Write secret to file
+    try:
+        with open(secret_file, "w") as f:
+            f.write(secret)
+        print(f'Secret written to file: "{secret_file}"')
+    except OSError as ioe:
+        print(f'Error writing secret to file: {ioe}')
 
 register_client(
     KEYCLOAK_URL,

--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -71,10 +71,10 @@ def register_client(
         client_ids = [client['clientId'] for client in clients]
         print(client_ids)
         
-        cl_id = keycloak_admin.get_client_id("{client_name}")
-        print(f'Retrieving client_id for client "{client_name}", id: {cl_id}.')
-        secret = keycloak_admin.get_client_secrets(cl_id)["value"]
-        print(f'Successfully retrieved secret for client "{client_name}".')
+        internal_client_id = keycloak_admin.get_client_id("{client_name}")
+        print(f'Retrieving client_id for client "{client_name}", id: {internal_client_id}.')
+        secret = keycloak_admin.get_client_secrets(internal_client_id)["value"]
+        print(f'Successfully retrieved secret for client "{client_name}": {secret}.')
     except KeycloakPostError as e:
         print(f"Could not retrieve secret for client '{client_name}': {e}")
         return

--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -11,7 +11,6 @@ Idempotent:
 import os
 from keycloak import KeycloakAdmin, KeycloakPostError
 
-
 def get_env_var(name: str) -> str:
     """Fetch an environment variable or raise ValueError if missing."""
     value = os.environ.get(name)
@@ -19,70 +18,75 @@ def get_env_var(name: str) -> str:
         raise ValueError(f"Missing required environment variable: {name}")
     return value
 
+
 def register_client(
-    keycloak_url: str,
-    keycloak_realm: str,
-    keycloak_admin_username: str,
-    keycloak_admin_password: str,
+    keycloak_admin: KeycloakAdmin,
     client_name: str,
     client_id: str,
     namespace: str,
-    secret_file: str = "/shared/secret.txt",
-):
-    print(f"Connecting to Keycloak server: {keycloak_url} (realm={keycloak_realm})")
-    keycloak_admin = KeycloakAdmin(
-        server_url=keycloak_url,
-        username=keycloak_admin_username,
-        password=keycloak_admin_password,
-        realm_name=keycloak_realm,
-        user_realm_name='master'
-    )
-
-    # Ensure client exists
-    internal_client_id = keycloak_admin.get_client_id(client_name)
+) -> str:
+    """
+    Ensure a Keycloak client exists.
+    Returns the internal client ID.
+    """
+    internal_client_id = keycloak_admin.get_client_id(f"{client_id}")
     if internal_client_id:
-        print(f'Client "{client_name}" already exists with ID: {internal_client_id}')
-    else:
-        try:
-            internal_client_id = keycloak_admin.create_client(
-                {
-                    "name": client_name,
-                    "clientId": client_id,
-                    "standardFlowEnabled": True,
-                    "directAccessGrantsEnabled": True,
-                    "fullScopeAllowed": False,
-                    "publicClient": False # Enable client authentication
-                }
-            )
+        print(f'Client "{client_id}" already exists with ID: {internal_client_id}')
+        return internal_client_id
 
-            print(f'Created Keycloak client "{client_id}": {internal_client_id}')
-        except KeycloakPostError as e:
-            print(f'Could not create Keycloak client "{client_id}": {e}')
-
-    # Always try to get the secret
     try:
-        internal_client_id = keycloak_admin.get_client_id(f"{client_id}")
-        print(f'Retrieving client_id for client "{client_id}", id: {internal_client_id}.')
+        client_representation = {
+            "name": client_name,
+            "clientId": client_id,
+            "standardFlowEnabled": True,
+            "directAccessGrantsEnabled": True,
+            "fullScopeAllowed": False,
+            "publicClient": False,  # Enable client authentication
+        }
+        internal_client_id = keycloak_admin.create_client(client_representation)
+        print(f'Created Keycloak client "{client_id}": {internal_client_id}')
+        return internal_client_id
+    except KeycloakPostError as e:
+        print(f'Could not create client "{client_id}": {e}')
+        raise
+
+
+def get_secret(
+    keycloak_admin: KeycloakAdmin,
+    internal_client_id: str,
+    client_name: str,
+    secret_file: str = "secret.txt",
+) -> None:
+    """
+    Retrieve the secret for a Keycloak client and write it to a file.
+    """
+    try:
         secret = keycloak_admin.get_client_secrets(internal_client_id)["value"]
         print(f'Successfully retrieved secret for client "{client_name}".')
     except KeycloakPostError as e:
         print(f"Could not retrieve secret for client '{client_name}': {e}")
         return
 
-    # Write secret to file
     try:
         with open(secret_file, "w") as f:
             f.write(secret)
         print(f'Secret written to file: "{secret_file}"')
     except OSError as ioe:
-        print(f'Error writing secret to file: {ioe}')
+        print(f"Error writing secret to file: {ioe}")
 
-register_client(
-    keycloak_url=get_env_var("KEYCLOAK_URL"),
-    keycloak_realm=get_env_var("KEYCLOAK_REALM"),
-    keycloak_admin_username=get_env_var("KEYCLOAK_ADMIN_USERNAME"),
-    keycloak_admin_password=get_env_var("KEYCLOAK_ADMIN_PASSWORD"),
-    client_name=get_env_var("CLIENT_NAME"),
-    client_id=get_env_var("CLIENT_ID"),
-    namespace=get_env_var("NAMESPACE"),
+
+keycloak_admin = KeycloakAdmin(
+    server_url=get_env_var("KEYCLOAK_URL"),
+    username=get_env_var("KEYCLOAK_ADMIN_USERNAME"),
+    password=get_env_var("KEYCLOAK_ADMIN_PASSWORD"),
+    realm_name=get_env_var("KEYCLOAK_REALM"),
+    user_realm_name="master",
 )
+
+client_name = get_env_var("CLIENT_NAME")
+client_id = get_env_var("CLIENT_ID")
+namespace = get_env_var("NAMESPACE")
+
+internal_client_id = register_client(keycloak_admin, client_name, client_id, namespace)
+print(f'Client id: "{internal_client_id}"')
+get_secret(keycloak_admin, internal_client_id, client_name, secret_file="/shared/secret.txt")

--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -55,7 +55,7 @@ def register_client(
                 "standardFlowEnabled": True,
                 "directAccessGrantsEnabled": True,
                 "fullScopeAllowed": False,
-                "publicClient": True # Disable client authentication
+                "publicClient": False # Enable client authentication
             }
         )
 

--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -51,7 +51,7 @@ def register_client(
         raise
 
 
-def get_secret(
+def write_secret(
     keycloak_admin: KeycloakAdmin,
     internal_client_id: str,
     client_name: str,
@@ -68,9 +68,9 @@ def get_secret(
         return
 
     try:
-        with open(secret_file, "w") as f:
+        with open(secret_file_path, "w") as f:
             f.write(secret)
-        print(f'Secret written to file: "{secret_file}"')
+        print(f'Secret written to file: "{secret_file_path}"')
     except OSError as ioe:
         print(f"Error writing secret to file: {ioe}")
 
@@ -89,4 +89,4 @@ namespace = get_env_var("NAMESPACE")
 
 internal_client_id = register_client(keycloak_admin, client_name, client_id, namespace)
 print(f'Client id: "{internal_client_id}"')
-get_secret(keycloak_admin, internal_client_id, client_name, secret_file="/shared/secret.txt")
+write_secret(keycloak_admin, internal_client_id, client_name, secret_file="/shared/secret.txt")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR allows the containerInit to register the client and retrieve it's secret so it can be passed to the main container for further interactions with Keycloak 

## Related issue(s)

Fixes #
