### PR TITLE
Chore: Bump kagenti operator version.

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -149,7 +149,7 @@ kagenti-operator-chart:
   controllerManager:
     container:
       image:
-        tag: 0.2.0-alpha.19
+        tag: 0.2.0-alpha.20
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
The latest version of kagenti-operator is alpha-0.20, currently we are shipping alpha-0.19.

0.20 fixed a bug in the AgentCard operator.

We should bump to 0.20 for now to fix the AgentCard operator.

The next version of kagenti-operator (0.21) should ship along with https://github.com/kagenti/kagenti/pull/766 since it changes the protocol label format.