### PR TITLE
🐛  fix defaults for mcp inspector transport

### DIFF
--- a/kagenti/ui/lib/tool_details_page.py
+++ b/kagenti/ui/lib/tool_details_page.py
@@ -166,7 +166,7 @@ def render_mcp_tool_details_content(tool_k8s_name: str):
     console_url = (
         f"{mcp_inspector_url}?"
         f"serverUrl={encoded_server_url}&"
-        f"transport=streamable_http&"
+        f"transport=streamable-http&"
         f"MCP_PROXY_FULL_ADDRESS={encoded_proxy_url}"
     )
 

--- a/kagenti/ui/pages/03_Observability.py
+++ b/kagenti/ui/pages/03_Observability.py
@@ -45,7 +45,7 @@ encoded_proxy_url = quote(mcp_proxy_url, safe="")
 mcp_inspector_dashboard_url = (
     f"{mcp_inspector_url}?"
     f"serverUrl={encoded_gateway_url}&"
-    f"transport=streamable_http&"
+    f"transport=streamable-http&"
     f"MCP_PROXY_FULL_ADDRESS={encoded_proxy_url}"
 )
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

 Fix defaults for mcp inspector transport so that MCP inspector starts with streamable HTTP transport.

## Related issue(s)

Fixes #343
