### PR TITLE
🐛 fix usage of mcp-gateway chart and remove unnecessary services

### DIFF
--- a/charts/kagenti-deps/templates/keycloak-operand.yaml
+++ b/charts/kagenti-deps/templates/keycloak-operand.yaml
@@ -17,15 +17,6 @@ spec:
     httpEnabled: true
     httpPort: 8080
   instances: 1
-  ports:
-    - name: http
-      containerPort: 8080
-    - name: startup
-      containerPort: 9000 
-    - name: readiness
-      containerPort: 9000
-    - name: liveness
-      containerPort: 9000
   networkPolicy:
     enabled: true
   update:

--- a/charts/kagenti/templates/mcp-gateway.yaml
+++ b/charts/kagenti/templates/mcp-gateway.yaml
@@ -38,7 +38,7 @@ spec:
             type: PathPrefix
             value: /mcp
       backendRefs:
-        - name: mcp-gateway-broker
+        - name: mcp-broker
           port: 8080
 ---          
 apiVersion: route.openshift.io/v1
@@ -57,48 +57,4 @@ spec:
     name: mcp-gateway-istio
     weight: 100
   wildcardPolicy: None
----
-# TODO - verify if this service required in stand-alone install of mcp-gateway chart
-apiVersion: v1
-kind: Service
-metadata:
-  name: mcp-broker
-  namespace:  "{{ .Values.mcpGateway.namespaces.mcpSystem }}"
-  labels:
-    component: broker
-spec:
-  type: ClusterIP
-  selector:
-    app.kubernetes.io/instance: kagenti
-    app.kubernetes.io/name: mcp-gateway
-    component: broker-router
-  ports:
-    - name: http
-      port: 8080
-      targetPort: 8080
-      protocol: TCP
-    - name: grpc
-      port: 50051
-      targetPort: 50051
-      protocol: TCP
----
-# TODO - verify if this service required in stand-alone install of mcp-gateway chart
-apiVersion: v1
-kind: Service
-metadata:
-  name: mcp-config
-  namespace:  "{{ .Values.mcpGateway.namespaces.mcpSystem }}"
-  labels:
-    component: config-api
-spec:
-  type: ClusterIP
-  selector:
-    app.kubernetes.io/instance: kagenti
-    app.kubernetes.io/name: mcp-gateway
-    component: broker-router
-  ports:
-    - name: http
-      port: 8181
-      targetPort: 8181
-      protocol: TCP
 {{- end }}

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -73,7 +73,7 @@ kagenti-platform-operator-chart:
 # ------------------------------------------------------------------
 # subchart configs
 mcp-gateway:
-  fullnameOverride: mcp-gateway 
+  fullnameOverride: mcp
   envoyFilter:
     namespace: istio-system
 # main chart configs    

--- a/docs/ocp/openshift-install.md
+++ b/docs/ocp/openshift-install.md
@@ -97,7 +97,7 @@ To start, ensure your `kubectl` or `oc` is configured to point to your OpenShift
    Install the kagenti chart as follows:
 
    ```shell
-   helm upgrade --install kagenti ./charts/kagenti/ -n kagenti-system --create-namespace -f ./charts/kagenti/.secrets.yaml
+   helm upgrade --install kagenti ./charts/kagenti/ -n kagenti-system --create-namespace -f ./charts/kagenti/.secrets.yaml --set ui.tag=${LATEST_TAG}
    ```
 
 ## Access the UI


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR fixes the usage of the mcp-gateway chart by correcting service name references and removes unnecessary service definitions and Keycloak port configurations.

- Corrects the fullnameOverride for mcp-gateway from mcp-gateway to mcp to align with actual service names
- Removes duplicate mcp-broker and mcp-config service definitions that are already provided by the mcp-gateway subchart
- Removes redundant Keycloak port configurations that are already defined by defaults

Solves issues identified by review in #325

## Related issue(s)

Fixes #325
