### PR TITLE
Add project status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@
 
 ## Value Proposition
 
+![License](https://img.shields.io/github/license/kagenti/kagenti)
+![Python](https://img.shields.io/pypi/pyversions/kagenti)
+![Contributors](https://img.shields.io/github/contributors/kagenti/kagenti)
+![Issues](https://img.shields.io/github/issues/kagenti/kagenti)
+![Pull Requests](https://img.shields.io/github/issues-pr/kagenti/kagenti)
+
+
 Despite the extensive variety of frameworks available for developing agent-based applications, there is a distinct lack of standardized methods for deploying and operating agent code in production environments, as well as for exposing it through a standardized API. Agents are adept at reasoning, planning, and interacting with various tools, but their full potential can be limited by these deployment challenges. **Kagenti** addresses this gap by enhancing existing agent frameworks with the following key components:
 
 - **Kubernetes Platform Operator**: Facilitates the deployment and configuration of agents along with infrastructure dependencies on Kubernetes. It enables scaling and updating configurations seamlessly.


### PR DESCRIPTION
## Description
This PR adds project status badges to the README to provide quick visual information about the project's status, version, and other key metrics.

## Changes
- Added badges for License, Python version, Contributors, Issues, and Pull Requests
- Badges are placed at the top of the README for easy visibility

## Related Issue
Closes #388

## Benefits
- Quick visual information for potential users and contributors
- Professional appearance
- Easy to scan project status at a glance
- Better GitHub preview experience

## Screenshots
The badges will appear at the top of the README showing:
- License information
- Python version compatibility
- Number of contributors
- Open issues count
- Open pull requests count

## Checklist
- [x] I have read the contributing guidelines
- [x] My changes follow the project's code style
- [x] I have tested my changes
- [x] My changes generate no new warnings
