### PR TITLE
fix: update COPY paths in backend and ui-v2 Dockerfiles

### DIFF
--- a/kagenti/backend/Dockerfile
+++ b/kagenti/backend/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:0.9.24 /uv /bin/uv
 
 # Copy dependency files
-COPY pyproject.toml ./
+COPY backend/pyproject.toml ./
 
 # Create virtual environment and install dependencies
 RUN uv venv /app/.venv && \
@@ -38,7 +38,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY --from=builder /app/.venv /app/.venv
 
 # Copy application code
-COPY app/ ./app/
+COPY backend/app/ ./app/
 
 # Set environment variables
 ENV PATH="/app/.venv/bin:$PATH"

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -7,7 +7,7 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 # Copy package files
-COPY package.json ./
+COPY ui-v2/package.json ./
 # Note: If using npm, use package-lock.json instead
 # COPY package-lock.json ./
 
@@ -15,7 +15,7 @@ COPY package.json ./
 RUN npm install
 
 # Copy source code
-COPY . .
+COPY ui-v2/ .
 
 # Build the application
 RUN npm run build
@@ -24,7 +24,7 @@ RUN npm run build
 FROM nginx:1.25-alpine
 
 # Copy nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY ui-v2/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary

- Update `COPY` source paths in `backend/Dockerfile` and `ui-v2/Dockerfile` to be relative to the `./kagenti` build context root
- The build workflow (`build.yaml`) uses `context: ./kagenti` for all images, so `COPY` paths must reference `backend/...` and `ui-v2/...` instead of assuming the context is the Dockerfile's directory
- Same pattern already applied to auth Dockerfiles in PR #704

### Files changed

| File | Change |
|------|--------|
| `kagenti/backend/Dockerfile` | `COPY pyproject.toml` → `COPY backend/pyproject.toml`, `COPY app/` → `COPY backend/app/` |
| `kagenti/ui-v2/Dockerfile` | `COPY package.json` → `COPY ui-v2/package.json`, `COPY . .` → `COPY ui-v2/ .`, `COPY nginx.conf` → `COPY ui-v2/nginx.conf` |

Fixes #709