### PR TITLE
fix corresponding docs for gateway

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -50,7 +50,7 @@ spec:
   - name: mcp-gateway
     namespace: gateway-system
   hostnames:
-  - "weather-tool.mcp.test.com" #note this is matching the gateway listener. It is purely for internal routing by envoy
+  - "weather-tool.mcp.local" #note this is matching the gateway listener. It is purely for internal routing by envoy
   rules:
   - matches:
     - path:
@@ -166,7 +166,7 @@ spec:
   - name: mcp-gateway
     namespace: gateway-system
   hostnames:
-  - 'slack-tool.mcp.test.com' #note this is matching the gateway listener. It is purely for internal routing by envoy'
+  - 'slack-tool.mcp.local' #note this is matching the gateway listener. It is purely for internal routing by envoy'
   rules:
   - matches:
     - path:


### PR DESCRIPTION
changing doc to reflect that mcp gateway by default uses `*.mcp.local` instead of `*.mcp.test.com`. 