### PR TITLE
fix: pin image tags to v0.5.0-alpha.7 and harden build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,23 +69,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Compute image tags and OCI labels in shell to avoid sporadic
-      # "Bad credentials" errors from docker/metadata-action's GitHub API calls.
+      # This action automatically creates useful tags based on the Git event.
+      # In this case, it will use the Git tag as the Docker image tag.
       - name: Extract Docker metadata for ${{ matrix.image_config.name }}
         id: meta
-        run: |
-          IMAGE="ghcr.io/${{ github.repository }}/${{ matrix.image_config.name }}"
-          TAG="${{ github.ref_name }}"
-          echo "tags=${IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
-          {
-            echo "labels<<LABELS_EOF"
-            echo "org.opencontainers.image.title=${{ matrix.image_config.name }}"
-            echo "org.opencontainers.image.source=https://github.com/${{ github.repository }}"
-            echo "org.opencontainers.image.version=${TAG}"
-            echo "org.opencontainers.image.revision=${{ github.sha }}"
-            echo "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-            echo "LABELS_EOF"
-          } >> "$GITHUB_OUTPUT"
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ matrix.image_config.name }}
+          tags: |
+            # extract tag from git ref, e.g., v1.0.0 -> 1.0.0
+            type=ref,event=tag
 
       - name: Build and push ${{ matrix.image_config.name }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6


### PR DESCRIPTION
## Summary

- Pin `ui.frontend.tag` and `ui.backend.tag` in Helm values to `v0.5.0-alpha.7` (the latest successfully published version) so Kind CI can pull known-good images instead of failing with `ImagePullBackOff`
- Replace `docker/metadata-action` in `build.yaml` with a shell step that computes image tags and OCI labels locally, eliminating sporadic "Bad credentials" errors caused by GitHub token rotation during API calls

### Context

After PR #710 fixed the Dockerfile COPY paths and tag `v0.5.0-alpha.7` was pushed, all 6 images built successfully. However:

1. The Helm chart defaults still used `tag: latest` which doesn't exist on ghcr.io — the Ansible installer overrides this with the latest git tag, but having a concrete working default is safer
2. The `docker/metadata-action` occasionally fails with `Bad credentials` due to transient GitHub token issues ([example](https://github.com/kagenti/kagenti/actions/runs/22103568279/job/63879713539))

### Files changed

| File | Change |
|------|--------|
| `charts/kagenti/values.yaml` | Pin frontend and backend image tags to `v0.5.0-alpha.7` |
| `.github/workflows/build.yaml` | Replace `docker/metadata-action` with shell-based tag/label computation |

Refs #709