### PR TITLE
fix: resolve some docker hub rate limits for images

### DIFF
--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -44,6 +44,7 @@ components:
 
 common:
   kubectlImage: "quay.io/kubestellar/kubectl:1.30.14"
+  postgresImage: "quay.io/fedora/postgresql-16"
 
 # ------------------------------------------------------------------
 #  Components Configurations

--- a/charts/kagenti/templates/otel-collector-restart-job.yaml
+++ b/charts/kagenti/templates/otel-collector-restart-job.yaml
@@ -80,7 +80,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: restarter
-        image: bitnami/kubectl:latest
+        image: {{ .Values.common.kubectlImage | default "bitnami/kubectl:latest" }}
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
Probably there is more docker hub issues that could fail, but I encountered only these ones while trying to use the installer in openshift

- Set `common.postgresImage` to quay.io/fedora/postgresql-16 to avoid Docker Hub rate limits for the `mlflow` create-db init container and was already referenced in `charts/kagenti-deps/templates/mlflow.yaml` but did not exist.
- Use `common.kubectlImage` for `otel-collector-restart-job` instead of `bitnami/kubectl:latest` from Docker Hub

## Related issue(s)

## (Optional) Testing Instructions

Fixes #
