### PR TITLE
:memo: Let MCP Gateway share the Kagenti Gateway

### DIFF
--- a/charts/kagenti/templates/mcp-gateway-ns-labeler.yaml
+++ b/charts/kagenti/templates/mcp-gateway-ns-labeler.yaml
@@ -87,13 +87,8 @@ spec:
               for ns in "{{ .Values.mcpGateway.namespaces.mcpSystem }}" "{{ .Release.Namespace }}"; do
                 echo "Labeling namespace: $ns"
                 for i in $(seq 1 $MAX_RETRIES); do
-                  if [ "$ns" = "{{ .Values.mcpGateway.namespaces.mcpSystem }}" ]; then
-                    kubectl label namespace "$ns" \
-                      istio-discovery=enabled istio.io/dataplane-mode=ambient --overwrite && break
-                  else
-                    kubectl label namespace "$ns" \
+                  kubectl label namespace "$ns" \
                       istio-discovery=enabled istio.io/dataplane-mode=ambient shared-gateway-access="true" --overwrite && break
-                  fi
                   echo "  Attempt $i/$MAX_RETRIES failed, retrying in ${RETRY_DELAY}s..."
                   sleep $RETRY_DELAY
                 done

--- a/charts/kagenti/templates/mcp-gateway.yaml
+++ b/charts/kagenti/templates/mcp-gateway.yaml
@@ -37,8 +37,8 @@ metadata:
     {{- include "kagenti.labels" . | nindent 4 }}
 spec:
   parentRefs:
-    - name: mcp-gateway
-      namespace: "{{ .Values.mcpGateway.namespaces.gatewaySystem }}"
+    - name: http
+      namespace: kagenti-system
   hostnames:
   - "{{ .Values.mcpGateway.hostname }}"
   rules:


### PR DESCRIPTION
Resolves #377

Currently we can't curl the MCP from outside the cluster because only the Kagenti gateway is exposed outside the cluster.

- One approach to solve is to let MCP Gateway pods use Kagenti's Gateway
- The other approach is the create extraPortMappings for the Gateway in mcp-system and let MCP Gateway continue using that Gateway.

This PR uses the first approach.  To test, deploy using `deployments/ansible/run-install.sh` and verify `curl -v mcp.127-0-0-1.sslip.io:8080/.well-known/oauth-protected-resource` returns JSON.  It isn't clear if the MCP 

An alternative is to add port mappings for the other Gateway.

@pdettori @huang195 Let me know which approach is preferred