### PR TITLE
🌱 Report E2E result before cleanup finishes

### DIFF
--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -349,12 +349,12 @@ jobs:
           SKIP_DESTROY: 'false'
 
   # ==========================================================================
-  # Post Results Comment
+  # Post Results - Reports E2E result immediately, doesn't wait for cleanup
   # ==========================================================================
   post-results:
     name: Post Results
     runs-on: ubuntu-latest
-    needs: [authorize, e2e-tests, cleanup]
+    needs: [authorize, e2e-tests]
     if: always() && needs.authorize.outputs.authorized == 'true'
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary
- **PR workflow**: Remove `cleanup` from `post-results` job dependencies so the commit status (pass/fail) is posted as soon as E2E tests complete, without waiting for cluster destruction
- **Main workflow**: Add an `E2E Result` gate job that reports test outcome immediately — cleanup continues in the background

## Why
Currently the PR commit status waits for cleanup to finish before reporting success/failure. Cleanup can take 10-15 minutes and has no bearing on whether tests passed. This change lets maintainers see the test result sooner and merge without waiting for infrastructure teardown.

## What changes
- `e2e-hypershift-pr.yaml`: `post-results.needs` changed from `[authorize, e2e-tests, cleanup]` to `[authorize, e2e-tests]`
- `e2e-hypershift.yaml`: Added `result` gate job that depends only on `e2e-ocp-kagenti-operator`

## Test plan
- [ ] Trigger `/run-e2e` on a test PR and verify commit status appears before cleanup finishes
- [ ] Verify cleanup still runs to completion in background
- [ ] Verify `E2E Result` gate job passes/fails correctly on main workflow

🤖 Generated with [Claude Code](https://claude.ai/code)