### PR TITLE
🌱 Pass OPENAI_API_KEY to HyperShift CI deploy

### DIFF
--- a/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
+++ b/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
@@ -24,17 +24,19 @@ export ANSIBLE_PYTHON_INTERPRETER
 # Use MAIN_REPO_ROOT so secrets are shared across worktrees
 SECRETS_FILE="$MAIN_REPO_ROOT/deployments/envs/.secret_values.yaml"
 if [ ! -f "$SECRETS_FILE" ]; then
-    echo "Creating minimal secrets file for CI..."
-    cat > "$SECRETS_FILE" << 'EOF'
+    # Use real OPENAI_API_KEY from env if available (passed from GitHub secrets)
+    OPENAI_KEY="${OPENAI_API_KEY:-ci-test-openai-key}"
+    echo "Creating secrets file for CI..."
+    cat > "$SECRETS_FILE" <<EOF
 # Auto-generated secrets for CI
 global: {}
 charts:
   kagenti:
     values:
       secrets:
-        # Placeholder - not needed for basic E2E tests
         githubUser: "ci-user"
         githubToken: "ci-token-placeholder"
+        openaiApiKey: "${OPENAI_KEY}"
 EOF
 fi
 

--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -260,6 +260,7 @@ jobs:
         run: bash .github/scripts/hypershift/ci/70-deploy-kagenti.sh
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Set up Python
         if: success()

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -150,6 +150,7 @@ jobs:
         run: bash .github/scripts/hypershift/ci/70-deploy-kagenti.sh
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Set up Python
         if: success()


### PR DESCRIPTION
## Summary

The weather-service agent on OpenShift uses OpenAI (gpt-4o-mini) for LLM calls. Without the API key in the HyperShift CI deploy, the `openai-secret` K8s secret gets a placeholder value, causing the agent to return empty responses.

## Changes

- `e2e-hypershift-pr.yaml`: Pass `OPENAI_API_KEY` secret to the Deploy Kagenti step
- `70-deploy-kagenti.sh`: Include `openaiApiKey` in the secrets file from the `OPENAI_API_KEY` env var (falls back to placeholder if unset — safe for environments without the secret)

## Test plan

- [x] Verified on local HyperShift cluster (mlfl5) — agent conversation tests pass
- [ ] HyperShift CI should pass agent conversation tests after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)