### PR TITLE
🌱 adjust resource limits for kagenti helm charts

### DIFF
--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -120,6 +120,14 @@ containerRegistry:
   env:
     otelTracesExporter: "none"
     logLevel: "info"
+  # Resource defaults for the registry container
+  resources:
+    limits:
+      cpu: 300m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
 # ------------------------------------------------------------------
 #  Metrics Server Configuration

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -155,12 +155,16 @@ spec:
           ports:
             - containerPort: 8501
           resources:
+            {{- if .Values.ui.resources }}
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+            {{- else }}
             limits:
-              cpu: 250m
-              memory: 1Gi
+              cpu: 300m
+              memory: 512Mi
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 256Mi
+            {{- end }}
       volumes:
         - name: cache
           emptyDir: {}

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -56,6 +56,14 @@ ui:
   tag: v0.2.0-alpha.2
   hostname: kagenti-ui.localtest.me
   url: http://kagenti-ui.localtest.me:8080
+  # Resource defaults for the UI container (can be overridden)
+  resources:
+    limits:
+      cpu: 300m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
 # ------------------------------------------------------------------
 #  UI OAuth Secret Creator Configuration
@@ -112,7 +120,11 @@ kagenti-operator-chart:
       # - "--enable-client-registration=false"
       resources:
         limits:
+          cpu: 300m
           memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
 
 # ------------------------------------------------------------------
 #  Kagenti Operator Configuration
@@ -129,7 +141,11 @@ kagenti-operator-chart:
       - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
       resources:
         limits:
+          cpu: 300m
           memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -106,27 +106,6 @@ keycloak:
   realm: demo
 
 # ------------------------------------------------------------------
-#  Platform Operator Configuration
-# ------------------------------------------------------------------
-kagenti-operator-chart:
-  controllerManager:
-    container:
-      args:
-      - "--leader-elect"
-      - "--metrics-bind-address=:8443"
-      - "--health-probe-bind-address=:8081"
-      - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
-      # TODO this should be controllable with a helm value flag in kagenti-platform-operator-chart
-      # - "--enable-client-registration=false"
-      resources:
-        limits:
-          cpu: 300m
-          memory: 512Mi
-        requests:
-          cpu: 100m
-          memory: 256Mi
-
-# ------------------------------------------------------------------
 #  Kagenti Operator Configuration
 # ------------------------------------------------------------------
 kagenti-operator-chart:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

adjust resource limits for the kagenti helm charts

This PR addresses issues of scheduler not being able to place Kagenti components when running on a dev cluster with limited resources.
