### PR TITLE
🐛 Fix Kind CI dockerhost EndpointSlice IPv6 validation failure

### DIFF
--- a/.github/scripts/common/70-configure-dockerhost.sh
+++ b/.github/scripts/common/70-configure-dockerhost.sh
@@ -6,8 +6,8 @@ source "$SCRIPT_DIR/../lib/logging.sh"
 
 log_step "70" "Configuring dockerhost service"
 
-# Get Docker host IP
-DOCKER_HOST_IP=$(docker network inspect kind | jq -r '.[].IPAM.Config[] | select(.Gateway != null) | .Gateway' | head -1)
+# Get Docker host IP (filter for IPv4 — EndpointSlice requires addressType: IPv4)
+DOCKER_HOST_IP=$(docker network inspect kind | jq -r '.[].IPAM.Config[] | select(.Gateway != null) | .Gateway' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
 if [ -z "$DOCKER_HOST_IP" ] || [ "$DOCKER_HOST_IP" = "null" ]; then
     log_error "Could not determine Docker host IP"


### PR DESCRIPTION
## Summary

- Fix `Configure dockerhost service for Kind` CI step that fails on recent GitHub runner images
- Filter `docker network inspect kind` output to select only IPv4 gateways, matching the EndpointSlice `addressType: IPv4` declaration

## Root Cause Analysis

**Symptom**: All Kind CI runs failing since 2026-02-12 evening with:
```
The EndpointSlice "dockerhost" is invalid: endpoints[0].addresses[0]:
Invalid value: "fc00:f853:ccd:e793::1": must be a valid IPv4 address
```

**Affected runs**: PR #679 (`fix-keycloak`), two dependabot PRs — 4 consecutive failures on the same step.

**Root cause**: `.github/scripts/common/70-configure-dockerhost.sh` uses `docker network inspect kind | jq ... | head -1` to get the Docker gateway IP. The Kind network has both IPv4 and IPv6 IPAM configs. On recent GitHub runner images (`ubuntu-24.04 20260209+`), the IPv6 gateway (`fc00:f853:ccd:e793::1`) is returned first. The EndpointSlice is declared with `addressType: IPv4`, so applying an IPv6 address fails validation.

**Introduced**: Latent bug since commit 13cbe64a (2025-11-26, "Add modular deployment scripts for CI and local use"). Surfaced when runner images changed IPAM ordering.

**Fix**: Add `grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'` to filter for IPv4 addresses before `head -1`.

## Test plan

- [ ] Kind CI `Deploy & Test` job passes (specifically `Configure dockerhost service for Kind` step)
- [ ] Unblocks PR #679 and dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)