### PR TITLE
🐛  Ensure UI env-var precedence and dedupe when building CRs (custom > .env > env-set)

### DIFF
--- a/kagenti/ui/README.md
+++ b/kagenti/ui/README.md
@@ -187,7 +187,7 @@ Precedence when names collide (highest → lowest):
 2. `.env` file imports — override entries from environment variable sets
 3. Environment variable sets (ConfigMap) — lowest precedence
 
-This precedence is enforced when the UI builds the Kubernetes CustomResource manifest (see `lib/build_utils.py`). The operator applies the `podTemplateSpec` from the CustomResource directly to the created Deployment, so correctness is enforced at resource construction time.
+This precedence is achieved by relying on Kubernetes' "last-wins" behavior when duplicate environment variable names are present in the manifest (see `lib/build_utils.py`). The UI does not explicitly deduplicate or enforce precedence; instead, the order of environment variables in the generated CustomResource ensures that higher-precedence values override lower-precedence ones at deployment time.
 
 ## License
 

--- a/kagenti/ui/README.md
+++ b/kagenti/ui/README.md
@@ -173,6 +173,22 @@ Default credentials (when auth is enabled):
 - **Username**: admin
 - **Password**: admin
 
+## Environment Variable Precedence
+
+When creating Agent or Tool resources from the UI, environment variables can come from three sources:
+
+- **Environment variable sets** (from the `environments` ConfigMap)
+- **.env file imports** (imported from a repository `.env` file)
+- **Custom environment variables** added manually in the UI
+
+Precedence when names collide (highest → lowest):
+
+1. Custom environment variables (user-added) — highest precedence, override any conflicting entries
+2. `.env` file imports — override entries from environment variable sets
+3. Environment variable sets (ConfigMap) — lowest precedence
+
+This precedence is enforced when the UI builds the Kubernetes CustomResource manifest (see `lib/build_utils.py`). The operator applies the `podTemplateSpec` from the CustomResource directly to the created Deployment, so correctness is enforced at resource construction time.
+
 ## License
 
 Copyright 2025 IBM Corp.

--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -1963,7 +1963,7 @@ def render_import_form(
                             if skipped_user_duplicates:
                                 st_object.warning(
                                     (
-                                        f"⚠️ Skipped {len(skipped_user_duplicates)} variables already defined by the user: "
+                                        f"⚠️ Skipped {len(skipped_user_duplicates)} variables already defined by the user or previously imported: "
                                         + ", ".join(skipped_user_duplicates)
                                     )
                                 )

--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -185,12 +185,9 @@ def _merge_env_vars(
     order = []
 
     def _emit_warning(message: str) -> None:
-        try:
-            if st_object:
-                st_object.warning(message)
-            else:
-                logger.warning(message)
-        except Exception:
+        if st_object:
+            st_object.warning(message)
+        else:
             logger.warning(message)
 
     def _apply_env_list(env_list: Optional[list], context: str) -> None:

--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -1958,12 +1958,12 @@ def render_import_form(
                                 "Successfully imported env vars from the .env file"
                             )
                             if skipped_user_duplicates:
-                                st_object.warning(
-                                    (
-                                        f"⚠️ Skipped {len(skipped_user_duplicates)} variables already defined by the user or previously imported: "
-                                        + ", ".join(skipped_user_duplicates)
-                                    )
+                                joined = ", ".join(skipped_user_duplicates)
+                                msg = (
+                                    f"⚠️ Skipped {len(skipped_user_duplicates)} variables already "
+                                    f"defined by the user or previously imported: {joined}"
                                 )
+                                st_object.warning(msg)
                             if replaced_count:
                                 st_object.info(
                                     f"Replaced {replaced_count} configmap-origin variables with values from the .env file"

--- a/kagenti/ui/lib/build_utils.py
+++ b/kagenti/ui/lib/build_utils.py
@@ -169,6 +169,48 @@ def _is_valid_env_entry(env_var: dict) -> bool:
     return bool(has_structured or has_plain)
 
 
+def _merge_env_vars(
+    base: Optional[list], overrides: Optional[list], st_object=None
+) -> list:
+    """Merge two lists of k8s env var dicts by name.
+
+    Entries from `overrides` take precedence and will replace entries from
+    `base` when the names collide. Order is preserved from `base`, with any
+    new override-only entries appended in their provided order.
+
+    Invalid env entries (per `_is_valid_env_entry`) are ignored and a
+    warning is logged or emitted to `st_object` when available.
+    """
+    merged = {}
+    order = []
+
+    def _emit_warning(message: str) -> None:
+        try:
+            if st_object:
+                st_object.warning(message)
+            else:
+                logger.warning(message)
+        except Exception:
+            logger.warning(message)
+
+    def _apply_env_list(env_list: Optional[list], context: str) -> None:
+        if not env_list:
+            return
+        for ev in env_list:
+            if not _is_valid_env_entry(ev):
+                _emit_warning(f"Skipping invalid {context} env entry: {ev}")
+                continue
+            name = ev.get("name").strip()
+            if name not in merged:
+                order.append(name)
+            merged[name] = ev
+
+    _apply_env_list(base, "base")
+    _apply_env_list(overrides, "override")
+
+    return [merged[n] for n in order]
+
+
 # Pipeline mode constants
 DEV_EXTERNAL_MODE = "dev-external"
 DEV_LOCAL_MODE = "dev-local"
@@ -316,11 +358,15 @@ def _construct_tool_resource_body(
     client_secret_for_env = _get_keycloak_client_secret(
         st_object, f"{k8s_resource_name}-client"
     )
-    final_env_vars = list(constants.DEFAULT_ENV_VARS)
-    if additional_env_vars:
-        final_env_vars.extend(additional_env_vars)
+    final_env_vars = _merge_env_vars(
+        constants.DEFAULT_ENV_VARS, additional_env_vars, st_object
+    )
     if client_secret_for_env:
-        final_env_vars.append({"name": "CLIENT_SECRET", "value": client_secret_for_env})
+        final_env_vars = _merge_env_vars(
+            final_env_vars,
+            [{"name": "CLIENT_SECRET", "value": client_secret_for_env}],
+            st_object,
+        )
 
     # Extract service ports from pod_config or use defaults
     if pod_config and pod_config.get("service_ports"):
@@ -664,13 +710,19 @@ def _construct_agent_resource_body(
     client_secret_for_env = _get_keycloak_client_secret(
         st_object, f"{k8s_resource_name}-client"
     )
-    final_env_vars = list(constants.DEFAULT_ENV_VARS)
-    if additional_env_vars:
-        final_env_vars.extend(additional_env_vars)
+    final_env_vars = _merge_env_vars(
+        constants.DEFAULT_ENV_VARS, additional_env_vars, st_object
+    )
     if client_secret_for_env:
-        final_env_vars.append({"name": "CLIENT_SECRET", "value": client_secret_for_env})
-    final_env_vars.append(
-        {"name": "GITHUB_SECRET_NAME", "value": constants.GIT_USER_SECRET_NAME}
+        final_env_vars = _merge_env_vars(
+            final_env_vars,
+            [{"name": "CLIENT_SECRET", "value": client_secret_for_env}],
+            st_object,
+        )
+    final_env_vars = _merge_env_vars(
+        final_env_vars,
+        [{"name": "GITHUB_SECRET_NAME", "value": constants.GIT_USER_SECRET_NAME}],
+        st_object,
     )
 
     pull_secrets = _get_image_pull_secrets(
@@ -1868,27 +1920,56 @@ def render_import_form(
                         env_content = response.text
                         imported_vars = parse_env_file(env_content, st_object)
                         if imported_vars:
-                            existing_names = {
-                                var["name"] for var in st.session_state[custom_env_key]
+                            # Distinguish user-added vars vs configmap-loaded vars
+                            existing_user_names = {
+                                var["name"]
+                                for var in st.session_state[custom_env_key]
+                                if not var.get("configmap_origin", False)
                             }
-                            new_vars = [
-                                var
-                                for var in imported_vars
-                                if var["name"] not in existing_names
-                            ]
-                            duplicate_vars = [
-                                var
-                                for var in imported_vars
-                                if var["name"] in existing_names
-                            ]
-                            st.session_state[custom_env_key].extend(new_vars)
+                            # Map configmap-origin entries by name to allow replacement
+                            configmap_index_by_name = {
+                                var["name"]: idx
+                                for idx, var in enumerate(
+                                    st.session_state[custom_env_key]
+                                )
+                                if var.get("configmap_origin", False)
+                            }
+
+                            skipped_user_duplicates = []
+                            replaced_count = 0
+                            appended = []
+
+                            for var in imported_vars:
+                                name = var.get("name")
+                                if not name:
+                                    continue
+                                if name in existing_user_names:
+                                    skipped_user_duplicates.append(name)
+                                    continue
+                                # mark origin so we can enforce precedence later
+                                var["import_origin"] = "env_file"
+                                if name in configmap_index_by_name:
+                                    # replace the configmap-origin entry
+                                    idx = configmap_index_by_name[name]
+                                    st.session_state[custom_env_key][idx] = var
+                                    replaced_count += 1
+                                else:
+                                    st.session_state[custom_env_key].append(var)
+                                    appended.append(name)
+
                             st_object.success(
                                 "Successfully imported env vars from the .env file"
                             )
-                            if duplicate_vars:
-                                # pylint: disable=line-too-long
+                            if skipped_user_duplicates:
                                 st_object.warning(
-                                    f"⚠️ Skipped {len(duplicate_vars)} duplicate variables {', '.join([var['name'] for var in duplicate_vars])}"
+                                    (
+                                        f"⚠️ Skipped {len(skipped_user_duplicates)} variables already defined by the user: "
+                                        + ", ".join(skipped_user_duplicates)
+                                    )
+                                )
+                            if replaced_count:
+                                st_object.info(
+                                    f"Replaced {replaced_count} configmap-origin variables with values from the .env file"
                                 )
                             st.session_state[import_dialog_key] = False
                             st.rerun()
@@ -1935,6 +2016,12 @@ def render_import_form(
             if key in env_options and isinstance(env_options[key], list):
                 final_additional_envs.extend(env_options[key])
 
+    # We'll process custom env vars into buckets so we can enforce precedence:
+    # selected_env_sets (already added) < configmap-loaded < .env imports < user-custom
+    configmap_bucket = []
+    envfile_bucket = []
+    user_bucket = []
+
     if custom_env_vars:
         for env_var in custom_env_vars:
             # Skip invalid entries centrally
@@ -1943,32 +2030,41 @@ def render_import_form(
 
             name = (env_var.get("name") or "").strip()
 
-            # Structured env var (valueFrom)
+            # Build canonical entry
             if "valueFrom" in env_var and isinstance(env_var.get("valueFrom"), dict):
-                final_additional_envs.append(
-                    {"name": name, "valueFrom": env_var["valueFrom"]}
-                )
-                continue
-
-            # Sometimes structured JSON may be stored under 'value' as a dict
-            if isinstance(env_var.get("value"), dict):
-                # Only allow known keys to be included for manifest predictability
+                env_entry = {"name": name, "valueFrom": env_var["valueFrom"]}
+            elif isinstance(env_var.get("value"), dict):
                 allowed_keys = ["valueFrom", "configMapKeyRef", "secretKeyRef"]
                 env_entry = {"name": name}
                 for key in allowed_keys:
                     if key in env_var["value"]:
                         env_entry[key] = env_var["value"][key]
-                final_additional_envs.append(env_entry)
-                continue
-
-            # Plain string value (helper ensured non-empty)
-            val = env_var.get("value")
-            if isinstance(val, str):
-                final_additional_envs.append({"name": name, "value": val.strip()})
             else:
-                logger.warning(
-                    f"Skipping env var '{name}' with non-string value: {val!r}"
-                )
+                val = env_var.get("value")
+                if isinstance(val, str):
+                    env_entry = {"name": name, "value": val.strip()}
+                else:
+                    logger.warning(
+                        f"Skipping env var '{name}' with non-string value: {val!r}"
+                    )
+                    continue
+
+            # Bucket by origin flags
+            if env_var.get("configmap_origin", False):
+                configmap_bucket.append(env_entry)
+            elif env_var.get("import_origin") == "env_file":
+                envfile_bucket.append(env_entry)
+            else:
+                user_bucket.append(env_entry)
+
+    # Order: selected env sets (already added), then configmap-loaded vars,
+    # then imported .env vars, then user-provided custom vars
+    if configmap_bucket:
+        final_additional_envs.extend(configmap_bucket)
+    if envfile_bucket:
+        final_additional_envs.extend(envfile_bucket)
+    if user_bucket:
+        final_additional_envs.extend(user_bucket)
 
     custom_obj_api = get_custom_objects_api()
     if not custom_obj_api or not core_v1_api:

--- a/kagenti/ui/lib/kube.py
+++ b/kagenti/ui/lib/kube.py
@@ -299,7 +299,7 @@ def _handle_kube_api_exception(st_object, e, resource_name, action="fetching"):
         if hasattr(e, "body"):
             try:
                 st_object.code(e.body, language="json")
-            except:  # pylint: disable=bare-except
+            except Exception:
                 st_object.text(f"Raw error body: {e.body}")
     else:
         st_object.error(f"An unexpected error occurred {action} {resource_name}: {e}")

--- a/kagenti/ui/tests/conftest.py
+++ b/kagenti/ui/tests/conftest.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import types
-
 
 def make_log_container():
     class C:

--- a/kagenti/ui/tests/test_integration_resource_body.py
+++ b/kagenti/ui/tests/test_integration_resource_body.py
@@ -115,16 +115,79 @@ def test_env_file_overrides_env_set():
     assert ports[0].get("value") == "2222"
 
 
-def test_custom_overrides_env_file():
-    # .env defines PORT=2222, user custom defines PORT=3333 -> custom should win
+def test_custom_overrides_env_file(monkeypatch):
+    # Validate the actual bucketing/extension logic used by the UI import flow.
+    # The UI builds `final_additional_envs` by extending lists in this order:
+    # selected env sets (env_set) < configmap-loaded < .env imports < user custom
+    # That assembly can produce duplicate names before the final merge step.
     from lib import constants
 
+    # Simulate an env set coming from configmap
+    env_set = [{"name": "PORT", "value": "1111"}]
+
+    # Simulate imported .env file
     env_file = [{"name": "PORT", "value": "2222"}]
-    custom = [{"name": "PORT", "value": "3333"}]
 
-    merged1 = build_utils._merge_env_vars(constants.DEFAULT_ENV_VARS, env_file)
-    merged2 = build_utils._merge_env_vars(merged1, custom)
+    # Simulate custom user-provided vars (not marked as configmap-origin)
+    custom_vars = [{"name": "PORT", "value": "3333"}]
 
-    ports = [e for e in merged2 if e.get("name") == "PORT"]
-    assert len(ports) == 1
-    assert ports[0].get("value") == "3333"
+    # Emulate how render_import_form assembles final_additional_envs
+    final_additional_envs = []
+    # selected env sets first
+    final_additional_envs.extend(env_set)
+
+    # In the UI, custom_env_vars are bucketed into configmap_bucket, envfile_bucket, user_bucket
+    configmap_bucket = []
+    envfile_bucket = []
+    user_bucket = []
+
+    # For this test we treat the env_file entry as coming from an import (envfile_bucket)
+    for v in env_file:
+        envfile_bucket.append(v)
+
+    for v in custom_vars:
+        # user-provided (no configmap_origin or import_origin flags)
+        user_bucket.append(v)
+
+    # Extend in the same order as the UI
+    final_additional_envs.extend(configmap_bucket)
+    final_additional_envs.extend(envfile_bucket)
+    final_additional_envs.extend(user_bucket)
+
+    # Before the final merge, duplicates will exist (three PORT entries if configmap_bucket had one)
+    ports_before = [e for e in final_additional_envs if e.get("name") == "PORT"]
+    # env_set + envfile + user -> should be 3 entries
+    assert len(ports_before) == 3
+
+    # Now pass through the constructor which performs the final merge with DEFAULT_ENV_VARS
+    monkeypatch.setattr(
+        build_utils,
+        "get_secret_data",
+        lambda core_v1_api, namespace, name, key: "gituser",
+    )
+    monkeypatch.setattr(build_utils, "_get_keycloak_client_secret", lambda st, name: "")
+
+    st = DummySt()
+
+    body = build_utils._construct_tool_resource_body(
+        st_object=st,
+        core_v1_api=None,
+        build_namespace="test-ns",
+        resource_name="my-tool",
+        resource_type="Tool",
+        repo_url="https://example.com/repo.git",
+        protocol="mcp",
+        framework="test",
+        additional_env_vars=final_additional_envs,
+        registry_config=None,
+        pod_config=None,
+        image_pull_secret=None,
+    )
+
+    assert body is not None
+
+    env_list = body["spec"]["podTemplateSpec"]["spec"]["containers"][0]["env"]
+    ports_after = [e for e in env_list if e.get("name") == "PORT"]
+    # After the constructor merge, duplicates must be deduplicated and the user value should win
+    assert len(ports_after) == 1
+    assert ports_after[0].get("value") == "3333"

--- a/kagenti/ui/tests/test_integration_resource_body.py
+++ b/kagenti/ui/tests/test_integration_resource_body.py
@@ -103,15 +103,14 @@ def test_custom_env_overrides_default(monkeypatch):
 
 def test_env_file_overrides_env_set():
     # env set defines PORT=1111, .env defines PORT=2222 -> .env should win
-    from lib import constants
-
     env_set = [{"name": "PORT", "value": "1111"}]
     env_file = [{"name": "PORT", "value": "2222"}]
 
-    merged1 = build_utils._merge_env_vars(constants.DEFAULT_ENV_VARS, env_set)
-    merged2 = build_utils._merge_env_vars(merged1, env_file)
+    # Mimic actual code flow: start with env_set, then merge in env_file
+    selected_env_sets = list(env_set)
+    merged = build_utils._merge_env_vars(selected_env_sets, env_file)
 
-    ports = [e for e in merged2 if e.get("name") == "PORT"]
+    ports = [e for e in merged if e.get("name") == "PORT"]
     assert len(ports) == 1
     assert ports[0].get("value") == "2222"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Implement deterministic merging and deduplication of environment variables in the UI so user-provided values always take precedence. This prevents duplicate/conflicting env entries from being written into the generated Kubernetes CustomResource PodTemplateSpec.

### Motivation:

Previously the UI simply concatenated default/configmap env sets, imported [.env](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) entries and user custom vars, which produced duplicate env entries in the generated CR. The operator passes the podTemplateSpec through to the Deployment unchanged, so precedence must be enforced where the CR is constructed (UI).
Users expect explicitly-specified custom variables to override any imported or default values.

### Notes

Certain system-managed variables like CLIENT_SECRET and GITHUB_SECRET_NAME intentionally override user values.

### Testing

Unit / integration tests added and run locally:
12 tests passed in UI test suite

### Migration / compatibility notes

No changes required on the operator side — the change only affects how the UI constructs CRs.
Existing CRs already created remain unchanged. New/updated CRs created by the UI will dedupe env vars and apply the precedence rules.

## Related issue(s)

Fixes #135
