### PR TITLE
fix(ci): add agent logs to HyperShift failure diagnostics

### DIFF
--- a/.github/scripts/hypershift/ci/85-collect-failure-info.sh
+++ b/.github/scripts/hypershift/ci/85-collect-failure-info.sh
@@ -64,6 +64,26 @@ if [ -n "${KUBECONFIG:-}" ] && [ -f "${KUBECONFIG:-}" ]; then
     oc get pods -n kagenti-system 2>/dev/null || echo "(namespace not found or cluster not reachable)"
 
     echo ""
+    echo "=== Pods in team1 ==="
+    oc get pods -n team1 2>/dev/null || echo "(namespace not found)"
+
+    echo ""
+    echo "=== Weather Service Agent Logs (last 50 lines) ==="
+    oc logs -n team1 deployment/weather-service --tail=50 2>/dev/null || echo "(not available)"
+
+    echo ""
+    echo "=== Weather Service Agent Env Vars (LLM config) ==="
+    oc get deployment weather-service -n team1 -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{.valueFrom.secretKeyRef.name}{"\n"}{end}' 2>/dev/null || echo "(not available)"
+
+    echo ""
+    echo "=== Weather Tool MCP Logs (last 30 lines) ==="
+    oc logs -n team1 deployment/weather-tool --tail=30 2>/dev/null || echo "(not available)"
+
+    echo ""
+    echo "=== OTEL Collector Errors (last 20 lines) ==="
+    oc logs -n kagenti-system deployment/otel-collector --tail=100 2>/dev/null | grep -iE "error|fail|warn" | tail -20 || echo "(none found)"
+
+    echo ""
     echo "=== Recent Events ==="
     oc get events -A --sort-by='.lastTimestamp' 2>/dev/null | tail -50 || echo "(events not available)"
 else


### PR DESCRIPTION
## Summary
- Add weather-service agent logs, env var inspection, weather-tool MCP logs, and OTEL collector error filtering to `85-collect-failure-info.sh`
- Currently the diagnostic script only captures pod status and cluster events, making it impossible to diagnose agent-level failures from CI output

## Context
RCA of the recent HyperShift E2E failures ([run #22594480261](https://github.com/kagenti/kagenti/actions/runs/22594480261), [run #22580521679](https://github.com/kagenti/kagenti/actions/runs/22580521679)) showed:
- `test_agent_simple_query` and `test_agent_multiturn_conversation` failed with `TaskState.submitted` / 0 artifacts
- The weather agent's LLM call was failing silently (unhandled exception in `graph.astream()`)
- **Root cause**: OpenAI API issue (confirmed by PR #806 switching to Mistral MAAS)
- **Amplifying factor**: No agent pod logs in CI diagnostics — the actual error was invisible

## New diagnostic sections
| Section | Purpose |
|---------|---------|
| Pods in team1 | See agent/tool pod status |
| Weather Service Agent Logs | Reveals LLM errors, MCP failures, startup issues |
| Weather Service Env Vars | Verify LLM_API_BASE, LLM_MODEL, secret refs |
| Weather Tool MCP Logs | Check MCP tool server health |
| OTEL Collector Errors | Filtered error/warn lines from collector |

## Test plan
- [x] `bash -n .github/scripts/hypershift/ci/85-collect-failure-info.sh`
- [ ] Next HyperShift E2E failure will include agent logs in the diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)