### PR TITLE
chore: bump kagenti-webhook to v0.4.0-alpha.4

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.2.0-alpha.20
 - name: kagenti-webhook-chart
   repository: oci://ghcr.io/kagenti/kagenti-extensions
-  version: 0.4.0-alpha.3
-digest: sha256:cc91902369ec675a1cee99b1ad973135e744b748af22faa125d3d8523a124876
-generated: "2026-02-16T12:01:10.20847-05:00"
+  version: 0.4.0-alpha.4
+digest: sha256:7ed9e3c1daf12cdc33865a6d74ac26c887923aafa49a8b2f7ea33818405887bf
+generated: "2026-02-24T09:58:19.585497-05:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -11,6 +11,6 @@ dependencies:
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 - name: kagenti-webhook-chart
-  version: 0.4.0-alpha.3
+  version: 0.4.0-alpha.4
   repository: oci://ghcr.io/kagenti/kagenti-extensions
   condition: components.platformWebhook.enabled


### PR DESCRIPTION
## Summary

Bumps the kagenti-webhook subchart from `v0.4.0-alpha.3` to `v0.4.0-alpha.4`, picking up several important fixes from kagenti-extensions.

Closes #752

## Fixes included in v0.4.0-alpha.4

| kagenti-extensions PR | Fix |
|----|-----|
| #142 | Auto-create ServiceAccount for SPIRE-enabled workloads |
| #142 | RBAC: add `serviceaccounts` get/create permission to ClusterRole |
| #142 | spiffe-helper runs as UID 1000 (matching client-registration) — fixes SVID `Permission denied` |
| #133 | Inbound bypass paths for public endpoints (`/.well-known/*`, `/healthz`, etc.) |
| #126 | Fix inbound validation |
| #130 | Enable Istio ambient mesh on demo namespaces |
| #122 | Gate client-registration injection, improve isAlreadyInjected |

## Changes

| File | Change |
|------|--------|
| `charts/kagenti/Chart.yaml` | Bump `kagenti-webhook-chart` version `0.4.0-alpha.3` -> `0.4.0-alpha.4` |
| `charts/kagenti/Chart.lock` | Regenerated via `helm dependency update` |

## Test plan

- [ ] `helm dependency update charts/kagenti/` succeeds
- [ ] Fresh `make install` on Kind cluster deploys webhook with `v0.4.0-alpha.4` image
- [ ] Import SPIRE-enabled agent via UI: ServiceAccount auto-created, spiffe-helper UID is 1000
- [ ] Agent client-registration reads SVID without permission errors
- [ ] `GET /.well-known/agent.json` bypasses JWT validation (returns 200 without token)
