### PR TITLE
Fix: Upgraded Phoenix PostgreSQL  to use ARM64 compatible image

### DIFF
--- a/charts/kagenti-deps/templates/phoenix-postgres.yaml
+++ b/charts/kagenti-deps/templates/phoenix-postgres.yaml
@@ -83,7 +83,7 @@ spec:
             secretKeyRef:
               name: otel-db-secret
               key: password
-        image: quay.io/fedora/postgresql-15
+        image: quay.io/sclorg/postgresql-16-c9s:latest
         imagePullPolicy: IfNotPresent
         name: postgres
         ports:


### PR DESCRIPTION
Upgrades the Phoenix PostgreSQL database from `quay.io/fedora/postgresql-15` to `quay.io/sclorg/postgresql-16-c9s:latest` for ARM64 compatibility.

**Changes:**
- Updated Phoenix PostgreSQL image to use SCL (Software Collections) PostgreSQL 16 image
- This image supports both x86_64 and ARM64 architectures
- Resolves issues running on Apple Silicon and other ARM64 platforms

**Testing:**
- Verified PostgreSQL 16.8 starts successfully
- Confirmed Phoenix connects and runs migrations
- All pods running and healthy


