### PR TITLE
MCP Gateway with auth enabled

### DIFF
--- a/kagenti/installer/app/resources/gateway-crd.yaml
+++ b/kagenti/installer/app/resources/gateway-crd.yaml
@@ -1,6 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: mcpservers.mcp.kagenti.com
 spec:
   group: mcp.kagenti.com
@@ -8,96 +11,253 @@ spec:
     kind: MCPServer
     listKind: MCPServerList
     plural: mcpservers
-    singular: mcpserver
     shortNames:
     - mcpsrv
+    singular: mcpserver
   scope: Namespaced
   versions:
   - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - name: Ready
-      type: string
-      jsonPath: .status.conditions[?(@.type=='Ready')].status
-    - name: Targets
-      type: string
-      jsonPath: .spec.targetRefs[*].name
-    - name: Prefix
-      type: string
-      jsonPath: .spec.toolPrefix
-    - name: Age
-      type: date
-      jsonPath: .metadata.creationTimestamp
     schema:
       openAPIV3Schema:
-        type: object
-        description: MCPServer defines a collection of MCP (Model Context Protocol) servers to be aggregated by the gateway. It enables discovery and federation of tools from multiple backend MCP servers through HTTPRoute references.
+        description: |-
+          MCPServer defines a collection of MCP (Model Context Protocol) servers to be aggregated by the gateway.
+          It enables discovery and federation of tools from multiple backend MCP servers through HTTPRoute references,
+          providing a declarative way to configure which MCP servers should be accessible through the gateway.
         properties:
           apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            type: object
-            description: Spec defines the desired state of the MCPServer resource
-            required:
-            - targetRef
+            description: |-
+              MCPServerSpec defines the desired state of MCPServer.
+              It specifies which HTTPRoutes point to MCP servers and how their tools should be federated.
             properties:
-              targetRef:
+              credentialRef:
+                description: |-
+                  CredentialRef references a Secret containing authentication credentials for the MCP server.
+                  The Secret should contain a key with the authentication token or credentials.
+                  The controller will aggregate these credentials and make them available to the broker
+                  via environment variables following the pattern: KAGENTI_{MCP_NAME}_CRED
+                properties:
+                  key:
+                    default: token
+                    description: |-
+                      Key is the key within the Secret that contains the credential value.
+                      If not specified, defaults to "token".
+                    type: string
+                  name:
+                    description: Name is the name of the Secret resource.
+                    type: string
+                required:
+                - name
                 type: object
-                description: TargetRef specifies an HTTPRoute that points to a backend MCP server
+              path:
+                default: /mcp
+                description: |-
+                  Path specifies the URL path where the MCP server endpoint is exposed.
+                  If not specified, defaults to "/mcp".
+                  This allows connecting to MCP servers that use custom paths like "/v1/mcp" or "/api/mcp".
+                type: string
+              targetRef:
+                description: |-
+                  TargetRef specifies an HTTPRoute that points to a backend MCP server.
+                  The referenced HTTPRoute should have backend services that implement the MCP protocol.
+                  The controller will discover the backend service from this HTTPRoute and configure
+                  the broker to federate tools from that MCP server.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group of the target resource.
+                    enum:
+                    - gateway.networking.k8s.io
+                    type: string
+                  kind:
+                    default: HTTPRoute
+                    description: Kind is the kind of the target resource.
+                    enum:
+                    - HTTPRoute
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    type: string
+                  namespace:
+                    description: Namespace of the target resource (optional, defaults
+                      to same namespace)
+                    type: string
                 required:
                 - group
                 - kind
                 - name
-                properties:
-                  group:
-                    type: string
-                    default: gateway.networking.k8s.io
-                    enum:
-                    - gateway.networking.k8s.io
-                    description: Group of the target resource
-                  kind:
-                    type: string
-                    default: HTTPRoute
-                    enum:
-                    - HTTPRoute
-                    description: Kind of the target resource
-                  name:
-                    type: string
-                    description: Name of the HTTPRoute
-                  namespace:
-                    type: string
-                    description: Namespace of the HTTPRoute (optional, defaults to same namespace)
+                type: object
               toolPrefix:
+                description: |-
+                  ToolPrefix is the prefix to add to all federated tools from referenced servers.
+                  This helps avoid naming conflicts when aggregating tools from multiple sources.
+                  For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_'
+                  ensure they can coexist as 'server1_search' and 'server2_search'.
                 type: string
-                description: ToolPrefix is the prefix to add to all federated tools from referenced servers. This helps avoid naming conflicts when aggregating tools from multiple sources.
-          status:
+                x-kubernetes-validations:
+                - message: toolPrefix is immutable once set
+                  rule: self == oldSelf || oldSelf == ''
+            required:
+            - targetRef
             type: object
-            description: Status represents the observed state of the MCPServer resource
+          status:
+            description: |-
+              MCPServerStatus represents the observed state of the MCPServer resource.
+              It contains conditions that indicate whether the referenced servers have been
+              successfully discovered and are ready for use.
             properties:
               conditions:
-                type: array
-                description: Conditions represent the latest available observations of the MCPServer's state
+                description: |-
+                  Conditions represent the latest available observations of the MCPServer's state.
+                  Common conditions include 'Ready' to indicate if all referenced servers are accessible.
                 items:
-                  type: object
-                  required:
-                  - type
-                  - status
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-                    reason:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
                     message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
-                    lastTransitionTime:
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                      format: date-time
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: mcpvirtualservers.mcp.kagenti.com
+spec:
+  group: mcp.kagenti.com
+  names:
+    kind: MCPVirtualServer
+    listKind: MCPVirtualServerList
+    plural: mcpvirtualservers
+    shortNames:
+    - mcpvs
+    singular: mcpvirtualserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tools.length()
+      name: Tools
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPVirtualServer defines a virtual server that exposes a specific set of tools.
+          It enables tool-level access control and federation by specifying which tools
+          should be accessible through this virtual endpoint.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              MCPVirtualServerSpec defines the desired state of MCPVirtualServer.
+              It specifies which tools should be exposed by this virtual server.
+            properties:
+              description:
+                description: Description provides a human-readable description of
+                  this virtual server's purpose.
+                type: string
+              tools:
+                description: |-
+                  Tools specifies the list of tool names to expose through this virtual server.
+                  These tools must be available from the underlying MCP servers configured in the system.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+            required:
+            - tools
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/kagenti/installer/app/resources/gateway-deployment.yaml
+++ b/kagenti/installer/app/resources/gateway-deployment.yaml
@@ -135,7 +135,7 @@ spec:
             name: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kagenti/mcp-gateway:v0.1.1
+          image: ghcr.io/kagenti/mcp-gateway:v0.1.2
           imagePullPolicy: Always
           command:
             - ./mcp_gateway
@@ -219,7 +219,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kagenti/mcp-gateway:v0.1.1
+          image: ghcr.io/kagenti/mcp-gateway:v0.1.2
           imagePullPolicy: Always
           command:
             - ./mcp_gateway

--- a/kagenti/installer/app/resources/gateway-deployment.yaml
+++ b/kagenti/installer/app/resources/gateway-deployment.yaml
@@ -133,6 +133,11 @@ spec:
         - name: config-volume
           configMap:
             name: mcp-gateway-config
+        - name: mcp-credentials
+          secret:
+            secretName: mcp-aggregated-credentials
+            defaultMode: 0400
+            optional: true  # broker can still work without credentials
       containers:
         - name: mcp-broker-router
           image: ghcr.io/kagenti/mcp-gateway:v0.1.2
@@ -150,6 +155,9 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /config
+            - name: mcp-credentials
+              mountPath: /etc/mcp-credentials
+              readOnly: true
           ports:
             - name: http
               containerPort: 8080

--- a/kagenti/installer/app/resources/gateway-deployment.yaml
+++ b/kagenti/installer/app/resources/gateway-deployment.yaml
@@ -22,9 +22,15 @@ rules:
   - apiGroups: ["mcp.kagenti.com"]
     resources: ["mcpservers/status"]
     verbs: ["get", "update", "patch"]
+  - apiGroups: ["mcp.kagenti.com"]
+    resources: ["mcpvirtualservers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes/status"]
+    verbs: ["get", "update", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -33,6 +39,12 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
@@ -123,7 +135,7 @@ spec:
             name: mcp-gateway-config
       containers:
         - name: mcp-broker-router
-          image: ghcr.io/kagenti/mcp-gateway:v0.1
+          image: ghcr.io/kagenti/mcp-gateway:v0.1.1
           imagePullPolicy: Always
           command:
             - ./mcp_gateway
@@ -131,6 +143,10 @@ spec:
             - --mcp-broker-public-address=0.0.0.0:8080
             - --mcp-router-address=0.0.0.0:50051
             - --log-level=-4  # info level
+          envFrom:
+            - secretRef:
+                name: mcp-aggregated-credentials
+                optional: true  # broker can still work without credentials
           volumeMounts:
             - name: config-volume
               mountPath: /config
@@ -184,7 +200,7 @@ spec:
       serviceAccountName: mcp-controller
       containers:
         - name: mcp-controller
-          image: ghcr.io/kagenti/mcp-gateway:v0.1
+          image: ghcr.io/kagenti/mcp-gateway:v0.1.1
           imagePullPolicy: Always
           command:
             - ./mcp_gateway

--- a/kagenti/installer/app/resources/gateway-deployment.yaml
+++ b/kagenti/installer/app/resources/gateway-deployment.yaml
@@ -177,6 +177,25 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-config
+  namespace: mcp-system
+  labels:
+    app: mcp-broker-router
+    component: config-api
+spec:
+  selector:
+    app: mcp-broker-router
+    component: broker-router
+  ports:
+    - name: http
+      port: 8181
+      targetPort: 8181
+      protocol: TCP
+  type: ClusterIP
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
New auth features have been added to the MCP Gateway. This pulls in these changes, and also the corresponding changes to CRD, deployments, configs, secrets, etc.

I have verified that Slack agent can communicate with the Slack tools via the MCP Gateway. Again, I will create a separate PR for doc update to include end-to-end instructions.