### PR TITLE
fix: Revert UI OAuth realm to master for working login

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ Use `deployments/ansible/run-install.sh --help` for options. For more detailed i
 ### Access the UI
 
 ```bash
+# Show service URLs and credentials
+.github/scripts/local-setup/show-services.sh
+
 open http://kagenti-ui.localtest.me:8080
-# Login: admin / admin
+# Login with credentials from show-services.sh output (default: admin / admin)
 ```
 
 From the UI you can:

--- a/charts/kagenti/templates/NOTES.txt
+++ b/charts/kagenti/templates/NOTES.txt
@@ -14,10 +14,9 @@ echo "https://$(kubectl get route kagenti-ui -n kagenti-system -o jsonpath='{.st
 ```
 {{- end }}
 
-The initial credentials for Keycloak can be shown with the command:
+Show all service URLs and credentials:
 ```
-{{- $command := `kubectl get secret keycloak-initial-admin -n keycloak -o go-template='Username: {{.data.username | base64decode}}  password: {{.data.password | base64decode}}{{"\n"}}'` -}}
-{{ $command | indent 2 }}
+  .github/scripts/local-setup/show-services.sh
 ```
 
 

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -117,7 +117,7 @@ keycloak:
   adminPasswordKey: password
   url: http://keycloak-service.keycloak:8080
   publicUrl: http://keycloak.localtest.me:8080
-  realm: demo
+  realm: master
 
 # ------------------------------------------------------------------
 #  Kagenti Operator Configuration


### PR DESCRIPTION
## Summary

- Revert `keycloak.realm` from `demo` back to `master` so `keycloak-initial-admin` credentials (`admin/admin`) work for UI login
- Fix `show-services.sh` Kind detection (check kubectl context for `kind-` prefix before `oc whoami`)
- Update Helm `NOTES.txt` to reference `show-services.sh`
- Update README quick start to reference `show-services.sh`

The demo realm approach requires the agent-oauth-secret container image to be up-to-date (to create the realm and test user), and introduces race conditions between jobs. Reverting to master realm restores working login with zero configuration.

Closes #652

## Test plan

- [ ] Deploy to Kind: `kind delete cluster --name kagenti && .worktrees/master-realm/.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy`
- [ ] Run `.worktrees/master-realm/.github/scripts/local-setup/show-services.sh` — should show `admin / admin (master realm)`
- [ ] Open `http://kagenti-ui.localtest.me:8080` — login with `admin / admin` should succeed
- [ ] Keycloak login page should show "Keycloak" (not "Demo")

🤖 Generated with [Claude Code](https://claude.com/claude-code)