### PR TITLE
chore(deps): Bump docker/build-push-action from 6.19.1 to 6.19.2

### DIFF
--- a/.github/workflows/build-dependency-images.yml
+++ b/.github/workflows/build-dependency-images.yml
@@ -58,7 +58,7 @@ jobs:
             type=raw,value=${{ matrix.image_config.tag }}
 
       - name: Build and push ${{ matrix.image_config.name }}
-        uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47  # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: ${{ matrix.image_config.path }}
           file: ${{ matrix.image_config.path }}/Dockerfile

--- a/.github/workflows/build-hypershift-ci-image.yaml
+++ b/.github/workflows/build-hypershift-ci-image.yaml
@@ -51,7 +51,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47  # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .github/dockerfiles/hypershift-ci
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push ${{ matrix.image_config.name }}
-        uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47  # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: ${{ matrix.image_config.path }}/${{ matrix.image_config.name }}
           file: ${{ matrix.image_config.path }}/${{ matrix.image_config.name }}/Dockerfile

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push ${{ matrix.image_config.name }}
-        uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47  # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: ${{ matrix.image_config.path }}/${{ matrix.image_config.name }}
           file: ${{ matrix.image_config.path }}/${{ matrix.image_config.name }}/Dockerfile


### PR DESCRIPTION
## Summary

- Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 6.19.1 to 6.19.2
- Preserves port in `GIT_AUTH_TOKEN` host ([docker/build-push-action#1458](https://github.com/docker/build-push-action/pull/1458))
- Replaces dependabot PR #675 which could not be rebased/recreated due to branch protection issues

## Test plan

- [ ] CI passes (all workflows using `docker/build-push-action` use the updated pin hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)