### PR TITLE
feat: add SPIRE identity toggle to UI agent/tool import pages

### DIFF
--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -30,6 +30,10 @@ APP_KUBERNETES_IO_NAME = "app.kubernetes.io/name"
 APP_KUBERNETES_IO_MANAGED_BY = "app.kubernetes.io/managed-by"
 APP_KUBERNETES_IO_COMPONENT = "app.kubernetes.io/component"
 
+# SPIRE identity labels (matched by kagenti-webhook pod_mutator.go)
+KAGENTI_SPIRE_LABEL = "kagenti.io/spire"
+KAGENTI_SPIRE_ENABLED_VALUE = "enabled"
+
 # Labels - Values
 KAGENTI_UI_CREATOR_LABEL = "kagenti-ui"
 KAGENTI_OPERATOR_LABEL_NAME = "kagenti-operator"

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -160,6 +160,8 @@ export const ImportAgentPage: React.FC = () => {
 
   // AuthBridge sidecar injection (default enabled for agents)
   const [authBridgeEnabled, setAuthBridgeEnabled] = useState(true);
+  // SPIRE identity
+  const [spireEnabled, setSpireEnabled] = useState(false);
 
   // Validation state
   const [validated, setValidated] = useState<Record<string, 'success' | 'error' | 'default'>>({});
@@ -452,6 +454,7 @@ export const ImportAgentPage: React.FC = () => {
         servicePorts,
         createHttpRoute,
         authBridgeEnabled,
+        spireEnabled,
         // Shipwright build configuration (always enabled)
         shipwrightConfig,
       });
@@ -477,6 +480,7 @@ export const ImportAgentPage: React.FC = () => {
         servicePorts,
         createHttpRoute,
         authBridgeEnabled,
+        spireEnabled,
       });
     }
   };
@@ -965,6 +969,16 @@ export const ImportAgentPage: React.FC = () => {
                   isChecked={authBridgeEnabled}
                   onChange={(_e, checked) => setAuthBridgeEnabled(checked)}
                   description="When enabled, the webhook injects AuthBridge sidecars (envoy-proxy, go-processor, client-registration) into the agent pod for token exchange."
+              />
+              </FormGroup>
+
+              {/* SPIRE Identity */}
+              <FormGroup fieldId="spireEnabled">
+                <Checkbox
+                  id="spireEnabled"
+                  label="Enable SPIRE identity (spiffe-helper sidecar)"
+                  isChecked={spireEnabled}
+                  onChange={(_e, checked) => setSpireEnabled(checked)}
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -141,6 +141,8 @@ export const ImportToolPage: React.FC = () => {
 
   // AuthBridge sidecar injection (default disabled for tools)
   const [authBridgeEnabled, setAuthBridgeEnabled] = useState(false);
+  // SPIRE identity
+  const [spireEnabled, setSpireEnabled] = useState(false);
 
   // Validation state
   const [validated, setValidated] = useState<Record<string, 'success' | 'error' | 'default'>>({});
@@ -431,6 +433,7 @@ export const ImportToolPage: React.FC = () => {
         servicePorts: showPodConfig ? servicePorts : undefined,
         createHttpRoute,
         authBridgeEnabled,
+        spireEnabled,
       });
     } else {
       // Image deployment
@@ -452,6 +455,7 @@ export const ImportToolPage: React.FC = () => {
         servicePorts: showPodConfig ? servicePorts : undefined,
         createHttpRoute,
         authBridgeEnabled,
+        spireEnabled,
       });
     }
   };
@@ -908,6 +912,16 @@ export const ImportToolPage: React.FC = () => {
                   isChecked={authBridgeEnabled}
                   onChange={(_e, checked) => setAuthBridgeEnabled(checked)}
                   description="When enabled, the webhook injects AuthBridge sidecars (envoy-proxy, go-processor, client-registration) into the tool pod for token exchange."
+              />
+              </FormGroup>
+
+              {/* SPIRE Identity */}
+              <FormGroup fieldId="spireEnabled">
+                <Checkbox
+                  id="spireEnabled"
+                  label="Enable SPIRE identity (spiffe-helper sidecar)"
+                  isChecked={spireEnabled}
+                  onChange={(_e, checked) => setSpireEnabled(checked)}
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -157,6 +157,8 @@ export const agentService = {
     createHttpRoute?: boolean;
     // AuthBridge sidecar injection
     authBridgeEnabled?: boolean;
+    // SPIRE identity
+    spireEnabled?: boolean;
     shipwrightConfig?: ShipwrightBuildConfig;
   }): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
     return apiFetch('/agents', {
@@ -445,6 +447,8 @@ export const toolService = {
     createHttpRoute?: boolean;
     // AuthBridge sidecar injection
     authBridgeEnabled?: boolean;
+    // SPIRE identity
+    spireEnabled?: boolean;
   }): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
     return apiFetch('/tools', {
       method: 'POST',


### PR DESCRIPTION
## Summary

- Add `kagenti.io/spire: enabled` label support to agent and tool deployment manifests, triggered by a new `spireEnabled` checkbox on the UI import pages
- The label is propagated through all deployment paths: direct image deploy, Shipwright source builds (stored in build annotation), and finalize-build endpoints
- Add 8 unit tests covering SPIRE label presence/absence on agent deployments, tool deployments, tool StatefulSets, and Shipwright config annotations

Closes #737

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/test_shipwright.py::TestSpireLabel -v` (8 tests)
- [ ] All existing tests still pass: `uv run pytest tests/ -v` (97 tests)
- [ ] Pre-commit passes: `pre-commit run --all-files`
- [ ] Kind cluster: deploy agent with SPIRE enabled via UI, verify `kagenti.io/spire: enabled` label on pod template and spiffe-helper sidecar injection
- [ ] Kind cluster: deploy agent without SPIRE toggle, verify label is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)