### PR TITLE
🐛 Make cleanup job resilient to step failures

### DIFF
--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -337,6 +337,7 @@ jobs:
         run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
 
       - name: Destroy HyperShift cluster
+        continue-on-error: true  # Cleanup must not fail the job
         run: bash .github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -348,10 +349,12 @@ jobs:
 
       - name: Release CI slot
         if: always()
+        continue-on-error: true  # Slot release must not fail the job
         run: bash .github/scripts/hypershift/ci/slots/release.sh "${{ needs.e2e-tests.outputs.slot_id }}"
 
       - name: Summary
         if: always()
+        continue-on-error: true  # Summary must not fail the job
         run: bash .github/scripts/hypershift/ci/99-summary.sh
         env:
           CLUSTER_SUFFIX: ${{ env.CLUSTER_SUFFIX }}

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -274,6 +274,7 @@ jobs:
       - name: Destroy HyperShift cluster
         # Use the same cleanup script as pre-cleanup - it handles CLUSTER_SUFFIX
         # This ensures cleanup works even if e2e job failed before setting outputs
+        continue-on-error: true  # Cleanup must not fail the job
         run: bash .github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -285,10 +286,12 @@ jobs:
 
       - name: Release CI slot
         if: always()
+        continue-on-error: true  # Slot release must not fail the job
         run: bash .github/scripts/hypershift/ci/slots/release.sh "${{ needs.e2e-ocp-kagenti-operator.outputs.slot_id }}"
 
       - name: Summary
         if: always()
+        continue-on-error: true  # Summary must not fail the job
         run: bash .github/scripts/hypershift/ci/99-summary.sh
         env:
           CLUSTER_SUFFIX: ${{ env.CLUSTER_SUFFIX }}


### PR DESCRIPTION
## Summary

Add `continue-on-error: true` to all steps in the cleanup job of both HyperShift workflows:
- `e2e-hypershift.yaml` (push to main)
- `e2e-hypershift-pr.yaml` (PR comment triggered)

Steps affected: Destroy cluster, Release CI slot, Summary.

## Why

Run [#21831897165](https://github.com/kagenti/kagenti/actions/runs/21831897165) shows the cleanup job failing because checkout failed (PR head was likely force-pushed), which cascaded to slot release and summary also failing. The cleanup job should never fail — it exists for best-effort resource cleanup, not as a quality gate.

## Test plan

- [ ] Verify cleanup job succeeds even when individual steps fail
- [ ] Verify slot release failure doesn't block cleanup completion