### PR TITLE
fix: pass KEYCLOAK_URL to oauth-secret job in OpenShift mode

### DIFF
--- a/charts/kagenti/templates/ui-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/ui-oauth-secret-job.yaml
@@ -100,9 +100,9 @@ spec:
           value: {{ .Values.keycloak.adminUsernameKey | quote }}
         - name: KEYCLOAK_ADMIN_PASSWORD_KEY
           value: {{ .Values.keycloak.adminPasswordKey | quote }}
-        {{- if not .Values.openshift }}
         - name: KEYCLOAK_URL
           value: {{ .Values.keycloak.url | quote }}
+        {{- if not .Values.openshift }}
         - name: KEYCLOAK_PUBLIC_URL
           value: {{ .Values.keycloak.publicUrl | quote }}
         - name: ROOT_URL


### PR DESCRIPTION
## Summary

- Fix SSL certificate verification failure in `kagenti-ui-oauth-secret-job` on OpenShift
- Move `KEYCLOAK_URL` env var outside the `openshift` conditional in the Helm template so the job uses the internal Keycloak service URL for admin API calls instead of the external HTTPS route
- The route's TLS certificate (signed by the OpenShift ingress CA) is not in the pod's service account CA bundle, causing the job to fail silently

## Root Cause

The Helm template `charts/kagenti/templates/ui-oauth-secret-job.yaml` excluded `KEYCLOAK_URL` when `openshift=true`. Without it, the job discovered the Keycloak URL from the OpenShift route (HTTPS) and failed with `SSL: CERTIFICATE_VERIFY_FAILED`. The job exhausted its retries and was cleaned up by the 300s TTL, leaving no visible trace. The missing secret caused `kagenti-backend` to stay in `CreateContainerConfigError`.

## Test plan

- [ ] Deploy on OpenShift with `openshift: true` and verify `kagenti-ui-oauth-secret` is created
- [ ] Verify `kagenti-backend` starts successfully
- [ ] Verify Kind deployment still works (non-OpenShift path unchanged)

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)