### PR TITLE
fix: update COPY paths in auth Dockerfiles for ./kagenti build context

### DIFF
--- a/kagenti/auth/api-oauth-secret/Dockerfile
+++ b/kagenti/auth/api-oauth-secret/Dockerfile
@@ -5,11 +5,11 @@ FROM python:3.12-slim
 WORKDIR /app
 
 # Install dependencies first (better layer caching)
-COPY requirements.txt .
+COPY auth/api-oauth-secret/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy script
-COPY register_api_client.py .
+COPY auth/api-oauth-secret/register_api_client.py .
 
 # Create non-root user for runtime security
 RUN useradd -u 1001 -m appuser && \

--- a/kagenti/auth/mlflow-oauth-secret/Dockerfile
+++ b/kagenti/auth/mlflow-oauth-secret/Dockerfile
@@ -4,13 +4,13 @@ FROM python:3.12-slim
 # Set work directory
 WORKDIR /app
 
-# Copy your script and ensure it's readable
-COPY mlflow_oauth_secret.py .
-RUN chmod 644 mlflow_oauth_secret.py
-
-# Install dependencies
-COPY requirements.txt .
+# Install dependencies first (better layer caching)
+COPY auth/mlflow-oauth-secret/requirements.txt .
 RUN chmod 644 requirements.txt && pip install --no-cache-dir -r requirements.txt
+
+# Copy scripts and ensure they're readable
+COPY auth/mlflow-oauth-secret/mlflow_oauth_secret.py .
+RUN chmod 644 mlflow_oauth_secret.py
 
 # OpenShift runs as random UID, ensure /app is accessible
 RUN chmod -R g=u /app


### PR DESCRIPTION
## Summary

- Fix `api-oauth-secret` Dockerfile COPY paths to use `auth/api-oauth-secret/` prefix matching the `./kagenti` build context set in `build.yaml`
- Fix `mlflow-oauth-secret` Dockerfile COPY paths with the same context-relative pattern
- Both Dockerfiles were missed during the refactoring in #493, which changed the build context from component-local to `./kagenti` for all auth images

## Verification

Both images build successfully locally:
```
docker build -f kagenti/auth/api-oauth-secret/Dockerfile kagenti/    # ✓
docker build -f kagenti/auth/mlflow-oauth-secret/Dockerfile kagenti/  # ✓
```

Fixes #703

## Test plan

- [ ] CI `build-and-push` job succeeds for `api-oauth-secret` image
- [ ] CI `build-and-push` job succeeds for `mlflow-oauth-secret` image
- [ ] Verify no regression in `ui-oauth-secret` and `agent-oauth-secret` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)