### PR TITLE
feat(skills): add context-safe execution pattern to reduce session costs

### DIFF
--- a/.claude/scripts/lib/context-safe.sh
+++ b/.claude/scripts/lib/context-safe.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# context-safe.sh - Helper functions for keeping Claude Code context window small
+#
+# These functions redirect command output to log files and return only
+# exit codes + brief summaries to the conversation context.
+#
+# Log directory convention:
+#   TDD sessions:  /tmp/kagenti/tdd/$WORKTREE/   (worktree-scoped, survives iterations)
+#   RCA sessions:  /tmp/kagenti/rca/$WORKTREE/   (worktree-scoped)
+#   K8s debugging: /tmp/kagenti/k8s/$CLUSTER/    (cluster-scoped)
+#   General:       /tmp/kagenti/logs/$$-<timestamp>/ (PID-scoped, unique per session)
+#
+# Usage in skills:
+#   export CONTEXT_SAFE_LOG_DIR=/tmp/kagenti/tdd/$WORKTREE
+#   source .claude/scripts/lib/context-safe.sh
+#   run_captured "Deploy kagenti" $CONTEXT_SAFE_LOG_DIR/deploy.log helm upgrade ...
+#
+# Or inline (without sourcing):
+#   command > $LOG_DIR/output.log 2>&1 && echo "OK" || echo "FAIL (see $LOG_DIR/output.log)"
+
+CONTEXT_SAFE_LOG_DIR="${CONTEXT_SAFE_LOG_DIR:-/tmp/kagenti/logs/$$-$(date +%s)}"
+mkdir -p "$CONTEXT_SAFE_LOG_DIR" 2>/dev/null
+
+# Run a command with output captured to a specific file.
+# Usage: run_captured "description" output_file command [args...]
+# Returns: exit code of the command
+# Prints: "OK: description" or "FAIL: description (exit=N, see output_file)"
+run_captured() {
+    local desc="$1" output_file="$2"
+    shift 2
+    mkdir -p "$(dirname "$output_file")" 2>/dev/null
+    "$@" > "$output_file" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "OK: $desc"
+    else
+        echo "FAIL: $desc (exit=$rc, see $output_file)"
+    fi
+    return $rc
+}
+
+# Run a command quietly, showing only a summary.
+# On failure, shows last N lines (default 5) for quick diagnosis.
+# Full output is always available in the log file.
+# Usage: run_quiet "description" command [args...]
+# Usage: TAIL_LINES=10 run_quiet "description" command [args...]
+run_quiet() {
+    local desc="$1"
+    shift
+    local tail_lines="${TAIL_LINES:-5}"
+    local output_file="${CONTEXT_SAFE_LOG_DIR}/cmd-$$-$(date +%s).log"
+    "$@" > "$output_file" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "OK: $desc"
+    else
+        echo "FAIL: $desc (exit=$rc, log=$output_file)"
+        echo "--- last $tail_lines lines ---"
+        tail -"$tail_lines" "$output_file"
+        echo "---"
+    fi
+    return $rc
+}
+
+# Run kubectl command with output to file.
+# Usage: kube_captured "description" output_file kubectl_args...
+# Example: kube_captured "list pods" /tmp/pods.log get pods -n kagenti-system
+kube_captured() {
+    local desc="$1" output_file="$2"
+    shift 2
+    run_captured "$desc" "$output_file" kubectl "$@"
+}
+
+# Run a test suite and parse results.
+# Usage: run_tests "description" output_file test_command [args...]
+# Prints: "PASS: description (N tests)" or "FAIL: description (N failed, see output_file)"
+run_tests() {
+    local desc="$1" output_file="$2"
+    shift 2
+    "$@" > "$output_file" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        # Try to extract test count from pytest output
+        local count
+        count=$(grep -oP '\d+ passed' "$output_file" 2>/dev/null | head -1)
+        echo "PASS: $desc${count:+ ($count)}"
+    else
+        local failed
+        failed=$(grep -oP '\d+ failed' "$output_file" 2>/dev/null | head -1)
+        echo "FAIL: $desc${failed:+ ($failed)} (exit=$rc, see $output_file)"
+        echo "--- last 5 lines ---"
+        tail -5 "$output_file"
+        echo "---"
+    fi
+    return $rc
+}
+
+# Clean up old log files (older than 1 hour)
+cleanup_logs() {
+    find "$CONTEXT_SAFE_LOG_DIR" -name "cmd-*" -mmin +60 -delete 2>/dev/null
+    echo "OK: Cleaned up old logs"
+}

--- a/.claude/skills/ci:monitoring/SKILL.md
+++ b/.claude/skills/ci:monitoring/SKILL.md
@@ -7,6 +7,19 @@ description: Monitor running CI jobs, wait for completion, create tasks for resu
 
 Monitor running CI pipelines and report results. Creates task items for each CI check being monitored.
 
+## Context-Safe Execution (MANDATORY)
+
+**CI log downloads MUST go to files.** Status checks (`gh pr checks`) are small and OK inline.
+
+```bash
+export LOG_DIR=/tmp/kagenti/ci/$(basename $(git rev-parse --show-toplevel))
+mkdir -p $LOG_DIR
+
+# When downloading logs after completion:
+gh run view <run-id> --log-failed > $LOG_DIR/ci-run-<run-id>.log 2>&1; echo "EXIT:$?"
+# Analyze in subagent: Task(subagent_type='Explore') with Grep
+```
+
 ## When to Use
 
 - After pushing to a PR, to track CI completion

--- a/.claude/skills/ci:status/SKILL.md
+++ b/.claude/skills/ci:status/SKILL.md
@@ -7,6 +7,23 @@ description: Check PR CI status - all checks, failures, test results, and artifa
 
 Check the current CI status for a PR and create task items for any failures.
 
+## Context-Safe Execution (MANDATORY)
+
+**CI log output MUST go to files.** `gh pr checks` is small and OK inline.
+`gh run view --log-failed` and artifact downloads MUST redirect:
+
+```bash
+export LOG_DIR=/tmp/kagenti/ci/$(basename $(git rev-parse --show-toplevel))
+mkdir -p $LOG_DIR
+
+# Small output OK inline:
+gh pr checks <PR-number>
+
+# Large output MUST redirect:
+gh run view <run-id> --log-failed > $LOG_DIR/ci-run-<run-id>.log 2>&1; echo "EXIT:$?"
+# Analyze in subagent: Task(subagent_type='Explore') with Grep on the log file
+```
+
 ## When to Use
 
 - After pushing changes to a PR

--- a/.claude/skills/helm:debug/SKILL.md
+++ b/.claude/skills/helm:debug/SKILL.md
@@ -5,6 +5,19 @@ description: Debug Helm chart issues - template rendering, value overrides, hook
 
 # Debug Helm Charts
 
+## Context-Safe Execution (MANDATORY)
+
+**Helm template output can be hundreds of lines.** Always redirect to files:
+
+```bash
+export LOG_DIR=/tmp/kagenti/helm/${WORKTREE:-$(basename $(git rev-parse --show-toplevel))}
+mkdir -p $LOG_DIR
+
+# Redirect helm template output
+helm template kagenti charts/kagenti -n kagenti-system > $LOG_DIR/rendered.yaml 2>&1 && echo "OK" || echo "FAIL"
+# Analyze in subagent: Task(subagent_type='Explore') with Grep to find specific templates/values
+```
+
 ## When to Use
 
 - Helm install/upgrade fails

--- a/.claude/skills/hypershift:debug/SKILL.md
+++ b/.claude/skills/hypershift:debug/SKILL.md
@@ -7,6 +7,20 @@ description: Debug AWS resources for HyperShift clusters - identify stuck resour
 
 This skill helps debug AWS resources related to HyperShift clusters, identifying resources that may be blocking cluster deletion or orphaned infrastructure.
 
+## Context-Safe Execution (MANDATORY)
+
+**AWS CLI and kubectl output MUST go to files.**
+
+```bash
+export LOG_DIR=/tmp/kagenti/hypershift/${CLUSTER:-debug}
+mkdir -p $LOG_DIR
+
+# Pattern: redirect AWS/kubectl output
+aws ec2 describe-vpcs ... > $LOG_DIR/vpcs.log 2>&1 && echo "OK" || echo "FAIL"
+kubectl get hostedclusters -A > $LOG_DIR/clusters.log 2>&1 && echo "OK" || echo "FAIL"
+# Analyze in subagent: Task(subagent_type='Explore') with Grep
+```
+
 ## When to Use
 
 - Cluster deletion is stuck (finalizer not removed)

--- a/.claude/skills/k8s/SKILL.md
+++ b/.claude/skills/k8s/SKILL.md
@@ -7,6 +7,23 @@ description: Kubernetes debugging and troubleshooting skills. Debug pods, check 
 
 Skills for debugging and troubleshooting Kubernetes deployments.
 
+## Context-Safe Execution (MANDATORY)
+
+**All kubectl/oc commands MUST redirect output to files.** Commands in this skill are shown
+in bare form for readability, but when executing them, always use this pattern:
+
+```bash
+# Set log directory (use cluster name or worktree to avoid session collisions)
+export LOG_DIR=/tmp/kagenti/k8s/${CLUSTER:-local}
+mkdir -p $LOG_DIR
+
+# Pattern: redirect output, return status
+kubectl <command> > $LOG_DIR/<descriptive-name>.log 2>&1 && echo "OK" || echo "FAIL (see $LOG_DIR/<descriptive-name>.log)"
+
+# When investigating failures: use Task(subagent_type='Explore') to read log files
+# NEVER read large kubectl output directly into main conversation context
+```
+
 ## Available Sub-Skills
 
 | Skill | Description |

--- a/.claude/skills/k8s:health/SKILL.md
+++ b/.claude/skills/k8s:health/SKILL.md
@@ -7,6 +7,26 @@ description: Check comprehensive platform health including deployments, pods, se
 
 This skill helps you perform comprehensive platform health checks and identify issues quickly.
 
+## Context-Safe Execution (MANDATORY)
+
+**All kubectl/oc commands MUST redirect output to files.** Commands below are shown in bare
+form for readability. When executing, always redirect:
+
+```bash
+export LOG_DIR=/tmp/kagenti/k8s/${CLUSTER:-local}
+mkdir -p $LOG_DIR
+
+# Example: health check script
+.github/scripts/verify_deployment.sh > $LOG_DIR/health-check.log 2>&1 && echo "OK: healthy" || echo "FAIL (see $LOG_DIR/health-check.log)"
+
+# Example: kubectl commands
+kubectl get pods -A > $LOG_DIR/all-pods.log 2>&1 && echo "OK" || echo "FAIL"
+kubectl get deployments -A > $LOG_DIR/deployments.log 2>&1 && echo "OK" || echo "FAIL"
+
+# Analyze results in subagent — NEVER read large output in main context
+# Use Task(subagent_type='Explore') to read log files and return summaries
+```
+
 ## When to Use
 
 - After deployments or cluster restarts

--- a/.claude/skills/k8s:live-debugging/SKILL.md
+++ b/.claude/skills/k8s:live-debugging/SKILL.md
@@ -7,6 +7,22 @@ description: Iterative debugging workflow for fixing issues on a running cluster
 
 Iterative debugging workflow for fixing issues on a running HyperShift cluster.
 
+## Context-Safe Execution (MANDATORY)
+
+**All kubectl/oc commands MUST redirect output to files.** Live debugging generates
+the most context pollution because of iterative check-fix-recheck loops.
+
+```bash
+export LOG_DIR=/tmp/kagenti/k8s/${CLUSTER:-local}
+mkdir -p $LOG_DIR
+
+# Every kubectl command → redirect to file
+kubectl <command> > $LOG_DIR/<name>.log 2>&1 && echo "OK" || echo "FAIL"
+
+# Analyze in subagent: Task(subagent_type='Explore') to read log files
+# Use subagents for BOTH failure analysis AND verifying expected behavior
+```
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/.claude/skills/k8s:logs/SKILL.md
+++ b/.claude/skills/k8s:logs/SKILL.md
@@ -7,6 +7,26 @@ description: Query and analyze logs from Kagenti platform components, search for
 
 This skill helps you query and analyze logs from the Kagenti platform components.
 
+## Context-Safe Execution (MANDATORY)
+
+**All kubectl log commands MUST redirect output to files.** Log output is the single biggest
+source of context pollution. Commands below are shown in bare form for readability.
+When executing, always redirect:
+
+```bash
+export LOG_DIR=/tmp/kagenti/k8s/${CLUSTER:-local}
+mkdir -p $LOG_DIR
+
+# Pattern for all log commands:
+kubectl logs -n <ns> <target> --tail=100 > $LOG_DIR/<component>.log 2>&1 && echo "OK" || echo "FAIL"
+
+# NEVER dump logs into main context — always analyze in subagent:
+# Task(subagent_type='Explore') to read $LOG_DIR/<component>.log and:
+#   - Find errors/warnings
+#   - Check for specific patterns
+#   - Return a concise summary
+```
+
 ## When to Use
 
 - User asks "show me logs for X"

--- a/.claude/skills/k8s:pods/SKILL.md
+++ b/.claude/skills/k8s:pods/SKILL.md
@@ -7,6 +7,22 @@ description: Debug and troubleshoot pod issues including crashes, failures, netw
 
 This skill provides systematic approaches to debugging pod issues in the Kagenti platform.
 
+## Context-Safe Execution (MANDATORY)
+
+**All kubectl/oc commands MUST redirect output to files.** Commands below are shown in bare
+form for readability. When executing, always redirect:
+
+```bash
+export LOG_DIR=/tmp/kagenti/k8s/${CLUSTER:-local}
+mkdir -p $LOG_DIR
+
+# Pattern for all kubectl commands:
+kubectl <command> > $LOG_DIR/<descriptive-name>.log 2>&1 && echo "OK" || echo "FAIL (see $LOG_DIR/<descriptive-name>.log)"
+
+# Analyze in subagent: Task(subagent_type='Explore') to read log files
+# Use subagents for BOTH failure analysis AND verifying expected behavior
+```
+
 ## When to Use
 
 - Pods are crashlooping or failing

--- a/.claude/skills/kagenti:deploy/SKILL.md
+++ b/.claude/skills/kagenti:deploy/SKILL.md
@@ -7,6 +7,19 @@ description: Deploy or redeploy the Kagenti Kind cluster using the Python instal
 
 This skill guides you through deploying or redeploying the Kagenti Kind cluster using the Python installer.
 
+## Context-Safe Execution (MANDATORY)
+
+**Deploy scripts produce hundreds of lines.** Always redirect to files:
+
+```bash
+export LOG_DIR=/tmp/kagenti/deploy/$(basename $(git rev-parse --show-toplevel))
+mkdir -p $LOG_DIR
+
+# Pattern: redirect deploy output
+./.github/scripts/local-setup/kind-full-test.sh ... > $LOG_DIR/deploy.log 2>&1; echo "EXIT:$?"
+# On failure: Task(subagent_type='Explore') with Grep to find errors
+```
+
 ## When to Use
 
 - Setting up new local development cluster

--- a/.claude/skills/kagenti:operator/SKILL.md
+++ b/.claude/skills/kagenti:operator/SKILL.md
@@ -7,6 +7,19 @@ description: Deploy and manage Kagenti operator, agents, and tools on Kubernetes
 
 Deploy and manage Kagenti operator, agents, and tools on Kubernetes clusters.
 
+## Context-Safe Execution (MANDATORY)
+
+**Deploy/build commands produce large output.** Always redirect to files:
+
+```bash
+export LOG_DIR=/tmp/kagenti/deploy/$(basename $(git rev-parse --show-toplevel))
+mkdir -p $LOG_DIR
+
+# Pattern: redirect build/deploy output
+command > $LOG_DIR/<name>.log 2>&1; echo "EXIT:$?"
+# On failure: Task(subagent_type='Explore') with Grep to find errors
+```
+
 ## When to Use
 
 - Deploying Kagenti platform to a cluster

--- a/.claude/skills/openshift:debug/SKILL.md
+++ b/.claude/skills/openshift:debug/SKILL.md
@@ -7,6 +7,20 @@ description: Debug OpenShift-specific resources, operators, and platform issues
 
 Debug OpenShift-specific resources and platform issues.
 
+## Context-Safe Execution (MANDATORY)
+
+**All oc/kubectl commands MUST redirect output to files.**
+
+```bash
+export LOG_DIR=/tmp/kagenti/k8s/${CLUSTER:-local}
+mkdir -p $LOG_DIR
+
+# Pattern: redirect oc/kubectl output
+oc get clusteroperators > $LOG_DIR/cluster-operators.log 2>&1 && echo "OK" || echo "FAIL"
+oc describe clusterversion version > $LOG_DIR/cluster-version.log 2>&1 && echo "OK" || echo "FAIL"
+# Analyze in subagent: Task(subagent_type='Explore') with Grep
+```
+
 ## When to Use
 
 - OpenShift operators not working

--- a/.claude/skills/rca/SKILL.md
+++ b/.claude/skills/rca/SKILL.md
@@ -29,6 +29,25 @@ flowchart TD
 
 Root cause analysis workflows for systematic failure investigation.
 
+## Context-Safe Execution (MANDATORY)
+
+**RCA is the highest-risk activity for context pollution.** Investigation involves
+reading CI logs, kubectl output, and test results — all of which must stay out of
+the main conversation context.
+
+```bash
+# Session-scoped log directory
+export LOG_DIR=/tmp/kagenti/rca/$(basename $(git rev-parse --show-toplevel))
+mkdir -p $LOG_DIR
+```
+
+**Rules:**
+1. **ALL diagnostic commands** redirect output to `$LOG_DIR/<name>.log`
+2. **ALL log analysis** happens in subagents: `Task(subagent_type='Explore')`
+3. The subagent reads the log, extracts findings, and returns a concise summary
+4. The main context only sees: exit codes, OK/FAIL status, and subagent summaries
+5. **NEVER** read CI logs, kubectl output, or test results directly in main context
+
 ## Auto-Select Sub-Skill
 
 When this skill is invoked, determine the right sub-skill based on context:

--- a/.claude/skills/test:run-hypershift/SKILL.md
+++ b/.claude/skills/test:run-hypershift/SKILL.md
@@ -7,6 +7,19 @@ description: Run E2E tests on HyperShift cluster
 
 > **Auto-approved**: All test execution on hosted HyperShift clusters is auto-approved.
 
+## Context-Safe Execution (MANDATORY)
+
+**Test output MUST go to files.** Test runs produce hundreds of lines.
+
+```bash
+export LOG_DIR=/tmp/kagenti/tdd/${WORKTREE:-$CLUSTER}
+mkdir -p $LOG_DIR
+
+# Pattern: redirect test output
+command > $LOG_DIR/test-run.log 2>&1; echo "EXIT:$?"
+# On failure: Task(subagent_type='Explore') with Grep to find FAILED|ERROR
+```
+
 ## When to Use
 
 - Running full E2E tests including MLflow, Phoenix, auth
@@ -17,7 +30,8 @@ description: Run E2E tests on HyperShift cluster
 
 ```bash
 KUBECONFIG=~/clusters/hcp/kagenti-hypershift-custom-$CLUSTER/auth/kubeconfig \
-  ./.github/scripts/local-setup/hypershift-full-test.sh $CLUSTER --include-test
+  ./.github/scripts/local-setup/hypershift-full-test.sh $CLUSTER --include-test \
+  > $LOG_DIR/test-all.log 2>&1; echo "EXIT:$?"
 ```
 
 ## Run Specific Tests
@@ -25,7 +39,8 @@ KUBECONFIG=~/clusters/hcp/kagenti-hypershift-custom-$CLUSTER/auth/kubeconfig \
 ```bash
 KUBECONFIG=~/clusters/hcp/kagenti-hypershift-custom-$CLUSTER/auth/kubeconfig \
   ./.github/scripts/local-setup/hypershift-full-test.sh $CLUSTER \
-  --include-test --pytest-filter "test_agent or test_mlflow"
+  --include-test --pytest-filter "test_agent or test_mlflow" \
+  > $LOG_DIR/test-filtered.log 2>&1; echo "EXIT:$?"
 ```
 
 ## Run from Worktree

--- a/.claude/skills/test:run-kind/SKILL.md
+++ b/.claude/skills/test:run-kind/SKILL.md
@@ -7,6 +7,19 @@ description: Run E2E tests on local Kind cluster
 
 > **Auto-approved**: All test execution on Kind is auto-approved.
 
+## Context-Safe Execution (MANDATORY)
+
+**Test output MUST go to files.** Test runs produce hundreds of lines.
+
+```bash
+export LOG_DIR=/tmp/kagenti/tdd/$(basename $(git rev-parse --show-toplevel))
+mkdir -p $LOG_DIR
+
+# Pattern: redirect test output
+command > $LOG_DIR/test-run.log 2>&1; echo "EXIT:$?"
+# On failure: Task(subagent_type='Explore') with Grep to find FAILED|ERROR
+```
+
 ## When to Use
 
 - Running E2E tests locally on Kind
@@ -16,13 +29,13 @@ description: Run E2E tests on local Kind cluster
 ## Run All Tests
 
 ```bash
-./.github/scripts/local-setup/kind-full-test.sh --include-test
+./.github/scripts/local-setup/kind-full-test.sh --include-test > $LOG_DIR/test-all.log 2>&1; echo "EXIT:$?"
 ```
 
 ## Run Specific Tests
 
 ```bash
-./.github/scripts/local-setup/kind-full-test.sh --include-test --pytest-filter "test_agent"
+./.github/scripts/local-setup/kind-full-test.sh --include-test --pytest-filter "test_agent" > $LOG_DIR/test-filtered.log 2>&1; echo "EXIT:$?"
 ```
 
 ## Run with pytest Directly

--- a/.claude/skills/testing:kubectl-debugging/SKILL.md
+++ b/.claude/skills/testing:kubectl-debugging/SKILL.md
@@ -7,6 +7,19 @@ description: Common kubectl commands for debugging Kagenti components
 
 Common kubectl commands for debugging Kagenti components.
 
+## Context-Safe Execution (MANDATORY)
+
+**All kubectl/oc commands MUST redirect output to files.** Commands below are shown in bare
+form for readability. When executing, always redirect:
+
+```bash
+export LOG_DIR=/tmp/kagenti/k8s/${CLUSTER:-local}
+mkdir -p $LOG_DIR
+
+# Pattern: kubectl <command> > $LOG_DIR/<name>.log 2>&1 && echo "OK" || echo "FAIL"
+# Analyze in subagent: Task(subagent_type='Explore') with Grep
+```
+
 ## Table of Contents
 
 - [Setting Up Environment](#setting-up-environment)


### PR DESCRIPTION
## Summary

- Add "Context Budget" section to CLAUDE.md with mandatory rules for output-to-file pattern
- Update 23 skills with "Context-Safe Execution (MANDATORY)" headers requiring command output redirection to session-scoped log files
- Create `.claude/scripts/lib/context-safe.sh` helper library with `run_captured()`, `run_quiet()`, `run_tests()` functions
- Log directories scoped by `$WORKTREE` or `$CLUSTER` to prevent collisions between parallel sessions
- Subagent-based log analysis using `Task(subagent_type='Explore')` with `Grep` (targeted search, not full file reads)

### Problem

Build output, kubectl responses, test results, and CI logs dumped into conversation history get re-read on every subsequent turn, causing exponential context growth in long TDD/RCA sessions.

### Solution

Every command producing >5 lines redirects to `$LOG_DIR/<name>.log` and returns only an exit code. Analysis happens in subagents that use Grep with context lines to find relevant information without reading entire files.

### Skills updated

| Category | Skills |
|----------|--------|
| TDD | `tdd`, `tdd:ci`, `tdd:hypershift`, `tdd:kind` |
| K8s | `k8s`, `k8s:health`, `k8s:pods`, `k8s:logs`, `k8s:live-debugging` |
| RCA | `rca`, `rca:ci`, `rca:hypershift`, `rca:kind` |
| CI | `ci:status`, `ci:monitoring` |
| Deploy | `kagenti:deploy`, `kagenti:operator` |
| Debug | `helm:debug`, `hypershift:debug`, `openshift:debug` |
| Test | `test:run-hypershift`, `test:run-kind`, `testing:kubectl-debugging` |

## Test plan

- [ ] Verify skills load correctly when invoked
- [ ] Run a TDD session using the updated patterns and confirm output stays out of context
- [ ] Verify parallel sessions with different worktrees use separate log directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)