### PR TITLE
📖: Include troubleshooting for blank loading UI page on MacOS

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -215,6 +215,12 @@ Restart the following:
 kubectl rollout restart daemonset -n istio-system  ztunnel
 kubectl rollout restart -n kagenti-system deployment http-istio
 ```
+### Blank UI page on macOS after installation
+On macOS, if **Privacy and Content Restrictions** are enabled (under  
+System Settings → Screen Time → Content & Privacy Restrictions),  
+then after the Kagenti installation completes, opening the UI may display a blank loading page.
+
+To fix, disable these restrictions and restart the UI.
 
 ### kagenti-installer complains "Please start the Docker daemon." when using Colima instead of Docker Desktop
 


### PR DESCRIPTION
## Summary
On MacOS, if privacy and content restrictions are enabled, UI will be stuck on blank loading page indefinitely. Update demo docs Troubleshooting section to include this + the fix.
## Related issue(s)
https://github.com/kagenti/kagenti/issues/295
