### PR TITLE
fix: Use correct commit SHAs for github/codeql-action v4

### DIFF
--- a/.github/workflows/build-hypershift-ci-image.yaml
+++ b/.github/workflows/build-hypershift-ci-image.yaml
@@ -71,6 +71,6 @@ jobs:
 
       - name: Upload Trivy scan results
         if: github.event_name != 'pull_request'
-        uses: github/codeql-action/upload-sarif@ab28d5ce09b08e4700b2296d39d684a7ac71d1e7  # v4
+        uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314  # v4
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -53,7 +53,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to Security tab
-        uses: github/codeql-action/upload-sarif@ab28d5ce09b08e4700b2296d39d684a7ac71d1e7  # v4
+        uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314  # v4
         with:
           sarif_file: scorecard.sarif
 

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -467,17 +467,17 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ab28d5ce09b08e4700b2296d39d684a7ac71d1e7  # v4
+        uses: github/codeql-action/init@6bc82e05fd0ea64601dd4b465378bbcf57de0314  # v4
         with:
           languages: python
           # Use security-extended queries for more thorough analysis
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ab28d5ce09b08e4700b2296d39d684a7ac71d1e7  # v4
+        uses: github/codeql-action/autobuild@6bc82e05fd0ea64601dd4b465378bbcf57de0314  # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ab28d5ce09b08e4700b2296d39d684a7ac71d1e7  # v4
+        uses: github/codeql-action/analyze@6bc82e05fd0ea64601dd4b465378bbcf57de0314  # v4
         with:
           category: "/language:python"
 


### PR DESCRIPTION
## Summary

Fix OpenSSF Scorecard workflow failing with "imposter commit" error by using correct commit SHAs instead of annotated tag object SHAs.

**Files changed:** `scorecard.yaml`, `build-hypershift-ci-image.yaml`, `security-scans.yaml`
**Actions fixed:** `init`, `autobuild`, `analyze`, `upload-sarif` (5 occurrences)

## Why Tag Object SHAs Don't Work

Git has two types of tags:

| Type | How Created | Tag SHA |
|------|-------------|---------|
| Lightweight | `git tag v1.0.0 <commit>` | Equals commit SHA |
| Annotated | `git tag -a v1.0.0 -m "msg"` | **Different** from commit SHA |

**Annotated tags** are separate git objects with metadata (author, date, message). The tag object SHA is NOT the commit SHA.

### The API Trap

```bash
# This returns the TAG OBJECT SHA, not the commit!
gh api repos/github/codeql-action/git/refs/tags/v4 --jq '.object.sha'
# Returns: ab28d5ce... (tag object)

# You must dereference to get the actual commit:
gh api repos/github/codeql-action/git/tags/ab28d5ce... --jq '.object.sha'
# Returns: 6bc82e05... (commit)
```

### Why OpenSSF Rejects Tag Object SHAs

1. GitHub Actions runtime: Resolves `ab28d5ce...` → finds tag → follows to commit → works ✅
2. OpenSSF Scorecard API: "Is `ab28d5ce...` a commit?" → No, it's a tag object → **"imposter commit"** ❌

## The Fix

| Before (Tag Object) | After (Commit) |
|---------------------|----------------|
| `ab28d5ce09b08e4700b2296d39d684a7ac71d1e7` | `6bc82e05fd0ea64601dd4b465378bbcf57de0314` |

## How to Pin Actions Correctly

```bash
# Get the correct SHA for any action version
get_action_commit() {
  local repo=$1 tag=$2
  local ref=$(gh api "repos/$repo/git/refs/tags/$tag")
  local sha=$(echo "$ref" | jq -r '.object.sha')
  local type=$(echo "$ref" | jq -r '.object.type')
  
  if [ "$type" = "tag" ]; then
    # Annotated tag - dereference
    gh api "repos/$repo/git/tags/$sha" --jq '.object.sha'
  else
    # Lightweight tag - use directly
    echo "$sha"
  fi
}

# Usage
get_action_commit "github/codeql-action" "v4"
```

## Test Plan

- [ ] Merge and verify scorecard workflow passes on push to main
- [ ] Verify OpenSSF Scorecard badge loads: https://scorecard.dev/viewer/?uri=github.com/kagenti/kagenti

🤖 Generated with [Claude Code](https://claude.ai/code)