### PR TITLE
fix: detect Podman in Docker compatibility mode during preflight

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/00_preflight.yaml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/00_preflight.yaml
@@ -15,6 +15,27 @@
     - not (enable_openshift | default(false))
     - container_engine | default('docker') == 'docker'
 
+- name: Preflight - Detect Podman masquerading as Docker
+  command: docker info --format "{{ '{{' }}.Host.MemTotal{{ '}}' }},{{ '{{' }}.Host.CPUs{{ '}}' }}"
+  register: docker_podman_compat_info
+  failed_when: false
+  changed_when: false
+  when:
+    - create_kind_cluster | default(false)
+    - not (enable_openshift | default(false))
+    - container_engine | default('docker') == 'docker'
+    - docker_info.rc | default(1) != 0
+
+- name: Preflight - Use Podman compat result when Docker format fails
+  set_fact:
+    docker_info: "{{ docker_podman_compat_info }}"
+  when:
+    - create_kind_cluster | default(false)
+    - not (enable_openshift | default(false))
+    - container_engine | default('docker') == 'docker'
+    - docker_info.rc | default(1) != 0
+    - docker_podman_compat_info.rc | default(1) == 0
+
 - name: Preflight - Get container runtime info (Podman)
   command: podman info --format "{{ '{{' }}.Host.MemTotal{{ '}}' }},{{ '{{' }}.Host.CPUs{{ '}}' }}"
   register: podman_info


### PR DESCRIPTION
## Summary

- Preflight resource check now auto-detects when `docker` is actually Podman in compatibility mode (e.g., Podman Desktop replacing Docker Desktop on macOS)
- Users no longer need to manually set `container_engine: podman` when Podman provides the `docker` binary

## Problem

When Podman is installed as a Docker replacement, the `docker` binary uses Podman's Go template fields (`.Host.MemTotal`, `.Host.CPUs`) instead of Docker's (`.MemTotal`, `.NCPU`). This causes the preflight check to fail with:

```
can't evaluate field MemTotal in type system.infoReport
```

## Solution

The preflight now:
1. Tries the standard Docker info format first
2. If that fails, retries with Podman's format using the same `docker` binary
3. Uses whichever succeeds — no user configuration change needed

This is a transparent fallback; `container_engine: docker` works for both real Docker and Podman-as-Docker.

## Test plan

- [ ] `container_engine: docker` with real Docker — works as before
- [ ] `container_engine: docker` with Podman compat — auto-detects and succeeds
- [ ] `container_engine: podman` — unchanged behavior