### PR TITLE
feat: Automate kagenti-ui-oauth-secret creation for OpenShift

### DIFF
--- a/charts/kagenti/templates/ui-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/ui-oauth-secret-job.yaml
@@ -1,0 +1,122 @@
+{{- if and .Values.components.ui.enabled .Values.ui.auth.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kagenti-ui-oauth-secret-writer
+  namespace: {{ .Values.ui.namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kagenti-ui-oauth-secret-writer
+  namespace: {{ .Values.ui.namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "delete", "patch"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kagenti-ui-oauth-secret-writer-binding
+  namespace: {{ .Values.ui.namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: kagenti-ui-oauth-secret-writer
+    namespace: {{ .Values.ui.namespace }}
+roleRef:
+  kind: Role
+  name: kagenti-ui-oauth-secret-writer
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kagenti-ui-oauth-keycloak-route-reader
+  namespace: {{ .Values.keycloak.namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ .Values.keycloak.adminSecretName | quote }}]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kagenti-ui-oauth-keycloak-route-reader-binding
+  namespace: {{ .Values.keycloak.namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: kagenti-ui-oauth-secret-writer
+    namespace: {{ .Values.ui.namespace }}
+roleRef:
+  kind: Role
+  name: kagenti-ui-oauth-keycloak-route-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kagenti-ui-oauth-secret-job
+  namespace: {{ .Values.ui.namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "kagenti.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: kagenti-ui-oauth-secret-writer
+      restartPolicy: Never
+      containers:
+      - name: ui-oauth-secret-creator
+        image: {{ .Values.uiOAuthSecret.image }}:{{ .Values.uiOAuthSecret.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: KEYCLOAK_REALM
+          value: "master"
+        - name: KEYCLOAK_ADMIN_SECRET_NAME
+          value: {{ .Values.keycloak.adminSecretName | quote }}
+        - name: KEYCLOAK_ADMIN_USERNAME_KEY
+          value: {{ .Values.keycloak.adminUsernameKey | quote }}
+        - name: KEYCLOAK_ADMIN_PASSWORD_KEY
+          value: {{ .Values.keycloak.adminPasswordKey | quote }}
+        - name: NAMESPACE
+          value: {{ .Values.ui.namespace | quote }}
+        - name: CLIENT_ID
+          value: "kagenti"
+        - name: SECRET_NAME
+          value: "kagenti-ui-oauth-secret"
+        - name: OPENSHIFT_ENABLED
+          value: {{ .Values.openshift | quote }}
+        - name: KEYCLOAK_NAMESPACE
+          value: {{ .Values.keycloak.namespace | quote }}
+        - name: UI_NAMESPACE
+          value: {{ .Values.ui.namespace | quote }}
+        - name: SSL_CERT_FILE
+          value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+  backoffLimit: 3
+{{- end }}
+

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -21,6 +21,44 @@ spec:
         app: kagenti-ui
     spec:
       serviceAccountName: kagenti-ui-service-account
+      {{- if .Values.ui.auth.enabled }}
+      initContainers:
+      - name: wait-for-oauth-secret
+        image: {{ .Values.common.kubectlImage }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for OAuth secret to be created..."
+          MAX_ATTEMPTS=60
+          ATTEMPT=0
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            if kubectl get secret kagenti-ui-oauth-secret -n {{ .Values.ui.namespace }} >/dev/null 2>&1; then
+              echo "OAuth secret found. Verifying required keys..."
+              REQUIRED_KEYS="CLIENT_ID CLIENT_SECRET AUTH_ENDPOINT TOKEN_ENDPOINT REDIRECT_URI"
+              ALL_PRESENT=true
+              for KEY in $REQUIRED_KEYS; do
+                if ! kubectl get secret kagenti-ui-oauth-secret -n {{ .Values.ui.namespace }} -o jsonpath='{.data.'$KEY'}' >/dev/null 2>&1; then
+                  echo "Missing key: $KEY"
+                  ALL_PRESENT=false
+                fi
+              done
+              if [ "$ALL_PRESENT" = "true" ]; then
+                echo "All required OAuth keys are present. Proceeding..."
+                exit 0
+              else
+                echo "Some keys are missing. Waiting 2 seconds... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+                sleep 2
+              fi
+            else
+              echo "OAuth secret not found. Waiting 2 seconds... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+              sleep 2
+            fi
+          done
+          echo "ERROR: OAuth secret not ready after $MAX_ATTEMPTS attempts. Proceeding anyway but authentication may not work."
+          exit 0
+      {{- end }}
       containers:
         - name: kagenti-ui-container
           image: "{{ .Values.ui.image }}:{{ .Values.ui.tag }}"
@@ -35,7 +73,7 @@ spec:
                 secretKeyRef:
                   name: "kagenti-ui-oauth-secret"
                   key: "SSL_CERT_FILE"
-                  optional: {{ (not .Values.openshift) }}
+                  optional: {{ or (not .Values.openshift) (not .Values.ui.auth.enabled) }}
             - name: "CLIENT_ID"
               valueFrom:
                 secretKeyRef:

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -53,6 +53,22 @@ ui:
   tag: v0.1.0-alpha.7
 
 # ------------------------------------------------------------------
+#  UI OAuth Secret Creator Configuration
+# ------------------------------------------------------------------
+uiOAuthSecret:
+  image: ghcr.io/kagenti/kagenti/ui-oauth-secret
+  tag: latest
+
+# ------------------------------------------------------------------
+#  Keycloak Configuration
+# ------------------------------------------------------------------
+keycloak:
+  namespace: keycloak
+  adminSecretName: keycloak-initial-admin
+  adminUsernameKey: username
+  adminPasswordKey: password
+
+# ------------------------------------------------------------------
 #  Platform Operator Configuration
 # ------------------------------------------------------------------
 kagenti-platform-operator-chart:

--- a/deployments/ui/kagenti-ui.yaml
+++ b/deployments/ui/kagenti-ui.yaml
@@ -21,6 +21,42 @@ spec:
         app: kagenti-ui
     spec:
       serviceAccountName: kagenti-ui-service-account
+      initContainers:
+      - name: wait-for-oauth-secret
+        image: bitnami/kubectl:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for OAuth secret to be created..."
+          MAX_ATTEMPTS=60
+          ATTEMPT=0
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            if kubectl get secret kagenti-ui-oauth-secret -n kagenti-system >/dev/null 2>&1; then
+              echo "OAuth secret found. Verifying required keys..."
+              REQUIRED_KEYS="CLIENT_ID CLIENT_SECRET AUTH_ENDPOINT TOKEN_ENDPOINT REDIRECT_URI"
+              ALL_PRESENT=true
+              for KEY in $REQUIRED_KEYS; do
+                if ! kubectl get secret kagenti-ui-oauth-secret -n kagenti-system -o jsonpath='{.data.'$KEY'}' >/dev/null 2>&1; then
+                  echo "Missing key: $KEY"
+                  ALL_PRESENT=false
+                fi
+              done
+              if [ "$ALL_PRESENT" = "true" ]; then
+                echo "All required OAuth keys are present. Proceeding..."
+                exit 0
+              else
+                echo "Some keys are missing. Waiting 2 seconds... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+                sleep 2
+              fi
+            else
+              echo "OAuth secret not found. Waiting 2 seconds... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+              sleep 2
+            fi
+          done
+          echo "ERROR: OAuth secret not ready after $MAX_ATTEMPTS attempts. Proceeding anyway but authentication may not work."
+          exit 0
       containers:
         - name: kagenti-ui-container
           image: ghcr.io/kagenti/kagenti/ui:latest
@@ -89,6 +125,12 @@ spec:
                 secretKeyRef:
                   name: "kagenti-ui-oauth-secret"
                   key: "SCOPE"
+                  optional: true
+            - name: "SSL_CERT_FILE"
+              valueFrom:
+                secretKeyRef:
+                  name: "kagenti-ui-oauth-secret"
+                  key: "SSL_CERT_FILE"
                   optional: true
             - name: "MCP_PROXY_FULL_ADDRESS"
               valueFrom:

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -1,141 +1,454 @@
 import json
+import logging
 import os
+import sys
+from typing import Optional, Dict, Any, Tuple, Union
 from keycloak import KeycloakAdmin, KeycloakPostError
-from kubernetes import client, config
+from kubernetes import client, config, dynamic
+from kubernetes.client import api_client
 import base64
 
-KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM")
-if KEYCLOAK_REALM is None:
-    raise Exception('Expected environment variable "KEYCLOAK_REALM"')
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
 
-KEYCLOAK_ADMIN_USERNAME = os.environ.get("KEYCLOAK_ADMIN_USERNAME")
-if KEYCLOAK_ADMIN_USERNAME is None:
-    raise Exception('Expected environment variable "KEYCLOAK_ADMIN_USERNAME"')
-
-KEYCLOAK_ADMIN_PASSWORD = os.environ.get("KEYCLOAK_ADMIN_PASSWORD")
-if KEYCLOAK_ADMIN_PASSWORD is None:
-    raise Exception('Expected environment variable "KEYCLOAK_ADMIN_PASSWORD"')
-
-NAMESPACE = os.environ.get("NAMESPACE")
-if NAMESPACE is None:
-    raise Exception('Expected environment variable "NAMESPACE"')
-
-CLIENT_ID = os.environ.get("CLIENT_ID")
-if CLIENT_ID is None:
-    raise Exception('Expected environment variable "CLIENT_ID"')
-
-ROOT_URL = os.environ.get("ROOT_URL")
-if ROOT_URL is None:
-    raise Exception('Expected environment variable "ROOT_URL"')
-
-SECRET_NAME = os.environ.get("SECRET_NAME")
-if SECRET_NAME is None:
-    raise Exception('Expected environment variable "SECRET_NAME"')
-
-KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL")
-if KEYCLOAK_URL is None:
-    print(
-        f'Expected environment variable "KEYCLOAK_URL". Skipping client registration of {CLIENT_ID}.'
-    )
-    exit()  # KEYCLOAK_URL is optional so do not raise an error
+# Constants
+DEFAULT_KEYCLOAK_NAMESPACE = "keycloak"
+DEFAULT_UI_NAMESPACE = "kagenti-system"
+DEFAULT_KEYCLOAK_ROUTE_NAME = "keycloak"
+DEFAULT_UI_ROUTE_NAME = "kagenti-ui"
+DEFAULT_KEYCLOAK_REALM = "master"
+DEFAULT_ADMIN_SECRET_NAME = "keycloak-initial-admin"
+DEFAULT_ADMIN_USERNAME_KEY = "username"
+DEFAULT_ADMIN_PASSWORD_KEY = "password"
+OAUTH_REDIRECT_PATH = "/oauth2/callback"
+OAUTH_SCOPE = "openid profile email"
+SERVICE_ACCOUNT_CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
 
-# TODO: use the function from kagenti/ui/lib/kube.py
+class ConfigurationError(Exception):
+    """Raised when required configuration is missing or invalid."""
+
+    pass
+
+
+class KubernetesResourceError(Exception):
+    """Raised when Kubernetes resource operations fail."""
+
+    pass
+
+
+class KeycloakOperationError(Exception):
+    """Raised when Keycloak operations fail."""
+
+    pass
+
+
+def get_required_env(key: str) -> str:
+    """Get a required environment variable or raise ConfigurationError."""
+    value = os.environ.get(key)
+    if value is None or value == "":
+        raise ConfigurationError(f'Required environment variable: "{key}" is not set')
+    return value
+
+
+def get_optional_env(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Get an optional environment variable with optional default."""
+    return os.environ.get(key, default)
+
+
 def is_running_in_cluster() -> bool:
+    """Check if running inside a Kubernetes cluster."""
     return bool(os.getenv("KUBERNETES_SERVICE_HOST"))
 
 
-# TODO: refactor this function so kagenti-client-registration image can use it
-def register_client(keycloak_admin: KeycloakAdmin, client_id: str, client_payload):
-    # Create client
-    internal_client_id = None
+def get_openshift_route_url(
+    dyn_client: dynamic.DynamicClient, namespace: str, route_name: str
+) -> str:
+    """Get the URL for an OpenShift route.
+
+    Args:
+        dyn_client: Kubernetes dynamic client
+        namespace: Namespace where the route exists
+        route_name: Name of the route resource
+
+    Returns:
+        HTTPS URL for the route
+
+    Raises:
+        KubernetesResourceError: If route cannot be fetched
+    """
     try:
-        internal_client_id = keycloak_admin.create_client(client_payload)
+        route_api = dyn_client.resources.get(
+            api_version="route.openshift.io/v1", kind="Route"
+        )
+        route = route_api.get(name=route_name, namespace=namespace)
+        host = route.spec.host
 
-        print(f'Created Keycloak client "{client_id}": {internal_client_id}')
-    except KeycloakPostError as e:
-        print(f'Could not create Keycloak client "{client_id}": {e}')
-
-        error_json = json.loads(e.error_message)
-        if error_json["errorMessage"] == f"Client {client_id} already exists":
-            internal_client_id = keycloak_admin.get_client_id(client_id)
-            print(
-                f'Obtained internal client ID of existing client "{client_id}": {internal_client_id}'
+        if not host:
+            raise KubernetesResourceError(
+                f"Route {route_name} in namespace {namespace} has no host defined"
             )
 
-    return internal_client_id
+        # Routes use edge TLS termination by default, so use https
+        return f"https://{host}"
+    except Exception as e:
+        error_msg = f"Could not fetch OpenShift route {route_name} in namespace {namespace}: {e}"
+        logger.error(error_msg)
+        raise KubernetesResourceError(error_msg) from e
 
 
-keycloak_admin = KeycloakAdmin(
-    server_url=KEYCLOAK_URL,
-    username=KEYCLOAK_ADMIN_USERNAME,
-    password=KEYCLOAK_ADMIN_PASSWORD,
-    realm_name=KEYCLOAK_REALM,
-    user_realm_name="master",  # user_realm_name is the realm where the admin user is defined
-)
+def read_keycloak_credentials(
+    v1_client: client.CoreV1Api,
+    secret_name: str,
+    namespace: str,
+    username_key: str,
+    password_key: str,
+) -> Tuple[str, str]:
+    """Read Keycloak admin credentials from a Kubernetes secret.
 
-internal_client_id = register_client(
-    keycloak_admin,
-    CLIENT_ID,
-    {
-        "clientId": CLIENT_ID,
-        "name": CLIENT_ID,
-        "description": "",
-        "rootUrl": ROOT_URL,
-        "adminUrl": ROOT_URL,
-        "baseUrl": "",
-        "enabled": True,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [ROOT_URL + "/*"],
-        "webOrigins": [ROOT_URL],
-        "standardFlowEnabled": True,
-        "implicitFlowEnabled": False,
-        "directAccessGrantsEnabled": False,
-        "publicClient": False,
-        "frontchannelLogout": True,
-        "protocol": "openid-connect",
-        "fullScopeAllowed": True,
-    },
-)
+    Args:
+        v1_client: Kubernetes CoreV1Api client
+        secret_name: Name of the secret
+        namespace: Namespace where secret exists
+        username_key: Key in secret data for username
+        password_key: Key in secret data for password
 
-# Get client secret
-secrets = keycloak_admin.get_client_secrets(internal_client_id)
-client_secret = secrets.get("value", "") if secrets else ""
-data = {
-    "ENABLE_AUTH": "true",  # string true
-    "CLIENT_SECRET": client_secret,
-    "CLIENT_ID": CLIENT_ID,
-    "AUTH_ENDPOINT": "http://keycloak.localtest.me:8080/realms/master/protocol/openid-connect/auth",
-    "TOKEN_ENDPOINT": "http://keycloak.keycloak.svc.cluster.local:8080/realms/master/protocol/openid-connect/token",
-    "REDIRECT_URI": "http://kagenti-ui.localtest.me:8080/oauth2/callback",
-    "SCOPE": "openid profile email",
-}
+    Returns:
+        Tuple of (username, password)
 
-# Connect to Kubernetes API
-if is_running_in_cluster():
-    config.load_incluster_config()
-else:
-    config.load_kube_config()
-v1 = client.CoreV1Api()
-
-# Create the Kubernetes secret
-try:
-    # Try to create first
-    secret_body = client.V1Secret(
-        api_version="v1",
-        kind="Secret",
-        metadata=client.V1ObjectMeta(name=SECRET_NAME),
-        type="Opaque",
-        string_data=data,
-    )
-    v1.create_namespaced_secret(namespace=NAMESPACE, body=secret_body)
-    print(f"Created new secret '{SECRET_NAME}'.")
-except client.exceptions.ApiException as e:
-    # Patch if it already exists
-    if e.status == 409:
-        v1.patch_namespaced_secret(
-            name=SECRET_NAME, namespace=NAMESPACE, body={"stringData": data}
+    Raises:
+        KubernetesResourceError: If secret cannot be read or keys are missing
+    """
+    try:
+        logger.info(
+            f"Reading Keycloak admin credentials from secret {secret_name} in namespace {namespace}"
         )
-        print(f"Patched existing secret '{SECRET_NAME}'.")
+        secret = v1_client.read_namespaced_secret(secret_name, namespace)
+
+        if username_key not in secret.data:
+            raise KubernetesResourceError(
+                f"Secret {secret_name} in namespace {namespace} missing key '{username_key}'"
+            )
+        if password_key not in secret.data:
+            raise KubernetesResourceError(
+                f"Secret {secret_name} in namespace {namespace} missing key '{password_key}'"
+            )
+
+        username = base64.b64decode(secret.data[username_key]).decode("utf-8").strip()
+        password = base64.b64decode(secret.data[password_key]).decode("utf-8").strip()
+
+        logger.info("Successfully read credentials from secret")
+        return username, password
+    except client.exceptions.ApiException as e:
+        error_msg = f"Could not read Keycloak admin secret {secret_name} in namespace {namespace}: {e}"
+        logger.error(error_msg)
+        raise KubernetesResourceError(error_msg) from e
+    except Exception as e:
+        error_msg = f"Unexpected error reading secret: {e}"
+        logger.error(error_msg)
+        raise KubernetesResourceError(error_msg) from e
+
+
+def configure_ssl_verification(ssl_cert_file: Optional[str]) -> Union[str, bool]:
+    """Configure SSL verification based on certificate file availability.
+
+    Args:
+        ssl_cert_file: Path to SSL certificate file
+
+    Returns:
+        Path to cert file if available and exists, False otherwise
+    """
+    if ssl_cert_file and os.path.exists(ssl_cert_file):
+        logger.info(f"Using SSL certificate file: {ssl_cert_file}")
+        return ssl_cert_file
     else:
-        raise
+        logger.warning("SSL verification disabled - using self-signed certificates")
+        return False
+
+
+def register_client(
+    keycloak_admin: KeycloakAdmin, client_id: str, client_payload: Dict[str, Any]
+) -> str:
+    """Register a client in Keycloak or retrieve existing client ID.
+
+    Args:
+        keycloak_admin: Keycloak admin client
+        client_id: Desired client ID
+        client_payload: Client configuration payload
+
+    Returns:
+        Internal client ID
+
+    Raises:
+        KeycloakOperationError: If client cannot be created or retrieved
+    """
+    try:
+        internal_client_id = keycloak_admin.create_client(client_payload)
+        logger.info(f'Created Keycloak client "{client_id}": {internal_client_id}')
+        return internal_client_id
+    except KeycloakPostError as e:
+        logger.debug(f'Keycloak client creation error for "{client_id}": {e}')
+
+        try:
+            error_json = json.loads(e.error_message)
+            if error_json.get("errorMessage") == f"Client {client_id} already exists":
+                internal_client_id = keycloak_admin.get_client_id(client_id)
+                logger.info(
+                    f'Using existing Keycloak client "{client_id}": {internal_client_id}'
+                )
+                return internal_client_id
+        except (json.JSONDecodeError, KeyError, TypeError):
+            pass  # Error message format doesn't match expected pattern
+
+        error_msg = f'Failed to create or retrieve Keycloak client "{client_id}": {e}'
+        logger.error(error_msg)
+        raise KeycloakOperationError(error_msg) from e
+
+
+def create_or_update_secret(
+    v1_client: client.CoreV1Api, namespace: str, secret_name: str, data: Dict[str, str]
+) -> None:
+    """Create or update a Kubernetes secret.
+
+    Args:
+        v1_client: Kubernetes CoreV1Api client
+        namespace: Target namespace
+        secret_name: Name of the secret
+        data: Secret data dictionary
+
+    Raises:
+        KubernetesResourceError: If secret creation/update fails
+    """
+    try:
+        secret_body = client.V1Secret(
+            api_version="v1",
+            kind="Secret",
+            metadata=client.V1ObjectMeta(name=secret_name),
+            type="Opaque",
+            string_data=data,
+        )
+        v1_client.create_namespaced_secret(namespace=namespace, body=secret_body)
+        logger.info(f"Created new secret '{secret_name}'")
+    except client.exceptions.ApiException as e:
+        if e.status == 409:
+            # Secret already exists, update it
+            try:
+                v1_client.patch_namespaced_secret(
+                    name=secret_name, namespace=namespace, body={"stringData": data}
+                )
+                logger.info(f"Updated existing secret '{secret_name}'")
+            except Exception as patch_error:
+                error_msg = f"Failed to update secret '{secret_name}': {patch_error}"
+                logger.error(error_msg)
+                raise KubernetesResourceError(error_msg) from patch_error
+        else:
+            error_msg = f"Failed to create secret '{secret_name}': {e}"
+            logger.error(error_msg)
+            raise KubernetesResourceError(error_msg) from e
+
+
+def main() -> None:
+    """Main execution function."""
+    try:
+        # Load required configuration
+        keycloak_realm = get_required_env("KEYCLOAK_REALM")
+        namespace = get_required_env("NAMESPACE")
+        client_id = get_required_env("CLIENT_ID")
+        secret_name = get_required_env("SECRET_NAME")
+
+        # Load optional configuration
+        openshift_enabled = (
+            get_optional_env("OPENSHIFT_ENABLED", "false").lower() == "true"
+        )
+        keycloak_namespace = get_optional_env(
+            "KEYCLOAK_NAMESPACE", DEFAULT_KEYCLOAK_NAMESPACE
+        )
+        ui_namespace = get_optional_env("UI_NAMESPACE", DEFAULT_UI_NAMESPACE)
+
+        admin_secret_name = get_optional_env(
+            "KEYCLOAK_ADMIN_SECRET_NAME", DEFAULT_ADMIN_SECRET_NAME
+        )
+        admin_username_key = get_optional_env(
+            "KEYCLOAK_ADMIN_USERNAME_KEY", DEFAULT_ADMIN_USERNAME_KEY
+        )
+        admin_password_key = get_optional_env(
+            "KEYCLOAK_ADMIN_PASSWORD_KEY", DEFAULT_ADMIN_PASSWORD_KEY
+        )
+
+        keycloak_admin_username = get_optional_env("KEYCLOAK_ADMIN_USERNAME")
+        keycloak_admin_password = get_optional_env("KEYCLOAK_ADMIN_PASSWORD")
+        ssl_cert_file = get_optional_env("SSL_CERT_FILE")
+
+        # For backward compatibility with vanilla k8s
+        root_url = get_optional_env("ROOT_URL")
+        keycloak_url = get_optional_env("KEYCLOAK_URL")
+        keycloak_public_url = get_optional_env("KEYCLOAK_PUBLIC_URL")
+
+        # Connect to Kubernetes API
+        if is_running_in_cluster():
+            config.load_incluster_config()
+        else:
+            config.load_kube_config()
+
+        v1_client = client.CoreV1Api()
+        dyn_client = dynamic.DynamicClient(api_client.ApiClient())
+
+        # Load Keycloak admin credentials
+        if not keycloak_admin_username or not keycloak_admin_password:
+            keycloak_admin_username, keycloak_admin_password = (
+                read_keycloak_credentials(
+                    v1_client,
+                    admin_secret_name,
+                    keycloak_namespace,
+                    admin_username_key,
+                    admin_password_key,
+                )
+            )
+
+        if not keycloak_admin_username or not keycloak_admin_password:
+            raise ConfigurationError(
+                "Keycloak admin credentials must be provided via environment variables or secret"
+            )
+
+        # Determine URLs based on environment
+        if openshift_enabled:
+            logger.info("OpenShift mode enabled, fetching routes...")
+
+            # In OpenShift, route URLs are public (external)
+            keycloak_public_url = get_openshift_route_url(
+                dyn_client, keycloak_namespace, DEFAULT_KEYCLOAK_ROUTE_NAME
+            )
+            logger.info(f"Keycloak public URL (route): {keycloak_public_url}")
+
+            root_url = get_openshift_route_url(
+                dyn_client, ui_namespace, DEFAULT_UI_ROUTE_NAME
+            )
+            logger.info(f"UI URL: {root_url}")
+
+            # For OpenShift, use internal service URL for token exchange if KEYCLOAK_URL is provided
+            # Otherwise, use the route URL for both (backward compatibility)
+            if keycloak_url:
+                logger.info(
+                    f"Using separate URLs - Internal (token): {keycloak_url}, External (auth): {keycloak_public_url}"
+                )
+            else:
+                keycloak_url = keycloak_public_url
+                logger.info(
+                    "KEYCLOAK_URL not set, using route URL for both auth and token endpoints"
+                )
+        else:
+            # Vanilla Kubernetes mode - URLs must be provided
+            if not keycloak_url:
+                raise ConfigurationError(
+                    "KEYCLOAK_URL environment variable required for vanilla k8s mode"
+                )
+            if not root_url:
+                raise ConfigurationError(
+                    "ROOT_URL environment variable required for vanilla k8s mode"
+                )
+            logger.info(
+                f"Using provided URLs - Keycloak: {keycloak_url}, UI: {root_url}"
+            )
+
+            # If KEYCLOAK_PUBLIC_URL is not set, use KEYCLOAK_URL for both
+            # Otherwise, KEYCLOAK_URL is internal (for token exchange), KEYCLOAK_PUBLIC_URL is external (for browser)
+            if not keycloak_public_url:
+                keycloak_public_url = keycloak_url
+                logger.info(
+                    "KEYCLOAK_PUBLIC_URL not set, using KEYCLOAK_URL for both auth and token endpoints"
+                )
+            else:
+                logger.info(
+                    f"Using separate URLs - Internal (token): {keycloak_url}, External (auth): {keycloak_public_url}"
+                )
+
+        # Configure SSL verification
+        verify_ssl = configure_ssl_verification(ssl_cert_file)
+
+        # Initialize Keycloak admin client
+        keycloak_admin = KeycloakAdmin(
+            server_url=keycloak_url,
+            username=keycloak_admin_username,
+            password=keycloak_admin_password,
+            realm_name=keycloak_realm,
+            user_realm_name=DEFAULT_KEYCLOAK_REALM,
+            verify=verify_ssl,
+        )
+
+        # Register client
+        client_payload = {
+            "clientId": client_id,
+            "name": client_id,
+            "description": "",
+            "rootUrl": root_url,
+            "adminUrl": root_url,
+            "baseUrl": "",
+            "enabled": True,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [root_url + "/*"],
+            "webOrigins": [root_url],
+            "standardFlowEnabled": True,
+            "implicitFlowEnabled": False,
+            "directAccessGrantsEnabled": False,
+            "publicClient": False,
+            "frontchannelLogout": True,
+            "protocol": "openid-connect",
+            "fullScopeAllowed": True,
+        }
+
+        internal_client_id = register_client(keycloak_admin, client_id, client_payload)
+
+        # Get client secret
+        secrets = keycloak_admin.get_client_secrets(internal_client_id)
+        client_secret = secrets.get("value", "") if secrets else ""
+
+        if not client_secret:
+            logger.warning(f"No client secret found for client {client_id}")
+
+        # Construct OAuth endpoints
+        # AUTH_ENDPOINT uses public URL for browser redirects
+        # TOKEN_ENDPOINT uses internal URL for server-to-server calls
+        auth_endpoint_url = keycloak_public_url if keycloak_public_url else keycloak_url
+        auth_endpoint = (
+            f"{auth_endpoint_url}/realms/{keycloak_realm}/protocol/openid-connect/auth"
+        )
+        token_endpoint = (
+            f"{keycloak_url}/realms/{keycloak_realm}/protocol/openid-connect/token"
+        )
+        redirect_uri = f"{root_url}{OAUTH_REDIRECT_PATH}"
+
+        logger.info("OAuth Configuration:")
+        logger.info(f"  AUTH_ENDPOINT: {auth_endpoint}")
+        logger.info(f"  TOKEN_ENDPOINT: {token_endpoint}")
+        logger.info(f"  REDIRECT_URI: {redirect_uri}")
+
+        # Prepare secret data
+        secret_data = {
+            "ENABLE_AUTH": "true",
+            "CLIENT_SECRET": client_secret,
+            "CLIENT_ID": client_id,
+            "AUTH_ENDPOINT": auth_endpoint,
+            "TOKEN_ENDPOINT": token_endpoint,
+            "REDIRECT_URI": redirect_uri,
+            "SCOPE": OAUTH_SCOPE,
+            "SSL_CERT_FILE": SERVICE_ACCOUNT_CA_PATH,
+        }
+
+        # Create or update Kubernetes secret
+        create_or_update_secret(v1_client, namespace, secret_name, secret_data)
+
+        logger.info("OAuth secret creation completed successfully")
+
+    except (ConfigurationError, KubernetesResourceError, KeycloakOperationError) as e:
+        logger.error(f"Error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        logger.exception(f"Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/kagenti/installer/app/resources/global-environments.yaml
+++ b/kagenti/installer/app/resources/global-environments.yaml
@@ -4,6 +4,7 @@ metadata:
   name: global-environments
 data:
   KEYCLOAK_URL: "http://keycloak.keycloak:8080"
+  KEYCLOAK_PUBLIC_URL: "http://keycloak.localtest.me:8080"
   KEYCLOAK_REALM: "master"
   KEYCLOAK_ADMIN_USERNAME: "admin"
   KEYCLOAK_ADMIN_PASSWORD: "admin"

--- a/kagenti/installer/app/resources/ui-oauth-secret.yaml
+++ b/kagenti/installer/app/resources/ui-oauth-secret.yaml
@@ -17,6 +17,11 @@ spec:
             configMapKeyRef:
               name: global-environments
               key: KEYCLOAK_URL
+        - name: KEYCLOAK_PUBLIC_URL
+          valueFrom:
+            configMapKeyRef:
+              name: global-environments
+              key: KEYCLOAK_PUBLIC_URL
         - name: KEYCLOAK_REALM
           valueFrom:
             configMapKeyRef:
@@ -72,3 +77,4 @@ roleRef:
   kind: Role
   name: secret-writer
   apiGroup: rbac.authorization.k8s.io
+


### PR DESCRIPTION
## Automate kagenti-ui-oauth-secret Creation for OpenShift

### Summary

Automates the creation of `kagenti-ui-oauth-secret` via a Helm post-install hook that registers the UI as an OAuth client with Keycloak and creates the necessary Kubernetes secret.

### Changes

- **New Helm template** (`ui-oauth-secret-job.yaml`): Kubernetes Job with ServiceAccount and RBAC that runs as a Helm hook to create the OAuth secret

- **UI template updates**: Added init container to wait for OAuth secret availability before UI pod startup, and added `SSL_CERT_FILE` environment variable for SSL certificate verification

- **Enhanced `auth_secret.py`**: 
  - Added logging system and type hints
  - Improved error handling with custom exceptions
  - Support for both OpenShift (route discovery) and vanilla Kubernetes (explicit URLs)
  - Reads Keycloak admin credentials from Kubernetes secrets when not provided via env vars
  - Support for separate internal/external Keycloak URLs
    - `KEYCLOAK_URL`: Internal service URL (for server-to-server token exchange)
    - `KEYCLOAK_PUBLIC_URL`: External/public URL (for browser redirects in AUTH_ENDPOINT)

- **Installer updates**:
  - `global-environments.yaml`: Added `KEYCLOAK_PUBLIC_URL` configuration
  - `ui-oauth-secret.yaml`: Added `KEYCLOAK_PUBLIC_URL` environment variable to the OAuth secret job

- **UI deployment updates**:
  - Added init container to wait for OAuth secret creation before UI startup
  - Added `SSL_CERT_FILE` environment variable from OAuth secret

### Configuration

The job reads configuration from Helm values:

- `keycloak.namespace`: Keycloak namespace (default: `keycloak`)
- `keycloak.adminSecretName`: Secret containing admin credentials (default: `keycloak-initial-admin`)
- `uiOAuthSecret.image` & `tag`: Container image for the secret creator

For the installer:
- `KEYCLOAK_URL`: Internal service URL (e.g., `http://keycloak.keycloak:8080`)
- `KEYCLOAK_PUBLIC_URL`: External/public URL (e.g., `http://keycloak.localtest.me:8080`)

### How It Works

1. **OpenShift Mode**: Automatically discovers Keycloak and UI URLs from OpenShift Routes. Uses route URL for `AUTH_ENDPOINT` (browser redirects) and optionally internal service URL for `TOKEN_ENDPOINT` (server-to-server).

2. **Vanilla Kubernetes Mode**: Requires explicit `KEYCLOAK_URL` and `ROOT_URL`. Optionally accepts `KEYCLOAK_PUBLIC_URL` for separate internal/external endpoints.

3. **URL Resolution**:
   - `AUTH_ENDPOINT`: Uses `KEYCLOAK_PUBLIC_URL` if provided, otherwise falls back to `KEYCLOAK_URL`
   - `TOKEN_ENDPOINT`: Always uses `KEYCLOAK_URL` (internal service) for efficient server-to-server communication

### Testing

- Tested on OpenShift cluster
- Tested on Kind cluster with Gateway component
- Verified OAuth flow: login redirect → Keycloak authentication → token exchange → UI access
- Verified UI when auth is turned off
