### PR TITLE
🔒 chore(deps): block ESLint ecosystem major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,14 @@ updates:
       # Block until ESLint 8→9 migration is done (see #905).
       - dependency-name: "@typescript-eslint/parser"
         update-types: [version-update:semver-major]
+      - dependency-name: "@typescript-eslint/eslint-plugin"
+        update-types: [version-update:semver-major]
+      # ESLint 9+/10+ requires flat config and all plugins upgraded together.
+      # Block until ESLint 8→9 migration is done (see #905).
+      - dependency-name: "eslint"
+        update-types: [version-update:semver-major]
+      - dependency-name: "eslint-plugin-react-hooks"
+        update-types: [version-update:semver-major]
 
   # Go (TUI) — Go module dependencies
   - package-ecosystem: gomod


### PR DESCRIPTION
## Summary

Add Dependabot `ignore` rules to block three additional breaking upgrade paths in `kagenti/ui-v2`:

1. **`eslint` major bumps** — ESLint 9+/10+ drops the `.eslintrc.*` config format entirely in favor of flat config (`eslint.config.js`). The project uses `.eslintrc.cjs`. Additionally, all ESLint plugins have peer dependency conflicts with ESLint 9+/10+. Closed PR: #909.

2. **`@typescript-eslint/eslint-plugin` major bumps** — Plugin and parser share internal modules (`scope-manager`, `types`, `typescript-estree`, `visitor-keys`) and must be at the same major version. Bumping plugin to v8 while parser stays at v7 causes unsatisfied peer dependencies. Closed PR: #908.

3. **`eslint-plugin-react-hooks` major bumps** — v5 requires ESLint 9+, incompatible with current ESLint 8 setup.

All of these must be upgraded together as part of the ESLint 8→9 migration tracked in #905.

Minor/patch updates within the current major versions are still allowed for all packages.

## Test plan

- [ ] Dependabot no longer creates PRs for `eslint` major bumps
- [ ] Dependabot no longer creates PRs for `@typescript-eslint/eslint-plugin` major bumps
- [ ] Dependabot no longer creates PRs for `eslint-plugin-react-hooks` major bumps
- [ ] Minor/patch updates for all packages still come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)