### PR TITLE
Bump kagenti-extensions webhook chart to 0.4.0-alpha.5

### DIFF
--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -11,6 +11,6 @@ dependencies:
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 - name: kagenti-webhook-chart
-  version: 0.4.0-alpha.4
+  version: 0.4.0-alpha.5
   repository: oci://ghcr.io/kagenti/kagenti-extensions
   condition: components.platformWebhook.enabled


### PR DESCRIPTION
## Summary
- Bumps the `kagenti-webhook-chart` dependency version from `0.4.0-alpha.4` to `0.4.0-alpha.5` in `charts/kagenti/Chart.yaml`

## Test plan
- [ ] Verify the updated chart dependency resolves correctly
- [ ] Validate Helm chart templating with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)