### PR TITLE
❇️ : Add image pull secret input field for deploying from existing images

### DIFF
--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -1904,16 +1904,16 @@ def render_import_form(
         # *** The Kagenti installer will only copy the necessary configuration (like ConfigMaps and Secrets) for those specific
         #     namespaces.
         st_object.write(
-            f"Provide Docker image details to deploy a new {resource_type.lower()}."
+            f"Provide container image details to deploy a new {resource_type.lower()}."
         )
         docker_image_url = st_object.text_input(
-            "Docker Image (e.g., myrepo/myimage:tag)",
+            "Container Image (e.g., myrepo/myimage:tag)",
             key=f"{resource_type.lower()}_docker_image",
         )
         repo_secret_name = st_object.text_input(
             "Image Pull Secret Name (optional, leave empty for public images)",
             key=f"{resource_type.lower()}_repo_secret",
-            help="Name of the Kubernetes secret containing credentials for private Docker registries",
+            help="Name of the Kubernetes secret containing credentials for private container registries",
         )
         selected_protocol = default_protocol
         if protocol_options:


### PR DESCRIPTION
## Summary

This PR adds a new input field to the Kagenti UI that allows users to specify a custom image pull secret name when deploying Agents or MCP Servers from existing container images. The specified secret name is then added to the Component CR's `imagePullSecrets` field.

**Example Component CR output:**

```yaml
spec:
  deployer:
    kubernetes:
      imageSpec:
        image: myrepo/myimage
        imageTag: v1.0.0
        imageRegistry: docker.io
        imagePullSecrets:
          - name: my-custom-secret
```

### Motivation

Previously, users could only specify image pull secrets when building from source via `registry_config`. This PR extends that capability to deployments from existing images, allowing users to:
- Deploy from private Docker registries (Quay, Docker Hub, GHCR , etc.)
- Use custom secret names instead of hardcoded values
- Deploy both public and private images with the same workflow
- 
## Related issue(s)

Depends on: https://github.com/kagenti/kagenti-operator/pull/124
Fixes #370 
