### PR TITLE
🐛 fix handling of ENABLE_AUTH when running locally

### DIFF
--- a/kagenti/ui/Home.py
+++ b/kagenti/ui/Home.py
@@ -34,15 +34,19 @@ def render_login():
     Render the login page.
     """
 
-    ENABLE_AUTH = os.environ.get("ENABLE_AUTH")
+    # Default to 'false' when the env var is missing so calling .lower() is safe
+    ENABLE_AUTH = os.environ.get("ENABLE_AUTH", "false")
+    # Normalize once into a boolean to avoid repeated .lower() calls and None issues
+    enable_auth_enabled = str(ENABLE_AUTH).lower() == "true"
+
     if ENABLE_AUTH_STRING not in st.session_state:
-        if ENABLE_AUTH.lower() == "true":
+        if enable_auth_enabled:
             logger.info("Authentication is enabled")
         else:
             logger.info("Authentication is disabled")
 
     st.session_state[ENABLE_AUTH_STRING] = False
-    if ENABLE_AUTH.lower() == "true":
+    if enable_auth_enabled:
         st.session_state[ENABLE_AUTH_STRING] = True
 
         st.markdown("---")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR fixes a bug in the authentication handling logic when running locally. The issue occurred when the ENABLE_AUTH environment variable was not set, causing a NoneType error when calling .lower() on None.

## Key Changes:

Added a default value of "false" for the ENABLE_AUTH environment variable to prevent None errors
Normalized the authentication check into a single boolean variable to avoid repeated string operations

## Related issue(s)

Fixes #345 
