### PR TITLE
fix: switch CI LLM from OpenAI to Mistral MAAS

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -129,8 +129,8 @@ data:
         "name": "LLM_API_KEY",
         "valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}
       },
-      {"name": "LLM_API_BASE", "value": "https://api.openai.com/v1"},
-      {"name": "LLM_MODEL", "value": "gpt-4o-mini-2024-07-18"}
+      {"name": "LLM_API_BASE", "value": "https://mistral-small-24b-w8a8-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"},
+      {"name": "LLM_MODEL", "value": "mistral-small-24b-w8a8"}
     ]
   mcp-weather: |
     [

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -48,7 +48,7 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://api.openai.com/v1"
+          value: "https://mistral-small-24b-w8a8-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"
         - name: OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
@@ -60,7 +60,7 @@ spec:
               name: openai-secret
               key: apikey
         - name: LLM_MODEL
-          value: "gpt-4o-mini"
+          value: "mistral-small-24b-w8a8"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:


### PR DESCRIPTION
## Summary
- OpenAI API credits exhausted — weather-service conversation tests fail silently (empty responses, `TaskState.submitted`, 0 artifacts)
- Switch HyperShift CI to use Mistral MAAS (`mistral-small-24b-w8a8`) via Red Hat AI Services
- Kind CI is unaffected (uses Ollama)

## Changes
- OCP deployment YAML: `LLM_API_BASE` → Mistral endpoint, `LLM_MODEL` → `mistral-small-24b-w8a8`
- Helm ConfigMap `openai` environment block: same swap
- CI scripts (`20-create-secrets.sh`, `70-deploy-kagenti.sh`): read `LLM_API_KEY` first, fall back to `OPENAI_API_KEY`
- Workflows: pass `KAGENTI_CI_MISTRAL_API_KEY` GitHub secret

## Prerequisites
Set the GitHub secret before merging:
```bash
source .env.maas
gh secret set KAGENTI_CI_MISTRAL_API_KEY --body "$KAGENTI_CI_MISTRAL_API_KEY" --repo kagenti/kagenti
```

## Test plan
- [x] Set `KAGENTI_CI_MISTRAL_API_KEY` GitHub secret
- [x] Trigger HyperShift PR CI (`/run-e2e`) and verify conversation tests pass
- [ ] Verify Kind CI still passes (uses Ollama, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)