### PR TITLE
🔒 chore(deps): block breaking Dependabot upgrades for PF and ESLint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,10 @@ updates:
       # Block until ESLint 8→9 migration is done (see #905).
       - dependency-name: "eslint-plugin-react-refresh"
         versions: [">=0.5.0"]
+      # typescript-eslint parser and plugin must be upgraded together.
+      # Block until ESLint 8→9 migration is done (see #905).
+      - dependency-name: "@typescript-eslint/parser"
+        update-types: [version-update:semver-major]
 
   # Go (TUI) — Go module dependencies
   - package-ecosystem: gomod


### PR DESCRIPTION
## Summary

Add Dependabot `ignore` rules to block four breaking upgrade paths in `kagenti/ui-v2`:

1. **`@patternfly/*` major version bumps** — PatternFly packages must be upgraded together (PF5→PF6); partial upgrades cause CSS variable conflicts, duplicate bundles, and broken React context. Closed PRs: #896, #902.

2. **`eslint-plugin-react-refresh` >=0.5.0** — Version 0.5.x changed its peer dependency from `eslint >=8.40` to `eslint ^9 || ^10`. Our project uses ESLint 8, making this incompatible. Closed PR: #895. Tracking issue: #905.

3. **`@typescript-eslint/parser` major bumps** — Parser and plugin share internal modules (`scope-manager`, `types`, `typescript-estree`, `visitor-keys`) that must be at the same major version. Bumping parser to v8 while plugin stays at v7 causes duplication and CI failures. Closed PR: #897. Tracking issue: #905.

4. **`@typescript-eslint/eslint-plugin` major bumps** — Same reasoning as the parser: plugin and parser share internal modules and must stay at the same major version. Tracking issue: #905.

Minor/patch updates within the current major versions are still allowed for all packages.

## Test plan

- [ ] Dependabot no longer creates PRs for `@patternfly/*` major bumps
- [ ] Dependabot no longer creates PRs for `eslint-plugin-react-refresh` >=0.5.0
- [ ] Dependabot no longer creates PRs for `@typescript-eslint/parser` major bumps
- [ ] Dependabot no longer creates PRs for `@typescript-eslint/eslint-plugin` major bumps
- [ ] Minor/patch updates for all packages still come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)