### PR TITLE
fix: grant stale workflow the permissions it needs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,8 +14,10 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Deny all permissions at workflow level; the reusable workflow declares its own
-permissions: {}
+# Minimum permissions required by the reusable stale workflow
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:


### PR DESCRIPTION
## Summary

- The caller `stale.yaml` had `permissions: {}` which blocks the reusable workflow from obtaining `issues: write` and `pull-requests: write`, causing `startup_failure` on every scheduled run since [6d243d3](https://github.com/kagenti/kagenti/commit/6d243d36f4747771bd12b34cdac001ed50a3b790).
- Grant exactly the permissions the reusable workflow needs instead of denying all.

## Test plan

- [x] Trigger the stale workflow manually via `workflow_dispatch` and confirm it no longer fails with `startup_failure`