### PR TITLE
🐛 use only istio-discovery=enabled label for mcp gateway namespaces

### DIFF
--- a/charts/kagenti/templates/mcp-gateway-namespaces.yaml
+++ b/charts/kagenti/templates/mcp-gateway-namespaces.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "kagenti.labels" . | nindent 4 }}
     istio-discovery: enabled
-    istio.io/dataplane-mode: ambient
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "-10"

--- a/charts/kagenti/templates/mcp-gateway-ns-labeler.yaml
+++ b/charts/kagenti/templates/mcp-gateway-ns-labeler.yaml
@@ -70,7 +70,6 @@ spec:
         - "label"
         - "namespace"
         - "{{ .Values.mcpGateway.namespaces.mcpSystem }}"
-        - "istio.io/dataplane-mode=ambient" 
         - "istio-discovery=enabled" 
         - "--overwrite"  
 {{- end }}  


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Use only istio-discovery=enabled label for mcp gateway namespaces. It looks like the behavior is different on OCP 4.18 (IBM Cloud ROKS) vs 4.19 (on AWS with Installer provisioned OCP) - these seem to be the label that work for both scenarios.


