### PR TITLE
Fix: correct PostgreSQL PersistentVolume mount path in keycloak-k8s chart

### DIFF
--- a/charts/kagenti-deps/templates/keycloak-k8s.yaml
+++ b/charts/kagenti-deps/templates/keycloak-k8s.yaml
@@ -184,7 +184,7 @@ spec:
               containerPort: 5432
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/postgresql
+              mountPath: /var/lib/postgresql/data
   volumeClaimTemplates:
     - metadata:
         name: postgres-data


### PR DESCRIPTION
## Summary
The PostgreSQL StatefulSet was mounting the PersistentVolume at /var/lib/postgresql, but PostgreSQL's PGDATA is /var/lib/postgresql/data by default. This caused data to be written to the container's overlay filesystem instead of the PersistentVolume, resulting in data loss on pod restarts.

This commit fixes the mountPath to /var/lib/postgresql/data so data is written directly to the PersistentVolume and persists across restarts.

Tested by:
- Creating test data in PostgreSQL
- Scaling StatefulSet to 0 and back to 1
- Verifying data persists after restart