### PR TITLE
fix: switch CI LLM to Llama 3.2 3B for reliable tool calling

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -129,8 +129,8 @@ data:
         "name": "LLM_API_KEY",
         "valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}
       },
-      {"name": "LLM_API_BASE", "value": "https://mistral-small-24b-w8a8-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"},
-      {"name": "LLM_MODEL", "value": "mistral-small-24b-w8a8"}
+      {"name": "LLM_API_BASE", "value": "https://llama-3-2-3b-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"},
+      {"name": "LLM_MODEL", "value": "llama-3-2-3b"}
     ]
   mcp-weather: |
     [

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -48,7 +48,7 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://mistral-small-24b-w8a8-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"
+          value: "https://llama-3-2-3b-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"
         - name: OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
@@ -60,7 +60,7 @@ spec:
               name: openai-secret
               key: apikey
         - name: LLM_MODEL
-          value: "mistral-small-24b-w8a8"
+          value: "llama-3-2-3b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:


### PR DESCRIPTION
## Summary
- Mistral Small 24B does not reliably support function/tool calling, causing weather-service agent to fail when invoking the MCP weather tool
- Switch to Llama 3.2 3B Instruct (MAAS) which supports function calling (verified locally)
- Kind CI is unaffected (uses Ollama)

## Changes
- OCP deployment YAML: `LLM_API_BASE` → Llama 3.2 endpoint, `LLM_MODEL` → `llama-3-2-3b`
- Helm ConfigMap `openai` environment block: same swap

## Prerequisites
Update the GitHub secret before triggering CI:
```bash
source .env.maas
gh secret set OPENAI_API_KEY --body "$MAAS_LLAMA32_API_KEY" --repo kagenti/kagenti
```

## Test plan
- [x] Verified Llama 3.2 3B tool calling works (curl test with `get_weather` function)
- [x] Update `OPENAI_API_KEY` GitHub secret
- [x] Trigger HyperShift PR CI (`/run-e2e`) and verify conversation tests pass
- [ ] Verify Kind CI still passes (uses Ollama, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)