### PR TITLE
Bump OpenShift version to 4.20.11 

### DIFF
--- a/.github/dockerfiles/hypershift-ci/Dockerfile
+++ b/.github/dockerfiles/hypershift-ci/Dockerfile
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 # === PINNED VERSIONS ===
 # Update these to upgrade tooling
-ARG OC_VERSION=4.20.10
+ARG OC_VERSION=4.20.11
 ARG AWS_CLI_VERSION=2.15.0
 ARG GO_VERSION=1.23.5
 

--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -68,7 +68,7 @@ fi
 # Configuration with defaults
 REPLICAS="${REPLICAS:-2}"
 INSTANCE_TYPE="${INSTANCE_TYPE:-m5.xlarge}"
-OCP_VERSION="${OCP_VERSION:-4.20.10}"
+OCP_VERSION="${OCP_VERSION:-4.20.11}"
 
 # Cluster suffix - if not set, use positional arg, then default to username
 # Set CLUSTER_SUFFIX="" to generate a random suffix

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -27,7 +27,7 @@ on:
       ocp_version:
         description: 'OpenShift version'
         required: false
-        default: '4.20.10'
+        default: '4.20.11'
       skip_destroy:
         description: 'Skip cluster destruction (for debugging)'
         required: false
@@ -50,7 +50,7 @@ env:
   # For push to main: run number (each push gets fresh cluster)
   # For workflow_dispatch: user-provided or run_number
   CLUSTER_SUFFIX: ${{ inputs.cluster_name || (github.event.pull_request.number && format('pr{0}', github.event.pull_request.number)) || github.run_number }}
-  OCP_VERSION: ${{ inputs.ocp_version || '4.20.10' }}
+  OCP_VERSION: ${{ inputs.ocp_version || '4.20.11' }}
   # Slot management for parallel CI runs
   MAX_SLOTS: ${{ inputs.max_parallel || '6' }}
   SLOT_TIMEOUT: '60'  # Minutes to wait for an available slot


### PR DESCRIPTION
## Summary

Bump the default OpenShift version from 4.20.10 to 4.20.11 to test the HyperShift CI infrastructure with a newer patch release.

## Changes

- Updated `OCP_VERSION` default in `.github/scripts/hypershift/create-cluster.sh`
- Updated `OCP_VERSION` default in `.github/workflows/e2e-hypershift.yaml`
- Updated `OC_VERSION` in `.github/dockerfiles/hypershift-ci/Dockerfile`

## Test Plan

- [ ] HyperShift CI creates cluster successfully with OpenShift 4.20.11
- [ ] Kagenti platform deploys successfully
- [ ] Weather agent/tool builds complete
- [ ] E2E tests pass

## Notes

This is a minimal change to validate that the CI pipeline handles OpenShift version updates correctly. The version bump from 4.20.10 to 4.20.11 is a patch release and should be compatible with all existing configurations.

## Related Issues

[#309 ](https://github.com/kagenti/kagenti/issues/309)