### PR TITLE
fix: default mlflow.auth.enabled to false in kagenti chart

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -210,7 +210,8 @@ mlflow:
   url: http://mlflow.localtest.me:8080
   auth:
     # Enable Keycloak OAuth2 authentication for MLflow
-    enabled: true
+    # Set to true in ocp_values.yaml for production deployments
+    enabled: false
     # Kubernetes secret name containing OAuth credentials
     secretName: mlflow-oauth-secret
 


### PR DESCRIPTION
## Summary
- Changes `mlflow.auth.enabled` default from `true` to `false` in `charts/kagenti/values.yaml`
- Prevents MLflow OAuth resource failures on Kind clusters when running ad-hoc `helm upgrade` commands (e.g., after `make build-load-ui`)
- No impact on OpenShift deployments — `ocp_values.yaml` already overrides to `true`

## Test plan
- [ ] Run `make build-load-ui` followed by the suggested `helm upgrade` command on a Kind cluster — should no longer fail due to MLflow auth resources
- [ ] Verify OpenShift deployment still picks up `mlflow.auth.enabled: true` from `ocp_values.yaml`

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)