### PR TITLE
chore: bump ui-v2 and backend image tags to v0.5.0-alpha.10

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -59,7 +59,7 @@ ui:
   # Frontend (UI v2) configuration
   frontend:
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.5.0-alpha.9
+    tag: v0.5.0-alpha.10
     resources:
       limits:
         cpu: 100m
@@ -73,7 +73,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.5.0-alpha.9
+    tag: v0.5.0-alpha.10
     resources:
       limits:
         cpu: 250m

--- a/deployments/ansible/kind/preload-images.txt
+++ b/deployments/ansible/kind/preload-images.txt
@@ -17,6 +17,6 @@ quay.io/containers/buildah:v1.37.5
 quay.io/keycloak/keycloak:26.3.3
 ghcr.io/shipwright-io/build/shipwright-build-controller:v0.14.0
 ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.14.0
-ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.9
+ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.10
 ghcr.io/kagenti/kagenti-operator/kagenti-operator:0.2.0-alpha.19
-ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.9
+ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.10


### PR DESCRIPTION
## Summary

- Update `ui-v2` and `backend` image tags from `v0.5.0-alpha.9` to `v0.5.0-alpha.10` in Helm chart values and Kind preload images list.

## Files changed

- `charts/kagenti/values.yaml` — frontend and backend image tags
- `deployments/ansible/kind/preload-images.txt` — preloaded image references

## Test plan

- [ ] Fresh Kind install picks up the new images
- [ ] UI and backend are functional after install