### PR TITLE
feat: tool env var UI parity with agents

### DIFF
--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -1839,7 +1839,7 @@ async def finalize_tool_shipwright_build(
         if request.envVars:
             env_vars = _build_tool_env_vars(request.envVars)
         elif tool_config_dict.get("envVars"):
-            env_vars = list(DEFAULT_ENV_VARS) + tool_config_dict["envVars"]
+            env_vars = _build_tool_env_vars([EnvVar(**ev) for ev in tool_config_dict["envVars"]])
         else:
             env_vars = _build_tool_env_vars()
 

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -407,7 +407,14 @@ export const toolService = {
     namespace: string;
     protocol: string;
     framework: string;
-    envVars?: Array<{ name: string; value: string }>;
+    envVars?: Array<{
+      name: string;
+      value?: string;
+      valueFrom?: {
+        secretKeyRef?: { name: string; key: string };
+        configMapKeyRef?: { name: string; key: string };
+      };
+    }>;
     servicePorts?: Array<{
       name: string;
       port: number;
@@ -547,7 +554,14 @@ export const toolShipwrightService = {
       framework?: string;
       workloadType?: 'deployment' | 'statefulset';
       persistentStorage?: { enabled: boolean; size: string };
-      envVars?: Array<{ name: string; value: string }>;
+      envVars?: Array<{
+        name: string;
+        value?: string;
+        valueFrom?: {
+          secretKeyRef?: { name: string; key: string };
+          configMapKeyRef?: { name: string; key: string };
+        };
+      }>;
       servicePorts?: Array<{
         name: string;
         port: number;


### PR DESCRIPTION
## Summary
- Adds Secret and ConfigMap reference support to tool env vars (backend models, `_build_tool_env_vars()` helper, and both create/finalize endpoints)
- Upgrades the Import Tool page env var section to match agents: type selector (Direct Value / Secret / ConfigMap), "Import from File/URL" button with `EnvImportModal`, and empty state text
- Updates `toolService.create` and `toolService.finalizeBuild` TypeScript types to support `valueFrom`
- Reorders deployment method radio buttons so "Build from Source" appears first and is the default

Closes #702

## Test plan
- [ ] Navigate to Tools > Import Tool and verify the env var section shows "Import from File/URL" and "Add Variable" buttons
- [ ] Add a variable and verify the type selector (Direct Value / Secret / ConfigMap) works
- [ ] Select "Secret" type and verify secret-name / key fields appear
- [ ] Select "ConfigMap" type and verify configmap-name / key fields appear
- [ ] Use "Import from File/URL" to import a `.env` file and verify variables populate
- [ ] Verify "Build from Source" is the first deployment method option and selected by default
- [ ] Deploy a tool with mixed env var types (direct + secret ref) and verify the Kubernetes manifest is correct
- [ ] Run `npx tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)