### PR TITLE
chore: Bump UI/backend image tags to v0.5.0-alpha.9

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -59,7 +59,7 @@ ui:
   # Frontend (UI v2) configuration
   frontend:
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.5.0-alpha.8
+    tag: v0.5.0-alpha.9
     resources:
       limits:
         cpu: 100m
@@ -73,7 +73,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.5.0-alpha.8
+    tag: v0.5.0-alpha.9
     resources:
       limits:
         cpu: 250m

--- a/deployments/ansible/kind/preload-images.txt
+++ b/deployments/ansible/kind/preload-images.txt
@@ -17,6 +17,6 @@ quay.io/containers/buildah:v1.37.5
 quay.io/keycloak/keycloak:26.3.3
 ghcr.io/shipwright-io/build/shipwright-build-controller:v0.14.0
 ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.14.0
-ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.8
+ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.9
 ghcr.io/kagenti/kagenti-operator/kagenti-operator:0.2.0-alpha.19
-ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.8
+ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.9


### PR DESCRIPTION
## Summary
- Update Helm chart defaults for `ui.frontend.tag` and `ui.backend.tag` to `v0.5.0-alpha.9`
- Update Kind preload image list to pull `ui-v2` and `backend` at `v0.5.0-alpha.9`
- Keep chart/install defaults aligned with the new release tag

## Test plan
- [ ] Run `helm template ./charts/kagenti` and confirm rendered UI/backend image tags are `v0.5.0-alpha.9`
- [ ] Run `deployments/ansible/run-install.sh --env dev --preload` and verify preload includes updated UI/backend images
- [ ] Deploy and confirm UI + backend pods use `v0.5.0-alpha.9`

Made with [Cursor](https://cursor.com)