### PR TITLE
chore: bump kagenti-operator to 0.2.0-alpha.21

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-alpha.20
+  version: 0.2.0-alpha.21
 - name: kagenti-webhook-chart
   repository: oci://ghcr.io/kagenti/kagenti-extensions
   version: 0.4.0-alpha.5
-digest: sha256:78ecdec88cf67d017ff3dc6c5450545f5b79b8b8806fd19a6c9321f132c3d793
-generated: "2026-02-25T12:44:28.679149-05:00"
+digest: sha256:88e98f9ae2b96a8e5a6644c663ff81b7ae97cd568077df963b8c89be4d9cc953
+generated: "2026-03-02T10:48:11.442622Z"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "0.1.2"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-alpha.20  # TODO: Bump after kagenti-operator PR #159 merges (removes AgentBuild CRD)
+  version: 0.2.0-alpha.21
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 - name: kagenti-webhook-chart

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -149,7 +149,7 @@ kagenti-operator-chart:
   controllerManager:
     container:
       image:
-        tag: 0.2.0-alpha.20
+        tag: 0.2.0-alpha.21
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
## Summary
- Bump kagenti-operator chart and image tag to 0.2.0-alpha.21 (latest version from 3 days ago)

## Changes
- Update `charts/kagenti/Chart.yaml` dependency version to `0.2.0-alpha.21`
- Update `charts/kagenti/values.yaml` controller manager image tag to `0.2.0-alpha.21`
- Regenerate `charts/kagenti/Chart.lock`
- Remove stale TODO comment about kagenti-operator https://github.com/kagenti/kagenti-operator/pull/159 