### PR TITLE
✨ Feature: Show only enabled namespaces in UI

### DIFF
--- a/kagenti/installer/app/config.py
+++ b/kagenti/installer/app/config.py
@@ -28,19 +28,21 @@ OPERATOR_NAMESPACE = "kagenti-system"
 TEKTON_VERSION = "v0.66.0"
 KEYCLOAK_URL = "http://keycloak.localtest.me:8080/realms/master"
 
+
 # --- Container Engine Options ---
 class ContainerEngine(str, Enum):
     PODMAN = "podman"
     DOCKER = "docker"
 
-CONTAINER_ENGINE =  "docker"
+
+CONTAINER_ENGINE = "docker"
 
 # --- Dependency Version Requirements ---
 # Defines the minimum (inclusive) and maximum (exclusive) required versions for tools.
 REQ_VERSIONS = {
     "kind": {"min": "0.20.0", "max": "0.99.0"},
     "docker": {"min": "5.0.0", "max": "29.0.0"},
-    "podman": {"min":"5.0.0", "max":"5.6.0"},
+    "podman": {"min": "5.0.0", "max": "5.6.0"},
     "kubectl": {"min": "1.29.0", "max": "1.35.0"},
     "helm": {"min": "3.14.0", "max": "3.19.0"},
     "git": {"min": "2.30.0", "max": "3.0.0"},
@@ -67,6 +69,7 @@ OPERATOR_GIT_REPO = "https://github.com/kagenti/kagenti-operator.git"
 UI_FALLBACK_VERSION = "v0.0.4-alpha.13"
 UI_GIT_REPO = "https://github.com/kagenti/kagenti.git"
 
+
 # --- Enum for Skippable Components ---
 class InstallableComponent(str, Enum):
     """Enumeration of all components that can be installed or skipped."""
@@ -82,6 +85,11 @@ class InstallableComponent(str, Enum):
     MCP_GATEWAY = "mcp_gateway"
     KEYCLOAK = "keycloak"
     AGENTS = "agents"
-    METRICS_SERVER= "metrics_server"
+    METRICS_SERVER = "metrics_server"
     INSPECTOR = "inspector"
     CERT_MANAGER = "cert_manager"
+
+
+## Kubernetes Labels and Selectors
+ENABLED_NAMESPACE_LABEL_KEY = "kagenti-enabled"
+ENABLED_NAMESPACE_LABEL_VALUE = "true"

--- a/kagenti/ui/lib/common_ui.py
+++ b/kagenti/ui/lib/common_ui.py
@@ -28,9 +28,11 @@ from .utils import (
 from .kube import (
     is_deployment_ready,
     get_kubernetes_namespace,
+    get_enabled_namespaces,
     get_all_namespaces,
 )
 from . import constants
+
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments, too-many-locals, too-many-branches, too-many-statements
 def render_resource_catalog(
@@ -40,12 +42,11 @@ def render_resource_catalog(
     # pylint: disable=unused-argument
     get_details_func: Callable,
     render_details_func: Callable,
-    custom_obj_api: Optional[
-        kubernetes.client.CustomObjectsApi
-    ],
+    custom_obj_api: Optional[kubernetes.client.CustomObjectsApi],
     generic_api_client: Optional[kubernetes.client.ApiClient],
     session_state_key_selected_resource: str,
     delete_resource_func: Optional[Callable] = None,
+    show_enabled_namespaces_only: bool = False,
 ):
     # pylint: disable=line-too-long
     """
@@ -63,7 +64,7 @@ def render_resource_catalog(
         generic_api_client (Optional[kubernetes.client.ApiClient]): The Kubernetes API client for generic resources.
         session_state_key_selected_resource (str): The Streamlit session state key for the selected resource.
         delete_resource_func (Optional[Callable]): A function to delete a resource. Should accept (api_client, resource_name, namespace).
-
+        enabled_namespaces_only (bool): If True, only list enabled namespaces in the selector.
 
     Returns:
         None
@@ -71,7 +72,11 @@ def render_resource_catalog(
     st_object.header(f"{resource_type_name} Catalog")
 
     # --- Namespace Selector ---
-    available_namespaces = get_all_namespaces(generic_api_client)
+    available_namespaces = []
+    if show_enabled_namespaces_only:
+        available_namespaces = get_enabled_namespaces(generic_api_client)
+    else:
+        available_namespaces = get_all_namespaces(generic_api_client)
 
     # Get the initial/current namespace
     current_namespace_from_kube_lib = get_kubernetes_namespace()
@@ -214,7 +219,6 @@ def render_resource_catalog(
                             )
                             st.rerun()
 
-
                         # Enable the Delete button if delete function is provided in arg list
                         if delete_resource_func:
                             # pylint: disable=line-too-long
@@ -230,7 +234,7 @@ def render_resource_catalog(
                                     "🗑️ Delete",
                                     key=delete_button_key,
                                     type="secondary",
-                                    help=f"Delete {resource_type_name} '{item_name}'"
+                                    help=f"Delete {resource_type_name} '{item_name}'",
                                 ):
                                     st.session_state[delete_confirm_key] = True
                                     # Refresh screen to show confirmation buttons
@@ -247,23 +251,27 @@ def render_resource_catalog(
                                         "✅ Yes",
                                         key=confirm_button_key,
                                         type="primary",
-                                        help="Confirm deletion"
+                                        help="Confirm deletion",
                                     ):
                                         try:
                                             # Call the delete function
                                             delete_resource_func(
                                                 custom_obj_api,
                                                 item_name,
-                                                namespace_to_use
+                                                namespace_to_use,
                                             )
-                                            st.success(f"Successfully deleted {resource_type_name} '{item_name}'")
+                                            st.success(
+                                                f"Successfully deleted {resource_type_name} '{item_name}'"
+                                            )
 
                                             # Reset confirmation state
                                             st.session_state[delete_confirm_key] = False
                                             st.rerun()
 
                                         except Exception as e:
-                                            st.error(f"Failed to delete {resource_type_name}: {str(e)}")
+                                            st.error(
+                                                f"Failed to delete {resource_type_name}: {str(e)}"
+                                            )
                                             st.session_state[delete_confirm_key] = False
 
                                 with col_cancel:
@@ -271,7 +279,7 @@ def render_resource_catalog(
                                     if st.button(
                                         "❌ No",
                                         key=cancel_button_key,
-                                        help="Cancel deletion"
+                                        help="Cancel deletion",
                                     ):
                                         st.session_state[delete_confirm_key] = False
                                         st.rerun()
@@ -279,6 +287,7 @@ def render_resource_catalog(
             st_object.info(
                 f"No '{resource_type_name}' custom resources with the required labels found in the '{namespace_to_use}' namespace."
             )
+
 
 def display_resource_metadata(st_object, resource_details: dict):
     """
@@ -311,11 +320,14 @@ def display_resource_metadata(st_object, resource_details: dict):
     st_object.markdown("---")
     return tags
 
+
 def check_auth():
-    '''If authentication is enabled, display content only if the user is logged in'''
-    if constants.ENABLE_AUTH_STRING in st.session_state and \
-            st.session_state[constants.ENABLE_AUTH_STRING] and \
-            constants.TOKEN_STRING not in st.session_state:
+    """If authentication is enabled, display content only if the user is logged in"""
+    if (
+        constants.ENABLE_AUTH_STRING in st.session_state
+        and st.session_state[constants.ENABLE_AUTH_STRING]
+        and constants.TOKEN_STRING not in st.session_state
+    ):
         st.page_link("Home.py", label="Click here to login", icon="🏠")
 
         # Stop rendering other content

--- a/kagenti/ui/lib/constants.py
+++ b/kagenti/ui/lib/constants.py
@@ -34,6 +34,9 @@ APP_KUBERNETES_IO_NAME = "app.kubernetes.io/name"
 RESOURCE_TYPE_AGENT = "agent"
 RESOURCE_TYPE_TOOL = "tool"
 
+ENABLED_NAMESPACE_LABEL_KEY = "kagenti-enabled"
+ENABLED_NAMESPACE_LABEL_VALUE = "true"
+
 # --- External Service URLs ---
 KEYCLOAK_CONSOLE_URL_OFF_CLUSTER = (
     "http://keycloak.localtest.me:8080/admin/master/console/"

--- a/kagenti/ui/pages/01_Agent_Catalog.py
+++ b/kagenti/ui/pages/01_Agent_Catalog.py
@@ -36,6 +36,7 @@ custom_obj_api = get_custom_objects_api()  # Use the correct function name
 # Get the generic ApiClient (for listing namespaces - returned by the cached function)
 generic_api_client, _, _ = get_kube_api_client_cached()
 
+
 # Wrapper function to call delete_custom_resource with agent-specific parameters
 # pylint: disable=redefined-outer-name
 def delete_agent_resource(custom_obj_api, name, namespace):
@@ -50,8 +51,9 @@ def delete_agent_resource(custom_obj_api, name, namespace):
         version="v1alpha1",
         namespace=namespace,
         plural="components",
-        name=name
+        name=name,
     )
+
 
 render_resource_catalog(
     st_object=st,
@@ -63,4 +65,5 @@ render_resource_catalog(
     generic_api_client=generic_api_client,  # Pass the generic ApiClient
     session_state_key_selected_resource="selected_agent_name",
     delete_resource_func=delete_agent_resource,
+    show_enabled_namespaces_only=True,
 )

--- a/kagenti/ui/pages/02_Tool_Catalog.py
+++ b/kagenti/ui/pages/02_Tool_Catalog.py
@@ -36,6 +36,7 @@ custom_obj_api = get_custom_objects_api()  # Correct function to get CustomObjec
 # Get the generic ApiClient (for listing namespaces - returned by the cached function)
 generic_api_client, _, _ = get_kube_api_client_cached()
 
+
 # Wrapper function to call delete_custom_resource with agent-specific parameters
 # pylint: disable=redefined-outer-name
 def delete_tool_resource(custom_obj_api, name, namespace):
@@ -50,8 +51,9 @@ def delete_tool_resource(custom_obj_api, name, namespace):
         version="v1alpha1",
         namespace=namespace,
         plural="components",
-        name=name
+        name=name,
     )
+
 
 render_resource_catalog(
     st_object=st,
@@ -63,4 +65,5 @@ render_resource_catalog(
     generic_api_client=generic_api_client,  # Pass the generic ApiClient
     session_state_key_selected_resource="selected_tool_name",
     delete_resource_func=delete_tool_resource,
+    show_enabled_namespaces_only=True,
 )

--- a/kagenti/ui/pages/04_Import_New_Agent.py
+++ b/kagenti/ui/pages/04_Import_New_Agent.py
@@ -45,4 +45,5 @@ render_import_form(
     k8s_api_client=k8s_api_client,
     k8s_client_status_msg=k8s_client_msg,
     k8s_client_status_icon=k8s_client_icon,
+    show_enabled_namespaces_only=True,
 )

--- a/kagenti/ui/pages/05_Import_New_Tool.py
+++ b/kagenti/ui/pages/05_Import_New_Tool.py
@@ -22,10 +22,7 @@ from lib.build_utils import render_import_form
 from lib.kube import get_kube_api_client_cached
 
 # --- Define Tool-Specific Settings for the Import Form ---
-TOOL_EXAMPLE_SUBFOLDERS = [
-    "mcp/weather_tool",
-    "mcp/slack_tool"
-]
+TOOL_EXAMPLE_SUBFOLDERS = ["mcp/weather_tool", "mcp/slack_tool"]
 TOOL_PROTOCOL_OPTIONS = ["streamable_http", "sse"]
 
 check_auth()
@@ -42,10 +39,11 @@ render_import_form(
     default_framework="Python",
     k8s_api_client=k8s_api_client,
     k8s_client_status_msg=k8s_client_msg,
-    k8s_client_status_icon=k8s_client_icon
+    k8s_client_status_icon=k8s_client_icon,
+    show_enabled_namespaces_only=True,
 )
 
 st.markdown("---")
-#st.warning(
+# st.warning(
 #    "**Note:** The build process for 'Tools' currently uses the same 'Component' CRD mechanism."
-#)
+# )


### PR DESCRIPTION
## Summary
- Updated `cluster.py` to label agent namespaces with `kagenti-enabled=true` during installation.
- Added selector functionality to `get_all_namespaces()` and created a `get_enabled_namespaces()` wrapper to filter by the new label (`kube.py`).
- Updated UI components to display only enabled namespaces.
- Added function docstrings to 2 functions in `build_utils.py` to pass lint check.
- Successful local testing of installation and new UI image (see screenshots below).

Sorry about the messy commit changes! The pre-commit tasks triggered with my `git commit` and reformatted some of the files.

## Fixes
The installer enables namespaces for listing or deploying agents and tools. Such namespaces have been created with secrets by the installer. Although any namespace in theory could be used, that would require additional manual steps. This solution labels the namespaces during preparation (e.g. kagenti-enabled="true")and then filter the namespaces by label in the UI

## Related issue(s)
#134

## Screenshots
<img width="937" height="139" alt="Screenshot 2025-10-07 at 8 06 34 PM" src="https://github.com/user-attachments/assets/910df32a-7b59-4c98-877e-50cf1d0f022c" />
<img width="875" height="70" alt="Screenshot 2025-10-07 at 9 56 17 PM" src="https://github.com/user-attachments/assets/75bccf3c-a4be-43a8-a640-e3d50602f8e2" />

<img width="1484" height="802" alt="Screenshot 2025-10-07 at 8 17 22 PM" src="https://github.com/user-attachments/assets/b8c2377f-eac7-447e-8fd2-6ae97cf3870e" />
<img width="1462" height="774" alt="Screenshot 2025-10-07 at 8 20 22 PM" src="https://github.com/user-attachments/assets/c8e09e41-4275-4a37-b7f1-5ab32334d427" />
