### PR TITLE
feat: Enable UI authentication with Keycloak on OpenShift

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -30,6 +30,12 @@ spec:
               value: "/app/.cache/uv"
             - name: "ENABLE_AUTH"
               value: "{{- .Values.ui.auth.enabled }}"
+            - name: "SSL_CERT_FILE"
+              valueFrom:
+                secretKeyRef:
+                  name: "kagenti-ui-oauth-secret"
+                  key: "SSL_CERT_FILE"
+                  optional: {{ (not .Values.openshift) }}
             - name: "CLIENT_ID"
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
# Enable UI Authentication with Keycloak on OpenShift

## Summary
Enables Keycloak-based authentication for the Kagenti UI on OpenShift, resolving SSL certificate verification issues with self-signed certificates. Fixes #317

## Changes
- **SSL Fix**: ~~Monkey-patched `httpx.Client` and `httpx.AsyncClient` to disable SSL verification for OpenShift self-signed certificates~~ **Uses `SSL_CERT_FILE` environment variable with Kubernetes CA bundle** to properly verify OpenShift route certificates
- ~~**Enable Auth**: Set `ui.auth.enabled: true` by default in `values.yaml`~~ **Auth remains disabled by default** - users can enable via values.yaml
- **Documentation**: Updated OpenShift install guide with prerequisites and authentication setup instructions

## Prerequisites
Users must create `kagenti-ui-oauth-secret` in `kagenti-system` namespace with Keycloak OAuth configuration ~~before accessing the UI~~. **The secret must include `SSL_CERT_FILE` key pointing to the CA bundle path.** See documentation for details.

## Files Changed
- ~~`kagenti/ui/Home.py` - SSL bypass implementation~~ **No code changes**
- ~~`charts/kagenti/values.yaml` - Enable auth flag~~ **No changes to values.yaml**
- `docs/ocp/openshift-install.md` - Setup instructions with Keycloak client configuration
- `charts/kagenti/templates/ui.yaml` - Added `SSL_CERT_FILE` env var (optional on vanilla k8s, required on OpenShift)

## Testing
- Tested patching the env var on OpenShift Kagenti UI
- Login/logout flow verified  
- [To do] test the helm install and check if changes don't break Kind deployment  

---