### PR TITLE
Add barebones installer environment for minimal kagenti-operator experiments.

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -76,6 +76,8 @@ ansible-playbook -i localhost, -c local deployments/ansible/installer-playbook.y
 - Development (full dev configuration): `../envs/dev_values.yaml` (enables UI,
    platform operator, mcpGateway, istio where required).
 - Minimal dev (no auth): `../envs/dev_values_minimal.yaml`.
+- Barebones (operator only): `../envs/barebones_operator_values.yaml` (only kagenti-operator
+   with CRDs and controller, cert-manager only - no build pipelines).
 - OpenShift / OCP example: `../envs/ocp_values.yaml`.
 
 Pick one or more of the files in `deployments/envs` and pass them via
@@ -147,6 +149,12 @@ deployments/ansible/run-install.sh --env dev
 
 ```bash
 deployments/ansible/run-install.sh --env minimal
+```
+
+- Barebones (operator only):
+
+```bash
+deployments/ansible/run-install.sh --env barebones
 ```
 
 - OpenShift / OCP:

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -364,7 +364,7 @@
       kubeconfig: ""
       release_namespace: "{{ (charts['kagenti'] | default({})).get('namespace', 'kagenti-system') }}"
       state: present
-      create_namespace: false
+      create_namespace: true
       wait: true
       timeout: "{{ helm_wait_timeout }}s"
       values: >-

--- a/deployments/ansible/run-install.sh
+++ b/deployments/ansible/run-install.sh
@@ -37,7 +37,7 @@ usage() {
 Usage: ${0##*/} [options] [-- ansible-playbook-args]
 
 Options:
-  --env <dev|minimal|ocp>   Use a named environment file from deployments/envs
+  --env <dev|minimal|auth|barebones|ocp>   Use a named environment file from deployments/envs
   --env-file <path>         Add an explicit environment values file (can repeat)
   --secret <path>           Path to secret values file (example: ../envs/.secret_values.yaml)
   --preload                 Set kind_images_preload=true
@@ -62,6 +62,7 @@ while [[ $# -gt 0 ]]; do
         dev) ENV_FILES+=("$SCRIPT_DIR/../envs/dev_values.yaml") ;;
         minimal) ENV_FILES+=("$SCRIPT_DIR/../envs/dev_values_minimal.yaml") ;;
         auth) ENV_FILES+=("$SCRIPT_DIR/../envs/dev_values_minimal_auth.yaml") ;;
+        barebones) ENV_FILES+=("$SCRIPT_DIR/../envs/barebones_operator_values.yaml") ;;
         ocp) ENV_FILES+=("$SCRIPT_DIR/../envs/ocp_values.yaml") ;;
         *) echo "Unknown env: $1" >&2; exit 2 ;;
       esac

--- a/deployments/envs/barebones_operator_values.yaml
+++ b/deployments/envs/barebones_operator_values.yaml
@@ -1,0 +1,79 @@
+# Barebones Kagenti installation - Operator (CRDs + Controller) only
+# Minimal dependencies for kagenti-operator with Agent and AgentCard CRDs and controllers
+# No build pipelines - use pre-built images with Agent resources directly
+
+####################################################################
+# Minimal kubectl-applied dependencies
+####################################################################
+gatewayApi:
+  enabled: false
+
+# cert-manager is required for operator webhook certificates
+certManager:
+  enabled: true
+
+# tekton disabled - no need for AgentBuild, use Agent resources with pre-built images
+tekton:
+  enabled: false
+
+toolhiveCRDs:
+  enabled: false
+
+toolhiveOperator:
+  enabled: false
+
+kiali:
+  enabled: false
+
+charts:
+  ####################################################################
+  # kagenti-deps - disable all optional components
+  ####################################################################
+  kagenti-deps:
+    enabled: false
+
+  ####################################################################
+  # kagenti - only kagentiOperator enabled
+  ####################################################################
+  kagenti:
+    enabled: true
+    values:
+      openshift: false
+      components:
+        agentNamespaces:
+          enabled: false
+        platformOperator:
+          enabled: false  # Old operator - deprecated
+        kagentiOperator:
+          enabled: true   # NEW operator with AgentCard CRDs
+        ui:
+          enabled: false
+        mcpGateway:
+          enabled: false
+        istio:
+          enabled: false
+
+  ####################################################################
+  # istio - disabled
+  ####################################################################
+  istio:
+    enabled: false
+
+  ####################################################################
+  # mcp-gateway - disabled
+  ####################################################################
+  mcpGateway:
+    enabled: false
+
+  ####################################################################
+  # spire - disabled
+  ####################################################################
+  spire:
+    enabled: false
+
+####################################################################
+# Kind cluster settings
+####################################################################
+kind_images_preload: false
+# docker or podman
+container_engine: docker


### PR DESCRIPTION
Here I've added a barebones option to the Ansible installer. Why?

We've had a number of users ask for "light weight" deployments, with only an Operator. 

These users would like the basic discovery capabilities and simple lifecycle management.

This install pattern enables that.

It's also useful for Kagenti developers because it allows us to uncover hidden dependencies.

It's also a good opportunity to explore creating an API server with its own AuthProvider interface, so that the UI can work even if fundamental components like KeyCloak are disabled or swapped with new components.