### PR TITLE
Fix Playwright Page type import for Node.js 25 ESM compatibility

### DIFF
--- a/kagenti/ui-v2/e2e/agent-chat.spec.ts
+++ b/kagenti/ui-v2/e2e/agent-chat.spec.ts
@@ -14,7 +14,7 @@
  *   KEYCLOAK_USER: Keycloak username (default: admin)
  *   KEYCLOAK_PASSWORD: Keycloak password (default: admin)
  */
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const KEYCLOAK_USER = process.env.KEYCLOAK_USER || 'admin';
 const KEYCLOAK_PASSWORD = process.env.KEYCLOAK_PASSWORD || 'admin';


### PR DESCRIPTION
## Summary
- Fix `SyntaxError: The requested module '@playwright/test' does not provide an export named 'Page'` in Playwright UI E2E tests
- `Page` is a TypeScript type (interface), not a runtime JavaScript export. Node.js 25's stricter ESM module resolution rejects it as a named import. Adding `type` keyword ensures it's completely erased during transpilation.
- Verified fix passes all 3 agent-chat Playwright tests on HyperShift cluster (lpvc)

## Test plan
- [x] Verified root cause: `import { Page }` fails on Node.js v25.6.1 ESM
- [x] Applied fix: `import { type Page }` 
- [x] Ran Playwright tests against HyperShift lpvc cluster: 3 passed (16.3s)
- [ ] CI Kind E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)