### PR TITLE
🐛 fix broken helm chart

### DIFF
--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -2,17 +2,14 @@ apiVersion: v2
 name: kagenti
 description: A Helm chart for deploying the kagenti platform
 type: application
-version: 0.1.0
-appVersion: "1.0"
+version: 0.1.2
+appVersion: "0.1.2"
 
 dependencies:
 - name: kagenti-platform-operator-chart
-  version: 0.2.0-alpha.16
-  repository: oci://ghcr.io/kagenti/kagenti-operator
-  condition: components.platformOperator.enabled
-- name: kagenti-operator-chart
   version: 0.2.0-alpha.17
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  condition: components.kagentiOperator.enabled
+  condition: components.platformOperator.enabled
+
 
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The Kagenti Helm Chart is declaring as dependencies BOTH the platform operator and the agent operator, which have conflicting objects resulting in install errors.

