### PR TITLE
🐛 Validate container image name and tag in import pages

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -223,6 +223,22 @@ export const ImportToolPage: React.FC = () => {
     }
   };
 
+  // Validate image tag according to OCI distribution-spec
+  // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull
+  const isValidImageTag = (tag: string): boolean => {
+    if (!tag) return true; // empty tag is allowed (omitted)
+    const pattern = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/;
+    return pattern.test(tag);
+  };
+
+  // Validate container image name according to OCI distribution-spec
+  // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull
+  const isValidImageName = (image: string): boolean => {
+    if (!image) return false;
+    const pattern = /^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*$/;
+    return pattern.test(image);
+  };
+
   // Validate environment variable name according to Kubernetes rules
   const isValidEnvVarName = (name: string): boolean => {
     if (!name) return false;
@@ -385,9 +401,20 @@ export const ImportToolPage: React.FC = () => {
       if (!containerImage) {
         newValidated.containerImage = 'error';
         isValid = false;
+      } else if (!isValidImageName(containerImage)) {
+        newValidated.containerImage = 'error';
+        isValid = false;
       } else {
         newValidated.containerImage = 'success';
       }
+    }
+
+    // Image tag validation (applies to both deployment methods)
+    if (imageTag && !isValidImageTag(imageTag)) {
+      newValidated.imageTag = 'error';
+      isValid = false;
+    } else {
+      newValidated.imageTag = 'success';
     }
 
     setValidated(newValidated);
@@ -694,7 +721,17 @@ export const ImportToolPage: React.FC = () => {
                       value={imageTag}
                       onChange={(_e, value) => setImageTag(value)}
                       placeholder="v0.0.1"
+                      validated={validated.imageTag}
                     />
+                    <FormHelperText>
+                      <HelperText>
+                        <HelperTextItem variant={validated.imageTag === 'error' ? 'error' : 'default'}>
+                          {validated.imageTag === 'error'
+                            ? 'Invalid tag — must start with a letter, digit, or underscore and contain only letters, digits, dots, hyphens, and underscores (max 128 chars)'
+                            : 'Tag for the built container image'}
+                        </HelperTextItem>
+                      </HelperText>
+                    </FormHelperText>
                   </FormGroup>
 
                   <Divider style={{ margin: '24px 0' }} />
@@ -793,7 +830,9 @@ export const ImportToolPage: React.FC = () => {
                       <HelperText>
                         <HelperTextItem variant={validated.containerImage === 'error' ? 'error' : 'default'}>
                           {validated.containerImage === 'error'
-                            ? 'Container image is required'
+                            ? (!containerImage
+                              ? 'Container image is required'
+                              : 'Invalid image name — use lowercase letters, digits, dots, underscores, hyphens, and slashes only (no colon — the tag is a separate field)')
                             : 'Full image path without tag (e.g., quay.io/myorg/my-tool)'}
                         </HelperTextItem>
                       </HelperText>
@@ -806,7 +845,17 @@ export const ImportToolPage: React.FC = () => {
                       value={imageTag}
                       onChange={(_e, value) => setImageTag(value)}
                       placeholder="latest"
+                      validated={validated.imageTag}
                     />
+                    <FormHelperText>
+                      <HelperText>
+                        <HelperTextItem variant={validated.imageTag === 'error' ? 'error' : 'default'}>
+                          {validated.imageTag === 'error'
+                            ? 'Invalid tag — must start with a letter, digit, or underscore and contain only letters, digits, dots, hyphens, and underscores (max 128 chars)'
+                            : 'Tag for the container image (e.g., latest, v1.0.0)'}
+                        </HelperTextItem>
+                      </HelperText>
+                    </FormHelperText>
                   </FormGroup>
 
                   <FormGroup label="Image Pull Secret" fieldId="imagePullSecret">


### PR DESCRIPTION
## Summary

Add client-side validation for container image name and tag fields on the Import Tool and Import Agent pages. The image name is validated against the OCI distribution-spec repository name grammar, and the image tag is validated against the OCI tag format. This prevents users from entering colons or other invalid characters that cause Kubernetes `InvalidImageName` errors, leaving agents/tools stuck on "Progressing" with no UI-visible error.

Key changes:
- Add `isValidImageName()` validation using the OCI distribution-spec regex for repository names
- Add `isValidImageTag()` validation using the OCI tag regex (`[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`)
- Update `validateForm()` to reject invalid image names and tags before submission
- Show inline error messages with guidance on allowed characters

## Related issue(s)

Resolves #755
Mitigates #636