### PR TITLE
:seedling: Disable spellcheck job in GitHub Actions

### DIFF
--- a/.github/spellcheck_action.yml
+++ b/.github/spellcheck_action.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   spellchecker:
+    # disable spellcheck with 'false' value.
+    if: false
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Disabled the spellcheck job by setting 'if' to false.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We decided to disable the spellchecker from the pipeline 

## Related issue(s)

Fixes #
