### PR TITLE
change from mcp.test.com to mcp.local to match the default of gateway…

### DIFF
--- a/kagenti/installer/app/resources/mcp-gateway.yaml
+++ b/kagenti/installer/app/resources/mcp-gateway.yaml
@@ -23,7 +23,7 @@ spec:
         namespaces:
           from: All
     - name: mcps 
-      hostname: '*.mcp.test.com' #public accessibly MCP host (doesn't need dns as it is for rewritten hosts)
+      hostname: '*.mcp.local' #public accessibly MCP host (doesn't need dns as it is for rewritten hosts)
       port: 8080
       protocol: HTTP
       allowedRoutes:


### PR DESCRIPTION
To address: https://github.com/kagenti/mcp-gateway/issues/418, so we have consistency between script install and ansible install of mcp gateway helmchart