### PR TITLE
🌱 Add github:pr-review skill for automated PR reviews

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -216,6 +216,7 @@
     "github:issues": { "path": ".claude/skills/github:issues/SKILL.md" },
     "github:last-week": { "path": ".claude/skills/github:last-week/SKILL.md" },
     "github:my-status": { "path": ".claude/skills/github:my-status/SKILL.md" },
+    "github:pr-review": { "path": ".claude/skills/github:pr-review/SKILL.md" },
     "github:prs": { "path": ".claude/skills/github:prs/SKILL.md" },
     "helm": { "path": ".claude/skills/helm/SKILL.md" },
     "helm:debug": { "path": ".claude/skills/helm:debug/SKILL.md" },

--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -10,6 +10,7 @@ flowchart TD
     GH -->|Weekly summary| WEEK["github:last-week"]:::github
     GH -->|Triage issues| ISSUES["github:issues"]:::github
     GH -->|PR health| PRS["github:prs"]:::github
+    GH -->|Review PR| PRREVIEW["github:pr-review"]:::github
 
     WEEK -->|calls| ISSUES
     WEEK -->|calls| PRS
@@ -43,6 +44,9 @@ What do you need?
     ├─ Analyze open PRs (CI status, review needed)
     │   → github:prs
     │
+    ├─ Review a specific PR (inline comments, conventions)
+    │   → github:pr-review
+    │
     └─ Create an issue with proper template
         → repo:issue
 ```
@@ -54,6 +58,7 @@ What do you need?
 | `github:my-status` | Personal dashboard: your open PRs, pending reviews, assigned issues |
 | `github:last-week` | Weekly report: merged PRs, new issues, CI health, priority analysis |
 | `github:issues` | Issue triage: stale, blocking, no attention, should-close |
+| `github:pr-review` | Automated PR review: inline comments, conventions, security checks |
 | `github:prs` | PR health: passing CI without review, stale, conflicts |
 
 ## Related Skills


### PR DESCRIPTION
## Summary

Adds a new `github:pr-review` Claude Code skill that automates PR reviews with inline GitHub comments.

Key changes:
- New skill at `.claude/skills/github:pr-review/SKILL.md` with a 5-phase workflow: Gather → Analyze → Review → Draft → Submit
- Checks against Kagenti-specific conventions: signed commits, PR format, security, per-area linting (Python, Helm/K8s, Shell, YAML, Dockerfiles), tests, and docs
- Drafts inline comments for user approval before posting reviews via `gh api`
- Context-safe: large diffs redirected to `/tmp/kagenti/review/` and analyzed by subagents
- Updated `github/SKILL.md` router with new skill in diagram, auto-select tree, and available skills table
- Registered in `.claude/settings.json`

