### PR TITLE
CI: Use org-wide reusable stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,18 +1,9 @@
 # Stale Issue and PR Management
 #
-# Automatically marks issues and PRs as stale after 60 days of inactivity,
-# then closes them after a 14-day grace period. This keeps the backlog
-# focused and encourages timely resolution.
+# Thin caller for the org-wide reusable stale workflow.
+# Configuration and defaults are managed centrally in kagenti/.github.
 #
-# Exempt labels:
-#   - Issues: 'high priority', 'bug' (never auto-closed)
-#   - PRs: 'high priority' (never auto-closed)
-#
-# Token Requirements:
-# - No external tokens needed
-# - Uses GITHUB_TOKEN for issue/PR management
-#
-# Reference: https://github.com/actions/stale
+# Reference: https://github.com/kagenti/.github/blob/main/.github/workflows/stale.yaml
 #
 name: Close Stale Issues and PRs
 
@@ -23,36 +14,6 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-permissions:
-  issues: write         # Label and close stale issues
-  pull-requests: write  # Label and close stale PRs
-
 jobs:
   stale:
-    name: Mark and Close Stale Items
-    runs-on: ubuntu-latest
-    steps:
-      - name: Process stale issues and PRs
-        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
-        with:
-          days-before-stale: 60
-          days-before-close: 14
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-          stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
-            If this issue is still relevant, please comment or remove the stale label.
-          stale-pr-message: >
-            This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
-            If this PR is still relevant, please comment or remove the stale label.
-          close-issue-message: >
-            This issue was closed because it has been stale for 14 days with no activity.
-            Feel free to reopen if this is still relevant.
-          close-pr-message: >
-            This pull request was closed because it has been stale for 14 days with no activity.
-            Feel free to reopen if this is still relevant.
-          exempt-issue-labels: 'high priority,bug'
-          exempt-pr-labels: 'high priority'
-          operations-per-run: 100
+    uses: kagenti/.github/.github/workflows/stale.yaml@main


### PR DESCRIPTION
## Summary

- Replaces the inline stale workflow (from #748) with a thin caller that delegates to the centralized reusable workflow in `kagenti/.github`
- All configuration (days, exempt labels, messages) is now managed org-wide in kagenti/.github#39
- Reduces per-repo maintenance -- future changes only need to be made in one place

## Test plan

- [ ] Depends on kagenti/.github#39 being merged first
- [ ] Trigger manually via Actions tab to confirm the caller invokes the org workflow
- [ ] Verify stale labeling behavior is unchanged