### PR TITLE
fix: Export HYPERSHIFT_MGMT_KUBECONFIG_BASE64 in generated .env files

### DIFF
--- a/.github/scripts/hypershift/setup-hypershift-ci-credentials.sh
+++ b/.github/scripts/hypershift/setup-hypershift-ci-credentials.sh
@@ -813,7 +813,7 @@ cat > "$ENV_FILE" <<ENVFILE
 export KUBECONFIG="${MGMT_KUBECONFIG_PATH}"
 
 # GitHub Actions: base64-encoded (for secrets)
-HYPERSHIFT_MGMT_KUBECONFIG_BASE64="${HYPERSHIFT_MGMT_KUBECONFIG}"
+export HYPERSHIFT_MGMT_KUBECONFIG_BASE64="${HYPERSHIFT_MGMT_KUBECONFIG}"
 
 # =============================================================================
 # AWS Credentials - CI User (full permissions for cluster lifecycle)


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                           
                 
  Fixes missing `export` keyword for `HYPERSHIFT_MGMT_KUBECONFIG_BASE64` in generated `.env` files. Without the export, the auto-creation logic for kubeconfig files couldn't access the variable when sourcing the file.                                                              
                                                                                                                                                                                                                                                                                       


  ## (Optional) Testing Instructions

  1. Run `setup-hypershift-ci-credentials.sh` to generate a new `.env` file
  2. Source the `.env` file: `source .env.kagenti-team`
  3. Verify the variable is accessible: `echo $HYPERSHIFT_MGMT_KUBECONFIG_BASE64`
  4. Verify kubeconfig auto-creation works when the file doesn't exist