### PR TITLE
🌱 Expand cve:scan with code security review and doc audit

### DIFF
--- a/.claude/skills/cve/SKILL.md
+++ b/.claude/skills/cve/SKILL.md
@@ -18,20 +18,22 @@ reported through proper channels.
 
 ## Router
 
+```mermaid
+flowchart TD
+    START(["/cve"]) --> WHAT{"What is needed?"}
+    WHAT -->|"Scan / Check deps / Review"| SCAN["cve:scan"]:::cve
+    WHAT -->|"CVE found, need plan"| BRAINSTORM["cve:brainstorm"]:::block
+    WHAT -->|"No specific request"| SCAN
+
+    classDef cve fill:#D32F2F,stroke:#333,color:white
+    classDef block fill:#B71C1C,stroke:#333,color:white
+```
+
 When `/cve` is invoked, determine the entry point:
 
-```
-What is needed?
-    |
-    +-- "Scan for CVEs" / "Check dependencies" / "Security review"
-    |   -> cve:scan (full scan: dependencies + code + docs)
-    |
-    +-- CVE was found, need response plan
-    |   -> cve:brainstorm
-    |
-    +-- No specific request
-        -> cve:scan (default: scan first)
-```
+- **"Scan for CVEs"** / **"Check dependencies"** / **"Security review"** → `cve:scan`
+- **CVE was found, need response plan** → `cve:brainstorm`
+- **No specific request** → `cve:scan` (default: scan first)
 
 ## What cve:scan Covers
 

--- a/.claude/skills/cve:brainstorm/SKILL.md
+++ b/.claude/skills/cve:brainstorm/SKILL.md
@@ -5,6 +5,13 @@ description: Plan responsible CVE disclosure, guide silent fixes, and BLOCK all 
 
 # CVE Brainstorm — Responsible Disclosure & Public Output Gate
 
+## When to Use
+
+- After `cve:scan` detects a confirmed HIGH/CRITICAL CVE
+- When you need to plan responsible disclosure for a vulnerability
+- When deciding whether to fix silently (dependency bump) or report formally
+- Automatically invoked by `cve:scan` when findings are detected
+
 When a CVE is detected by `cve:scan`, this skill guides responsible disclosure
 and **blocks all public output** until the vulnerability is properly handled.
 

--- a/.claude/skills/cve:scan/SKILL.md
+++ b/.claude/skills/cve:scan/SKILL.md
@@ -82,7 +82,11 @@ Record the inventory as a table in the report:
 ## Phase 2: Trivy Scan (if available)
 
 ```bash
-which trivy 2>/dev/null && trivy --version
+which trivy 2>/dev/null
+```
+
+```bash
+trivy --version
 ```
 
 If installed, run filesystem and config scans:


### PR DESCRIPTION
## Summary

- Expands `cve:scan` from 3 phases to 6: dependency inventory, Trivy, LLM+WebSearch, **source code security review**, **documentation CVE audit**, and combined SUMMARY.md report
- Output goes to `.cves/` (gitignored) instead of `/tmp/` — easy to copy to Google Docs
- Supports multi-repo scanning with cross-repo security gap comparison
- Adds mermaid router diagram to `cve` parent skill
- Adds "When to Use" section to `cve:brainstorm`
- Fixes `skills:validate` issues (chained commands, missing sections)

Follows up on #694 (merged).

## Test plan

- [ ] Invoke `cve:scan` and verify 6-phase workflow runs
- [ ] Verify `.cves/SUMMARY.md` is generated with all sections
- [ ] Run `skills:validate` on cve, cve:scan, cve:brainstorm — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)