### PR TITLE
fix: handle operator-created deployment in weather-agent deploy script

### DIFF
--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -107,6 +107,11 @@ log_success "BuildRun completed successfully"
 
 log_info "Creating Deployment and Service..."
 
+# Clean up any operator-created deployment to apply our version
+# (the operator may auto-create a Deployment from the Shipwright Build)
+kubectl delete deployment weather-service -n team1 --ignore-not-found 2>/dev/null || true
+sleep 2
+
 # Apply Deployment manifest (use OCP-specific file with correct registry on OpenShift)
 if [ "$IS_OPENSHIFT" = "true" ]; then
     kubectl apply -f "$REPO_ROOT/kagenti/examples/agents/weather_service_deployment_ocp.yaml"


### PR DESCRIPTION
## Summary
- Fix `AlreadyExists` error in HyperShift E2E CI when deploying weather-service agent
- The new kagenti-operator v0.2.0-alpha.21 auto-creates Deployments from Shipwright Builds with `kagenti.io/type=agent` labels, causing a race condition with `74-deploy-weather-agent.sh`
- Add `kubectl delete deployment --ignore-not-found` before `kubectl apply` to handle both operator-created and fresh-cluster cases

## Context
CI failure: https://github.com/kagenti/kagenti/actions/runs/22580595411/job/65411353379

Blocked PR: #784 (bump kagenti-operator to 0.2.0-alpha.21)

## Test plan
- [ ] Merge this PR first, then re-run CI on PR #784
- [ ] Verify HyperShift E2E passes with operator v0.2.0-alpha.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)