### PR TITLE
fix: improve E2E agent conversation test diagnostics

### DIFF
--- a/kagenti/tests/e2e/common/test_agent_conversation.py
+++ b/kagenti/tests/e2e/common/test_agent_conversation.py
@@ -99,18 +99,24 @@ def _get_ssl_context():
 # ============================================================================
 
 
+# Truncation limits for diagnostic output in assertion messages
+_DIAG_TEXT_LIMIT = 200
+_DIAG_ARTIFACT_LIMIT = 100
+_DIAG_ERROR_LIMIT = 500
+
+
 def _extract_text_from_parts(parts):
-    """Extract text from A2A message/artifact parts."""
-    text = ""
-    for part in parts or []:
-        p = getattr(part, "root", part)
-        if hasattr(p, "text"):
-            text += p.text
-    return text
+    """Extract concatenated text from a list of A2A Part objects."""
+    return "".join(
+        p.text
+        for part in (parts or [])
+        for p in [getattr(part, "root", part)]
+        if hasattr(p, "text")
+    )
 
 
 def _task_diagnostic(task):
-    """Build diagnostic string for a task (for assertion messages)."""
+    """Build a diagnostic string from an A2A Task for assertion messages."""
     if not task:
         return "task=None"
     lines = []
@@ -121,13 +127,13 @@ def _task_diagnostic(task):
         if msg:
             text = _extract_text_from_parts(getattr(msg, "parts", []))
             if text:
-                lines.append(f"task.status.message={text[:200]}")
+                lines.append(f"task.status.message={text[:_DIAG_TEXT_LIMIT]}")
     artifacts = getattr(task, "artifacts", None)
     lines.append(f"task.artifacts count={len(artifacts) if artifacts else 0}")
     if artifacts:
         for i, art in enumerate(artifacts):
             art_text = _extract_text_from_parts(getattr(art, "parts", []))
-            lines.append(f"  artifact[{i}] text={art_text[:100]!r}")
+            lines.append(f"  artifact[{i}] text={art_text[:_DIAG_ARTIFACT_LIMIT]!r}")
     return "\n    ".join(lines)
 
 
@@ -233,7 +239,7 @@ class TestWeatherAgentConversation:
                 f"Agent returned a FAILED task\n"
                 f"  Agent URL: {agent_url}\n"
                 f"  Query: {user_message}\n"
-                f"  Error: {full_response[:500]}\n"
+                f"  Error: {full_response[:_DIAG_ERROR_LIMIT]}\n"
                 f"  Task details:\n    {_task_diagnostic(last_task)}"
             )
 
@@ -357,7 +363,7 @@ class TestWeatherAgentConversation:
                                 )
                             pytest.fail(
                                 f"Turn {turn}: Agent returned FAILED task\n"
-                                f"  Error: {full_response[:500]}\n"
+                                f"  Error: {full_response[:_DIAG_ERROR_LIMIT]}\n"
                                 f"  Task details:\n"
                                 f"    {_task_diagnostic(last_task)}"
                             )


### PR DESCRIPTION
## Summary
- Add diagnostic output to `test_agent_simple_query` and `test_agent_multiturn_conversation` E2E tests
- These tests have been failing on main with empty agent responses but no diagnostic info about **why**
- Now the assertion messages include task status (completed/failed), artifact details, and error messages

## Problem
The 3 pre-existing E2E failures on main ([run #22580521679](https://github.com/kagenti/kagenti/actions/runs/22580521679)):
```
FAILED test_agent_simple_query - Agent did not return any response
    Events received: ['Task(final)']
FAILED test_agent_multiturn_conversation - Turn 1: Agent did not return any response  
FAILED test_root_span_has_mlflow_attributes - Missing mlflow.spanOutputs (consequence of empty response)
```

The tests receive a completed A2A task but with no artifacts, and the assertion message gives no clue about the root cause (LLM error? MCP failure? A2A protocol issue?).

## Changes
- **`_extract_text_from_parts()`** - shared helper for extracting text from A2A parts
- **`_task_diagnostic()`** - builds diagnostic string with task status, state, artifact count/content
- **`TaskState.failed` detection** - checks task status for failures and reports the error message
- **Enhanced assertion messages** - include task details so CI failures are immediately actionable

## Investigation Notes
- Agent code (`ladas/agent-examples`, branch `genai-autoinstrumentation`) unchanged since Feb 11
- Agent uses `a2a-sdk==0.3.2` (locked), test client uses `a2a-sdk==0.3.22` (locked)
- Same tests passed on Feb 28, started failing Mar 2 — likely external factor (OpenAI API)
- The `test_root_span_has_mlflow_attributes` failure is a downstream consequence (no `mlflow.spanOutputs` because agent returned empty)

## Test plan
- [ ] HyperShift E2E CI will run these tests — even if they still fail, the diagnostic output will reveal the root cause
- [ ] Once root cause is identified from diagnostics, a follow-up fix can address it

🤖 Generated with [Claude Code](https://claude.com/claude-code)