### PR TITLE
:bug: Bump kagenti operator version to fix a bug preventing operator installation

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-alpha.18
+  version: 0.2.0-alpha.19
 - name: kagenti-webhook-chart
   repository: oci://ghcr.io/kagenti/kagenti-extensions
   version: 0.1.0-alpha.6
-digest: sha256:f287563b0b888ff498b8cf47388bae8144a246792b000577c1bbb91485a18b80
-generated: "2025-12-09T20:06:25.538924-05:00"
+digest: sha256:db87d632998631ad6c5b8a4ed7bca0af1fd6cee97020997c164591488a72bedd
+generated: "2025-12-11T09:44:02.754087-05:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "0.1.2"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-alpha.18
+  version: 0.2.0-alpha.19
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 - name: kagenti-webhook-chart

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -121,7 +121,7 @@ kagenti-operator-chart:
   controllerManager:
     container:
       image:
-        tag: 0.2.0-alpha.18
+        tag: 0.2.0-alpha.19
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
## Summary
This PR bumps the version of kagenti operator in the installer which fixes a problem that prevents installer to install the operator. 

## Related issue(s)

Fixes #463 
