### PR TITLE
🐛 fix setting up mcp inspector proxy URL

### DIFF
--- a/deployments/ui/kagenti-ui.yaml
+++ b/deployments/ui/kagenti-ui.yaml
@@ -90,6 +90,12 @@ spec:
                   name: "kagenti-ui-oauth-secret"
                   key: "SCOPE"
                   optional: true
+            - name: "MCP_PROXY_FULL_ADDRESS"
+              valueFrom:
+                 configMapKeyRef:
+                  name: "kagenti-ui-config"
+                  key: "MCP_PROXY_FULL_ADDRESS"
+                  optional: true      
           volumeMounts:
             - name: cache
               mountPath: /app/.cache

--- a/kagenti/installer/app/resources/mcp-inspector.yaml
+++ b/kagenti/installer/app/resources/mcp-inspector.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: mcp-inspector
-          image: ghcr.io/modelcontextprotocol/inspector:0.15.0
+          image: ghcr.io/modelcontextprotocol/inspector:0.17.0
           ports:
             - containerPort: 6274
             - containerPort: 6277

--- a/kagenti/ui/lib/constants.py
+++ b/kagenti/ui/lib/constants.py
@@ -44,6 +44,7 @@ KEYCLOAK_CONSOLE_URL_IN_CLUSTER = (
 TRACES_DASHBOARD_URL = "http://phoenix.localtest.me:8080"
 NETWORK_TRAFFIC_DASHBOARD_URL = "http://kiali.localtest.me:8080"
 MCP_INSPECTOR_URL = "http://mcp-inspector.localtest.me:8080"
+MCP_PROXY_FULL_ADDRESS = "http://mcp-proxy.localtest.me:8080"
 
 # --- Default Values for Import Forms ---
 DEFAULT_REPO_URL = "https://github.com/kagenti/agent-examples"

--- a/kagenti/ui/lib/tool_details_page.py
+++ b/kagenti/ui/lib/tool_details_page.py
@@ -79,6 +79,7 @@ def render_mcp_tool_details_content(tool_k8s_name: str):
     st.header(f"MCP Tool: {tool_k8s_name}")
 
     mcp_inspector_url = os.environ.get('MCP_INSPECTOR_URL', constants.MCP_INSPECTOR_URL)
+    mcp_proxy_url = os.environ.get('MCP_PROXY_FULL_ADDRESS', constants.MCP_PROXY_FULL_ADDRESS)
 
     custom_obj_api = get_custom_objects_api()
     if not custom_obj_api:
@@ -156,11 +157,11 @@ def render_mcp_tool_details_content(tool_k8s_name: str):
     st.link_button(
     "Connect with MCP Inspector",
     # TODO - transport should be a property of MCP server
-    url=f"{mcp_inspector_url}?serverUrl={mcp_server_url}&transport=streamable_http",
+    url=f"{mcp_inspector_url}?serverUrl={mcp_server_url}&transport=streamable_http&MCP_PROXY_FULL_ADDRESS={mcp_proxy_url}",
     help="Click to open the MCP Inspector in a new tab.",
     use_container_width=True,
     )
-    st.caption(f"Access MCP inspector: `{constants.MCP_INSPECTOR_URL}`")
+    st.caption(f"Access MCP inspector: `{mcp_inspector_url}`")
 
 
     st.subheader("MCP Server Interaction")

--- a/kagenti/ui/lib/tool_details_page.py
+++ b/kagenti/ui/lib/tool_details_page.py
@@ -21,7 +21,7 @@ import asyncio
 import json
 import logging
 import os
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote
 import streamlit as st
 from .utils import sanitize_for_session_state_key
 from .kube import (
@@ -152,12 +152,20 @@ def render_mcp_tool_details_content(tool_k8s_name: str):
             f"MCP Server URL for tool '{tool_k8s_name}' could not be determined. Cannot connect."
         )
         return
+    
+    # setup MCP inspector URL
+    encoded_server_url = quote(mcp_server_url, safe='')
+    encoded_proxy_url =  quote(mcp_proxy_url, safe='')
+    console_url = (f"{mcp_inspector_url}?"
+        f"serverUrl={encoded_server_url}&"
+        f"transport=streamable_http&"
+        f"MCP_PROXY_FULL_ADDRESS={encoded_proxy_url}")
 
     st.subheader("MCP Inspector")
     st.link_button(
     "Connect with MCP Inspector",
     # TODO - transport should be a property of MCP server
-    url=f"{mcp_inspector_url}?serverUrl={mcp_server_url}&transport=streamable_http&MCP_PROXY_FULL_ADDRESS={mcp_proxy_url}",
+    url=console_url,
     help="Click to open the MCP Inspector in a new tab.",
     use_container_width=True,
     )


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

 fix setting up mcp inspector proxy URL. Accounts for MCP_PROXY_FULL_ADDRESS being part of the [configuration](https://github.com/modelcontextprotocol/inspector?tab=readme-ov-file#configuration) and not an environment variable so it can only be set in the UI or passed as query parameter.

Fixes #72 
