### PR TITLE
fix(mcp): restore mcp-route attachment to mcp-gateway

### DIFF
--- a/charts/kagenti/templates/mcp-gateway.yaml
+++ b/charts/kagenti/templates/mcp-gateway.yaml
@@ -39,6 +39,8 @@ spec:
   parentRefs:
     - name: http
       namespace: kagenti-system
+    - name: mcp-gateway
+      namespace: "{{ .Values.mcpGateway.namespaces.gatewaySystem }}"
   hostnames:
   - "{{ .Values.mcpGateway.hostname }}"
   rules:


### PR DESCRIPTION
## Summary

- Adds `mcp-gateway` back as a second `parentRef` on the `mcp-route` HTTPRoute, fixing MCP Inspector connectivity broken by commit 68d2252

## Root Cause

Commit [`68d2252`](https://github.com/kagenti/kagenti/commit/68d2252) ("Let MCP Gateway share the Kagenti Gateway") moved the `mcp-route` parentRef from the dedicated `mcp-gateway` to the shared `http` gateway. This left the `mcp-gateway` Envoy with no backend routes, so the ext_proc processes requests correctly but Envoy has nowhere to forward them — resulting in 404 / connection reset and the MCP Inspector showing "Connection Error."

Adding `mcp-gateway` as a second parentRef preserves the shared gateway intent while restoring the dedicated gateway routing that the MCP Inspector relies on.

See full RCA in [#718 comment](https://github.com/kagenti/kagenti/issues/718#issuecomment-3921519316).

Fixes #718

## Test plan

- [ ] Deploy to Kind cluster and verify MCP Inspector can connect through `mcp-gateway-istio.gateway-system.svc.cluster.local:8080/mcp`
- [ ] Verify MCP gateway tab in Kagenti UI opens MCP Inspector without "Connection Error"
- [ ] Verify external access through the shared `http` gateway still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)