### PR TITLE
docs(auth): add API authentication documentation

### DIFF
--- a/docs/api-authentication.md
+++ b/docs/api-authentication.md
@@ -41,6 +41,11 @@ curl -H "Authorization: Bearer $TOKEN" \
   https://kagenti-api.example.com/api/v1/agents
 ```
 
+> **Note:** The default `kagenti-api` client is automatically assigned the
+> `kagenti-operator` realm role (configurable via `apiOAuthSecret.serviceAccountRole`).
+> Tokens obtained with this client's credentials already include this role, so no
+> additional user-role mapping is needed for programmatic access.
+
 ## Roles and Permissions
 
 Kagenti uses Role-Based Access Control (RBAC) with three roles:
@@ -88,8 +93,15 @@ apiOAuthSecret:
   enabled: true  # default: false
   clientId: kagenti-api
   secretName: kagenti-api-oauth-secret
-  serviceAccountRole: kagenti-operator
+  serviceAccountRole: kagenti-operator  # role assigned to the client's service account
 ```
+
+The provisioning job automatically assigns the `serviceAccountRole` (default:
+`kagenti-operator`) to the client's service account in Keycloak. Because Client
+Credentials Grant tokens are **not tied to an end-user**, the token's roles come
+entirely from the client's service account. This means tokens obtained with
+these credentials will already carry `kagenti-operator` permissions without any
+additional user-role mapping.
 
 **Retrieve credentials:**
 


### PR DESCRIPTION
## Summary

Phase 5 of API bearer token authentication ([Epic #639](https://github.com/kagenti/kagenti/issues/639)).

> **⚠️ Stacked PR**: This PR depends on [#672](https://github.com/kagenti/kagenti/pull/672) (Phase 4: API OAuth Secret Job). Please merge Phase 4 first.

This PR adds comprehensive documentation for external API access using bearer token authentication.

## New Documentation

**`docs/api-authentication.md`** covers:

- **Quick Start** - Curl commands to get started immediately
- **Roles and Permissions** - RBAC roles and endpoint permission matrix
- **Obtaining Tokens** - Client Credentials Grant flow with examples
- **Using Tokens** - Bearer header usage with Python example
- **Error Responses** - 401/403 error reference with troubleshooting
- **Creating Service Accounts** - Keycloak console and API instructions
- **Security Considerations** - Production best practices and warnings
- **Troubleshooting** - Common issues and debugging commands

## Stacked PR

This is PR 5/5 in the API authentication stack:
1. [#647](https://github.com/kagenti/kagenti/pull/647) RBAC Foundation ✅
2. [#648](https://github.com/kagenti/kagenti/pull/648) Protect Backend Endpoints
3. [#671](https://github.com/kagenti/kagenti/pull/671) Keycloak Realm Roles
4. [#672](https://github.com/kagenti/kagenti/pull/672) API OAuth Secret Job ← **Merge first**
5. **This PR** - Documentation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)