### PR TITLE
fix: use official ghcr.io image for ui-oauth-secret

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -86,8 +86,7 @@ ui:
 #  UI OAuth Secret Creator Configuration
 # ------------------------------------------------------------------
 uiOAuthSecret:
-  # image: ghcr.io/kagenti/kagenti/ui-oauth-secret
-  image: quay.io/pdettori/ui-oauth-secret
+  image: ghcr.io/kagenti/kagenti/ui-oauth-secret
   tag: latest
   # When true, mount the in-cluster serviceaccount CA
   # into the ui-oauth-secret job via the SSL_CERT_FILE environment variable.


### PR DESCRIPTION
## Summary

- Replaces test image `quay.io/pdettori/ui-oauth-secret` with `ghcr.io/kagenti/kagenti/ui-oauth-secret` in `charts/kagenti/values.yaml`
- Fixes UI login failure on Kind installs after #764 (realm bootstrap code missing from old test image)
- Aligns with the naming convention used by `agent-oauth-secret` and other platform images

## Root Cause

The test image was built before #764 added the realm bootstrap logic. On Kind install, the old image created the `kagenti` realm and OAuth secret but never created the admin user — causing "Invalid user credentials" on login.

## Test plan

- [ ] Deploy to Kind: `./.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy`
- [ ] Login at `http://kagenti-ui.localtest.me:8080` with `admin/admin` succeeds
- [ ] CI e2e-kind workflows pass (they rebuild from source via `25-build-oauth-secret-image.sh`)

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)