### PR TITLE
fix: prevent --preload failure when images are already cached

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/02_setup_cluster.yaml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/02_setup_cluster.yaml
@@ -125,10 +125,11 @@
 
     - name: Pull images concurrently
       shell: |
+        set -o pipefail
         FAIL=0
         PIDS=""
         for img in {{ preload_images | join(' ') }}; do
-          docker pull "$img" 2>&1 | grep -E "^(Status:|Error)" &
+          (docker pull "$img" 2>&1 | { grep -E "^(Status:|Error)" || true; }) &
           PIDS="$PIDS $!"
         done
         for pid in $PIDS; do


### PR DESCRIPTION
## Summary

- Fix `--preload` failing when Docker images are already cached locally
- The `grep -E "^(Status:|Error)"` filter returns rc=1 on no match, incorrectly treated as pull failure
- Add `set -o pipefail` + `|| true` on grep to properly distinguish real failures from no-match

Fixes #831

## Test plan

- [x] Ran `./deployments/ansible/run-install.sh --env dev --preload` with cached images — succeeded
- [ ] Verify with uncached images (fresh `docker system prune`) to confirm real failures still propagate

🤖 Generated with [Claude Code](https://claude.com/claude-code)