### PR TITLE
:bug: Create authbridge configmaps in user namespaces

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -210,26 +210,6 @@ data:
   TARGET_SCOPES: "openid auth-target-aud"
 ---
 # ——————————————————————————————————————————————————————————————————————————————
-#  ConfigMap for SPIFFE Helper in Namespace: {{ . }}
-# ——————————————————————————————————————————————————————————————————————————————
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: spiffe-helper-config
-  namespace: {{ . }}
-data:
-  helper.conf: |
-    agent_address = "/spiffe-workload-api/spire-agent.sock"
-    cmd = ""
-    cmd_args = ""
-    cert_dir = "/opt"
-    renew_signal = ""
-    svid_file_name = "svid.pem"
-    svid_key_file_name = "svid_key.pem"
-    svid_bundle_file_name = "svid_bundle.pem"
-    jwt_svids = [{jwt_audience="kagenti", jwt_svid_file_name="jwt_svid.token"}]
----
-# ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for Envoy in Namespace: {{ . }}
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: v1


### PR DESCRIPTION
## Summary
This PR installs configMaps in user namespaces (team1, team2, etc) which are required by AuthBridge sidecars:

- envoy-config
- authbridge-config 

## Related issue(s)

## (Optional) Testing Instructions

Fixes #
