### PR TITLE
docs: operator migration design V8 - RHOAI/ODH DataScienceCluster integration

### DIFF
--- a/docs/architecture/operator-migration-design.md
+++ b/docs/architecture/operator-migration-design.md
@@ -1,53 +1,64 @@
-# Kagenti Operator Migration Design
+# Kagenti Platform: Operator Migration Design
 
-> **Version**: 5.0 (Final)
-> **Date**: 2026-03-04
-> **Status**: Approved after 5-round architectural review
-> **Tracking Issue**: [#828](https://github.com/kagenti/kagenti/issues/828)
+**From Ansible/Helm to Kubernetes Operator — "Operator of Operators" Architecture**
+
+| Field | Value |
+|-------|-------|
+| Version | 8.0 (V8) |
+| Date | 2026-03-04 |
+| Status | 4-round adversarial architectural review (V5 baseline + 4 rounds with RHOAI/ODH integration) |
+| Authors | Paolo Dettori |
+| Assisted-By | Claude Opus 4.6 |
+
+---
 
 ## Table of Contents
 
-- [1. Executive Summary](#1-executive-summary)
-- [2. Background and Motivation](#2-background-and-motivation)
-  - [2.1 Current State: Ansible/Helm Installer](#21-current-state-ansiblehelm-installer)
-  - [2.2 Why Migrate to an Operator](#22-why-migrate-to-an-operator)
-  - [2.3 Product Manager Context](#23-product-manager-context)
-- [3. Architecture Overview](#3-architecture-overview)
-  - [3.1 Two-Tier Operator Model](#31-two-tier-operator-model)
-  - [3.2 Tier 1: Kagenti Platform Operator (Product)](#32-tier-1-kagenti-platform-operator-product)
-  - [3.3 Tier 1 Observability Controller](#33-tier-1-observability-controller)
-  - [3.4 Tier 2: Kagenti Quickstart Installer (Dev Tool)](#34-tier-2-kagenti-quickstart-installer-dev-tool)
-  - [3.5 Companion: kagenti-prereqs Helm Chart](#35-companion-kagenti-prereqs-helm-chart)
-- [4. CRD Design: KagentiPlatform](#4-crd-design-kagentiplatform)
-  - [4.1 Full CR Schema](#41-full-cr-schema)
-  - [4.2 Status Subresource](#42-status-subresource)
-  - [4.3 Infrastructure Validation](#43-infrastructure-validation)
-- [5. Controller Architecture](#5-controller-architecture)
-  - [5.1 Platform Controller](#51-platform-controller)
-  - [5.2 Observability Controller](#52-observability-controller)
-  - [5.3 Two Controllers, One CRD](#53-two-controllers-one-crd)
-  - [5.4 Phase-Based State Machine (Quickstart)](#54-phase-based-state-machine-quickstart)
-- [6. Component Interface and Extensibility](#6-component-interface-and-extensibility)
-  - [6.1 Component Interface](#61-component-interface)
-  - [6.2 Installation Strategies](#62-installation-strategies)
-  - [6.3 Adding a New Package](#63-adding-a-new-package)
-- [7. RBAC and Security](#7-rbac-and-security)
-  - [7.1 Product Operator RBAC (Tier 1)](#71-product-operator-rbac-tier-1)
-  - [7.2 Security Properties](#72-security-properties)
-  - [7.3 Comparison: Monolithic vs. Two-Tier RBAC](#73-comparison-monolithic-vs-two-tier-rbac)
-- [8. OLM Subscription Lifecycle (Quickstart)](#8-olm-subscription-lifecycle-quickstart)
-- [9. Day-2 Operations](#9-day-2-operations)
-  - [9.1 Upgrade Coordination](#91-upgrade-coordination)
-  - [9.2 Drift Detection](#92-drift-detection)
-  - [9.3 Health and Degradation Model](#93-health-and-degradation-model)
-  - [9.4 Deletion Policy](#94-deletion-policy)
-  - [9.5 Ansible vs. Operator Comparison](#95-ansible-vs-operator-comparison)
-- [10. Migration Path from Ansible](#10-migration-path-from-ansible)
-  - [10.1 Adoption via Server-Side Apply](#101-adoption-via-server-side-apply)
-  - [10.2 Graduation Path](#102-graduation-path)
-  - [10.3 UX Preservation](#103-ux-preservation)
-- [11. Implementation Timeline](#11-implementation-timeline)
-- [12. Consolidated Decision Record](#12-consolidated-decision-record)
+1. [Executive Summary](#1-executive-summary)
+2. [Background and Motivation](#2-background-and-motivation)
+3. [Architecture Overview](#3-architecture-overview)
+   - 3.1 [Three-Tier Deployment Model](#31-three-tier-deployment-model)
+   - 3.2 [Tier 1: Kagenti Platform Operator (Product)](#32-tier-1-kagenti-platform-operator-product)
+   - 3.3 [Tier 1 Observability Controller](#33-tier-1-observability-controller)
+   - 3.4 [Tier 2: RHOAI/ODH DataScienceCluster Integration](#34-tier-2-rhoaiodh-datasciencecluster-integration)
+   - 3.5 [Tier 3: Kagenti Quickstart Installer (Dev Tool)](#35-tier-3-kagenti-quickstart-installer-dev-tool)
+   - 3.6 [Companion: kagenti-prereqs Helm Chart](#36-companion-kagenti-prereqs-helm-chart)
+   - 3.7 [Formal Dependency Mapping](#37-formal-dependency-mapping)
+4. [CRD Design: KagentiPlatform](#4-crd-design-kagentiplatform)
+   - 4.1 [Full CR Schema](#41-full-cr-schema)
+   - 4.2 [Status Subresource](#42-status-subresource)
+   - 4.3 [Infrastructure Validation](#43-infrastructure-validation)
+5. [Controller Architecture](#5-controller-architecture)
+   - 5.1 [Platform Controller](#51-platform-controller)
+   - 5.2 [Observability Controller](#52-observability-controller)
+   - 5.3 [Two Controllers, One CRD](#53-two-controllers-one-crd)
+   - 5.4 [Phase-Based State Machine (Quickstart)](#54-phase-based-state-machine-quickstart)
+6. [Component Interface and Extensibility](#6-component-interface-and-extensibility)
+   - 6.1 [Component Interface](#61-component-interface)
+   - 6.2 [Installation Strategies](#62-installation-strategies)
+   - 6.3 [Adding a New Package](#63-adding-a-new-package)
+   - 6.4 [Unmanaged Component Semantics](#64-unmanaged-component-semantics)
+7. [RBAC and Security](#7-rbac-and-security)
+   - 7.1 [Product Operator RBAC](#71-product-operator-rbac)
+   - 7.2 [Security Properties](#72-security-properties)
+   - 7.3 [Comparison with Monolithic Approach](#73-comparison-with-monolithic-approach)
+   - 7.4 [OLM Dependency Strategy — Dual CSV Approach](#74-olm-dependency-strategy--dual-csv-approach)
+   - 7.5 [RBAC Verification for Unmanaged Health Checks](#75-rbac-verification-for-unmanaged-health-checks)
+8. [OLM Subscription Lifecycle (Quickstart)](#8-olm-subscription-lifecycle-quickstart)
+9. [Day-2 Operations](#9-day-2-operations)
+   - 9.1 [Upgrade Coordination](#91-upgrade-coordination)
+   - 9.2 [Drift Detection](#92-drift-detection)
+   - 9.3 [Health and Degradation Model](#93-health-and-degradation-model)
+   - 9.4 [Deletion Policy](#94-deletion-policy)
+   - 9.5 [Day-2 Comparison: Ansible vs. Operator](#95-day-2-comparison-ansible-vs-operator)
+   - 9.6 [Observability Deconfliction with RHOAI](#96-observability-deconfliction-with-rhoai)
+10. [Migration Path from Ansible](#10-migration-path-from-ansible)
+    - 10.1 [Adoption via Server-Side Apply](#101-adoption-via-server-side-apply)
+    - 10.2 [Graduation Path](#102-graduation-path)
+    - 10.3 [UX Preservation](#103-ux-preservation)
+11. [Implementation Timeline](#11-implementation-timeline)
+    - 11.1 [ODH Contribution Governance](#111-odh-contribution-governance)
+12. [Decision Record](#12-decision-record)
 - [Appendix A: Quickstart Phase Ordering](#appendix-a-quickstart-phase-ordering)
 - [Appendix B: Component Criticality Matrix](#appendix-b-component-criticality-matrix)
 
@@ -55,15 +66,17 @@
 
 ## 1. Executive Summary
 
-This document presents the final architecture for migrating the Kagenti platform installer from an Ansible/Helm-based approach to a Kubernetes Operator-based approach. The design was refined through 5 rounds of internal architectural review between a Lead Architect and a Quality Advocate, with human reviewer input on security, RBAC, and productization constraints.
+This document presents the architecture for migrating the Kagenti platform installer from an Ansible/Helm-based approach to a Kubernetes Operator-based approach. The design was refined through 5 rounds of internal architectural review (V1-V5), followed by 4 additional rounds incorporating product management feedback on RHOAI/ODH DataScienceCluster integration (V6-V8).
 
 ### Key Decisions
 
-- **Two-tier split**: A product-grade Platform Operator (Tier 1) manages only Kagenti's own components. An optional Quickstart Operator (Tier 2) handles infrastructure prerequisites for dev/PoC environments.
+- **Three-tier deployment model**: A product-grade Platform Operator (Tier 1) manages only Kagenti's own components. An ODH/RHOAI component handler (Tier 2) integrates Kagenti into the DataScienceCluster meta-operator. An optional Quickstart Operator (Tier 3) handles infrastructure prerequisites for dev/PoC environments.
 - **Validate, don't install**: The product operator checks that infrastructure prerequisites (Istio, Keycloak, SPIRE, etc.) exist but does NOT install them. This keeps RBAC narrow and enables Konflux/OLM certification.
 - **Single CRD, two controllers**: One `KagentiPlatform` CRD with a Platform Controller and an Observability Controller, minimizing user-facing surface area.
-- **Static prereqs chart**: A `kagenti-prereqs` Helm chart provides auditable, review-before-apply prerequisite manifests for production clusters.
-- **Narrow RBAC**: The product operator has no `escalate`, no CRD creation, no OLM management, and no third-party CR mutation. Read-only infrastructure validation only.
+- **RHOAI integration via thin wrapper**: The ODH component handler is a ~200-line adapter that creates a `KagentiPlatform` CR. The Kagenti team owns the operator logic; ODH integration is minimal.
+- **`managementState` tri-state**: Adopts the ODH/RHOAI `Managed | Removed | Unmanaged` pattern for component lifecycle control.
+- **Dual CSV bundles**: Standalone (soft OLM dependencies) and RHOAI (hard CRD requirements) variants from the same operator binary.
+- **Narrow RBAC**: The product operator has no escalate, no CRD creation, no OLM management, and no third-party CR mutation. Read-only infrastructure validation only.
 
 ---
 
@@ -73,125 +86,69 @@ This document presents the final architecture for migrating the Kagenti platform
 
 Kagenti currently uses an Ansible playbook (`roles/kagenti_installer`) that orchestrates 29+ sequential installation steps. The playbook handles:
 
-- **Platform-adaptive logic**: The same component (e.g., "install SPIRE") resolves to completely different actions depending on whether the target is Kind, OpenShift 4.18 (fallback to upstream SPIRE Helm charts), or OpenShift 4.19+ (ZTWIM operator via OLM). This requires runtime detection of the cluster type and OCP version with multi-step fallback chains.
-- **Cross-resource ordering with waits**: CRDs must exist before CRs can be created, operators must reach `Succeeded` before operands are applied, webhooks must be healthy before dependent resources are submitted. The playbook has retry loops ranging from 3 retries/15s (Helm installs) up to 90 retries/10s (TektonConfig readiness — 15 min).
-- **Conflict detection**: On OpenShift, existing OLM-installed operators (cert-manager, Tekton) need to be detected and skipped rather than re-installed.
-- **Post-install fixups**: Several resources created by operators need imperative patches afterward (TektonConfig security context, github-clone-step ConfigMap for Istio ambient, CA secret copying across namespaces, container registry DNS in Kind).
-- **Diagnostic collection on failure**: Ansible's rescue blocks collect targeted pod status and logs before failing.
-
-The two-level toggle architecture uses Ansible-level flags (controlling whether Ansible installs components natively) and Helm `components.*` toggles (controlling which resources Helm templates render). Environment files (`dev_values.yaml`, `ocp_values.yaml`, etc.) configure these for different deployment targets.
+- **Platform-adaptive logic**: The same component resolves to different actions depending on whether the target is Kind, OpenShift 4.18, or OpenShift 4.19+.
+- **Cross-resource ordering with waits**: CRDs before CRs, operators before operands, webhooks before dependent resources.
+- **Conflict detection**: Pre-installed OLM operators on OpenShift are detected and skipped.
+- **Post-install fixups**: TektonConfig patches, ConfigMap modifications, CA secret copying.
+- **Diagnostic collection on failure** via Ansible rescue blocks.
 
 ### 2.2 Why Migrate to an Operator
 
 | Driver | Ansible Limitation | Operator Advantage |
-|--------|--------------------|--------------------|
+|--------|-------------------|-------------------|
 | Self-healing | None. Manual re-run on failure. | Continuous reconciliation restores desired state. |
-| Drift detection | None. Manual `helm diff` required. | Controller detects and repairs drift automatically. |
+| Drift detection | None. Manual helm diff required. | Controller detects and repairs drift automatically. |
 | Day-2 operations | Re-run full playbook for any change. | Edit CR spec; controller applies minimal diff. |
 | Productization | Cannot ship via OLM/Konflux. | Native OLM distribution, Red Hat certification. |
-| Declarative UX | Imperative playbook execution. | `kubectl apply` a CR; watch status converge. |
-| GitOps | Not GitOps-friendly. | CR can be managed by ArgoCD. |
-| Observability | Check Ansible logs, manual `kubectl`. | `kubectl get kagentiplatform` shows full status. |
+| Declarative UX | Imperative playbook execution. | kubectl apply a CR; watch status converge. |
 
 ### 2.3 Product Manager Context
 
-Internal discussions established several constraints that directly shaped this architecture:
+As highlighted in internal discussions, "reducing as much of the dependencies as possible would be desirable as a prevention mechanism, otherwise we end up encoding that complexity somewhere." This directly informed the three-tier split.
 
-> "Reducing as much of the dependencies as possible would be desirable as a prevention mechanism, otherwise we end up encoding that complexity somewhere."
-
-This informed the two-tier split: the product operator is lean and certifiable; infrastructure complexity lives in an optional dev tool.
-
-> "As we move the kagenti pieces to the product, the operator pattern would make most sense especially."
-
-Team consensus that the operator pattern is the right long-term approach.
-
-Additionally, images for Kagenti need to be provided through Konflux once APIs are solidified (RHAIRFE-1351). The operator architecture is designed with this constraint from the start.
+The PM review (Adel Zaalouk, Andrew Block) identified that:
+- Most Kagenti dependencies already have Red Hat operator equivalents
+- RHOAI is a "meta operator" — Kagenti should be a component inside `DataScienceCluster`
+- Two scenarios must coexist: Kagenti as part of RHOAI, and Kagenti standalone for dev
 
 ---
 
 ## 3. Architecture Overview
 
-### 3.1 Two-Tier Operator Model
+### 3.1 Three-Tier Deployment Model
 
-The fundamental insight driving this architecture is that Kagenti has two fundamentally different concerns with different lifecycles and ownership:
+Kagenti has three deployment scenarios with different lifecycles and ownership:
 
-| Concern | What | Lifecycle | Owner |
-|---------|------|-----------|-------|
-| Kagenti itself | Operator, Webhook, UI, MCP Gateway | Product lifecycle (Konflux, OLM) | Kagenti team |
-| Infrastructure prerequisites | Istio, Keycloak, SPIRE, Tekton, etc. | External operator lifecycles | Platform team / cluster admin |
+| Tier | Name | Who Deploys | Target Environment | CRD Surface |
+|------|------|------------|-------------------|-------------|
+| **Tier 1** | Kagenti Platform Operator | OLM (standalone) or ODH operator (RHOAI) | Production OpenShift, vanilla K8s | `KagentiPlatform` |
+| **Tier 2** | RHOAI/ODH Integration | ODH meta-operator | Production RHOAI clusters | `DataScienceCluster.spec.components.kagenti` |
+| **Tier 3** | Kagenti Quickstart Installer | Developer | Kind, dev/PoC | `KagentiQuickstart` |
 
-Encoding infrastructure installation into the product operator would mean that when Istio breaks, **our** operator is on the hook. When OSSM v3 changes its CR schema, **our** operator must be updated. The two-tier model avoids this coupling entirely.
+**Key principle: Tier 1 is the reusable core.** Both Tier 2 (RHOAI) and Tier 3 (Quickstart) deploy Tier 1 underneath. They differ only in how prerequisites are satisfied and who creates the `KagentiPlatform` CR.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                     USER ENTRY POINTS                           │
-├──────────────────────┬──────────────────────┬───────────────────┤
-│  Dev / Kind          │  Production OCP      │  GitOps           │
-│  ./deploy.sh dev     │  OperatorHub +       │  ArgoCD applies   │
-│                      │  kagenti-prereqs     │  manifests from   │
-│                      │  chart               │  git repo         │
-└──────────┬───────────┴──────────┬───────────┴─────────┬─────────┘
-           │                      │                     │
-           ▼                      │                     │
-┌──────────────────────┐          │                     │
-│ Tier 2: Quickstart   │          │                     │
-│ Operator (dev only)  │          │                     │
-│                      │          │                     │
-│ Installs: Istio,     │          │                     │
-│ Keycloak, SPIRE,     │          │                     │
-│ Tekton, Shipwright,  │          │                     │
-│ cert-manager, etc.   │          │                     │
-│                      │          │                     │
-│ CRD: KagentiQuick-   │          │                     │
-│ start                │          │                     │
-│                      │          │                     │
-│ Creates once:        │          │                     │
-│ KagentiPlatform CR ──┼──┐       │                     │
-└──────────────────────┘  │       │                     │
-                          ▼       ▼                     ▼
-                    ┌─────────────────────────────────────────┐
-                    │ Tier 1: Kagenti Platform Operator       │
-                    │ (PRODUCT — Konflux / OLM)               │
-                    │                                         │
-                    │ CRD: KagentiPlatform                    │
-                    │                                         │
-                    │ ┌─────────────────────────────────────┐ │
-                    │ │ Platform Controller                 │ │
-                    │ │ • Validates infrastructure (r/o)    │ │
-                    │ │ • Installs: Agent Operator,         │ │
-                    │ │   Webhook, UI, MCP Gateway          │ │
-                    │ │ • Configures: agent namespaces,     │ │
-                    │ │   OAuth clients, SPIFFE configs     │ │
-                    │ │ • Drift detection + self-healing    │ │
-                    │ └─────────────────────────────────────┘ │
-                    │ ┌─────────────────────────────────────┐ │
-                    │ │ Observability Controller             │ │
-                    │ │ • Installs: OTel Collector (with    │ │
-                    │ │   Kagenti-specific pipeline config) │ │
-                    │ │ • Installs: Phoenix, MLflow         │ │
-                    │ │ • Owns GenAI semconv transforms     │ │
-                    │ └─────────────────────────────────────┘ │
-                    │                                         │
-                    │ Same OLM bundle, two controllers,       │
-                    │ one CRD, narrow RBAC                    │
-                    └─────────────────────────────────────────┘
-                                      │
-                          validates presence of
-                                      ▼
-                    ┌─────────────────────────────────────────┐
-                    │ Infrastructure (NOT managed by Kagenti) │
-                    │                                         │
-                    │ Istio (OSSM v3 / upstream Helm)         │
-                    │ Keycloak (RHBK / upstream Helm)         │
-                    │ SPIRE (ZTWIM / upstream Helm)           │
-                    │ Tekton (OpenShift Pipelines / upstream) │
-                    │ Shipwright (OpenShift Builds / upstream) │
-                    │ cert-manager (OCP operator / upstream)  │
-                    │ Gateway API CRDs                        │
-                    │                                         │
-                    │ Installed by: cluster admin, GitOps,    │
-                    │ kagenti-prereqs chart, or Quickstart    │
-                    └─────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│                  Deployment Scenarios                      │
+│                                                            │
+│  ┌─────────────┐  ┌──────────────────┐  ┌──────────────┐ │
+│  │   Tier 3    │  │     Tier 2       │  │  Standalone   │ │
+│  │  Quickstart │  │  RHOAI/ODH DSC   │  │  Tier 1 only  │ │
+│  │  (dev/PoC)  │  │  (product)       │  │  (adv. user)  │ │
+│  └──────┬──────┘  └────────┬─────────┘  └──────┬────────┘ │
+│         │                  │                    │          │
+│         │  creates CR      │  creates CR        │  user    │
+│         ▼                  ▼                    ▼          │
+│  ┌─────────────────────────────────────────────────────┐  │
+│  │          Tier 1: Kagenti Platform Operator          │  │
+│  │          (reconciles KagentiPlatform CR)             │  │
+│  └─────────────────────────────────────────────────────┘  │
+│                                                            │
+│  Prerequisites satisfied by:                               │
+│    Tier 3: Quickstart installs everything                  │
+│    Tier 2: DSCi + OLM dependencies handle infra            │
+│    Standalone: Admin uses kagenti-prereqs chart / manual    │
+└──────────────────────────────────────────────────────────┘
 ```
 
 ### 3.2 Tier 1: Kagenti Platform Operator (Product)
@@ -201,38 +158,212 @@ Encoding infrastructure installation into the product operator would mean that w
 - Validates that required infrastructure exists (CRDs present, services reachable) but does NOT install it.
 - Contains two controllers in one OLM bundle: Platform Controller and Observability Controller.
 - Single CRD: `KagentiPlatform`.
-- Narrow RBAC: no `escalate`, no CRD creation, no OLM management.
+- Narrow RBAC: no escalate, no CRD creation, no OLM management.
 
 ### 3.3 Tier 1 Observability Controller
 
 The Observability Controller is part of the Tier 1 OLM bundle but runs as a separate controller watching the same `KagentiPlatform` CRD. It manages:
 
-- OTel Collector with Kagenti-specific pipeline configuration (GenAI semantic convention transforms, span filtering for A2A, OAuth2 exporter for MLflow).
-- Phoenix (LLM observability backend).
-- MLflow (experiment tracking).
+- **OTel Collector** with Kagenti-specific pipeline configuration (GenAI semantic convention transforms, span filtering for A2A, OAuth2 exporter for MLflow).
+- **Phoenix** (LLM observability backend).
+- **MLflow** (experiment tracking).
 
-These are included in Tier 1 because the OTel Collector pipeline configuration is Kagenti-specific IP (not generic infrastructure). A user may disable observability entirely via `spec.observability.enabled: false`.
+These are included in Tier 1 because the OTel Collector pipeline configuration is Kagenti-specific IP (not generic infrastructure). A user may disable observability entirely via `spec.observability.managementState: Removed`.
 
-### 3.4 Tier 2: Kagenti Quickstart Installer (Dev Tool)
+### 3.4 Tier 2: RHOAI/ODH DataScienceCluster Integration
+
+#### 3.4.1 The DSC Component Pattern
+
+The ODH operator (RHOAI's meta-operator) uses a two-CRD pattern:
+
+- **`DSCInitialization`** — cluster-level setup: monitoring namespace, trusted CA bundles, network policies. Created once per cluster.
+- **`DataScienceCluster`** — component lifecycle management. Each component has a `managementState`:
+  - `Managed` — ODH operator installs and reconciles the component
+  - `Removed` — ODH operator deletes the component
+  - `Unmanaged` — ODH operator ignores; user manages directly
+
+The DSC v2 sample shows 15+ components:
+
+```yaml
+apiVersion: datasciencecluster.opendatahub.io/v2
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    dashboard:
+      managementState: "Managed"
+    kserve:
+      managementState: "Managed"
+    trustyai:
+      managementState: "Managed"
+    ray:
+      managementState: "Managed"
+    mlflowoperator:
+      managementState: "Removed"
+    kagenti:                          # <-- target state
+      managementState: "Managed"
+```
+
+#### 3.4.2 How Kagenti Fits the DSC Component Interface
+
+The ODH operator's component handler interface:
+
+```go
+type ComponentHandler interface {
+    GetComponentName() string
+    GetManagementState(dsc *DataScienceCluster) operatorv1.ManagementState
+    ReconcileComponent(ctx context.Context, cli client.Client,
+        dsc *DataScienceCluster, dsci *DSCInitialization, platform cluster.Platform) error
+    Cleanup(ctx context.Context, cli client.Client,
+        dsc *DataScienceCluster, dsci *DSCInitialization) error
+    UpdateStatus(ctx context.Context, cli client.Client,
+        dsc *DataScienceCluster, condition *conditionsv1.Condition) error
+}
+```
+
+**Kagenti's implementation** within the ODH operator is a thin adapter (~200 lines):
+
+```go
+// pkg/components/kagenti/kagenti.go (contributed to ODH operator)
+type Kagenti struct {
+    components.BaseComponent
+}
+
+func (k *Kagenti) ReconcileComponent(ctx context.Context, cli client.Client,
+    dsc *dscv2.DataScienceCluster, dsci *dsciv2.DSCInitialization,
+    platform cluster.Platform) error {
+
+    // 1. Ensure the Kagenti Platform Operator is installed via OLM
+    if err := k.ensureOperatorReady(ctx, cli); err != nil {
+        return err
+    }
+
+    // 2. Create or update the KagentiPlatform CR
+    platformCR := k.buildPlatformCR(dsc, dsci, platform)
+    if err := k.applyPlatformCR(ctx, cli, platformCR); err != nil {
+        return err
+    }
+
+    // 3. Wait for KagentiPlatform status to report Ready
+    return k.waitForPlatformReady(ctx, cli)
+}
+```
+
+**Key design principle: The ODH component is a thin wrapper that creates a `KagentiPlatform` CR.** The actual reconciliation logic lives in the Tier 1 operator. This means:
+- The Kagenti team owns the operator logic (ships via OLM as a separate operator)
+- The ODH integration is ~200 lines contributed upstream
+- The `KagentiPlatform` CRD is the single source of truth regardless of deployment mode
+
+#### 3.4.3 DSC API Surface for Kagenti
+
+The **minimal external API** exposed in the DSC spec:
+
+```yaml
+spec:
+  components:
+    kagenti:
+      managementState: "Managed"    # Managed | Removed | Unmanaged
+      agentNamespaces:
+        - team1
+        - team2
+      observability:
+        enabled: true
+```
+
+The **full internal API** (the complete `KagentiPlatform` spec) remains on the `KagentiPlatform` CRD. Users who need fine-grained control can set `managementState: Unmanaged` and manage the `KagentiPlatform` CR directly.
+
+#### 3.4.4 Lifecycle Modes and managementState Mapping
+
+| DSC `managementState` | Effect on Kagenti |
+|----------------------|-------------------|
+| `Managed` | ODH operator ensures `KagentiPlatform` CR exists, Kagenti Operator OLM Subscription is healthy. ODH owns the CR. |
+| `Removed` | ODH operator deletes the `KagentiPlatform` CR. Kagenti Operator's finalizer handles teardown. |
+| `Unmanaged` | ODH operator stops reconciling. User manages the `KagentiPlatform` CR directly. Kagenti Operator keeps running. |
+
+#### 3.4.5 KagentiPlatform CR Ownership Model
+
+| DSC `managementState` | CR Owner | User Can Edit CR? | What Happens on Edit |
+|----------------------|----------|-------------------|---------------------|
+| `Managed` | ODH operator | No (overwritten) | ODH reconciler overwrites on next cycle. User must change DSC fields instead. |
+| `Unmanaged` | User | Yes (full control) | ODH stops reconciling. User manages `KagentiPlatform` CR directly. Kagenti Operator still reconciles it. |
+| `Removed` | N/A | N/A | ODH deletes the CR. Kagenti Operator's finalizer runs teardown. |
+
+**Managed to Unmanaged graduation path:**
+
+```bash
+# Step 1: Start with RHOAI-managed Kagenti (DSC has kagenti.managementState: Managed)
+# Step 2: Inspect the generated KagentiPlatform CR
+kubectl get kagentiplatform kagenti -n kagenti-system -o yaml
+# Step 3: Switch to user-managed (edit DSC: kagenti.managementState: Unmanaged)
+# Step 4: Customize freely
+kubectl edit kagentiplatform kagenti -n kagenti-system
+```
+
+The ODH component handler uses SSA with field manager `odh-kagenti-component`. On transition to Unmanaged, the field manager is released. When `managed-by: odh-operator`, user edits trigger a warning event:
+
+```
+Warning  ManagedByODH  KagentiPlatform/kagenti  This CR is managed by the ODH operator.
+         Changes will be overwritten. Set kagenti.managementState: Unmanaged in
+         your DataScienceCluster to take direct control.
+```
+
+#### 3.4.6 DSCInitialization and Infrastructure Prerequisites
+
+When Kagenti runs inside RHOAI, infrastructure prerequisites are handled externally:
+
+| Prerequisite | How Satisfied in RHOAI | How Expressed |
+|-------------|----------------------|---------------|
+| Service Mesh (Istio) | RHOAI declares `servicemeshoperator3` as OLM dependency | OLM CSV `spec.dependencies` |
+| cert-manager | `openshift-cert-manager-operator` OLM dependency | OLM CSV `spec.dependencies` |
+| Pipelines (Tekton) | `openshift-pipelines-operator-rh` OLM dependency | OLM CSV `spec.dependencies` |
+| Builds (Shipwright) | `openshift-builds-operator` OLM dependency | OLM CSV `spec.dependencies` |
+| SPIRE/ZTWIM | `openshift-zero-trust-workload-identity-manager` OLM dependency (OCP 4.19+) | OLM CSV `spec.dependencies` |
+| Keycloak | `rhbk-operator` OLM dependency | OLM CSV `spec.dependencies` |
+| Monitoring | DSCInitialization `spec.monitoring` | DSCi reconciler |
+| Trusted CA | DSCInitialization `spec.trustedCABundle` | DSCi reconciler |
+
+The Kagenti Platform Operator's infrastructure validation still runs but all checks should pass. If they don't, the operator surfaces `phase: Blocked` with details.
+
+### 3.5 Tier 3: Kagenti Quickstart Installer (Dev Tool)
 
 - Optional. For dev/demo/PoC environments only.
 - NOT part of the product. NOT shipped via OLM or Konflux.
 - Replaces the current Ansible installer.
 - Manages all infrastructure prerequisites: Istio, Keycloak, SPIRE, Tekton, Shipwright, cert-manager, Gateway API, Kiali, etc.
 - CRD: `KagentiQuickstart`.
-- After installing infrastructure, creates a `KagentiPlatform` CR **once** (create-if-not-exists, never updates). The Platform Operator then takes over.
+- After installing infrastructure, creates a `KagentiPlatform` CR once (create-if-not-exists, never updates). The Platform Operator then takes over.
 - Has broader permissions (OLM CRUD, Helm installs, namespace creation) because it runs only in dev environments.
 
-### 3.5 Companion: kagenti-prereqs Helm Chart
+### 3.6 Companion: kagenti-prereqs Helm Chart
 
-For production OpenShift clusters where the Quickstart operator is not used, a static `kagenti-prereqs` Helm chart provides all prerequisite manifests (OLM Subscriptions, operand CRs, raw YAML). The admin can:
+For production OpenShift clusters where the Quickstart operator is not used and RHOAI is not installed, a static `kagenti-prereqs` Helm chart provides all prerequisite manifests. The admin can:
 
-- Inspect the chart before applying (audit trail).
-- Selectively enable components: `--set istio.enabled=true --set keycloak.enabled=true`.
-- Commit the rendered manifests to a GitOps repository.
-- Use it as a reference for crafting their own manifests.
+- Inspect the chart before applying (audit trail)
+- Selectively enable components: `--set istio.enabled=true --set keycloak.enabled=true`
+- Commit the rendered manifests to a GitOps repository
+- Use it as a reference for crafting their own manifests
 
-The chart lives in the Kagenti repo alongside the operator (`charts/kagenti-prereqs/`), is versioned and tested alongside the operator (same CI matrix), but is NOT an operator — it's a plain Helm chart the admin runs once.
+> **Note:** `kagenti-prereqs` is only for standalone K8s / vanilla OpenShift (no RHOAI). On RHOAI clusters, prerequisites are handled by DSCi + OLM dependencies.
+
+### 3.7 Formal Dependency Mapping
+
+From PM review — maps each Kagenti component to its Red Hat operator equivalent:
+
+| Kagenti Component | K8s (Kind) Install Method | OpenShift Operator (OLM) | Red Hat Product Name | OLM Package |
+|---|---|---|---|---|
+| **kagenti-operator** | Helm (bundled) | **To be productized** | — | `kagenti-operator` (future) |
+| **Istio** | Helm (istio-release) | `servicemeshoperator3` | OpenShift Service Mesh 3 | `servicemeshoperator3` |
+| **Tekton** | Direct manifest | `openshift-pipelines-operator-rh` | OpenShift Pipelines | `openshift-pipelines-operator-rh` |
+| **cert-manager** | Direct manifest | `openshift-cert-manager-operator` | cert-manager Operator | `openshift-cert-manager-operator` |
+| **Shipwright** | Direct manifest | `openshift-builds-operator` | OpenShift Builds | `openshift-builds-operator` |
+| **SPIRE** | Helm (spiffe.io) | `openshift-zero-trust-workload-identity-manager` | ZTWIM (OCP 4.19+) | `openshift-zero-trust-workload-identity-manager` |
+| **Keycloak** | Helm/direct | `rhbk-operator` | Red Hat build of Keycloak | `rhbk-operator` |
+| **Gateway API** | CRD manifest | Built into OSSM3 | — | (bundled with OSSM) |
+| **MCP Gateway** | Helm | **WIP** — Kuadrant MCP Gateway | RHCL? | TBD |
+| **Kiali** | Istio samples | `kiali-ossm` | Kiali (OSSM) | `kiali-ossm` |
+| **metrics-server** | Helm | Built-in (Prometheus Adapter) | — | N/A |
+| **Kagenti UI** | Helm (bundled) | Can be deployed by RHOAI meta-operator (via DSC) | — | (part of kagenti) |
 
 ---
 
@@ -249,17 +380,16 @@ metadata:
 spec:
   # --- Core Components (reconciled by Platform Controller) ---
   agentOperator:
-    enabled: true
-    image: ""               # Override; defaults to operator-bundled version
+    managementState: Managed        # Managed | Removed | Unmanaged
+    image: ""                       # Override; defaults to operator-bundled version
 
   webhook:
-    enabled: true           # SPIFFE identity injection
-    image: ""
+    managementState: Managed
 
   ui:
-    enabled: true
+    managementState: Managed
     auth:
-      enabled: true
+      managementState: Managed      # Can disable auth independently
       keycloak:
         url: https://keycloak.keycloak.svc.cluster.local:8443
         realm: master
@@ -268,7 +398,7 @@ spec:
     backend:  { image: "" }
 
   mcpGateway:
-    enabled: false
+    managementState: Removed
 
   agentNamespaces:
     - name: team1
@@ -278,40 +408,50 @@ spec:
 
   # --- Infrastructure References (validate only, do NOT install) ---
   infrastructure:
-    istio:       { required: true }
-    spire:       { required: true, trustDomain: localtest.me }
-    certManager: { required: true }
-    tekton:      { required: true }
-    shipwright:  { required: true }
-    gatewayApi:  { required: true }
+    istio:       { requirement: Required }     # Required | Optional | Ignored
+    spire:       { requirement: Required, trustDomain: localtest.me }
+    certManager: { requirement: Required }
+    tekton:      { requirement: Required }
+    shipwright:  { requirement: Required }
+    gatewayApi:  { requirement: Required }
 
   # --- Observability (reconciled by Observability Controller) ---
   observability:
-    enabled: true
+    managementState: Managed
     collector:
       exporters:
-        phoenix: { enabled: true }
+        phoenix: { managementState: Managed }
         mlflow:
-          enabled: true
-          auth: { enabled: true, clientSecretRef: { name: kagenti-mlflow-oauth } }
+          managementState: Managed
+          auth: { managementState: Managed, clientSecretRef: { name: kagenti-mlflow-oauth } }
     phoenix:
-      enabled: true
+      managementState: Managed
       storage: { type: postgresql, size: 10Gi }
     mlflow:
-      enabled: true
+      managementState: Managed
       storage: { size: 5Gi }
 
   # --- Global ---
   domain: localtest.me
-  deletionPolicy: Retain    # Retain | Delete
+  deletionPolicy: Retain            # Retain | Delete
   imageOverrides:
     registry: ""
     pullSecretRef: ""
 ```
 
+**managementState semantics:**
+- **Managed** — Operator installs and continuously reconciles
+- **Removed** — Operator deletes the component and its resources
+- **Unmanaged** — Operator ignores; user manages directly (useful for custom OTel pipeline or external MLflow)
+
+**Infrastructure requirement semantics:**
+- **Required** — Must be present. Operator blocks (`phase: Blocked`) if missing.
+- **Optional** — Operator checks but only degrades (`phase: Degraded`) if missing.
+- **Ignored** — Operator skips validation entirely.
+
 ### 4.2 Status Subresource
 
-Status is partitioned between the two controllers. Each writes to distinct sub-paths using separate SSA field managers to avoid conflicts.
+Status is partitioned between the two controllers. Each writes to distinct sub-paths using separate SSA field managers.
 
 ```yaml
 status:
@@ -345,15 +485,15 @@ status:
     mlflow:    { status: Ready }
 
   conditions:
-    - type: InfrastructureReady   # All required infra present
+    - type: InfrastructureReady
       status: "True"
-    - type: PlatformReady         # Core Kagenti components running
+    - type: PlatformReady
       status: "True"
-    - type: ObservabilityReady    # OTel/Phoenix/MLflow running
+    - type: ObservabilityReady
       status: "True"
-    - type: Available             # Core platform functional
+    - type: Available
       status: "True"
-    - type: FullyOperational      # Core + observability
+    - type: FullyOperational
       status: "True"
 ```
 
@@ -361,37 +501,7 @@ status:
 
 The Platform Controller validates infrastructure on every reconciliation by checking CRD existence and service readiness. When prerequisites are missing, the status provides actionable guidance including a pointer to the `kagenti-prereqs` Helm chart.
 
-The controller distinguishes between "never installed" (hard block) and "was working, now temporarily unhealthy" (grace period). A configurable grace period (default 10 minutes) prevents false `Blocked` status during infrastructure upgrades.
-
-```go
-func (r *Reconciler) evaluateInfraHealth(ctx context.Context,
-    p *v1alpha1.KagentiPlatform) InfraStatus {
-
-    for _, req := range p.Spec.Infrastructure.RequiredComponents() {
-        if !r.detector.HasCRD(ctx, req.CRDGroupResource) {
-            return InfraBlocked  // Hard block — never installed
-        }
-
-        prev := p.Status.Infrastructure[req.Name]
-        ready, msg, _ := req.ReadinessCheck(ctx)
-        if ready {
-            continue
-        }
-
-        if prev.Status == "Ready" {
-            // Was healthy, now unhealthy — apply grace period
-            if prev.LastReadyTime.Add(r.infraGracePeriod).After(time.Now()) {
-                r.setInfraCondition(p, req.Name, "Degraded", msg)
-                continue
-            }
-        }
-        return InfraBlocked
-    }
-    return InfraReady
-}
-```
-
-The Quickstart operator can also set an annotation (`kagenti.dev/infra-upgrade-in-progress`) before starting an upgrade, which extends the grace period indefinitely while present.
+The controller distinguishes between 'never installed' (hard block) and 'was working, now temporarily unhealthy' (grace period). A configurable grace period (default 10 minutes) prevents false `Blocked` status during infrastructure upgrades.
 
 ---
 
@@ -399,10 +509,8 @@ The Quickstart operator can also set an annotation (`kagenti.dev/infra-upgrade-i
 
 ### 5.1 Platform Controller
 
-The Platform Controller handles the core Kagenti lifecycle:
-
 ```go
-func (r *PlatformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *PlatformReconciler) Reconcile(ctx, req) (Result, error) {
     platform := &v1alpha1.KagentiPlatform{}
     r.Get(ctx, req.NamespacedName, platform)
 
@@ -413,7 +521,7 @@ func (r *PlatformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
     infraStatus := r.evaluateInfraHealth(ctx, platform)
     if infraStatus == InfraBlocked {
         platform.Status.Phase = "Blocked"
-        return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+        return Result{RequeueAfter: 30s}, nil
     }
 
     // 3. Install/update core Kagenti components
@@ -423,18 +531,18 @@ func (r *PlatformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
         }
     }
 
-    // 4. Configure agent namespaces (secrets, RBAC, labels)
+    // 4. Configure agent namespaces
     r.reconcileAgentNamespaces(ctx, platform)
 
     // 5. Set status
     platform.Status.Phase = "Ready"
-    return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil  // drift check
+    return Result{RequeueAfter: 5 * time.Minute}, nil
 }
 ```
 
 ### 5.2 Observability Controller
 
-The Observability Controller watches the same `KagentiPlatform` CRD but only reconciles the `spec.observability` section. It uses a hash of the observability spec to avoid unnecessary work when only core spec changes.
+Watches the same `KagentiPlatform` CRD but only reconciles the `spec.observability` section. Uses a hash of the observability spec to avoid unnecessary work when only core spec changes.
 
 ### 5.3 Two Controllers, One CRD
 
@@ -442,20 +550,18 @@ Both controllers ship in the same OLM bundle as separate Deployments. They use d
 
 ### 5.4 Phase-Based State Machine (Quickstart)
 
-The Quickstart Operator uses a phase-based state machine for infrastructure installation. Phases execute sequentially; components within a phase install concurrently:
+The Quickstart Operator uses a phase-based state machine:
 
 | Phase | Components | Notes |
 |-------|-----------|-------|
 | 1. Foundation | cert-manager, Gateway API CRDs, metrics-server | No dependencies |
-| 2. Mesh | Istio (base → istiod → CNI → ztunnel) | Strict internal ordering |
-| 3. Identity | SPIRE (server → agent → CSI → OIDC) | Strict internal ordering |
-| 4. Build | Tekton → Shipwright | Shipwright depends on Tekton |
-| 5. Auth | Keycloak (operator → instance → realm → clients) | Sequential |
+| 2. Mesh | Istio (base -> istiod -> CNI -> ztunnel) | Strict internal ordering |
+| 3. Identity | SPIRE (server -> agent -> CSI -> OIDC) | Strict internal ordering |
+| 4. Build | Tekton -> Shipwright | Shipwright depends on Tekton |
+| 5. Auth | Keycloak (operator -> instance -> realm -> clients) | Sequential |
 | 6. Observability | OTel Collector, Phoenix, MLflow | Concurrent |
 | 7. Platform | Ingress Gateway, container registry, Kiali | Concurrent |
 | 8. Handoff | Creates `KagentiPlatform` CR | Platform operator takes over |
-
-Empty phases (all components disabled) are skipped. Already-ready phases are short-circuited on subsequent reconciliations.
 
 ---
 
@@ -476,37 +582,43 @@ type Component interface {
 ### 6.2 Installation Strategies
 
 | Strategy | When Used | Example |
-|----------|-----------|---------|
-| `HelmComponent` | Vanilla K8s, or OCP when no OLM operator exists | Istio on K8s, Phoenix, MLflow |
-| `OLMComponent` | OpenShift with operator in catalog | OSSM v3, RHBK, OpenShift Pipelines |
-| `ManifestComponent` | Simple CRD/YAML-only installs | Gateway API CRDs, Kiali addons |
-| `ExternalComponent` | User-managed, validate connectivity only | External Keycloak, pre-existing Istio |
-
-The OpenShift vs. Kubernetes branching is encapsulated inside each component, not in the phase or reconciler:
-
-```go
-func (k *KeycloakComponent) Install(ctx context.Context, p *KagentiPlatform, env *Environment) error {
-    if p.Spec.Components.Keycloak.External != nil {
-        return k.validateExternal(ctx, p.Spec.Components.Keycloak.External)
-    }
-    if env.IsOpenShift {
-        return k.installViaOLM(ctx, p)   // RHBK Subscription → Keycloak CR
-    }
-    return k.installViaHelm(ctx, p)      // Helm chart with PostgreSQL
-}
-```
+|----------|----------|---------|
+| HelmComponent | Vanilla K8s, or OCP when no OLM operator exists | Istio on K8s, Phoenix, MLflow |
+| OLMComponent | OpenShift with operator in catalog | OSSM v3, RHBK, OpenShift Pipelines |
+| ManifestComponent | Simple CRD/YAML-only installs | Gateway API CRDs, Kiali addons |
+| ExternalComponent | User-managed, validate connectivity only | External Keycloak, pre-existing Istio |
 
 ### 6.3 Adding a New Package
 
-Adding a new component is a 3-file change with zero core refactoring:
+Adding a new component is a 3-file change:
 
 | File | Change |
 |------|--------|
 | `api/v1alpha1/types.go` | Add field to `ComponentsSpec` struct |
-| `controllers/components/newpkg.go` | Implement `Component` interface (embed `BaseHelmComponent` or `BaseOLMComponent`) |
+| `controllers/components/newpkg.go` | Implement `Component` interface |
 | `controllers/phases/<phase>.go` or `main.go` | Register in the appropriate phase |
 
-No changes to the reconciler, no changes to existing components.
+### 6.4 Unmanaged Component Semantics
+
+| Scenario | How Component Gets to `Unmanaged` | Operator Behavior |
+|----------|----------------------------------|-------------------|
+| **Operator deployed, user takes over** | User changes `Managed` -> `Unmanaged` | Operator **releases SSA field ownership** on the component's resources. Stops reconciling. Existing resources remain. Operator still reports health (read-only). |
+| **User pre-installed, operator acknowledges** | User sets `Unmanaged` from the start | Operator **never touches** the component's resources. Validates expected endpoints/CRDs exist (read-only). Reports status. |
+
+Both cases converge to the same steady state: operator doesn't write, only reads.
+
+```go
+func (c *Component) reconcileUnmanaged(ctx context.Context, prev operatorv1.ManagementState) error {
+    if prev == operatorv1.Managed {
+        c.releaseFieldOwnership(ctx)
+        c.recorder.Event(platform, "Normal", "Unmanaged",
+            fmt.Sprintf("%s is now user-managed.", c.Name()))
+    }
+    healthy, msg, err := c.IsReady(ctx)
+    c.updateStatusReadOnly(ctx, healthy, msg)
+    return err
+}
+```
 
 ---
 
@@ -514,113 +626,148 @@ No changes to the reconciler, no changes to existing components.
 
 ### 7.1 Product Operator RBAC (Tier 1)
 
-The product operator's ClusterRole is deliberately narrow:
-
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kagenti-platform-operator
-rules:
-  # Read-only: infrastructure validation
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["config.openshift.io"]
-    resources: ["clusterversions"]
-    verbs: ["get"]
+# Read-only: infrastructure validation
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["clusterversions"]
+  verbs: ["get"]
 
-  # Own CRDs
-  - apiGroups: ["kagenti.dev"]
-    resources: ["kagentiplatforms", "kagentiplatforms/status", "kagentiplatforms/finalizers"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+# Own CRDs
+- apiGroups: ["kagenti.dev"]
+  resources: ["kagentiplatforms", "kagentiplatforms/status", "kagentiplatforms/finalizers"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 
-  # Kagenti components (namespaced)
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["services", "configmaps", "secrets", "serviceaccounts"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Kagenti components (namespaced)
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services", "configmaps", "secrets", "serviceaccounts"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # Networking
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["httproutes", "referencegrants"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["route.openshift.io"]
-    resources: ["routes"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Networking
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["httproutes", "referencegrants"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # Agent Operator sub-chart (read-only)
-  - apiGroups: ["agent.kagenti.dev"]
-    resources: ["agents", "agentbuilds", "agentcards"]
-    verbs: ["get", "list", "watch"]
-
-  # Namespace management (agent namespaces)
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list", "create", "update", "patch"]
-
-  # Istio waypoints (read + create, not modify mesh)
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways"]
-    verbs: ["get", "list", "watch", "create"]
+# Namespace management (agent namespaces)
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "create", "update", "patch"]
 ```
 
 ### 7.2 Security Properties
 
 | Property | How Achieved |
 |----------|-------------|
-| Least privilege | Operator can only manage Kagenti-owned resources. Cannot create CRDs, manage OLM, or modify third-party operator CRs. |
-| No escalation | No `escalate` or `bind` verbs. Cannot create ClusterRoles or ClusterRoleBindings. |
-| Infrastructure isolation | Read-only access to infrastructure CRDs for validation. Cannot modify Istio, Keycloak, or SPIRE resources. |
-| Secret scoping | Per-namespace `secretRef` for agent namespaces. No single Secret with all credentials. |
-| Audit trail | All actions attributable to `kagenti-platform-operator` ServiceAccount in audit logs. |
-| Certifiability | RBAC surface passes Red Hat operator certification requirements. |
+| Least privilege | Operator can only manage Kagenti-owned resources |
+| No escalation | No 'escalate' or 'bind' verbs |
+| Infrastructure isolation | Read-only access to infrastructure CRDs for validation |
+| Secret scoping | Per-namespace secretRef for agent namespaces |
+| Audit trail | All actions attributable to kagenti-platform-operator ServiceAccount |
+| Certifiability | RBAC surface passes Red Hat operator certification requirements |
 
 ### 7.3 Comparison: Monolithic vs. Two-Tier RBAC
 
-| Permission | Monolithic Orchestrator (rejected) | Product Operator (V5) |
-|------------|------------------------------------|-----------------------|
-| CRD management | `create`, `update`, `delete` on ALL CRDs | `get`, `list`, `watch` only |
+| Permission | Monolithic Orchestrator (rejected) | Product Operator (V8) |
+|-----------|-----------------------------------|----------------------|
+| CRD management | create, update, delete on ALL CRDs | get, list, watch only |
 | OLM access | Full Subscription/InstallPlan/CSV CRUD | None |
-| Namespace scope | All namespaces | `kagenti-system` + agent namespaces |
-| RBAC verbs | `bind`, `escalate` | None |
+| Namespace scope | All namespaces | kagenti-system + agent namespaces |
+| RBAC verbs | bind, escalate | None |
 | Third-party CRs | Full CRUD on Istio, Keycloak, SPIRE | Read-only (validation) |
 | Blast radius | Compromised operator = cluster-admin equivalent | Compromised operator = Kagenti components only |
+
+### 7.4 OLM Dependency Strategy — Dual CSV Approach
+
+| Bundle | Target | Dependency Strategy | Rationale |
+|--------|--------|-------------------|-----------|
+| `kagenti-operator` (standalone) | OpenShift without RHOAI | `spec.dependencies` at package level (soft) | Admin may install deps incrementally. Operator starts, validates at runtime. |
+| `kagenti-operator` (RHOAI) | RHOAI DSC-managed | `spec.customresourcedefinitions.required` (hard) | RHOAI guarantees all deps. Hard block catches misconfigurations. |
+
+**Standalone CSV (soft dependencies):**
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kagenti-operator.v1.0.0
+spec:
+  dependencies:
+    - type: olm.package
+      value:
+        packageName: servicemeshoperator3
+        version: ">=3.0.0"
+    - type: olm.package
+      value:
+        packageName: openshift-cert-manager-operator
+        version: ">=1.0.0"
+  customresourcedefinitions:
+    owned:
+      - name: kagentiplatforms.kagenti.dev
+        version: v1alpha1
+        kind: KagentiPlatform
+```
+
+**RHOAI CSV (hard dependencies):**
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kagenti-operator.v1.0.0-rhoai
+spec:
+  customresourcedefinitions:
+    owned:
+      - name: kagentiplatforms.kagenti.dev
+        version: v1alpha1
+        kind: KagentiPlatform
+    required:
+      - name: istios.sailoperator.io
+        version: v1
+        kind: Istio
+      - name: keycloaks.k8s.keycloak.org
+        version: v2alpha1
+        kind: Keycloak
+      - name: clusterissuers.cert-manager.io
+        version: v1
+        kind: ClusterIssuer
+      - name: clusterspiffeids.spire.spiffe.io
+        version: v1alpha1
+        kind: ClusterSPIFFEID
+```
+
+Both bundles are generated by the same Konflux pipeline from the same operator binary.
+
+### 7.5 RBAC Verification for Unmanaged Health Checks
+
+| Unmanaged Component | Health Check Method | Required RBAC | Already in ClusterRole? |
+|---------------------|-------------------|---------------|------------------------|
+| MLflow | Deployment readiness in `kagenti-system` | `apps/deployments: get` | Yes |
+| Phoenix | Deployment readiness in `kagenti-system` | `apps/deployments: get` | Yes |
+| OTel Collector | Deployment readiness in `kagenti-system` | `apps/deployments: get` | Yes |
+| External MLflow | HTTP health probe | No RBAC needed | N/A |
+| External Keycloak | HTTP health probe | No RBAC needed | N/A |
+
+**Limitation:** Unmanaged health checks only work for resources in `kagenti-system` and declared `agentNamespaces`. Components deployed elsewhere report `Unknown` health.
 
 ---
 
 ## 8. OLM Subscription Lifecycle (Quickstart)
 
-The Quickstart Operator (Tier 2 only) manages OLM Subscriptions for OpenShift prerequisites with the following safeguards:
-
 | Aspect | Design Decision | Rationale |
 |--------|----------------|-----------|
-| Approval Policy | Always `Manual` | Prevents OLM from auto-upgrading operators and breaking operand CR schemas |
+| Approval Policy | Always Manual | Prevents OLM from auto-upgrading operators |
 | Version Gating | Compatibility matrix (compiled + ConfigMap override) | Only approve InstallPlans for tested CSV versions |
-| Operand CRs | `Unstructured` (no Go type imports) | Decouples from upstream API changes |
-| Health Checking | CSV phase + operator Pod readiness + operand status conditions | Three-layer verification before marking Ready |
-| Version Pinning | Compiled defaults + ConfigMap override | Fast CVE response without rebuilding the operator binary |
-
-The version manifest is compiled into the Quickstart operator binary with ConfigMap override for CVE response:
-
-```go
-var DefaultVersions = VersionManifest{
-    Istio:       {Chart: "istio/istiod", Version: "1.24.2"},
-    SPIRE:       {Chart: "spiffe/spire", Version: "0.23.0"},
-    Keycloak:    {Manifest: "github.com/keycloak/keycloak-k8s-resources", Version: "26.4"},
-    Tekton:      {Manifest: "storage.googleapis.com/tekton-releases/pipeline", Version: "0.62.2"},
-    CertManager: {Manifest: "github.com/cert-manager/cert-manager", Version: "1.16.3"},
-    // OLM channels for OpenShift
-    OSSM:        {OLMChannel: "stable-v3"},
-    RHBK:        {OLMChannel: "stable-v26.4"},
-    ZTWIM:       {OLMChannel: "stable-v1"},
-}
-```
+| Operand CRs | Unstructured (no Go type imports) | Decouples from upstream API changes |
+| Health Checking | CSV phase + operator Pod readiness + operand status conditions | Three-layer verification |
+| Version Pinning | Compiled defaults + ConfigMap override | Fast CVE response without rebuilding |
 
 ---
 
@@ -628,55 +775,68 @@ var DefaultVersions = VersionManifest{
 
 ### 9.1 Upgrade Coordination
 
-When infrastructure is upgraded (e.g., Istio OSSM v3.1 → v3.2), the Platform Operator may see transient unavailability. The grace period mechanism prevents false `Blocked` status:
-
-- Default grace period: **10 minutes** (configurable).
-- During grace period: status shows `Degraded`, not `Blocked`. Platform components remain operational.
-- The Quickstart operator can set annotation `kagenti.dev/infra-upgrade-in-progress` to extend the grace period indefinitely during planned upgrades.
-- After grace period expires without recovery: status escalates to `Blocked`.
+Default grace period: 10 minutes (configurable). During grace period, status shows `Degraded`, not `Blocked`. The Quickstart operator can set `kagenti.dev/infra-upgrade-in-progress` annotation to extend indefinitely.
 
 ### 9.2 Drift Detection
 
-Three-tiered watch strategy:
-
 | Tier | Mechanism | Latency | What It Catches |
-|------|-----------|---------|-----------------|
-| Tier 1: Security watches | controller-runtime `Watches` on `AuthorizationPolicy`, `ClusterSPIFFEID` | Immediate | Deleted/modified security policies |
-| Tier 2: Owned resources | controller-runtime `Owns()` on Deployments, Services | Immediate | Modified/deleted Kagenti components |
-| Tier 3: Periodic poll | `RequeueAfter: 5 minutes` | Up to 5 min | Everything else (ConfigMap drift, label changes) |
+|------|----------|---------|----------------|
+| Tier 1: Security watches | controller-runtime Watches on AuthorizationPolicy, ClusterSPIFFEID | Immediate | Deleted/modified security policies |
+| Tier 2: Owned resources | controller-runtime Owns() on Deployments, Services | Immediate | Modified/deleted Kagenti components |
+| Tier 3: Periodic poll | RequeueAfter: 5 minutes | Up to 5 min | Everything else |
 
 ### 9.3 Health and Degradation Model
 
 | Condition | Meaning | When True |
 |-----------|---------|-----------|
-| `Available` | Core platform is functional | All Critical + Required components healthy |
-| `Degraded` | Optional component unhealthy | Any Optional component (MLflow, Kiali) is down |
-| `FullyOperational` | Everything works | All components including optional are healthy |
-| `Blocked` | Cannot proceed | Missing infrastructure prerequisites |
-
-Component criticality is **computed dynamically** from the resolved config, not hardcoded. For example, Tekton is `Critical` only if `agentOperator.enabled` (build pipelines need it). Keycloak is `Critical` only if `ui.auth.enabled`.
+| Available | Core platform is functional | All Critical + Required components healthy |
+| Degraded | Optional component unhealthy | Any Optional component is down |
+| FullyOperational | Everything works | All components including optional ones healthy |
+| Blocked | Cannot proceed | Missing infrastructure prerequisites |
 
 ### 9.4 Deletion Policy
 
 | Policy | Behavior |
 |--------|----------|
-| `Retain` (default) | Finalizer removed, all components left running. Resources become unmanaged. |
-| `Delete` | Reverse-order teardown of Kagenti components. Requires explicit annotation `kagenti.dev/confirm-delete=yes-destroy-everything`. Infrastructure is NEVER deleted by the product operator. |
+| Retain (default) | Finalizer removed, all components left running. |
+| Delete | Reverse-order teardown. Requires `kagenti.dev/confirm-delete=yes-destroy-everything`. Infrastructure is NEVER deleted by the product operator. |
 
-A `ValidatingAdmissionWebhook` prevents accidental deletion with `Delete` policy unless the confirmation annotation is present.
-
-### 9.5 Ansible vs. Operator Comparison
+### 9.5 Day-2 Comparison: Ansible vs. Operator
 
 | Operation | Current (Ansible/Helm) | Proposed (Operator) |
-|-----------|----------------------|---------------------|
+|-----------|----------------------|-------------------|
 | Upgrade a component | Re-run full playbook (~15 min) | Edit CR or upgrade operator image |
-| Self-healing | None. Manual re-run. | Continuous reconciliation |
-| Drift detection | None. Manual `helm diff`. | Automatic, tiered watches |
+| Self-healing | None | Continuous reconciliation |
+| Drift detection | None | Automatic, tiered watches |
 | Add component post-install | Edit env file, re-run playbook | Edit CR; controller installs only the new component |
-| Remove component | Edit env file, re-run (orphaned resources) | Set `enabled: false`; controller cleans up |
+| Remove component | Edit env file, re-run (orphaned resources) | Set `managementState: Removed`; controller cleans up |
 | Multi-cluster | Run playbook per cluster | Apply CR per cluster (GitOps-friendly) |
-| Disaster recovery | Re-run from scratch | CR + secrets exist; controller converges |
-| Rollback | `helm rollback` per chart (manual) | Revert CR (or GitOps revision) |
+
+### 9.6 Observability Deconfliction with RHOAI
+
+When running inside RHOAI:
+
+| Component | RHOAI Provides | Kagenti Provides | Resolution |
+|-----------|---------------|-----------------|------------|
+| Monitoring (Prometheus) | DSCi `spec.monitoring` | Not provided | Use RHOAI's monitoring |
+| MLflow | DSC `mlflowoperator` component | Kagenti Observability Controller | Defer to RHOAI's MLflow when `mlflowoperator.managementState: Managed` in DSC |
+| OTel Collector | Not provided (Kagenti-specific) | GenAI semantic conventions, A2A span filtering | Kagenti-owned |
+| Phoenix | Not provided | LLM observability | Kagenti-owned |
+
+```go
+func (k *Kagenti) mapObservability(dsc *dscv2.DataScienceCluster) kagentiv1alpha1.ObservabilitySpec {
+    obs := kagentiv1alpha1.ObservabilitySpec{
+        ManagementState: operatorv1.Managed,
+        // ... GenAI pipeline config ...
+    }
+    if dsc.Spec.Components.MLflowOperator.ManagementState == operatorv1.Managed {
+        obs.MLflow.ManagementState = operatorv1.Removed // Defer to RHOAI
+    } else {
+        obs.MLflow.ManagementState = operatorv1.Managed
+    }
+    return obs
+}
+```
 
 ---
 
@@ -684,37 +844,31 @@ A `ValidatingAdmissionWebhook` prevents accidental deletion with `Delete` policy
 
 ### 10.1 Adoption via Server-Side Apply
 
-For existing clusters running the Ansible-installed stack, the Quickstart Operator can adopt existing resources using Kubernetes Server-Side Apply (SSA) with field ownership transfer. This is preferred over Helm release manipulation because SSA is a native, well-tested Kubernetes API.
+For existing clusters, the Quickstart Operator adopts resources using SSA with `ForceOwnership`:
 
-The adoption process per component:
-
-1. Discover existing resources by label, annotation, or well-known names.
-2. Apply SSA patch with `kagenti-quickstart` field manager and `ForceOwnership`.
-3. For Helm-installed resources: delete the Helm release Secret (tracking metadata only; actual resources remain).
-4. Label all adopted resources with `kagenti.dev/managed-by=quickstart`.
-5. Record provenance in status (original install method, version).
+1. Discover existing resources by label, annotation, or well-known names
+2. Apply SSA patch with `kagenti-quickstart` field manager
+3. Delete Helm release Secret (tracking metadata only; resources remain)
+4. Label adopted resources with `kagenti.dev/managed-by=quickstart`
+5. Record provenance in status
 
 ### 10.2 Graduation Path
 
 | Step | Action | Result |
 |------|--------|--------|
-| 1. Parallel install | Install Tier 1 operator alongside Ansible-managed cluster | Operator validates infra (passes), manages Kagenti components. Ansible still manages infra. |
-| 2. Quickstart adoption (optional) | Install Quickstart operator; it adopts existing infra resources | Quickstart manages infra lifecycle. Ansible no longer needed. |
-| 3. Production graduation | Delete `KagentiQuickstart` CR with `deletionPolicy: Retain` | Infra remains, managed by admin/GitOps. Platform operator continues. |
+| 1. Parallel install | Install Tier 1 operator alongside Ansible-managed cluster | Operator validates infra, manages Kagenti components. |
+| 2. Quickstart adoption | Install Quickstart operator; adopts existing infra resources | Quickstart manages infra lifecycle. Ansible no longer needed. |
+| 3. Production graduation | Delete KagentiQuickstart CR with `deletionPolicy: Retain` | Infra remains, managed by admin/GitOps. Platform operator continues. |
 
 ### 10.3 UX Preservation
 
-A `deploy.sh` wrapper script preserves the single-command experience:
-
 ```bash
-# Dev (Kind) — identical simplicity to Ansible:
+# Dev (Kind) — identical simplicity:
 ./deploy.sh dev
 
-# Production (OpenShift) — admin applied prereqs already:
+# Production (OpenShift):
 ./deploy.sh ocp
 ```
-
-The script includes the same preflight checks as the Ansible wrapper: Docker/Podman memory (>=16GB), CPU count (>=4), Helm version validation, and macOS SSL fixes.
 
 ---
 
@@ -722,38 +876,78 @@ The script includes the same preflight checks as the Ansible wrapper: Docker/Pod
 
 | Phase | Duration | Deliverables | Dependencies |
 |-------|----------|-------------|-------------|
-| **A: CRD + Platform Controller** | 4 weeks | `KagentiPlatform` CRD types, infra validation, core component installation (operator, webhook, UI), Helm SDK integration, envtest unit tests, Kind integration tests | None. Ansible continues working unchanged. |
-| **B: Observability + Prereqs Chart** | 3 weeks | Observability controller (OTel, Phoenix, MLflow), `kagenti-prereqs` Helm chart extracted from `kagenti-deps`, E2E validation | Phase A complete. |
-| **C: Quickstart Operator** | 3 weeks | Port Ansible phase logic to Go controller, all component strategies (Helm, OLM, Manifest), OpenShift/K8s detection, adoption logic (SSA), `deploy.sh` wrapper | Phase A complete. Phase B for full E2E. |
-| **D: Productization** | 2 weeks | Konflux pipeline, OLM bundle generation, Red Hat certification prep, documentation (prereqs guide, migration guide, API reference), deprecate Ansible | Phases A-C complete. |
+| A: CRD + Platform Controller | 4 weeks | `KagentiPlatform` CRD with `managementState`, infra validation, core component install, envtest | None |
+| B: Observability + Prereqs Chart | 3 weeks | Observability controller, `kagenti-prereqs` chart, MLflow deconfliction | Phase A |
+| C: Quickstart Operator (Tier 3) | 3 weeks | Port Ansible phases to Go, adoption logic, `deploy.sh` | Phase A |
+| D: ODH Component Handler (Tier 2) | 2 weeks | Kagenti component for ODH operator, DSC spec fields, OLM CSV with dependencies | Phase A |
+| E: Productization | 2 weeks | Konflux pipeline, OLM bundle, Red Hat cert prep, docs | Phases A-D |
 
-**Total estimated duration: ~12 weeks of focused development.**
+Phases C and D run in parallel. Total: ~12 weeks.
+
+### 11.1 ODH Contribution Governance
+
+#### Phased Upstream Strategy
+
+```
+Week 1-4:   Phase A — KagentiPlatform CRD + Platform Controller (standalone)
+Week 5-7:   Phase B/C/D in parallel
+              D.1: Write component handler + tests
+              D.2: Open upstream PR to opendatahub-io/opendatahub-operator
+              D.3: Ship overlay/fork for RHOAI internal testing
+Week 8-9:   Phase E — Productization (standalone OLM bundle)
+Week 8-14:  D.4 — Upstream review cycle (async, non-blocking)
+```
+
+#### Overlay Bridge Strategy
+
+While the upstream ODH PR is in review, an overlay image includes the Kagenti component handler:
+
+- Used only for RHOAI internal integration testing
+- Never shipped to customers before the upstream merge lands
+- Three technical gates: image tag `-internal` suffix, separate registry (`quay.io/kagenti-internal`), 90-day TTL expiry
+
+#### ODH RFC Ownership
+
+| Action | Owner | Deadline | Artifact |
+|--------|-------|----------|----------|
+| Draft ODH component RFC | Kagenti tech lead (Paolo Dettori) | End of Phase A, Week 2 | GitHub Issue on `opendatahub-io/opendatahub-operator` |
+| Present at ODH community meeting | Kagenti tech lead + PM | Week 3-4 | Slide deck / demo |
+| Open upstream PR | Kagenti developer (Phase D) | Week 5 | PR to ODH repo |
+| Track upstream review | Kagenti tech lead | Weekly | Status in standup |
 
 ---
 
-## 12. Consolidated Decision Record
+## 12. Decision Record
 
 | Decision | Rationale | Round |
 |----------|-----------|-------|
-| Two-tier operator split (Product vs. Quickstart) | Productization requires narrow RBAC and no third-party coupling. Complexity stays in the dev tool. | R3 |
-| Product operator validates but does not install infrastructure | Red Hat operator pattern. Reduces RBAC, eliminates third-party API coupling, enables Konflux certification. | R3 |
-| Single CRD with two controllers | Minimizes user-facing surface. Hash-based reconciliation avoids status conflicts. | R5 |
-| `kagenti-prereqs` static Helm chart | Bridges the gap between "validate only" and "30 manual steps." Admin can review, modify, or GitOps it. | R5 |
-| Narrow RBAC (no `escalate`, no CRD creation) | Passes Red Hat security review. Minimal blast radius on compromise. | R4 |
-| Quickstart creates Platform CR once, never updates | Clean ownership boundary. User can modify freely after creation. | R4 |
-| SSA for adoption, not Helm release import | Native K8s API, auditable field ownership, works across all install methods. | R5 |
-| Grace period + annotation for upgrade coordination | Prevents false `Blocked` during infra upgrades. No tight coupling. | R4 |
-| Component mode enum: `Managed | External | Disabled | Adopted` | Clear semantics, no ambiguity about who manages what. | R2 |
-| Version manifest compiled in binary + ConfigMap override | Fast CVE response without rebuilding. Sane defaults. | R4 |
-| Component interface with strategy embedding | Adding a new package is a 3-file change. No core refactoring. | R1 |
-| Deletion policy with confirmation annotation | Prevents accidental destruction of infrastructure. | R2 |
-| Dynamic component criticality (computed from config) | Tekton is Critical only if builds enabled. Avoids false alerts. | R3 |
+| Three-tier deployment model (Product, RHOAI/DSC, Quickstart) | PM feedback: RHOAI integration is primary productization vehicle | V6 (R2) |
+| ODH component handler creates `KagentiPlatform` CR (thin wrapper) | Mirrors kserve/ray pattern. ~200 lines contributed upstream | V6 (R2) |
+| `managementState` tri-state replaces `enabled: bool` | Aligns with ODH/RHOAI vocabulary | V6 (R2) |
+| Dual CSV bundles (standalone: soft deps, RHOAI: hard deps) | Standalone needs incremental adoption; RHOAI guarantees all deps | V7 (R3) |
+| Overlay image bridge for ODH contribution gap | Standard Red Hat practice. Non-blocking | V7 (R3) |
+| SSA field manager boundaries for CRD ownership transfer | Clean Managed->Unmanaged graduation | V7 (R3) |
+| ODH RFC filed by Week 2, owned by Kagenti tech lead | Early visibility prevents review bottleneck | V8 (R4) |
+| Overlay governance via technical gates (tag, registry, TTL) | Policy-only controls insufficient | V8 (R4) |
+| Unmanaged health checks: same RBAC, `Unknown` for off-namespace | No RBAC expansion needed | V8 (R4) |
+| Infrastructure `requirement: Required\|Optional\|Ignored` | Consistent vocabulary | V7 (R3) |
+| Observability deconfliction: defer MLflow to RHOAI | Avoids duplicate instances | V6 (R2) |
+| Formal dependency mapping table | Connects components to Red Hat operators | V6 (R2) |
+| Two-tier operator split (Product vs. Quickstart) | Productization requires narrow RBAC | V3 (original) |
+| Product operator validates but does not install infrastructure | Reduces RBAC, enables certification | V3 (original) |
+| Single CRD with two controllers | Minimizes user-facing surface | V5 (original) |
+| `kagenti-prereqs` static Helm chart | Bridges validate-only and 30 manual steps | V5 (original) |
+| Narrow RBAC (no escalate, no CRD creation) | Passes Red Hat security review | V4 (original) |
+| Quickstart creates Platform CR once, never updates | Clean ownership boundary | V4 (original) |
+| SSA for adoption, not Helm release import | Native K8s API, auditable | V5 (original) |
+| Grace period + annotation for upgrade coordination | Prevents false Blocked during upgrades | V4 (original) |
+| Component mode: Managed \| Removed \| Unmanaged | Clear semantics, ODH-compatible | V6 (R2) |
+| Deletion policy with confirmation annotation | Prevents accidental destruction | V2 (original) |
+| Dynamic component criticality (computed from config) | Avoids false alerts | V3 (original) |
 
 ---
 
 ## Appendix A: Quickstart Phase Ordering
-
-The Quickstart Operator's phase-based state machine mirrors the current Ansible installer's dependency graph:
 
 ```
 cert-manager ──┐
@@ -769,27 +963,23 @@ SPIRE ─────────► CSI driver ────────┘
 Keycloak ──────► realm ready ───────┘
 ```
 
-Each phase gates on the previous phase's health. Within a phase, independent components install concurrently. Empty phases (all components disabled) are skipped. Already-ready phases are short-circuited on subsequent reconciliations.
-
----
-
 ## Appendix B: Component Criticality Matrix
 
 Criticality is computed dynamically from the resolved `KagentiPlatform` spec:
 
 | Component | Default Criticality | Condition for Change |
-|-----------|--------------------|-----------------------|
+|-----------|-------------------|---------------------|
 | Istio | Critical | Always Critical when required |
 | SPIRE | Critical | Always Critical when required |
 | cert-manager | Critical | Always Critical when required |
 | Gateway API | Critical | Always Critical when required |
-| Tekton | Required | Critical if `agentOperator.enabled` |
-| Shipwright | Required | Critical if `agentOperator.enabled` |
-| Keycloak | Required | Critical if `ui.auth.enabled`; Optional if not |
-| OTel Collector | Optional | Required if `observability.enabled` |
-| Phoenix | Optional | Required if `observability.phoenix.enabled` |
+| Tekton | Required | Critical if `agentOperator` enabled |
+| Shipwright | Required | Critical if `agentOperator` enabled |
+| Keycloak | Required | Critical if `ui.auth` Managed; Optional if not |
+| OTel Collector | Optional | Required if `observability` Managed |
+| Phoenix | Optional | Required if `observability.phoenix` Managed |
 | MLflow | Optional | Always Optional |
 | Kiali | Optional | Always Optional |
 | MCP Inspector | Optional | Always Optional |
-| Metrics Server | Optional | Always Optional |
+| metrics-server | Optional | Always Optional |
 | Container Registry | Optional | Required on Kind (no external registry) |

--- a/docs/architecture/operator-migration-design.md
+++ b/docs/architecture/operator-migration-design.md
@@ -1,0 +1,795 @@
+# Kagenti Operator Migration Design
+
+> **Version**: 5.0 (Final)
+> **Date**: 2026-03-04
+> **Status**: Approved after 5-round architectural review
+> **Tracking Issue**: [#828](https://github.com/kagenti/kagenti/issues/828)
+
+## Table of Contents
+
+- [1. Executive Summary](#1-executive-summary)
+- [2. Background and Motivation](#2-background-and-motivation)
+  - [2.1 Current State: Ansible/Helm Installer](#21-current-state-ansiblehelm-installer)
+  - [2.2 Why Migrate to an Operator](#22-why-migrate-to-an-operator)
+  - [2.3 Product Manager Context](#23-product-manager-context)
+- [3. Architecture Overview](#3-architecture-overview)
+  - [3.1 Two-Tier Operator Model](#31-two-tier-operator-model)
+  - [3.2 Tier 1: Kagenti Platform Operator (Product)](#32-tier-1-kagenti-platform-operator-product)
+  - [3.3 Tier 1 Observability Controller](#33-tier-1-observability-controller)
+  - [3.4 Tier 2: Kagenti Quickstart Installer (Dev Tool)](#34-tier-2-kagenti-quickstart-installer-dev-tool)
+  - [3.5 Companion: kagenti-prereqs Helm Chart](#35-companion-kagenti-prereqs-helm-chart)
+- [4. CRD Design: KagentiPlatform](#4-crd-design-kagentiplatform)
+  - [4.1 Full CR Schema](#41-full-cr-schema)
+  - [4.2 Status Subresource](#42-status-subresource)
+  - [4.3 Infrastructure Validation](#43-infrastructure-validation)
+- [5. Controller Architecture](#5-controller-architecture)
+  - [5.1 Platform Controller](#51-platform-controller)
+  - [5.2 Observability Controller](#52-observability-controller)
+  - [5.3 Two Controllers, One CRD](#53-two-controllers-one-crd)
+  - [5.4 Phase-Based State Machine (Quickstart)](#54-phase-based-state-machine-quickstart)
+- [6. Component Interface and Extensibility](#6-component-interface-and-extensibility)
+  - [6.1 Component Interface](#61-component-interface)
+  - [6.2 Installation Strategies](#62-installation-strategies)
+  - [6.3 Adding a New Package](#63-adding-a-new-package)
+- [7. RBAC and Security](#7-rbac-and-security)
+  - [7.1 Product Operator RBAC (Tier 1)](#71-product-operator-rbac-tier-1)
+  - [7.2 Security Properties](#72-security-properties)
+  - [7.3 Comparison: Monolithic vs. Two-Tier RBAC](#73-comparison-monolithic-vs-two-tier-rbac)
+- [8. OLM Subscription Lifecycle (Quickstart)](#8-olm-subscription-lifecycle-quickstart)
+- [9. Day-2 Operations](#9-day-2-operations)
+  - [9.1 Upgrade Coordination](#91-upgrade-coordination)
+  - [9.2 Drift Detection](#92-drift-detection)
+  - [9.3 Health and Degradation Model](#93-health-and-degradation-model)
+  - [9.4 Deletion Policy](#94-deletion-policy)
+  - [9.5 Ansible vs. Operator Comparison](#95-ansible-vs-operator-comparison)
+- [10. Migration Path from Ansible](#10-migration-path-from-ansible)
+  - [10.1 Adoption via Server-Side Apply](#101-adoption-via-server-side-apply)
+  - [10.2 Graduation Path](#102-graduation-path)
+  - [10.3 UX Preservation](#103-ux-preservation)
+- [11. Implementation Timeline](#11-implementation-timeline)
+- [12. Consolidated Decision Record](#12-consolidated-decision-record)
+- [Appendix A: Quickstart Phase Ordering](#appendix-a-quickstart-phase-ordering)
+- [Appendix B: Component Criticality Matrix](#appendix-b-component-criticality-matrix)
+
+---
+
+## 1. Executive Summary
+
+This document presents the final architecture for migrating the Kagenti platform installer from an Ansible/Helm-based approach to a Kubernetes Operator-based approach. The design was refined through 5 rounds of internal architectural review between a Lead Architect and a Quality Advocate, with human reviewer input on security, RBAC, and productization constraints.
+
+### Key Decisions
+
+- **Two-tier split**: A product-grade Platform Operator (Tier 1) manages only Kagenti's own components. An optional Quickstart Operator (Tier 2) handles infrastructure prerequisites for dev/PoC environments.
+- **Validate, don't install**: The product operator checks that infrastructure prerequisites (Istio, Keycloak, SPIRE, etc.) exist but does NOT install them. This keeps RBAC narrow and enables Konflux/OLM certification.
+- **Single CRD, two controllers**: One `KagentiPlatform` CRD with a Platform Controller and an Observability Controller, minimizing user-facing surface area.
+- **Static prereqs chart**: A `kagenti-prereqs` Helm chart provides auditable, review-before-apply prerequisite manifests for production clusters.
+- **Narrow RBAC**: The product operator has no `escalate`, no CRD creation, no OLM management, and no third-party CR mutation. Read-only infrastructure validation only.
+
+---
+
+## 2. Background and Motivation
+
+### 2.1 Current State: Ansible/Helm Installer
+
+Kagenti currently uses an Ansible playbook (`roles/kagenti_installer`) that orchestrates 29+ sequential installation steps. The playbook handles:
+
+- **Platform-adaptive logic**: The same component (e.g., "install SPIRE") resolves to completely different actions depending on whether the target is Kind, OpenShift 4.18 (fallback to upstream SPIRE Helm charts), or OpenShift 4.19+ (ZTWIM operator via OLM). This requires runtime detection of the cluster type and OCP version with multi-step fallback chains.
+- **Cross-resource ordering with waits**: CRDs must exist before CRs can be created, operators must reach `Succeeded` before operands are applied, webhooks must be healthy before dependent resources are submitted. The playbook has retry loops ranging from 3 retries/15s (Helm installs) up to 90 retries/10s (TektonConfig readiness — 15 min).
+- **Conflict detection**: On OpenShift, existing OLM-installed operators (cert-manager, Tekton) need to be detected and skipped rather than re-installed.
+- **Post-install fixups**: Several resources created by operators need imperative patches afterward (TektonConfig security context, github-clone-step ConfigMap for Istio ambient, CA secret copying across namespaces, container registry DNS in Kind).
+- **Diagnostic collection on failure**: Ansible's rescue blocks collect targeted pod status and logs before failing.
+
+The two-level toggle architecture uses Ansible-level flags (controlling whether Ansible installs components natively) and Helm `components.*` toggles (controlling which resources Helm templates render). Environment files (`dev_values.yaml`, `ocp_values.yaml`, etc.) configure these for different deployment targets.
+
+### 2.2 Why Migrate to an Operator
+
+| Driver | Ansible Limitation | Operator Advantage |
+|--------|--------------------|--------------------|
+| Self-healing | None. Manual re-run on failure. | Continuous reconciliation restores desired state. |
+| Drift detection | None. Manual `helm diff` required. | Controller detects and repairs drift automatically. |
+| Day-2 operations | Re-run full playbook for any change. | Edit CR spec; controller applies minimal diff. |
+| Productization | Cannot ship via OLM/Konflux. | Native OLM distribution, Red Hat certification. |
+| Declarative UX | Imperative playbook execution. | `kubectl apply` a CR; watch status converge. |
+| GitOps | Not GitOps-friendly. | CR can be managed by ArgoCD. |
+| Observability | Check Ansible logs, manual `kubectl`. | `kubectl get kagentiplatform` shows full status. |
+
+### 2.3 Product Manager Context
+
+Internal discussions established several constraints that directly shaped this architecture:
+
+> "Reducing as much of the dependencies as possible would be desirable as a prevention mechanism, otherwise we end up encoding that complexity somewhere."
+
+This informed the two-tier split: the product operator is lean and certifiable; infrastructure complexity lives in an optional dev tool.
+
+> "As we move the kagenti pieces to the product, the operator pattern would make most sense especially."
+
+Team consensus that the operator pattern is the right long-term approach.
+
+Additionally, images for Kagenti need to be provided through Konflux once APIs are solidified (RHAIRFE-1351). The operator architecture is designed with this constraint from the start.
+
+---
+
+## 3. Architecture Overview
+
+### 3.1 Two-Tier Operator Model
+
+The fundamental insight driving this architecture is that Kagenti has two fundamentally different concerns with different lifecycles and ownership:
+
+| Concern | What | Lifecycle | Owner |
+|---------|------|-----------|-------|
+| Kagenti itself | Operator, Webhook, UI, MCP Gateway | Product lifecycle (Konflux, OLM) | Kagenti team |
+| Infrastructure prerequisites | Istio, Keycloak, SPIRE, Tekton, etc. | External operator lifecycles | Platform team / cluster admin |
+
+Encoding infrastructure installation into the product operator would mean that when Istio breaks, **our** operator is on the hook. When OSSM v3 changes its CR schema, **our** operator must be updated. The two-tier model avoids this coupling entirely.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     USER ENTRY POINTS                           │
+├──────────────────────┬──────────────────────┬───────────────────┤
+│  Dev / Kind          │  Production OCP      │  GitOps           │
+│  ./deploy.sh dev     │  OperatorHub +       │  ArgoCD applies   │
+│                      │  kagenti-prereqs     │  manifests from   │
+│                      │  chart               │  git repo         │
+└──────────┬───────────┴──────────┬───────────┴─────────┬─────────┘
+           │                      │                     │
+           ▼                      │                     │
+┌──────────────────────┐          │                     │
+│ Tier 2: Quickstart   │          │                     │
+│ Operator (dev only)  │          │                     │
+│                      │          │                     │
+│ Installs: Istio,     │          │                     │
+│ Keycloak, SPIRE,     │          │                     │
+│ Tekton, Shipwright,  │          │                     │
+│ cert-manager, etc.   │          │                     │
+│                      │          │                     │
+│ CRD: KagentiQuick-   │          │                     │
+│ start                │          │                     │
+│                      │          │                     │
+│ Creates once:        │          │                     │
+│ KagentiPlatform CR ──┼──┐       │                     │
+└──────────────────────┘  │       │                     │
+                          ▼       ▼                     ▼
+                    ┌─────────────────────────────────────────┐
+                    │ Tier 1: Kagenti Platform Operator       │
+                    │ (PRODUCT — Konflux / OLM)               │
+                    │                                         │
+                    │ CRD: KagentiPlatform                    │
+                    │                                         │
+                    │ ┌─────────────────────────────────────┐ │
+                    │ │ Platform Controller                 │ │
+                    │ │ • Validates infrastructure (r/o)    │ │
+                    │ │ • Installs: Agent Operator,         │ │
+                    │ │   Webhook, UI, MCP Gateway          │ │
+                    │ │ • Configures: agent namespaces,     │ │
+                    │ │   OAuth clients, SPIFFE configs     │ │
+                    │ │ • Drift detection + self-healing    │ │
+                    │ └─────────────────────────────────────┘ │
+                    │ ┌─────────────────────────────────────┐ │
+                    │ │ Observability Controller             │ │
+                    │ │ • Installs: OTel Collector (with    │ │
+                    │ │   Kagenti-specific pipeline config) │ │
+                    │ │ • Installs: Phoenix, MLflow         │ │
+                    │ │ • Owns GenAI semconv transforms     │ │
+                    │ └─────────────────────────────────────┘ │
+                    │                                         │
+                    │ Same OLM bundle, two controllers,       │
+                    │ one CRD, narrow RBAC                    │
+                    └─────────────────────────────────────────┘
+                                      │
+                          validates presence of
+                                      ▼
+                    ┌─────────────────────────────────────────┐
+                    │ Infrastructure (NOT managed by Kagenti) │
+                    │                                         │
+                    │ Istio (OSSM v3 / upstream Helm)         │
+                    │ Keycloak (RHBK / upstream Helm)         │
+                    │ SPIRE (ZTWIM / upstream Helm)           │
+                    │ Tekton (OpenShift Pipelines / upstream) │
+                    │ Shipwright (OpenShift Builds / upstream) │
+                    │ cert-manager (OCP operator / upstream)  │
+                    │ Gateway API CRDs                        │
+                    │                                         │
+                    │ Installed by: cluster admin, GitOps,    │
+                    │ kagenti-prereqs chart, or Quickstart    │
+                    └─────────────────────────────────────────┘
+```
+
+### 3.2 Tier 1: Kagenti Platform Operator (Product)
+
+- Shipped via Konflux and OLM. Red Hat certified.
+- Manages ONLY Kagenti-owned components: Agent Operator, Webhook, UI, MCP Gateway, Agent Namespaces, OAuth client setup.
+- Validates that required infrastructure exists (CRDs present, services reachable) but does NOT install it.
+- Contains two controllers in one OLM bundle: Platform Controller and Observability Controller.
+- Single CRD: `KagentiPlatform`.
+- Narrow RBAC: no `escalate`, no CRD creation, no OLM management.
+
+### 3.3 Tier 1 Observability Controller
+
+The Observability Controller is part of the Tier 1 OLM bundle but runs as a separate controller watching the same `KagentiPlatform` CRD. It manages:
+
+- OTel Collector with Kagenti-specific pipeline configuration (GenAI semantic convention transforms, span filtering for A2A, OAuth2 exporter for MLflow).
+- Phoenix (LLM observability backend).
+- MLflow (experiment tracking).
+
+These are included in Tier 1 because the OTel Collector pipeline configuration is Kagenti-specific IP (not generic infrastructure). A user may disable observability entirely via `spec.observability.enabled: false`.
+
+### 3.4 Tier 2: Kagenti Quickstart Installer (Dev Tool)
+
+- Optional. For dev/demo/PoC environments only.
+- NOT part of the product. NOT shipped via OLM or Konflux.
+- Replaces the current Ansible installer.
+- Manages all infrastructure prerequisites: Istio, Keycloak, SPIRE, Tekton, Shipwright, cert-manager, Gateway API, Kiali, etc.
+- CRD: `KagentiQuickstart`.
+- After installing infrastructure, creates a `KagentiPlatform` CR **once** (create-if-not-exists, never updates). The Platform Operator then takes over.
+- Has broader permissions (OLM CRUD, Helm installs, namespace creation) because it runs only in dev environments.
+
+### 3.5 Companion: kagenti-prereqs Helm Chart
+
+For production OpenShift clusters where the Quickstart operator is not used, a static `kagenti-prereqs` Helm chart provides all prerequisite manifests (OLM Subscriptions, operand CRs, raw YAML). The admin can:
+
+- Inspect the chart before applying (audit trail).
+- Selectively enable components: `--set istio.enabled=true --set keycloak.enabled=true`.
+- Commit the rendered manifests to a GitOps repository.
+- Use it as a reference for crafting their own manifests.
+
+The chart lives in the Kagenti repo alongside the operator (`charts/kagenti-prereqs/`), is versioned and tested alongside the operator (same CI matrix), but is NOT an operator — it's a plain Helm chart the admin runs once.
+
+---
+
+## 4. CRD Design: KagentiPlatform
+
+### 4.1 Full CR Schema
+
+```yaml
+apiVersion: kagenti.dev/v1alpha1
+kind: KagentiPlatform
+metadata:
+  name: kagenti
+  namespace: kagenti-system
+spec:
+  # --- Core Components (reconciled by Platform Controller) ---
+  agentOperator:
+    enabled: true
+    image: ""               # Override; defaults to operator-bundled version
+
+  webhook:
+    enabled: true           # SPIFFE identity injection
+    image: ""
+
+  ui:
+    enabled: true
+    auth:
+      enabled: true
+      keycloak:
+        url: https://keycloak.keycloak.svc.cluster.local:8443
+        realm: master
+        credentialsSecretRef: { name: kagenti-keycloak-admin }
+    frontend: { image: "" }
+    backend:  { image: "" }
+
+  mcpGateway:
+    enabled: false
+
+  agentNamespaces:
+    - name: team1
+      secretRef: { name: team1-credentials }
+    - name: team2
+      secretRef: { name: team2-credentials }
+
+  # --- Infrastructure References (validate only, do NOT install) ---
+  infrastructure:
+    istio:       { required: true }
+    spire:       { required: true, trustDomain: localtest.me }
+    certManager: { required: true }
+    tekton:      { required: true }
+    shipwright:  { required: true }
+    gatewayApi:  { required: true }
+
+  # --- Observability (reconciled by Observability Controller) ---
+  observability:
+    enabled: true
+    collector:
+      exporters:
+        phoenix: { enabled: true }
+        mlflow:
+          enabled: true
+          auth: { enabled: true, clientSecretRef: { name: kagenti-mlflow-oauth } }
+    phoenix:
+      enabled: true
+      storage: { type: postgresql, size: 10Gi }
+    mlflow:
+      enabled: true
+      storage: { size: 5Gi }
+
+  # --- Global ---
+  domain: localtest.me
+  deletionPolicy: Retain    # Retain | Delete
+  imageOverrides:
+    registry: ""
+    pullSecretRef: ""
+```
+
+### 4.2 Status Subresource
+
+Status is partitioned between the two controllers. Each writes to distinct sub-paths using separate SSA field managers to avoid conflicts.
+
+```yaml
+status:
+  phase: Ready              # Installing | Ready | Degraded | Blocked | Error
+  observedGeneration: 5
+
+  # Written by Platform Controller
+  environment:
+    platform: OpenShift     # or Kubernetes
+    version: "4.19"
+    preInstalled: [cert-manager, openshift-pipelines]
+  infrastructure:
+    certManager: { status: Ready, detected: true }
+    istio:       { status: Ready, detected: true }
+    spire:       { status: Ready, detected: true }
+    tekton:      { status: Ready, detected: true }
+    shipwright:  { status: Ready, detected: true }
+    gatewayApi:  { status: Ready, detected: true }
+  components:
+    agentOperator: { status: Ready }
+    ui:            { status: Ready }
+    webhook:       { status: Ready }
+  prerequisiteGuide:
+    helmChart: "oci://ghcr.io/kagenti/charts/kagenti-prereqs"
+    url: "https://kagenti.dev/docs/prerequisites"
+
+  # Written by Observability Controller
+  observability:
+    collector: { status: Ready }
+    phoenix:   { status: Ready }
+    mlflow:    { status: Ready }
+
+  conditions:
+    - type: InfrastructureReady   # All required infra present
+      status: "True"
+    - type: PlatformReady         # Core Kagenti components running
+      status: "True"
+    - type: ObservabilityReady    # OTel/Phoenix/MLflow running
+      status: "True"
+    - type: Available             # Core platform functional
+      status: "True"
+    - type: FullyOperational      # Core + observability
+      status: "True"
+```
+
+### 4.3 Infrastructure Validation
+
+The Platform Controller validates infrastructure on every reconciliation by checking CRD existence and service readiness. When prerequisites are missing, the status provides actionable guidance including a pointer to the `kagenti-prereqs` Helm chart.
+
+The controller distinguishes between "never installed" (hard block) and "was working, now temporarily unhealthy" (grace period). A configurable grace period (default 10 minutes) prevents false `Blocked` status during infrastructure upgrades.
+
+```go
+func (r *Reconciler) evaluateInfraHealth(ctx context.Context,
+    p *v1alpha1.KagentiPlatform) InfraStatus {
+
+    for _, req := range p.Spec.Infrastructure.RequiredComponents() {
+        if !r.detector.HasCRD(ctx, req.CRDGroupResource) {
+            return InfraBlocked  // Hard block — never installed
+        }
+
+        prev := p.Status.Infrastructure[req.Name]
+        ready, msg, _ := req.ReadinessCheck(ctx)
+        if ready {
+            continue
+        }
+
+        if prev.Status == "Ready" {
+            // Was healthy, now unhealthy — apply grace period
+            if prev.LastReadyTime.Add(r.infraGracePeriod).After(time.Now()) {
+                r.setInfraCondition(p, req.Name, "Degraded", msg)
+                continue
+            }
+        }
+        return InfraBlocked
+    }
+    return InfraReady
+}
+```
+
+The Quickstart operator can also set an annotation (`kagenti.dev/infra-upgrade-in-progress`) before starting an upgrade, which extends the grace period indefinitely while present.
+
+---
+
+## 5. Controller Architecture
+
+### 5.1 Platform Controller
+
+The Platform Controller handles the core Kagenti lifecycle:
+
+```go
+func (r *PlatformReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    platform := &v1alpha1.KagentiPlatform{}
+    r.Get(ctx, req.NamespacedName, platform)
+
+    // 1. Detect environment (OpenShift? version? pre-installed operators?)
+    env := r.detector.Detect(ctx)
+
+    // 2. Validate infrastructure prerequisites
+    infraStatus := r.evaluateInfraHealth(ctx, platform)
+    if infraStatus == InfraBlocked {
+        platform.Status.Phase = "Blocked"
+        return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+    }
+
+    // 3. Install/update core Kagenti components
+    for _, component := range r.coreComponents {
+        if component.Enabled(platform.Spec) {
+            component.Install(ctx, platform, env)
+        }
+    }
+
+    // 4. Configure agent namespaces (secrets, RBAC, labels)
+    r.reconcileAgentNamespaces(ctx, platform)
+
+    // 5. Set status
+    platform.Status.Phase = "Ready"
+    return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil  // drift check
+}
+```
+
+### 5.2 Observability Controller
+
+The Observability Controller watches the same `KagentiPlatform` CRD but only reconciles the `spec.observability` section. It uses a hash of the observability spec to avoid unnecessary work when only core spec changes.
+
+### 5.3 Two Controllers, One CRD
+
+Both controllers ship in the same OLM bundle as separate Deployments. They use distinct SSA field managers for status updates to avoid write conflicts. Each controller uses spec-hash comparison to skip reconciliation when only the other controller's section changed.
+
+### 5.4 Phase-Based State Machine (Quickstart)
+
+The Quickstart Operator uses a phase-based state machine for infrastructure installation. Phases execute sequentially; components within a phase install concurrently:
+
+| Phase | Components | Notes |
+|-------|-----------|-------|
+| 1. Foundation | cert-manager, Gateway API CRDs, metrics-server | No dependencies |
+| 2. Mesh | Istio (base → istiod → CNI → ztunnel) | Strict internal ordering |
+| 3. Identity | SPIRE (server → agent → CSI → OIDC) | Strict internal ordering |
+| 4. Build | Tekton → Shipwright | Shipwright depends on Tekton |
+| 5. Auth | Keycloak (operator → instance → realm → clients) | Sequential |
+| 6. Observability | OTel Collector, Phoenix, MLflow | Concurrent |
+| 7. Platform | Ingress Gateway, container registry, Kiali | Concurrent |
+| 8. Handoff | Creates `KagentiPlatform` CR | Platform operator takes over |
+
+Empty phases (all components disabled) are skipped. Already-ready phases are short-circuited on subsequent reconciliations.
+
+---
+
+## 6. Component Interface and Extensibility
+
+### 6.1 Component Interface
+
+```go
+type Component interface {
+    Name() string
+    Enabled(resolved *ResolvedConfig) bool
+    Install(ctx context.Context, p *KagentiPlatform, env *Environment) error
+    IsReady(ctx context.Context) (bool, string, error)
+    Uninstall(ctx context.Context) error
+}
+```
+
+### 6.2 Installation Strategies
+
+| Strategy | When Used | Example |
+|----------|-----------|---------|
+| `HelmComponent` | Vanilla K8s, or OCP when no OLM operator exists | Istio on K8s, Phoenix, MLflow |
+| `OLMComponent` | OpenShift with operator in catalog | OSSM v3, RHBK, OpenShift Pipelines |
+| `ManifestComponent` | Simple CRD/YAML-only installs | Gateway API CRDs, Kiali addons |
+| `ExternalComponent` | User-managed, validate connectivity only | External Keycloak, pre-existing Istio |
+
+The OpenShift vs. Kubernetes branching is encapsulated inside each component, not in the phase or reconciler:
+
+```go
+func (k *KeycloakComponent) Install(ctx context.Context, p *KagentiPlatform, env *Environment) error {
+    if p.Spec.Components.Keycloak.External != nil {
+        return k.validateExternal(ctx, p.Spec.Components.Keycloak.External)
+    }
+    if env.IsOpenShift {
+        return k.installViaOLM(ctx, p)   // RHBK Subscription → Keycloak CR
+    }
+    return k.installViaHelm(ctx, p)      // Helm chart with PostgreSQL
+}
+```
+
+### 6.3 Adding a New Package
+
+Adding a new component is a 3-file change with zero core refactoring:
+
+| File | Change |
+|------|--------|
+| `api/v1alpha1/types.go` | Add field to `ComponentsSpec` struct |
+| `controllers/components/newpkg.go` | Implement `Component` interface (embed `BaseHelmComponent` or `BaseOLMComponent`) |
+| `controllers/phases/<phase>.go` or `main.go` | Register in the appropriate phase |
+
+No changes to the reconciler, no changes to existing components.
+
+---
+
+## 7. RBAC and Security
+
+### 7.1 Product Operator RBAC (Tier 1)
+
+The product operator's ClusterRole is deliberately narrow:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kagenti-platform-operator
+rules:
+  # Read-only: infrastructure validation
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["config.openshift.io"]
+    resources: ["clusterversions"]
+    verbs: ["get"]
+
+  # Own CRDs
+  - apiGroups: ["kagenti.dev"]
+    resources: ["kagentiplatforms", "kagentiplatforms/status", "kagentiplatforms/finalizers"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+
+  # Kagenti components (namespaced)
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "configmaps", "secrets", "serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Networking
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "referencegrants"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Agent Operator sub-chart (read-only)
+  - apiGroups: ["agent.kagenti.dev"]
+    resources: ["agents", "agentbuilds", "agentcards"]
+    verbs: ["get", "list", "watch"]
+
+  # Namespace management (agent namespaces)
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create", "update", "patch"]
+
+  # Istio waypoints (read + create, not modify mesh)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["get", "list", "watch", "create"]
+```
+
+### 7.2 Security Properties
+
+| Property | How Achieved |
+|----------|-------------|
+| Least privilege | Operator can only manage Kagenti-owned resources. Cannot create CRDs, manage OLM, or modify third-party operator CRs. |
+| No escalation | No `escalate` or `bind` verbs. Cannot create ClusterRoles or ClusterRoleBindings. |
+| Infrastructure isolation | Read-only access to infrastructure CRDs for validation. Cannot modify Istio, Keycloak, or SPIRE resources. |
+| Secret scoping | Per-namespace `secretRef` for agent namespaces. No single Secret with all credentials. |
+| Audit trail | All actions attributable to `kagenti-platform-operator` ServiceAccount in audit logs. |
+| Certifiability | RBAC surface passes Red Hat operator certification requirements. |
+
+### 7.3 Comparison: Monolithic vs. Two-Tier RBAC
+
+| Permission | Monolithic Orchestrator (rejected) | Product Operator (V5) |
+|------------|------------------------------------|-----------------------|
+| CRD management | `create`, `update`, `delete` on ALL CRDs | `get`, `list`, `watch` only |
+| OLM access | Full Subscription/InstallPlan/CSV CRUD | None |
+| Namespace scope | All namespaces | `kagenti-system` + agent namespaces |
+| RBAC verbs | `bind`, `escalate` | None |
+| Third-party CRs | Full CRUD on Istio, Keycloak, SPIRE | Read-only (validation) |
+| Blast radius | Compromised operator = cluster-admin equivalent | Compromised operator = Kagenti components only |
+
+---
+
+## 8. OLM Subscription Lifecycle (Quickstart)
+
+The Quickstart Operator (Tier 2 only) manages OLM Subscriptions for OpenShift prerequisites with the following safeguards:
+
+| Aspect | Design Decision | Rationale |
+|--------|----------------|-----------|
+| Approval Policy | Always `Manual` | Prevents OLM from auto-upgrading operators and breaking operand CR schemas |
+| Version Gating | Compatibility matrix (compiled + ConfigMap override) | Only approve InstallPlans for tested CSV versions |
+| Operand CRs | `Unstructured` (no Go type imports) | Decouples from upstream API changes |
+| Health Checking | CSV phase + operator Pod readiness + operand status conditions | Three-layer verification before marking Ready |
+| Version Pinning | Compiled defaults + ConfigMap override | Fast CVE response without rebuilding the operator binary |
+
+The version manifest is compiled into the Quickstart operator binary with ConfigMap override for CVE response:
+
+```go
+var DefaultVersions = VersionManifest{
+    Istio:       {Chart: "istio/istiod", Version: "1.24.2"},
+    SPIRE:       {Chart: "spiffe/spire", Version: "0.23.0"},
+    Keycloak:    {Manifest: "github.com/keycloak/keycloak-k8s-resources", Version: "26.4"},
+    Tekton:      {Manifest: "storage.googleapis.com/tekton-releases/pipeline", Version: "0.62.2"},
+    CertManager: {Manifest: "github.com/cert-manager/cert-manager", Version: "1.16.3"},
+    // OLM channels for OpenShift
+    OSSM:        {OLMChannel: "stable-v3"},
+    RHBK:        {OLMChannel: "stable-v26.4"},
+    ZTWIM:       {OLMChannel: "stable-v1"},
+}
+```
+
+---
+
+## 9. Day-2 Operations
+
+### 9.1 Upgrade Coordination
+
+When infrastructure is upgraded (e.g., Istio OSSM v3.1 → v3.2), the Platform Operator may see transient unavailability. The grace period mechanism prevents false `Blocked` status:
+
+- Default grace period: **10 minutes** (configurable).
+- During grace period: status shows `Degraded`, not `Blocked`. Platform components remain operational.
+- The Quickstart operator can set annotation `kagenti.dev/infra-upgrade-in-progress` to extend the grace period indefinitely during planned upgrades.
+- After grace period expires without recovery: status escalates to `Blocked`.
+
+### 9.2 Drift Detection
+
+Three-tiered watch strategy:
+
+| Tier | Mechanism | Latency | What It Catches |
+|------|-----------|---------|-----------------|
+| Tier 1: Security watches | controller-runtime `Watches` on `AuthorizationPolicy`, `ClusterSPIFFEID` | Immediate | Deleted/modified security policies |
+| Tier 2: Owned resources | controller-runtime `Owns()` on Deployments, Services | Immediate | Modified/deleted Kagenti components |
+| Tier 3: Periodic poll | `RequeueAfter: 5 minutes` | Up to 5 min | Everything else (ConfigMap drift, label changes) |
+
+### 9.3 Health and Degradation Model
+
+| Condition | Meaning | When True |
+|-----------|---------|-----------|
+| `Available` | Core platform is functional | All Critical + Required components healthy |
+| `Degraded` | Optional component unhealthy | Any Optional component (MLflow, Kiali) is down |
+| `FullyOperational` | Everything works | All components including optional are healthy |
+| `Blocked` | Cannot proceed | Missing infrastructure prerequisites |
+
+Component criticality is **computed dynamically** from the resolved config, not hardcoded. For example, Tekton is `Critical` only if `agentOperator.enabled` (build pipelines need it). Keycloak is `Critical` only if `ui.auth.enabled`.
+
+### 9.4 Deletion Policy
+
+| Policy | Behavior |
+|--------|----------|
+| `Retain` (default) | Finalizer removed, all components left running. Resources become unmanaged. |
+| `Delete` | Reverse-order teardown of Kagenti components. Requires explicit annotation `kagenti.dev/confirm-delete=yes-destroy-everything`. Infrastructure is NEVER deleted by the product operator. |
+
+A `ValidatingAdmissionWebhook` prevents accidental deletion with `Delete` policy unless the confirmation annotation is present.
+
+### 9.5 Ansible vs. Operator Comparison
+
+| Operation | Current (Ansible/Helm) | Proposed (Operator) |
+|-----------|----------------------|---------------------|
+| Upgrade a component | Re-run full playbook (~15 min) | Edit CR or upgrade operator image |
+| Self-healing | None. Manual re-run. | Continuous reconciliation |
+| Drift detection | None. Manual `helm diff`. | Automatic, tiered watches |
+| Add component post-install | Edit env file, re-run playbook | Edit CR; controller installs only the new component |
+| Remove component | Edit env file, re-run (orphaned resources) | Set `enabled: false`; controller cleans up |
+| Multi-cluster | Run playbook per cluster | Apply CR per cluster (GitOps-friendly) |
+| Disaster recovery | Re-run from scratch | CR + secrets exist; controller converges |
+| Rollback | `helm rollback` per chart (manual) | Revert CR (or GitOps revision) |
+
+---
+
+## 10. Migration Path from Ansible
+
+### 10.1 Adoption via Server-Side Apply
+
+For existing clusters running the Ansible-installed stack, the Quickstart Operator can adopt existing resources using Kubernetes Server-Side Apply (SSA) with field ownership transfer. This is preferred over Helm release manipulation because SSA is a native, well-tested Kubernetes API.
+
+The adoption process per component:
+
+1. Discover existing resources by label, annotation, or well-known names.
+2. Apply SSA patch with `kagenti-quickstart` field manager and `ForceOwnership`.
+3. For Helm-installed resources: delete the Helm release Secret (tracking metadata only; actual resources remain).
+4. Label all adopted resources with `kagenti.dev/managed-by=quickstart`.
+5. Record provenance in status (original install method, version).
+
+### 10.2 Graduation Path
+
+| Step | Action | Result |
+|------|--------|--------|
+| 1. Parallel install | Install Tier 1 operator alongside Ansible-managed cluster | Operator validates infra (passes), manages Kagenti components. Ansible still manages infra. |
+| 2. Quickstart adoption (optional) | Install Quickstart operator; it adopts existing infra resources | Quickstart manages infra lifecycle. Ansible no longer needed. |
+| 3. Production graduation | Delete `KagentiQuickstart` CR with `deletionPolicy: Retain` | Infra remains, managed by admin/GitOps. Platform operator continues. |
+
+### 10.3 UX Preservation
+
+A `deploy.sh` wrapper script preserves the single-command experience:
+
+```bash
+# Dev (Kind) — identical simplicity to Ansible:
+./deploy.sh dev
+
+# Production (OpenShift) — admin applied prereqs already:
+./deploy.sh ocp
+```
+
+The script includes the same preflight checks as the Ansible wrapper: Docker/Podman memory (>=16GB), CPU count (>=4), Helm version validation, and macOS SSL fixes.
+
+---
+
+## 11. Implementation Timeline
+
+| Phase | Duration | Deliverables | Dependencies |
+|-------|----------|-------------|-------------|
+| **A: CRD + Platform Controller** | 4 weeks | `KagentiPlatform` CRD types, infra validation, core component installation (operator, webhook, UI), Helm SDK integration, envtest unit tests, Kind integration tests | None. Ansible continues working unchanged. |
+| **B: Observability + Prereqs Chart** | 3 weeks | Observability controller (OTel, Phoenix, MLflow), `kagenti-prereqs` Helm chart extracted from `kagenti-deps`, E2E validation | Phase A complete. |
+| **C: Quickstart Operator** | 3 weeks | Port Ansible phase logic to Go controller, all component strategies (Helm, OLM, Manifest), OpenShift/K8s detection, adoption logic (SSA), `deploy.sh` wrapper | Phase A complete. Phase B for full E2E. |
+| **D: Productization** | 2 weeks | Konflux pipeline, OLM bundle generation, Red Hat certification prep, documentation (prereqs guide, migration guide, API reference), deprecate Ansible | Phases A-C complete. |
+
+**Total estimated duration: ~12 weeks of focused development.**
+
+---
+
+## 12. Consolidated Decision Record
+
+| Decision | Rationale | Round |
+|----------|-----------|-------|
+| Two-tier operator split (Product vs. Quickstart) | Productization requires narrow RBAC and no third-party coupling. Complexity stays in the dev tool. | R3 |
+| Product operator validates but does not install infrastructure | Red Hat operator pattern. Reduces RBAC, eliminates third-party API coupling, enables Konflux certification. | R3 |
+| Single CRD with two controllers | Minimizes user-facing surface. Hash-based reconciliation avoids status conflicts. | R5 |
+| `kagenti-prereqs` static Helm chart | Bridges the gap between "validate only" and "30 manual steps." Admin can review, modify, or GitOps it. | R5 |
+| Narrow RBAC (no `escalate`, no CRD creation) | Passes Red Hat security review. Minimal blast radius on compromise. | R4 |
+| Quickstart creates Platform CR once, never updates | Clean ownership boundary. User can modify freely after creation. | R4 |
+| SSA for adoption, not Helm release import | Native K8s API, auditable field ownership, works across all install methods. | R5 |
+| Grace period + annotation for upgrade coordination | Prevents false `Blocked` during infra upgrades. No tight coupling. | R4 |
+| Component mode enum: `Managed | External | Disabled | Adopted` | Clear semantics, no ambiguity about who manages what. | R2 |
+| Version manifest compiled in binary + ConfigMap override | Fast CVE response without rebuilding. Sane defaults. | R4 |
+| Component interface with strategy embedding | Adding a new package is a 3-file change. No core refactoring. | R1 |
+| Deletion policy with confirmation annotation | Prevents accidental destruction of infrastructure. | R2 |
+| Dynamic component criticality (computed from config) | Tekton is Critical only if builds enabled. Avoids false alerts. | R3 |
+
+---
+
+## Appendix A: Quickstart Phase Ordering
+
+The Quickstart Operator's phase-based state machine mirrors the current Ansible installer's dependency graph:
+
+```
+cert-manager ──┐
+               ├──► kagenti-deps ──┐
+Gateway API ───┘                    │
+                                    ├──► kagenti (operator + UI + webhook)
+Istio ─────────► ztunnel ready ─────┘
+                                    │
+Tekton ────────► Shipwright ────────┘
+                                    │
+SPIRE ─────────► CSI driver ────────┘
+                                    │
+Keycloak ──────► realm ready ───────┘
+```
+
+Each phase gates on the previous phase's health. Within a phase, independent components install concurrently. Empty phases (all components disabled) are skipped. Already-ready phases are short-circuited on subsequent reconciliations.
+
+---
+
+## Appendix B: Component Criticality Matrix
+
+Criticality is computed dynamically from the resolved `KagentiPlatform` spec:
+
+| Component | Default Criticality | Condition for Change |
+|-----------|--------------------|-----------------------|
+| Istio | Critical | Always Critical when required |
+| SPIRE | Critical | Always Critical when required |
+| cert-manager | Critical | Always Critical when required |
+| Gateway API | Critical | Always Critical when required |
+| Tekton | Required | Critical if `agentOperator.enabled` |
+| Shipwright | Required | Critical if `agentOperator.enabled` |
+| Keycloak | Required | Critical if `ui.auth.enabled`; Optional if not |
+| OTel Collector | Optional | Required if `observability.enabled` |
+| Phoenix | Optional | Required if `observability.phoenix.enabled` |
+| MLflow | Optional | Always Optional |
+| Kiali | Optional | Always Optional |
+| MCP Inspector | Optional | Always Optional |
+| Metrics Server | Optional | Always Optional |
+| Container Registry | Optional | Required on Kind (no external registry) |


### PR DESCRIPTION
## Summary

- Updates the operator migration design from V5 to **V8**, incorporating 4 rounds of adversarial review with product management feedback on RHOAI/ODH integration
- Adds the RHOAI DataScienceCluster integration path as a first-class deployment tier
- Evolves from a two-tier to a **three-tier deployment model** (Product Operator, RHOAI/DSC, Quickstart)
- 795 lines expanded to ~1000 lines covering architecture, CRD schemas, controller design, RBAC, RHOAI integration, Day-2 operations, migration path, and implementation timeline

## Key Changes (V5 to V8)

| Area | V5 | V8 |
|------|----|----|
| Deployment model | Two-tier (Product + Quickstart) | **Three-tier** (Product + RHOAI/DSC + Quickstart) |
| RHOAI integration | Not addressed | Full DSC component handler pattern, API surface, ownership model |
| Component lifecycle | enabled: bool | managementState: Managed/Removed/Unmanaged (ODH-compatible) |
| OLM dependencies | Runtime validation only | **Dual CSV** (standalone: soft deps, RHOAI: hard CRD requirements) |
| Infrastructure config | required: bool | requirement: Required/Optional/Ignored |
| Observability | Independent stack | **Deconfliction with RHOAI** (defer MLflow when DSC manages it) |
| ODH contribution | Not planned | **Governance model**: overlay bridge, RFC ownership, timeline |

## New Sections

- **3.4** Tier 2: RHOAI/ODH DataScienceCluster Integration (DSC pattern, thin wrapper, API surface, CR ownership, DSCi prerequisites)
- **3.7** Formal Dependency Mapping (PM's Red Hat operator mappings)
- **6.4** Unmanaged Component Semantics
- **7.4** OLM Dual CSV Approach
- **9.6** Observability Deconfliction with RHOAI
- **11.1** ODH Contribution Governance (overlay bridge, RFC ownership)

## Architectural Decisions (22 total)

| Decision | Rationale | Round |
|----------|-----------|-------|
| Three-tier deployment model | RHOAI integration is primary productization vehicle | V6 |
| ODH component creates KagentiPlatform CR | Mirrors kserve/ray pattern, ~200 lines upstream | V6 |
| managementState tri-state | Aligns with ODH/RHOAI vocabulary | V6 |
| Dual CSV bundles | Different dependency strictness per context | V7 |
| Overlay bridge for ODH contribution gap | Standard Red Hat practice, non-blocking | V7 |
| SSA field manager for CRD ownership | Clean Managed to Unmanaged graduation | V7 |
| ODH RFC by Week 2 | Early visibility prevents review bottleneck | V8 |
| *Plus 15 decisions from original V1-V5 review* | | |

## Context: PM Feedback Incorporated

From internal discussion (Adel Zaalouk, Andrew Block, Paolo Dettori):
- RHOAI is a "meta operator" - Kagenti should be a DataScienceCluster component
- Most dependencies map to existing Red Hat operators (OSSM, RHBK, ZTWIM, etc.)
- Two scenarios: Kagenti inside RHOAI (product) + Kagenti standalone (dev)
- OLM dependency declaration for prerequisites

Closes #828

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Review three-tier architecture with the team
- [ ] Validate DSC component handler pattern with ODH maintainers
- [ ] Confirm dual CSV approach with Konflux team
- [ ] Review RBAC surface for Red Hat certification

🤖 Generated with [Claude Code](https://claude.com/claude-code)