### PR TITLE
fix: Create keycloak-admin-secret in agent namespaces and add AuthBridge keys to environments ConfigMap

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -197,10 +197,11 @@ data:
         "value": "slack-full-access"
       }
     ]
-  SPIRE_ENABLED: "true"
+  SPIRE_ENABLED: {{ if $root.Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
   KEYCLOAK_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
   KEYCLOAK_REALM: {{ $root.Values.keycloak.realm | quote }}
 ---
+{{- if not $root.Values.keycloak.adminExistingSecret }}
 # ——————————————————————————————————————————————————————————————————————————————
 #  Secret for Keycloak Admin Credentials in Namespace: {{ . }}
 #  Used by the client-registration sidecar to register agents as OAuth clients.
@@ -214,9 +215,11 @@ metadata:
     {{- include "kagenti.labels" $root | nindent 4 }}
 type: Opaque
 stringData:
-  KEYCLOAK_ADMIN_USERNAME: {{ $root.Values.keycloak.adminUsername | default "admin" | quote }}
-  KEYCLOAK_ADMIN_PASSWORD: {{ $root.Values.keycloak.adminPassword | default "admin" | quote }}
+  KEYCLOAK_ADMIN_USERNAME: {{ $root.Values.keycloak.adminUsername | quote }}
+  KEYCLOAK_ADMIN_PASSWORD: {{ $root.Values.keycloak.adminPassword | quote }}
 ---
+{{- end }}
+
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for AuthBridge in Namespace: {{ . }}
 # ——————————————————————————————————————————————————————————————————————————————

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -137,10 +137,14 @@ keycloak:
   adminSecretName: keycloak-initial-admin
   adminUsernameKey: username
   adminPasswordKey: password
-  # Admin credentials for the keycloak-admin-secret created in agent namespaces.
+  # Keycloak admin credentials for agent namespaces (keycloak-admin-secret).
   # Used by the client-registration sidecar to register agents as OAuth clients.
+  # For production, override via .secret_values.yaml or use an existing secret.
   adminUsername: admin
   adminPassword: admin
+  # Set to an existing Secret name to skip creating keycloak-admin-secret.
+  # The referenced secret must have KEYCLOAK_ADMIN_USERNAME and KEYCLOAK_ADMIN_PASSWORD keys.
+  # adminExistingSecret: ""
   url: http://keycloak-service.keycloak:8080
   publicUrl: http://keycloak.localtest.me:8080
   realm: kagenti

--- a/deployments/envs/secret_values.yaml.example
+++ b/deployments/envs/secret_values.yaml.example
@@ -29,3 +29,8 @@ charts:
         quayUser: 
         # (Optional) Your Quay token for building and pushing images (build-from-source).
         quayToken: 
+      keycloak:
+        # Keycloak admin credentials for agent namespace secrets (keycloak-admin-secret).
+        # Used by the AuthBridge client-registration sidecar. Default: admin/admin.
+        adminUsername: admin
+        adminPassword: admin

--- a/docs/install.md
+++ b/docs/install.md
@@ -307,23 +307,37 @@ The installer automatically creates `keycloak-admin-secret` in every agent names
 
 ### Customizing Credentials
 
-If your Keycloak admin credentials differ from the defaults, override them during installation:
+If your Keycloak admin credentials differ from the defaults, override them using a values file (preferred over `--set` to avoid exposing passwords in shell history and process listings):
 
-**Ansible installer** (via `dev_values.yaml` or `--set`):
+**Ansible installer** (via `.secret_values.yaml`):
 
-```bash
-deployments/ansible/run-install.sh --env dev \
-  --set charts.kagenti.values.keycloak.adminUsername=myadmin \
-  --set charts.kagenti.values.keycloak.adminPassword=mypassword
+Add to your `deployments/envs/.secret_values.yaml`:
+
+```yaml
+charts:
+  kagenti:
+    values:
+      keycloak:
+        adminUsername: myadmin
+        adminPassword: mypassword
 ```
 
-**Helm install** (direct):
+**Helm install** (via values file):
 
 ```bash
 helm upgrade --install kagenti ./charts/kagenti/ \
   -n kagenti-system --create-namespace \
-  --set keycloak.adminUsername=myadmin \
-  --set keycloak.adminPassword=mypassword
+  -f my-secret-values.yaml
+```
+
+### Using an Existing Secret
+
+If you already manage Keycloak admin credentials in a Secret (e.g., via an external secrets operator), you can skip the automatic secret creation entirely by setting `keycloak.adminExistingSecret` to the name of that secret. The referenced secret must contain `KEYCLOAK_ADMIN_USERNAME` and `KEYCLOAK_ADMIN_PASSWORD` keys:
+
+```bash
+helm upgrade --install kagenti ./charts/kagenti/ \
+  -n kagenti-system --create-namespace \
+  --set keycloak.adminExistingSecret=my-keycloak-admin-secret
 ```
 
 ### Manual Creation


### PR DESCRIPTION
## Summary

- Creates a keycloak-admin-secret Secret in each agent namespace with Keycloak admin credentials, required by the client-registration sidecar after kagenti/kagenti-extensions#161 moves admin credentials from ConfigMap to Secret.
- Adds SPIRE_ENABLED, KEYCLOAK_URL, and KEYCLOAK_REALM keys to the environments ConfigMap — these were previously missing from the installer and had to be applied manually via demo ConfigMaps.
- Adds keycloak.adminUsername and keycloak.adminPassword to values.yaml (default: admin/admin) so credentials can be overridden.

## Context

PR kagenti/kagenti-extensions#161 (rebased as kagenti/kagenti-extensions#179) changes the webhook client-registration sidecar to read KEYCLOAK_ADMIN_USERNAME and KEYCLOAK_ADMIN_PASSWORD from a keycloak-admin-secret Secret rather than the environments ConfigMap. Without this installer change, all agent namespaces would be missing the secret and client registration would fail.

## Test plan

- [ ] helm template kagenti charts/kagenti renders correctly: keycloak-admin-secret appears in each agent namespace
- [ ] environments ConfigMap includes SPIRE_ENABLED, KEYCLOAK_URL, KEYCLOAK_REALM keys
- [ ] Fresh install: client-registration sidecar starts without errors
- [ ] Existing install: helm upgrade creates the new secret in existing agent namespaces