### PR TITLE
🌱 Hypershift autoscaling enhancements

### DIFF
--- a/.github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
+++ b/.github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 
 echo "Cloning hypershift-automation..."
 
-# Clone from Ladas fork with additional tags support, VPC endpoint cleanup, and route table fix
+# Clone from Ladas fork with additional tags support, VPC endpoint cleanup, route table fix,
+# and NodePool autoscaling support
 # Using exact commit for reproducibility and safety
-HYPERSHIFT_AUTOMATION_COMMIT="59ae16b"
+HYPERSHIFT_AUTOMATION_COMMIT="9dff660"
 
 git clone --branch add-additional-tags-support \
     https://github.com/Ladas/hypershift-automation.git /tmp/hypershift-automation

--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -32,6 +32,9 @@
 #   # Custom instance type and replicas
 #   REPLICAS=3 INSTANCE_TYPE=m5.2xlarge ./.github/scripts/hypershift/create-cluster.sh
 #
+#   # Enable NodePool autoscaling (min 1, max 3 nodes)
+#   AUTOSCALE_MIN=1 AUTOSCALE_MAX=3 ./.github/scripts/hypershift/create-cluster.sh
+#
 
 set -euo pipefail
 
@@ -69,6 +72,12 @@ fi
 REPLICAS="${REPLICAS:-2}"
 INSTANCE_TYPE="${INSTANCE_TYPE:-m5.xlarge}"
 OCP_VERSION="${OCP_VERSION:-4.20.11}"
+
+# NodePool autoscaling (optional)
+# Set AUTOSCALE_MIN and AUTOSCALE_MAX to enable autoscaling
+# When set, the NodePool will be configured with cluster-autoscaler after creation
+AUTOSCALE_MIN="${AUTOSCALE_MIN:-}"
+AUTOSCALE_MAX="${AUTOSCALE_MAX:-}"
 
 # Cluster suffix - if not set, use positional arg, then default to username
 # Set CLUSTER_SUFFIX="" to generate a random suffix
@@ -229,6 +238,9 @@ echo "Cluster configuration:"
 echo "  Name:          $CLUSTER_NAME"
 echo "  Region:        $AWS_REGION"
 echo "  Replicas:      $REPLICAS"
+if [[ -n "$AUTOSCALE_MIN" ]] && [[ -n "$AUTOSCALE_MAX" ]]; then
+    echo "  Autoscaling:   min=$AUTOSCALE_MIN, max=$AUTOSCALE_MAX"
+fi
 echo "  Instance Type: $INSTANCE_TYPE"
 echo "  OCP Version:   $OCP_VERSION"
 echo "  Base Domain:   $BASE_DOMAIN"
@@ -292,12 +304,22 @@ cd "$HYPERSHIFT_AUTOMATION_DIR"
 # to all AWS resources (VPC, subnets, security groups, EC2 instances, etc.) and
 # allows IAM policies to restrict operations to only resources tagged with this value.
 # The tag key follows Kubernetes label conventions to avoid conflicts with other tools.
+
+# Build cluster config JSON
+CLUSTER_CONFIG='"name": "'"$CLUSTER_NAME"'", "region": "'"$AWS_REGION"'", "replicas": '"$REPLICAS"', "instance_type": "'"$INSTANCE_TYPE"'", "image": "'"$OCP_VERSION"'"'
+
+# Add autoscaling config if min and max are set
+if [[ -n "$AUTOSCALE_MIN" ]] && [[ -n "$AUTOSCALE_MAX" ]]; then
+    log_info "Autoscaling enabled: min=$AUTOSCALE_MIN, max=$AUTOSCALE_MAX"
+    CLUSTER_CONFIG="$CLUSTER_CONFIG"', "autoscaling": {"min": '"$AUTOSCALE_MIN"', "max": '"$AUTOSCALE_MAX"'}'
+fi
+
 ansible-playbook site.yml \
     -e '{"create": true, "destroy": false, "create_iam": false}' \
     -e '{"iam": {"hcp_role_name": "'"$HCP_ROLE_NAME"'"}}' \
     -e "domain=$BASE_DOMAIN" \
     -e "additional_tags=kagenti.io/managed-by=${MANAGED_BY_TAG}" \
-    -e '{"clusters": [{"name": "'"$CLUSTER_NAME"'", "region": "'"$AWS_REGION"'", "replicas": '"$REPLICAS"', "instance_type": "'"$INSTANCE_TYPE"'", "image": "'"$OCP_VERSION"'"}]}'
+    -e '{"clusters": [{'"$CLUSTER_CONFIG"'}]}'
 
 # ============================================================================
 # 7. Summary and Next Steps

--- a/.github/scripts/hypershift/setup-autoscaling.sh
+++ b/.github/scripts/hypershift/setup-autoscaling.sh
@@ -794,14 +794,18 @@ spec:
     # Value is a decimal string: "0.5" = 50% utilization threshold
     # Lower values = more aggressive scale-down (e.g., "0.3" = 30%)
     # Higher values = keep nodes longer (e.g., "0.7" = 70%)
-    utilizationThreshold: "${UTILIZATION_THRESHOLD}"
+    utilizationThreshold: \"${UTILIZATION_THRESHOLD}\"
 EOF"
             log_cmd "$CA_CMD"
             echo ""
 
             if [[ "$APPLY" == "true" ]]; then
-                eval "$CA_CMD"
-                log_success "ClusterAutoscaler created/updated"
+                if eval "$CA_CMD"; then
+                    log_success "ClusterAutoscaler created/updated"
+                else
+                    log_error "Failed to create/update ClusterAutoscaler"
+                    exit 1
+                fi
                 echo ""
             fi
 

--- a/.github/scripts/hypershift/setup-autoscaling.sh
+++ b/.github/scripts/hypershift/setup-autoscaling.sh
@@ -738,8 +738,13 @@ spec:
   # skipNodesWithLocalStorage: If true, nodes with pods using local storage
   # (emptyDir, hostPath) will NOT be considered for scale-down.
   #   true  = Protect nodes with local storage (safer for stateful apps)
-  #   false = Allow scale-down even with local storage (more aggressive)
-  skipNodesWithLocalStorage: true
+  #   false = Allow scale-down even with local storage (required for HyperShift)
+  #
+  # IMPORTANT: On HyperShift management clusters, most platform pods (Prometheus,
+  # Alertmanager, Thanos, ACM) use emptyDir for caching. Setting this to 'true'
+  # will BLOCK scale-down of underutilized nodes. These pods are designed to
+  # handle restarts - their emptyDir data (WAL, cache) can be safely recreated.
+  skipNodesWithLocalStorage: false
 
   # ============================================================================
   # RESOURCE LIMITS


### PR DESCRIPTION
 ## Summary
  - Add cost-optimized autoscaling with scheduler profile support
  - Add NodePool autoscaling for HyperShift hosted clusters
  - Enable autoscaling during cluster creation via environment variables

## Features
  - `--scheduler-profile` option for HighNodeUtilization (bin-packing)
  - `--aggressive` flag for faster scale-down timers
  - `--nodepool-all` flag to configure all NodePools at once
  - `AUTOSCALE_MIN`/`AUTOSCALE_MAX` env vars for create-cluster.sh

## Test plan
  - [ ] Run setup-autoscaling.sh --help
  - [ ] Test on existing HyperShift cluster
  - [ ] Create cluster with autoscaling enabled

## Related issue(s)

