### PR TITLE
feat: add AuthBridge toggle to UI agent/tool import page

### DIFF
--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -21,6 +21,7 @@ TOOLHIVE_MCP_PLURAL = settings.toolhive_mcp_plural
 KAGENTI_TYPE_LABEL = settings.kagenti_type_label
 KAGENTI_PROTOCOL_LABEL = settings.kagenti_protocol_label
 KAGENTI_FRAMEWORK_LABEL = settings.kagenti_framework_label
+KAGENTI_INJECT_LABEL = "kagenti.io/inject"
 KAGENTI_TRANSPORT_LABEL = "kagenti.io/transport"
 KAGENTI_WORKLOAD_TYPE_LABEL = "kagenti.io/workload-type"
 KAGENTI_DESCRIPTION_ANNOTATION = "kagenti.io/description"

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -158,6 +158,9 @@ export const ImportAgentPage: React.FC = () => {
   // HTTPRoute/Route creation
   const [createHttpRoute, setCreateHttpRoute] = useState(false);
 
+  // AuthBridge sidecar injection (default enabled for agents)
+  const [authBridgeEnabled, setAuthBridgeEnabled] = useState(true);
+
   // Validation state
   const [validated, setValidated] = useState<Record<string, 'success' | 'error' | 'default'>>({});
 
@@ -448,6 +451,7 @@ export const ImportAgentPage: React.FC = () => {
         startCommand: showStartCommand ? startCommand : undefined,
         servicePorts,
         createHttpRoute,
+        authBridgeEnabled,
         // Shipwright build configuration (always enabled)
         shipwrightConfig,
       });
@@ -472,6 +476,7 @@ export const ImportAgentPage: React.FC = () => {
         imagePullSecret: imagePullSecret || undefined,
         servicePorts,
         createHttpRoute,
+        authBridgeEnabled,
       });
     }
   };
@@ -949,6 +954,17 @@ export const ImportAgentPage: React.FC = () => {
                   label="Enable external access to the agent endpoint"
                   isChecked={createHttpRoute}
                   onChange={(_e, checked) => setCreateHttpRoute(checked)}
+                />
+              </FormGroup>
+
+              {/* AuthBridge Sidecar Injection */}
+              <FormGroup fieldId="authBridgeEnabled">
+                <Checkbox
+                  id="authBridgeEnabled"
+                  label="Enable AuthBridge sidecar injection"
+                  isChecked={authBridgeEnabled}
+                  onChange={(_e, checked) => setAuthBridgeEnabled(checked)}
+                  description="When enabled, the webhook injects AuthBridge sidecars (envoy-proxy, go-processor, client-registration) into the agent pod for token exchange."
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -139,6 +139,9 @@ export const ImportToolPage: React.FC = () => {
   // HTTPRoute/Route creation
   const [createHttpRoute, setCreateHttpRoute] = useState(false);
 
+  // AuthBridge sidecar injection (default disabled for tools)
+  const [authBridgeEnabled, setAuthBridgeEnabled] = useState(false);
+
   // Validation state
   const [validated, setValidated] = useState<Record<string, 'success' | 'error' | 'default'>>({});
 
@@ -427,6 +430,7 @@ export const ImportToolPage: React.FC = () => {
         envVars: envVars.filter((ev) => ev.name && (ev.value !== undefined || ev.valueFrom)),
         servicePorts: showPodConfig ? servicePorts : undefined,
         createHttpRoute,
+        authBridgeEnabled,
       });
     } else {
       // Image deployment
@@ -447,6 +451,7 @@ export const ImportToolPage: React.FC = () => {
         imagePullSecret: imagePullSecret || undefined,
         servicePorts: showPodConfig ? servicePorts : undefined,
         createHttpRoute,
+        authBridgeEnabled,
       });
     }
   };
@@ -892,6 +897,17 @@ export const ImportToolPage: React.FC = () => {
                   label="Enable external access to the tool endpoint"
                   isChecked={createHttpRoute}
                   onChange={(_e, checked) => setCreateHttpRoute(checked)}
+                />
+              </FormGroup>
+
+              {/* AuthBridge Sidecar Injection */}
+              <FormGroup fieldId="authBridgeEnabled">
+                <Checkbox
+                  id="authBridgeEnabled"
+                  label="Enable AuthBridge sidecar injection"
+                  isChecked={authBridgeEnabled}
+                  onChange={(_e, checked) => setAuthBridgeEnabled(checked)}
+                  description="When enabled, the webhook injects AuthBridge sidecars (envoy-proxy, go-processor, client-registration) into the tool pod for token exchange."
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -155,6 +155,8 @@ export const agentService = {
     }>;
     // HTTPRoute/Route creation
     createHttpRoute?: boolean;
+    // AuthBridge sidecar injection
+    authBridgeEnabled?: boolean;
     shipwrightConfig?: ShipwrightBuildConfig;
   }): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
     return apiFetch('/agents', {
@@ -359,6 +361,7 @@ export const shipwrightService = {
         protocol: string;
       }>;
       createHttpRoute?: boolean;
+      authBridgeEnabled?: boolean;
       imagePullSecret?: string;
     }
   ): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
@@ -440,6 +443,8 @@ export const toolService = {
     shipwrightConfig?: ShipwrightBuildConfig;
     // HTTPRoute/Route creation
     createHttpRoute?: boolean;
+    // AuthBridge sidecar injection
+    authBridgeEnabled?: boolean;
   }): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
     return apiFetch('/tools', {
       method: 'POST',
@@ -569,6 +574,7 @@ export const toolShipwrightService = {
         protocol: string;
       }>;
       createHttpRoute?: boolean;
+      authBridgeEnabled?: boolean;
       imagePullSecret?: string;
     }
   ): Promise<{ success: boolean; name: string; namespace: string; message: string }> {


### PR DESCRIPTION
## Summary

- Add "Enable AuthBridge sidecar injection" checkbox to **Import Agent** (default: enabled) and **Import Tool** (default: disabled) pages
- Sets `kagenti.io/inject: enabled` or `kagenti.io/inject: disabled` on pod template labels, which the webhook in `kagenti-extensions` uses to decide whether to inject AuthBridge sidecars
- Prevents port 9090 conflicts on tools (e.g. GitHub MCP tool) that don't need AuthBridge sidecars

Closes #739

## Changes

| Layer | File | Change |
|-------|------|--------|
| Constants | `constants.py` | Add `KAGENTI_INJECT_LABEL` |
| Backend | `agents.py` | `authBridgeEnabled` field (default `True`) on request models, inject label in `_build_common_labels`, stored in Shipwright config |
| Backend | `tools.py` | `authBridgeEnabled` field (default `False`) on request models, inject label in deployment/statefulset manifest builders, stored in Shipwright config |
| Frontend | `api.ts` | `authBridgeEnabled` param on agent/tool create + finalize APIs |
| Frontend | `ImportAgentPage.tsx` | Checkbox (default checked) + passed in both submit paths |
| Frontend | `ImportToolPage.tsx` | Checkbox (default unchecked) + passed in both submit paths |

## Test plan

- [ ] Deploy to Kind cluster and open UI
- [ ] Import Agent page: verify checkbox is **checked** by default
- [ ] Import Tool page: verify checkbox is **unchecked** by default
- [ ] Deploy a tool with AuthBridge disabled → verify pod has `kagenti.io/inject: disabled` label
- [ ] Deploy an agent with AuthBridge enabled → verify pod has `kagenti.io/inject: enabled` label
- [ ] Toggle off AuthBridge for an agent → verify `kagenti.io/inject: disabled` label
- [ ] Verify no lint/pre-commit regressions (`make lint` and `pre-commit run --all-files` pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)