### PR TITLE
fix: propagate AuthBridge inject label to tool pod templates

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.2.0-alpha.20
 - name: kagenti-webhook-chart
   repository: oci://ghcr.io/kagenti/kagenti-extensions
-  version: 0.4.0-alpha.4
-digest: sha256:7ed9e3c1daf12cdc33865a6d74ac26c887923aafa49a8b2f7ea33818405887bf
-generated: "2026-02-24T09:58:19.585497-05:00"
+  version: 0.4.0-alpha.5
+digest: sha256:78ecdec88cf67d017ff3dc6c5450545f5b79b8b8806fd19a6c9321f132c3d793
+generated: "2026-02-25T12:44:28.679149-05:00"

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -1102,6 +1102,7 @@ def _build_tool_deployment_manifest(
         KAGENTI_PROTOCOL_LABEL: VALUE_PROTOCOL_MCP,
         KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
         KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_INJECT_LABEL: "enabled" if auth_bridge_enabled else "disabled",
     }
 
     # SPIRE identity label (triggers spiffe-helper sidecar injection by kagenti-webhook)
@@ -1249,6 +1250,7 @@ def _build_tool_statefulset_manifest(
         KAGENTI_PROTOCOL_LABEL: VALUE_PROTOCOL_MCP,
         KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
         KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_INJECT_LABEL: "enabled" if auth_bridge_enabled else "disabled",
     }
 
     # SPIRE identity label (triggers spiffe-helper sidecar injection by kagenti-webhook)
@@ -2301,6 +2303,10 @@ def _build_deployment_from_mcpserver(mcpserver: Dict, namespace: str) -> Dict:
     # Add framework if present
     if KAGENTI_FRAMEWORK_LABEL in labels:
         pod_labels[KAGENTI_FRAMEWORK_LABEL] = labels[KAGENTI_FRAMEWORK_LABEL]
+
+    # Propagate inject label to pod template so the webhook can read it
+    if KAGENTI_INJECT_LABEL in labels:
+        pod_labels[KAGENTI_INJECT_LABEL] = labels[KAGENTI_INJECT_LABEL]
 
     # Build pod spec
     new_pod_spec = {


### PR DESCRIPTION
## Summary

- Propagates the `kagenti.io/inject` label to tool pod template labels so the kagenti-webhook can read it and respect the AuthBridge toggle setting
- The AuthBridge toggle PR (#744) added the label to deployment metadata but missed the pod template labels, causing the webhook to always inject sidecars regardless of the UI toggle
- Also bumps the kagenti-webhook chart dependency to `0.4.0-alpha.5`

### Root cause

The webhook reads labels from the **pod template** (`.spec.template.metadata.labels`), not from the deployment metadata (`.metadata.labels`). The AuthBridge toggle PR added `KAGENTI_INJECT_LABEL` to deployment-level labels and the first set of pod labels, but missed the second set of pod labels in `_build_tool_deployment_manifest`, `_build_tool_statefulset_manifest`, and the `_build_deployment_from_mcpserver` migration path.

### Changes

| File | Change |
|------|--------|
| `kagenti/backend/app/routers/tools.py` | Add `KAGENTI_INJECT_LABEL` to pod template labels in deployment builder, statefulset builder, and MCPServer migration |
| `charts/kagenti/Chart.lock` | Bump webhook chart to `0.4.0-alpha.5` |

Part of: #767

## Test plan

- [ ] Import a tool via Kagenti UI with AuthBridge toggle **unchecked**
- [ ] Verify the tool pod runs with 1/1 containers (no sidecars injected)
- [ ] Import a tool with AuthBridge toggle **checked**
- [ ] Verify the tool pod has AuthBridge sidecars injected
