### PR TITLE
ci: add stale issue and PR automation

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,58 @@
+# Stale Issue and PR Management
+#
+# Automatically marks issues and PRs as stale after 60 days of inactivity,
+# then closes them after a 14-day grace period. This keeps the backlog
+# focused and encourages timely resolution.
+#
+# Exempt labels:
+#   - Issues: 'high priority', 'bug' (never auto-closed)
+#   - PRs: 'high priority' (never auto-closed)
+#
+# Token Requirements:
+# - No external tokens needed
+# - Uses GITHUB_TOKEN for issue/PR management
+#
+# Reference: https://github.com/actions/stale
+#
+name: Close Stale Issues and PRs
+
+on:
+  # Run daily at 6 AM UTC
+  schedule:
+    - cron: '0 6 * * *'
+  # Allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  issues: write         # Label and close stale issues
+  pull-requests: write  # Label and close stale PRs
+
+jobs:
+  stale:
+    name: Mark and Close Stale Items
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process stale issues and PRs
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            If this issue is still relevant, please comment or remove the stale label.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            If this PR is still relevant, please comment or remove the stale label.
+          close-issue-message: >
+            This issue was closed because it has been stale for 14 days with no activity.
+            Feel free to reopen if this is still relevant.
+          close-pr-message: >
+            This pull request was closed because it has been stale for 14 days with no activity.
+            Feel free to reopen if this is still relevant.
+          exempt-issue-labels: 'high priority,bug'
+          exempt-pr-labels: 'high priority'
+          operations-per-run: 100


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`stale.yaml`) that automatically marks issues and PRs as stale after 60 days of inactivity, then closes them after a 14-day grace period
- Issues labeled `high priority` or `bug` are exempt; PRs labeled `high priority` are exempt
- Runs daily at 6 AM UTC with manual trigger support via `workflow_dispatch`

Closes #697

## Test plan

- [ ] CI passes (YAML linting via pre-commit)
- [ ] Trigger manually via Actions tab → "Close Stale Issues and PRs" → "Run workflow"
- [ ] Verify `stale` label gets applied to inactive items after threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)