### PR TITLE
:seedling: Bump kagenti-webhook and operator versions 

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-alpha.19
+  version: 0.2.0-alpha.20
 - name: kagenti-webhook-chart
   repository: oci://ghcr.io/kagenti/kagenti-extensions
-  version: 0.4.0-alpha.1
-digest: sha256:b21bcf62137939a32eb2aeb3cae86d5410f051c4644c26b4f911c622b112b7c1
-generated: "2026-02-05T15:24:54.508679-05:00"
+  version: 0.4.0-alpha.3
+digest: sha256:cc91902369ec675a1cee99b1ad973135e744b748af22faa125d3d8523a124876
+generated: "2026-02-16T12:01:10.20847-05:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,10 +7,10 @@ appVersion: "0.1.2"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-alpha.19  # TODO: Bump after kagenti-operator PR #159 merges (removes AgentBuild CRD)
+  version: 0.2.0-alpha.20  # TODO: Bump after kagenti-operator PR #159 merges (removes AgentBuild CRD)
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 - name: kagenti-webhook-chart
-  version: 0.4.0-alpha.2
+  version: 0.4.0-alpha.3
   repository: oci://ghcr.io/kagenti/kagenti-extensions
   condition: components.platformWebhook.enabled


### PR DESCRIPTION
## Summary
This PR updates Chart.yaml to bump up version of kagenti-webhook to v0.4.0-alpha.2 to pick the latest webhook code 

## Related issue(s)

## (Optional) Testing Instructions

Fixes #
