### PR TITLE
fix: replace env vars on re-import instead of silently skipping duplicates

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -258,10 +258,7 @@ export const ImportAgentPage: React.FC = () => {
   };
 
   const handleImportEnvVars = (importedVars: EnvVar[]) => {
-    // Merge imported variables with existing ones, avoiding duplicates
-    const existingNames = new Set(envVars.map(v => v.name));
-    const newVars = importedVars.filter(v => !existingNames.has(v.name));
-    setEnvVars([...envVars, ...newVars]);
+    setEnvVars(importedVars);
     setShowEnvVars(true);
   };
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -259,9 +259,7 @@ export const ImportToolPage: React.FC = () => {
   };
 
   const handleImportEnvVars = (importedVars: EnvVar[]) => {
-    const existingNames = new Set(envVars.map(v => v.name));
-    const newVars = importedVars.filter(v => !existingNames.has(v.name));
-    setEnvVars([...envVars, ...newVars]);
+    setEnvVars(importedVars);
     setShowEnvVars(true);
   };
 


### PR DESCRIPTION
Fixes #810

## Summary
- Fix env var import to replace all existing vars instead of silently skipping duplicates

## Changes
- `ImportAgentPage.tsx` and `ImportToolPage.tsx`: replace merge logic with full replacement in `handleImportEnvVars`.

## Test Plan
- [x] Import `.env.openai`, then import `.env.ollama`, verify it reflects solely the Ollama env vars.

https://github.com/user-attachments/assets/18755fa9-0db1-4010-a5ec-4e2016319188

