### PR TITLE
🐛 Fixes creation kind cluster if missing before preload.

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/02_setup_cluster.yaml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/02_setup_cluster.yaml
@@ -43,9 +43,8 @@
       fail:
         msg: >-
           Current kubectl context '{{ current_context.stdout }}' does not match the expected
-          kind cluster context 'kind-{{ kind_cluster_name }}'. Please switch to the correct context
-          or set create_kind_cluster=true to auto-create the cluster.
-      when: current_context.stdout != 'kind-{{ kind_cluster_name }}'
+          kind cluster context 'kind-{{ kind_cluster_name }}'. Please switch to the correct context manually.
+      when: current_context.stdout != "kind-" + kind_cluster_name
   when: create_kind_cluster | default(false)
 
 - name: Preload images into kind cluster when requested
@@ -57,12 +56,28 @@
       failed_when: false
       changed_when: false
 
-    - name: Verify kind cluster exists (or create it) before preloading
+    - name: Create kind cluster if missing before preloading
       command: >-
         kind create cluster --name {{ kind_cluster_name }} --config {{ (kind_container_registry_enabled | default(true)) | ternary(kind_config_registry, kind_config) }}
       args:
         chdir: "{{ playbook_dir }}"
       when: kind_cluster_name not in (kind_clusters_for_preload.stdout | default(''))
+
+    # Begin modifications with assistance from Copilot
+    - name: Verify kubectl context for kind cluster before preloading
+      command: kubectl config current-context
+      register: kubectl_current_context
+      failed_when: false
+      changed_when: false
+
+    - name: Fail if kube context is not pointing to the kagenti cluster before preloading
+      fail:
+        msg: >-
+          Kubectl current context ('{{ kubectl_current_context.stdout | default ('')}}') does not
+          match the expected context ('kind-{{ kind_cluster_name }}'). Please ensure your kubeconfig
+          is configured correctly.
+      when: kubectl_current_context.stdout != "kind-" + kind_cluster_name
+    # End modifications with assistance from Copilot
 
     - name: Stat preload images file
       stat:


### PR DESCRIPTION
## Summary

This PR fixes the bug where a local kind cluster does exist, but it is not kagenti.

In other words, the context is set to an existing kind cluster, which short-circuits the first check for kind cluster because [`kubectl_api.rc`](https://github.com/rubambiza/kagenti/blob/40f2b782ba8ba53ab462417646c106741a258a2c/deployments/ansible/roles/kagenti_installer/tasks/02_setup_cluster.yaml#L31) does, in fact, return 0. The alternative was to force the user to create the cluster manually, but I wanted to make this frictionless such that the `kagenti` cluster is automatically created for the user before preloading.

## Related issue(s)

Fixes #491 