### PR TITLE
🐛 Pin ossf/scorecard-action to v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif


### PR DESCRIPTION
The floating v2 tag was removed or doesn't exist, causing CI failures. Pin to specific version v2.4.3 for stability.

