### PR TITLE
fix: Use correct commit SHA for scorecard-action v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- Fix OpenSSF Scorecard workflow failing with "imposter commit" error
- The workflow was using the annotated tag object SHA (`99c09fe...`) instead of the actual commit SHA (`4eaacf0...`)
- The OpenSSF API only accepts dereferenced commit SHAs, not tag object SHAs

## Root Cause
When GitHub Actions are pinned using an annotated tag's SHA, the tag object SHA is different from the underlying commit SHA. The scorecard-action v2.4.3 tag is annotated:
- Tag object: `99c09fe975337306107572b4fdf4db224cf8e2f2`
- Actual commit: `4eaacf0543bb3f2c246792bd56e8cdeffafb205a`

## Test plan
- [ ] Merge PR and verify scorecard workflow passes on next push to main
- [ ] Verify OpenSSF Scorecard badge works: https://scorecard.dev/viewer/?uri=github.com/kagenti/kagenti

🤖 Generated with [Claude Code](https://claude.ai/code)