### PR TITLE
fix: Make postgres-otel database initialization idempotent

### DIFF
--- a/charts/kagenti-deps/templates/phoenix-postgres.yaml
+++ b/charts/kagenti-deps/templates/phoenix-postgres.yaml
@@ -38,7 +38,8 @@ data:
 
     psql -v ON_ERROR_STOP=1  <<-EOSQL
         ALTER DATABASE postgres OWNER TO testuser;
-        CREATE DATABASE mlflow OWNER testuser;
+        SELECT 'CREATE DATABASE mlflow OWNER testuser'
+        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'mlflow')\gexec
     EOSQL
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Fixes postgres-otel crash loop after cluster restarts by making the database initialization script idempotent.

After a cluster restart (e.g., Podman/Kind restart), `postgres-otel-0` entered a crash loop with the error:

```
ERROR: database "mlflow" already exists
```

This also caused `phoenix-0` to crash loop since it depends on postgres-otel.

Checks pg_database system catalog for the database
* Only executes CREATE DATABASE if it doesn't exist
* Returns cleanly if the database already exists
* Safe to run multiple times

