### PR TITLE
:book: Don't skip installing the cert manager

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -343,7 +343,7 @@ kubectl delete -n keycloak -f app/resources/keycloak.yaml
 kubectl apply -n keycloak -f app/resources/keycloak.yaml
 kubectl rollout restart daemonset -n istio-system  ztunnel
 kubectl rollout restart -n kagenti-system deployment http-istio
-uv run kagenti-installer --skip-install registry --skip-install tekton --skip-install addons --skip-install gateway --skip-install spire --skip-install mcp_gateway --skip-install metrics_server --skip-install inspector --skip-install cert_manager
+uv run kagenti-installer --skip-install registry --skip-install addons --skip-install gateway --skip-install spire --skip-install mcp_gateway --skip-install metrics_server --skip-install inspector
 kubectl rollout restart -n kagenti-system deployment kagenti-ui
 ```
 


### PR DESCRIPTION
## Summary

Resolves #358 by not skipping cert manager.

It isn't clear if the cert manager always needs to be re-installed, but I followed @cwiklik 's instruction and it worked for me.

## Related issue(s)

Fixes #385
