### PR TITLE
Switch CI LLM to Llama 4 Scout for stable MCP tool calling

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -129,8 +129,8 @@ data:
         "name": "LLM_API_KEY",
         "valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}
       },
-      {"name": "LLM_API_BASE", "value": "https://llama-3-2-3b-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"},
-      {"name": "LLM_MODEL", "value": "llama-3-2-3b"}
+      {"name": "LLM_API_BASE", "value": "https://llama-4-scout-17b-16e-w4a16-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"},
+      {"name": "LLM_MODEL", "value": "llama-4-scout-17b-16e-w4a16"}
     ]
   mcp-weather: |
     [

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -48,7 +48,7 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://llama-3-2-3b-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"
+          value: "https://llama-4-scout-17b-16e-w4a16-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"
         - name: OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
@@ -60,7 +60,7 @@ spec:
               name: openai-secret
               key: apikey
         - name: LLM_MODEL
-          value: "llama-3-2-3b"
+          value: "llama-4-scout-17b-16e-w4a16"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:


### PR DESCRIPTION
## Summary
- Switch CI LLM from Llama 3.2 3B to Llama 4 Scout 17B (`llama-4-scout-17b-16e-w4a16`) which provides stable MCP tool calling support
- Llama 3.2 3B (from #812) does not reliably handle MCP tool calling; after testing various MaaS models, Llama 4 Scout is the only one with stable support
- Requires updating `OPENAI_API_KEY` GitHub secret to the Llama 4 Scout API key

## Changes
- `charts/kagenti/templates/agent-namespaces.yaml` — update `openai` environment ConfigMap
- `kagenti/examples/agents/weather_service_deployment_ocp.yaml` — update OCP deployment manifest

## Test plan
- [ ] Verify `OPENAI_API_KEY` GitHub secret is updated for Llama 4 Scout endpoint
- [ ] CI E2E tests pass with weather-service agent using MCP tool calling
- [ ] Weather agent correctly invokes MCP weather tool via function calling

🤖 Generated with [Claude Code](https://claude.com/claude-code)