### PR TITLE
fix: FIXES CI: exclude job pods from failed pods health check

### DIFF
--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -11,5 +11,10 @@ dependencies:
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.platformOperator.enabled
 
+- name: kagenti-operator-chart
+  version: 0.2.0-alpha.17
+  repository: oci://ghcr.io/kagenti/kagenti-operator
+  condition: components.kagentiOperator.enabled
+
 
 

--- a/kagenti/tests/conftest.py
+++ b/kagenti/tests/conftest.py
@@ -76,6 +76,28 @@ def k8s_apps_client():
 
 
 @pytest.fixture(scope="session")
+def k8s_batch_client():
+    """
+    Load Kubernetes configuration and return BatchV1Api client.
+
+    Returns:
+        kubernetes.client.BatchV1Api: Kubernetes batch API client for Jobs
+
+    Raises:
+        pytest.fail: If cannot connect to Kubernetes cluster
+    """
+    try:
+        config.load_kube_config()
+    except config.ConfigException:
+        try:
+            config.load_incluster_config()
+        except config.ConfigException as e:
+            pytest.fail(f"Could not load Kubernetes config: {e}")
+
+    return client.BatchV1Api()
+
+
+@pytest.fixture(scope="session")
 def keycloak_admin_credentials(k8s_client) -> Dict[str, str]:
     """
     Get Keycloak admin credentials from Kubernetes secret.


### PR DESCRIPTION
Job pods can fail and be retried - this is expected Kubernetes behavior. The test_no_failed_pods test was catching transient job pod failures (e.g., kagenti-agent-oauth-secret-job retries) as platform health issues.

This change adds a helper function to identify pods owned by Jobs and excludes them from the failed pods check, since job retry failures are normal and don't indicate actual platform health problems.
