### PR TITLE
:bug: Add missing default for secret file path

### DIFF
--- a/kagenti/auth/client-registration/client_registration.py
+++ b/kagenti/auth/client-registration/client_registration.py
@@ -133,7 +133,7 @@ internal_client_id = register_client(
 
 try:
     secret_file_path = get_env_var("SECRET_FILE_PATH")
-except:
+except ValueError:
     secret_file_path = "/shared/secret.txt"
 print(
     f'Writing secret for client ID: "{client_id}" (internal client ID: "{internal_client_id}") to file: "{secret_file_path}"'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The default value of the Secret File Path is missing, so it fails if the Env. variable "SECRET_FILE_PATH" never set. 
## Related issue(s)

Fixes #
