### PR TITLE
Docs: add API bearer token authentication design

### DIFF
--- a/docs/plans/2025-02-05-api-bearer-token-auth-design.md
+++ b/docs/plans/2025-02-05-api-bearer-token-auth-design.md
@@ -168,11 +168,18 @@ apiOAuthSecret:
 
 ## Token Usage for External Clients
 
+### Default Service Account (`kagenti-api`)
+
+The auto-provisioned `kagenti-api` client is a shared credential intended for **testing and development only**.
+
+> **Warning:** Using a shared credential in production is an anti-pattern. It prevents audit traceability (you cannot identify which client made a request), complicates credential rotation, and violates least-privilege principles. For production deployments, each external client (service, script, automation) should have its own Keycloak service account client with appropriate roles. See documentation for creating additional service account clients in Keycloak.
+
 ### Getting a Token
 
 External clients obtain tokens by POSTing to the Keycloak token endpoint:
 
 ```bash
+# Using the default test credential (development/testing only)
 curl -X POST "http://keycloak.localtest.me:8080/realms/demo/protocol/openid-connect/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=client_credentials" \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Design document for protecting the Kagenti backend API with JWT bearer tokens from Keycloak. Covers:

- RBAC with three roles (viewer, operator, admin)
- Client Credentials Grant for external clients
- Auto-provisioned service account in Keycloak
- Endpoint permission matrix
- Implementation plan and file changes

## Related issue(s)

Fixes #630 
