### PR TITLE
Add Gateway VPC endpoint quota check

### DIFF
--- a/.github/scripts/hypershift/check-quotas.sh
+++ b/.github/scripts/hypershift/check-quotas.sh
@@ -149,6 +149,13 @@ EIP_COUNT=$(aws ec2 describe-addresses --region "$AWS_REGION" --query 'Addresses
 EIP_QUOTA=$(get_quota "ec2" "L-0263D0A3")
 show_quota_line "Elastic IPs" "$EIP_COUNT" "$EIP_QUOTA" 15 "ec2" "L-0263D0A3"
 
+# Count Gateway VPC Endpoints (S3/DynamoDB)
+GATEWAY_VPC_EP_COUNT=$(aws ec2 describe-vpc-endpoints --region "$AWS_REGION" \
+    --filters "Name=vpc-endpoint-type,Values=Gateway" \
+    --query 'VpcEndpoints | length(@)' --output text 2>/dev/null || echo "0")
+GATEWAY_VPC_EP_QUOTA=$(get_quota "vpc" "L-1B52E74A")
+show_quota_line "Gateway VPC endpoints per region" "$GATEWAY_VPC_EP_COUNT" "$GATEWAY_VPC_EP_QUOTA" 10 "vpc" "L-1B52E74A"
+
 echo ""
 
 # =============================================================================


### PR DESCRIPTION
Adds Gateway VPC endpoint quota check (L-1B52E74A) to the check-quotas script.                                                                                                                                                                                                       
          
  This quota monitors S3/DynamoDB Gateway endpoints used by HyperShift clusters. Without this check, we can hit limits during cluster creation without visibility into current usage.                                                                                                  
                             
  ## Testing                                                                                                                                                                                                                                                                           
  - [x] Verified quota check works on us-east-1                                                                                                                                                                                                                                        
  - [ ] Pre-commit hooks passed