### PR TITLE
fix: Post-merge Trivy scan should not fail CI

### DIFF
--- a/.github/workflows/security-post-merge.yaml
+++ b/.github/workflows/security-post-merge.yaml
@@ -10,8 +10,8 @@
 # - Trivy config scan: blocks on IaC misconfigurations (PR-specific)
 #
 # This workflow handles:
-# - Full blocking Trivy fs scan on the merged codebase
-# - Creates GitHub issues if new vulnerabilities are found
+# - Full Trivy fs scan on the merged codebase (never fails)
+# - Uploads SARIF results to GitHub Security tab (code-scanning alerts)
 #
 name: Post-Merge Security Scan
 
@@ -46,7 +46,8 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           severity: 'CRITICAL,HIGH'
-          exit-code: '1'
+          # Never fail - results are uploaded to GitHub Security tab (code-scanning)
+          exit-code: '0'
           ignore-unfixed: true
           format: 'table'
 


### PR DESCRIPTION
## Summary
Follow-up to #660. The post-merge Trivy scan still had `exit-code: '1'` which makes main CI red on every merge that touches dependency files.

Results are already uploaded as SARIF to the [Security tab](https://github.com/kagenti/kagenti/security/code-scanning) which handles tracking and dedup. No need to fail the workflow.

## Changes
- `exit-code: '1'` -> `exit-code: '0'` in `security-post-merge.yaml`
- Updated header comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)