### PR TITLE
docs: Add HyperShift development and testing guide to developer docum…

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -338,4 +338,316 @@ https://raw.githubusercontent.com/kagenti/agent-examples/main/a2a/weather_servic
 - Makefile UI targets: Run `make help-ui` for details
 - Environment Variables Import Design: `docs/env-import-feature-design.md`
 
+## HyperShift Development and Testing
+
+HyperShift enables rapid testing of Kagenti on OpenShift by creating ephemeral hosted clusters (sandboxes) where the control plane runs as pods on a management cluster and workers run in AWS. This approach is faster and more cost-effective than deploying full OpenShift clusters.
+
+### Why HyperShift?
+
+- **Fast cluster creation**: 10-15 minutes vs. 45 minutes for IPI
+- **Cost efficient**: Ephemeral clusters for testing, destroyed after use
+- **OpenShift validation**: Test platform features on real OpenShift (OCP 4.20, 4.21)
+- **Parallel testing**: Multiple developers can create isolated test clusters
+- **CI/CD integration**: Automated E2E testing on OpenShift via GitHub Actions
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────┐
+│  HyperShift Management Cluster (OpenShift)  │
+│  - Runs hosted cluster control planes       │
+│  - MCE 2.10 + HyperShift operator           │
+│  - Managed by platform team                 │
+│  └─────────────────────────────────────────┘
+         │
+         ├─► Hosted Cluster 1 (Your Test Cluster)
+         │   - Control plane: Pods on mgmt cluster
+         │   - Workers: EC2 instances in AWS
+         │
+         └─► Hosted Cluster 2 (Another Developer)
+             - Isolated namespace and AWS resources
+```
+
+### Prerequisites
+
+Before creating hosted clusters, you need:
+
+1. **Credentials Package** from the platform team containing:
+   - AWS credentials (IAM user for cluster creation)
+   - Management cluster kubeconfig (base64-encoded)
+   - Base domain and OIDC S3 bucket details
+
+2. **Required Tools**:
+   - AWS CLI configured
+   - kubectl and oc CLI
+   - jq for JSON processing
+   - Ansible (installed automatically by setup script)
+
+### Setting Up HyperShift Credentials
+
+#### Option 1: Using Credential Package (Recommended)
+
+If you received a credential package (`.tar.gz` file) from the platform team:
+
+```bash
+# Extract the package
+tar -xzf <package-name>.tar.gz
+cd <package-name>
+
+# Source the credentials
+source .env.<tag>
+
+# Verify setup
+echo $MANAGED_BY_TAG
+oc whoami --show-server  # Should show management cluster API
+```
+
+The `.env` file automatically creates the management cluster kubeconfig at `~/.kube/<tag>-mgmt.kubeconfig` if it doesn't exist.
+
+#### Option 2: Manual Setup
+
+If setting up from scratch, run the credential setup script:
+
+```bash
+cd kagenti
+
+# Set your managed-by tag (identifies your resources)
+export MANAGED_BY_TAG="your-name-dev"
+
+# Run setup (requires logged in to AWS and management cluster)
+./.github/scripts/hypershift/setup-hypershift-ci-credentials.sh
+
+# Source the generated credentials
+source .env.${MANAGED_BY_TAG}
+```
+
+This creates:
+- AWS IAM users with scoped permissions
+- OpenShift service account on management cluster
+- Local `.env.${MANAGED_BY_TAG}` file with all credentials
+
+### Creating a Hosted Cluster
+
+Once credentials are configured, create a test cluster:
+
+```bash
+# Navigate to repository root
+cd kagenti
+
+# Create cluster with random suffix
+./.github/scripts/hypershift/create-cluster.sh
+
+# Or specify a custom suffix
+./.github/scripts/hypershift/create-cluster.sh my-test
+
+# Keep cluster after creation (skip auto-destroy)
+./.github/scripts/hypershift/create-cluster.sh my-test --skip-cluster-destroy
+```
+
+**What happens:**
+1. Creates AWS infrastructure (VPC, subnets, security groups)
+2. Creates HostedCluster CR on management cluster
+3. Waits for control plane pods to be ready
+4. Creates worker NodePool (2x m5.xlarge by default)
+5. Waits for cluster to become accessible
+6. Outputs kubeconfig path
+
+**Cluster naming:**
+- Format: `${MANAGED_BY_TAG}-<suffix>`
+- Example: `my-team-my-test`
+- Must be ≤32 characters (AWS IAM role name limit)
+
+**Default configuration:**
+- OpenShift version: 4.20 (or `OCP_VERSION` env var)
+- Workers: 2 nodes (m5.xlarge)
+- Region: us-east-1
+- Namespace: `${MANAGED_BY_TAG}` on management cluster
+
+### Running Tests on HyperShift
+
+After creating a cluster, run the full E2E test suite:
+
+```bash
+# Run full test (deploy Kagenti + E2E tests)
+./.github/scripts/local-setup/hypershift-full-test.sh <cluster-suffix> --skip-cluster-destroy
+
+# Re-run tests on existing cluster (skip cluster creation)
+./.github/scripts/local-setup/hypershift-full-test.sh <cluster-suffix> --skip-cluster-create --skip-cluster-destroy
+
+# Deploy Kagenti only (no tests)
+./.github/scripts/hypershift/deploy-kagenti.sh <cluster-suffix>
+```
+
+**Test workflow:**
+1. Sets up kubeconfig for hosted cluster
+2. Deploys Kagenti platform via Ansible
+3. Runs E2E test suite (`kagenti/tests/e2e/`)
+4. Optionally destroys cluster after tests
+
+**Working with kubeconfig:**
+
+```bash
+# Kubeconfig is saved to standard location
+export KUBECONFIG=~/hypershift-clusters/${MANAGED_BY_TAG}-<suffix>/kubeconfig
+
+# Or use the helper to find it
+source .env.${MANAGED_BY_TAG}
+export KUBECONFIG=$(find ~/hypershift-clusters -name "kubeconfig" | grep ${MANAGED_BY_TAG}-<suffix>)
+
+# Verify access
+oc get nodes
+oc get co  # Check cluster operators
+```
+
+### Destroying a Hosted Cluster
+
+When finished testing, clean up resources:
+
+```bash
+# Destroy specific cluster
+./.github/scripts/hypershift/destroy-cluster.sh <cluster-suffix>
+
+# Or use full-test script with destroy flag
+./.github/scripts/local-setup/hypershift-full-test.sh <cluster-suffix> --include-cluster-destroy
+```
+
+**What gets deleted:**
+- HostedCluster CR and control plane pods
+- Worker NodePool and EC2 instances
+- AWS VPC, subnets, NAT gateways, load balancers
+- IAM roles and instance profiles
+
+**Important:** Cluster destruction can take 10-20 minutes. Monitor progress:
+
+```bash
+# Watch HostedCluster deletion
+oc get hostedcluster -n ${MANAGED_BY_TAG} -w
+
+# Check for stuck resources
+oc get hostedcluster -n ${MANAGED_BY_TAG} -o yaml | grep finalizers -A 5
+```
+
+### Cost Management
+
+Hosted clusters incur AWS costs while running:
+
+**Per cluster (running):**
+- 2x m5.xlarge workers: ~$0.38/hour (~$277/month if left running)
+- VPC/networking: ~$0.10/hour
+- EBS volumes: ~$0.10/GB/month
+
+**Best practices:**
+- Destroy clusters when not in use (evenings, weekends)
+- Use `--skip-cluster-destroy` only during active development
+- Monitor AWS costs via `aws ce get-cost-and-usage` or AWS Console
+- Tag all resources with `kagenti.io/managed-by` for tracking
+
+### Troubleshooting
+
+#### Cluster Creation Fails
+
+```bash
+# Check HostedCluster status
+oc get hostedcluster -n ${MANAGED_BY_TAG}
+oc describe hostedcluster ${MANAGED_BY_TAG}-<suffix> -n ${MANAGED_BY_TAG}
+
+# Check control plane pods
+oc get pods -n ${MANAGED_BY_TAG}-<suffix>
+
+# Check HyperShift operator logs
+oc logs -n hypershift deployment/operator -f
+```
+
+#### Workers Not Ready
+
+```bash
+# Check NodePool status
+oc get nodepool -n ${MANAGED_BY_TAG}
+oc describe nodepool ${MANAGED_BY_TAG}-<suffix> -n ${MANAGED_BY_TAG}
+
+# Check AWS EC2 instances (requires AWS credentials)
+aws ec2 describe-instances --filters "Name=tag:kubernetes.io/cluster/${MANAGED_BY_TAG}-<suffix>,Values=owned"
+```
+
+#### Cleanup Issues
+
+If cluster destruction hangs, manually remove finalizers:
+
+```bash
+# Remove finalizers from HostedCluster
+oc patch hostedcluster ${MANAGED_BY_TAG}-<suffix> -n ${MANAGED_BY_TAG} \
+  --type=merge -p '{"metadata":{"finalizers":[]}}'
+
+# Force delete if needed
+oc delete hostedcluster ${MANAGED_BY_TAG}-<suffix> -n ${MANAGED_BY_TAG} --force --grace-period=0
+```
+
+See [CLEANUP-TEST-RESULTS.md](../CLEANUP-TEST-RESULTS.md) for detailed cleanup findings.
+
+### CI/CD Integration
+
+The repository includes GitHub Actions workflows for automated HyperShift testing:
+
+- `.github/workflows/e2e-hypershift.yaml` - OpenShift 4.20 testing
+- `.github/workflows/e2e-hypershift-4.21.yaml` - OpenShift 4.21 testing (manual trigger)
+
+**Workflow features:**
+- Automatic cluster creation and cleanup
+- Slot-based parallelism (max 3 concurrent clusters)
+- Full E2E test suite execution
+- Artifact upload for debugging
+
+### Advanced Topics
+
+#### Management Cluster Setup
+
+For platform administrators deploying new management clusters, see:
+
+- [Terraform Management Cluster Guide](../terraform/README.md) - Complete deployment workflow
+- [Architecture Overview](../ARCHITECTURE-4.21.md) - Dual cluster strategy and design decisions
+- [Quick Start Guide](../QUICKSTART-4.21.md) - Step-by-step deployment (90 minutes)
+
+#### Customizing Hosted Clusters
+
+Modify cluster configuration by setting environment variables before creation:
+
+```bash
+# Use different OpenShift version
+export OCP_VERSION=4.21
+
+# Change worker instance type and count
+export INSTANCE_TYPE=m5.2xlarge
+export WORKER_COUNT=3
+
+# Use different AWS region
+export AWS_REGION=us-west-2
+
+# Create cluster with custom settings
+./.github/scripts/hypershift/create-cluster.sh custom
+```
+
+#### Multiple Hosted Clusters
+
+You can run multiple hosted clusters simultaneously:
+
+```bash
+# Create first cluster
+./.github/scripts/hypershift/create-cluster.sh dev1 --skip-cluster-destroy
+
+# Create second cluster (different suffix)
+./.github/scripts/hypershift/create-cluster.sh dev2 --skip-cluster-destroy
+
+# List all your clusters
+oc get hostedcluster -n ${MANAGED_BY_TAG}
+```
+
+Each cluster gets isolated AWS resources and namespace on the management cluster.
+
+### Additional Resources
+
+- [HyperShift Documentation](https://hypershift-docs.netlify.app/) - Official HyperShift docs
+- [MCE Documentation](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/multicluster_engine/multicluster_engine_overview) - MultiCluster Engine overview
+- [Credential Setup Script](../.github/scripts/hypershift/setup-hypershift-ci-credentials.sh) - Detailed script documentation
+- [Cleanup Test Results](../CLEANUP-TEST-RESULTS.md) - Known cleanup issues and workarounds
+
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                           
                  
  Adds comprehensive HyperShift development and testing documentation to the developer guide. This enables developers to easily create ephemeral OpenShift test clusters for validating Kagenti features.                                                                              
                                                                                                                                                                                                                                                                                       
  ## Changes

  - Added "HyperShift Development and Testing" section to `docs/dev-guide.md` (312 lines)
  - Covers credential setup, cluster creation, testing workflows, and cleanup
  - Includes troubleshooting, cost management, and CI/CD integration details
  - Links to Terraform documentation for platform administrators

  ## Why This Matters

  Developers can now quickly spin up OpenShift test environments without manual cluster provisioning, making it easier to test platform features on real OpenShift (4.20, 4.21) in 10-15 minutes instead of 45+ minutes with traditional IPI installation.