### PR TITLE
:bug: Fixes Missing Protocol Pulldown on Import Page

### DIFF
--- a/deployments/ui/kagenti-ui.yaml
+++ b/deployments/ui/kagenti-ui.yaml
@@ -23,8 +23,7 @@ spec:
       serviceAccountName: kagenti-ui-service-account
       containers:
         - name: kagenti-ui-container
-#          image: ghcr.io/kagenti/kagenti/ui:latest
-          image: kagenti-demo-ui:latest
+          image: ghcr.io/kagenti/kagenti/ui:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: UV_CACHE_DIR


### PR DESCRIPTION
## Summary
This PR fixes a missing protocol pulldown selector on Import Tool/Agent pages when user chooses deployment from existing container image.

<img width="1136" height="552" alt="image" src="https://github.com/user-attachments/assets/8fd8d49a-0fd0-4cdc-969a-d27faad79fd3" />


## Related issue(s)

Fixes #271 
