### PR TITLE
feat: Make Phoenix (observability) an optional component

### DIFF
--- a/.github/scripts/local-setup/show-services.sh
+++ b/.github/scripts/local-setup/show-services.sh
@@ -201,8 +201,8 @@ if [ "$VERBOSE" = "false" ]; then
         echo -e "  $(link "$MLFLOW_URL/#/experiments/0/chat-sessions" "$MLFLOW_URL/#/experiments/0/chat-sessions")  ${DIM}Chat Sessions${NC}"
     fi
 
-    # Phoenix
-    if [ -n "$PHOENIX_URL" ]; then
+    # Phoenix (only show if deployed)
+    if [ -n "$PHOENIX_URL" ] && $CLI get pods -n kagenti-system -l app=phoenix --no-headers 2>/dev/null | grep -q .; then
         echo -e "${MAGENTA}Phoenix${NC}"
         echo -e "  $(link "$PHOENIX_URL/projects/UHJvamVjdDox/spans" "$PHOENIX_URL/projects/UHJvamVjdDox/spans")  ${DIM}Trace Spans${NC}"
         echo -e "  $(link "$PHOENIX_URL/projects/UHJvamVjdDox/sessions" "$PHOENIX_URL/projects/UHJvamVjdDox/sessions")  ${DIM}Chat Sessions${NC}"
@@ -396,6 +396,7 @@ echo -e "${CYAN}                    (No authentication required)                
 echo "##########################################################################"
 echo ""
 
+if $CLI get pods -n kagenti-system -l app=phoenix --no-headers 2>/dev/null | grep -q .; then
 echo "---------------------------------------------------------------------------"
 echo -e "${MAGENTA}Phoenix (LLM Trace Visualization)${NC}"
 echo "---------------------------------------------------------------------------"
@@ -411,6 +412,7 @@ else
 fi
 echo -e "${BLUE}Auth:${NC}         None required"
 echo ""
+fi
 
 # Kind: show Kiali here (no OpenShift OAuth)
 if [ "$ENV_TYPE" = "kind" ]; then

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -166,10 +166,12 @@ data:
     exporters:
       debug:
         verbosity: detailed
+      {{- if $.Values.components.phoenix.enabled }}
       otlp/phoenix:
         endpoint: phoenix:4317
         tls:
           insecure: true
+      {{- end }}
       {{- if $.Values.components.mlflow.enabled }}
       otlphttp/mlflow:
         # Use traces_endpoint to specify exact URL (endpoint would append /v1/traces)
@@ -203,6 +205,7 @@ data:
         check_interval: 1s
         limit_mib: 1000
       batch:
+      {{- if $.Values.components.phoenix.enabled }}
       filter/phoenix:
         traces:
           span:
@@ -228,6 +231,7 @@ data:
               - set(attributes["llm.system"], attributes["gen_ai.system"]) where attributes["gen_ai.system"] != nil
               # Convert GenAI invocation parameters (temperature)
               - set(attributes["llm.invocation_parameters"], Concat(["{\"temperature\":", Concat([attributes["gen_ai.request.temperature"], "}"], "")], "")) where attributes["gen_ai.request.temperature"] != nil
+      {{- end }}
       {{- if $.Values.components.mlflow.enabled }}
       # Filter for MLflow: only keep agent spans, filter out A2A framework spans
       # A2A framework spans have names starting with "a2a."
@@ -276,10 +280,18 @@ data:
     service:
       extensions: [ health_check{{ if and $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled }}, oauth2client/mlflow{{ end }} ]
       pipelines:
+        {{- if $.Values.components.phoenix.enabled }}
         traces/phoenix:
           receivers: [ otlp ]
           processors: [ memory_limiter, filter/phoenix, transform/genai_to_openinference, batch ]
           exporters: [ otlp/phoenix ]
+        {{- end }}
+        {{- if and (not $.Values.components.phoenix.enabled) (not $.Values.components.mlflow.enabled) }}
+        traces/default:
+          receivers: [ otlp ]
+          processors: [ memory_limiter, batch ]
+          exporters: [ debug ]
+        {{- end }}
         {{- if $.Values.components.mlflow.enabled }}
         traces/mlflow:
           receivers: [ otlp ]

--- a/charts/kagenti-deps/templates/phoenix.yaml
+++ b/charts/kagenti-deps/templates/phoenix.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.components.otel.enabled }}
+{{- if .Values.components.phoenix.enabled }}
+{{- if not .Values.components.otel.enabled }}
+{{- fail "components.phoenix.enabled requires components.otel.enabled (Phoenix depends on the OTEL Collector)" }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -25,6 +25,8 @@ components:
     enabled: false
   otel:
     enabled: true
+  phoenix:
+    enabled: false
   mlflow:
     enabled: false
   containerRegistry:

--- a/charts/kagenti/templates/ui-routes-job.yaml
+++ b/charts/kagenti/templates/ui-routes-job.yaml
@@ -109,7 +109,9 @@ data:
     ROUTES_DATA=(
       "kagenti-system,mcp-inspector,true,MCP_INSPECTOR_URL"
       "kagenti-system,mcp-proxy,true,MCP_PROXY_FULL_ADDRESS"
+      {{- if .Values.components.phoenix.enabled }}
       "kagenti-system,phoenix,true,TRACES_DASHBOARD_URL"
+      {{- end }}
       "kagenti-system,kagenti-api,true,API_URL"
       "istio-system,kiali,true,NETWORK_TRAFFIC_DASHBOARD_URL"
       "keycloak,keycloak,true,KEYCLOAK_CONSOLE_URL"

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -12,7 +12,11 @@ metadata:
 data:
   DOMAIN_NAME: "{{ .Values.ui.domainName }}"
   API_URL: "http://{{ .Values.ui.api.hostname }}:8080"
+  {{- if .Values.components.phoenix.enabled }}
   TRACES_DASHBOARD_URL: "http://phoenix.{{ .Values.ui.domainName }}:8080"
+  {{- else }}
+  TRACES_DASHBOARD_URL: ""
+  {{- end }}
   NETWORK_TRAFFIC_DASHBOARD_URL: "http://kiali.{{ .Values.ui.domainName }}:8080"
   MCP_INSPECTOR_URL: "http://mcp-inspector.{{ .Values.ui.domainName }}:8080"
   MCP_PROXY_FULL_ADDRESS: "http://mcp-proxy.{{ .Values.ui.domainName }}:8080"
@@ -118,7 +122,7 @@ spec:
                 configMapKeyRef:
                   name: "{{ .Values.ui.configmap }}"
                   key: "TRACES_DASHBOARD_URL"
-                  optional: {{ (not .Values.openshift) }}
+                  optional: true
             - name: NETWORK_DASHBOARD_URL
               valueFrom:
                 configMapKeyRef:

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -17,6 +17,8 @@ components:
     enabled: true
   istio:
     enabled: true
+  phoenix:
+    enabled: false
 
 # Secrets — override via a .secrets.yaml file or --set secrets.<key>=<value>.
 # githubUser/githubToken are optional: only needed to deploy agents/tools from

--- a/deployments/envs/dev_values.yaml
+++ b/deployments/envs/dev_values.yaml
@@ -32,6 +32,8 @@ charts:
           enabled: true
         otel:
           enabled: true
+        phoenix:
+          enabled: false
         mlflow:
           enabled: false  # Disabled for Kind - requires full OTEL instrumentation
         mcpInspector:
@@ -66,6 +68,8 @@ charts:
         # additional artifacts required by MCP gateway
         mcpGateway:
           enabled: true
+        phoenix:
+          enabled: false
       # configs
       ui:
         auth:

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -36,6 +36,8 @@ charts:
           enabled: true
         otel:
           enabled: true
+        phoenix:
+          enabled: false
         mlflow:
           enabled: true
         spire:
@@ -84,6 +86,8 @@ charts:
         mcpGateway:
           enabled: true
         istio:
+          enabled: false
+        phoenix:
           enabled: false
       # configs
       mlflow:

--- a/docs/agents/otel-instrumentation.md
+++ b/docs/agents/otel-instrumentation.md
@@ -152,6 +152,8 @@ def on_complete(output):
 
 ## Phoenix (OpenInference) Requirements
 
+> **Note:** Phoenix is an optional component (`components.phoenix.enabled`). The OTEL Collector's Phoenix pipeline (`traces/phoenix`) is only deployed when Phoenix is enabled.
+
 Phoenix uses [OpenInference semantic conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md).
 
 ### Required Attributes

--- a/docs/components.md
+++ b/docs/components.md
@@ -407,7 +407,7 @@ A modern web dashboard built with React ([PatternFly](https://www.patternfly.org
 | **Agent Import** | Import A2A agents from any framework via Git URL or container image |
 | **Tool Deployment** | Deploy MCP tools directly from source or container image |
 | **Interactive Testing** | Chat interface to test agent capabilities |
-| **Monitoring** | View traces, logs, and network traffic via Phoenix and Kiali |
+| **Monitoring** | View traces, logs, and network traffic via Phoenix (optional) and Kiali |
 | **Authentication** | Keycloak-based login/logout with OAuth2 |
 | **MCP Gateway** | Browse and test MCP tools via MCP Inspector |
 
@@ -419,7 +419,7 @@ A modern web dashboard built with React ([PatternFly](https://www.patternfly.org
 | Agents | List, import, and manage agents |
 | Tools | List, import, and manage MCP tools |
 | MCP Gateway | View MCP Gateway status and launch MCP Inspector |
-| Observability | Access Phoenix traces and Kiali network dashboards |
+| Observability | Access Phoenix traces (when enabled) and Kiali network dashboards |
 | Admin | Keycloak and system configuration |
 
 ### Access
@@ -592,9 +592,9 @@ The Ingress Gateway routes external HTTP requests to internal services using the
 
 [Kiali](https://kiali.io) provides visualization of the service mesh topology and traffic flows.
 
-### Phoenix (Tracing)
+### Phoenix (Tracing) -- Optional
 
-LLM observability and tracing for agent interactions.
+LLM observability and tracing for agent interactions. Phoenix is **disabled by default** and can be enabled via `components.phoenix.enabled: true` in both the `kagenti-deps` and `kagenti` charts. Requires `components.otel.enabled: true`.
 
 ---
 

--- a/docs/developer/hypershift.md
+++ b/docs/developer/hypershift.md
@@ -333,7 +333,7 @@ Service routes:
 |---------|-----------------|
 | **Kagenti UI** | `oc get route -n kagenti-system kagenti-ui` |
 | **Keycloak Admin** | `oc get route -n keycloak keycloak` |
-| **Phoenix (Traces)** | `oc get route -n kagenti-system phoenix` |
+| **Phoenix (Traces)** | `oc get route -n kagenti-system phoenix` _(only when `components.phoenix.enabled: true`)_ |
 | **Kiali** | `oc get route -n istio-system kiali` |
 | **OpenShift Console** | `oc get route -n openshift-console console` |
 

--- a/docs/developer/kind.md
+++ b/docs/developer/kind.md
@@ -178,7 +178,7 @@ After deployment, services are available via `.localtest.me` domains:
 |---------|-----|
 | **Kagenti UI** | http://kagenti-ui.localtest.me:8080 |
 | **Keycloak Admin** | http://keycloak.localtest.me:8080/admin |
-| **Phoenix (Traces)** | http://phoenix.localtest.me:8080 |
+| **Phoenix (Traces)** | http://phoenix.localtest.me:8080 _(only when `components.phoenix.enabled: true`)_ |
 | **Kiali** | http://kiali.localtest.me:8080 |
 
 > **Note:** `.localtest.me` is a special domain that resolves to 127.0.0.1

--- a/docs/mlflow-integration.md
+++ b/docs/mlflow-integration.md
@@ -1,7 +1,8 @@
 # MLflow Integration for LLM Observability
 
 This document describes deploying MLflow alongside Phoenix for LLM trace
-collection in Kagenti E2E tests.
+collection in Kagenti E2E tests. Note that Phoenix is an optional component
+(`components.phoenix.enabled`, default: false) and can be deployed independently of MLflow.
 
 ## Overview
 

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -30,7 +30,7 @@ async def get_dashboard_config() -> DashboardConfigResponse:
     domain = settings.domain_name
 
     return DashboardConfigResponse(
-        traces=settings.traces_dashboard_url or f"http://phoenix.{domain}:8080",
+        traces=settings.traces_dashboard_url,
         network=settings.network_dashboard_url or f"http://kiali.{domain}:8080",
         mcpInspector=settings.mcp_inspector_url or f"http://mcp-inspector.{domain}:8080",
         mcpProxy=settings.mcp_proxy_full_address or f"http://mcp-proxy.{domain}:8080",

--- a/kagenti/backend/tests/test_dashboard_config.py
+++ b/kagenti/backend/tests/test_dashboard_config.py
@@ -1,0 +1,70 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for dashboard configuration endpoint.
+
+Validates Phoenix optional component behavior: when TRACES_DASHBOARD_URL
+is unset or empty, the /config/dashboards endpoint returns an empty traces URL
+instead of a fallback Phoenix URL.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.config import router
+
+
+@pytest.fixture
+def client():
+    """Create a test client with the config router."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestDashboardConfigPhoenixToggle:
+    """Test /config/dashboards response when Phoenix is disabled or enabled."""
+
+    def test_traces_dashboard_url_empty(self, client):
+        """When TRACES_DASHBOARD_URL is not set, traces should be empty string."""
+        with patch("app.core.auth.settings") as mock_auth_settings:
+            mock_auth_settings.enable_auth = False
+            with patch("app.routers.config.settings") as mock_settings:
+                mock_settings.traces_dashboard_url = ""
+                mock_settings.network_dashboard_url = ""
+                mock_settings.mcp_inspector_url = ""
+                mock_settings.mcp_proxy_full_address = ""
+                mock_settings.keycloak_console_url = ""
+                mock_settings.domain_name = "localtest.me"
+                mock_settings.effective_keycloak_url = "http://keycloak.localtest.me:8080"
+                mock_settings.effective_keycloak_realm = "kagenti"
+
+                response = client.get("/api/v1/config/dashboards")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["traces"] == ""
+                assert "phoenix" not in data["traces"]
+
+    def test_traces_dashboard_url_non_empty(self, client):
+        """When TRACES_DASHBOARD_URL is set, it should be returned."""
+        phoenix_url = "http://phoenix.localtest.me:8080"
+        with patch("app.core.auth.settings") as mock_auth_settings:
+            mock_auth_settings.enable_auth = False
+            with patch("app.routers.config.settings") as mock_settings:
+                mock_settings.traces_dashboard_url = phoenix_url
+                mock_settings.network_dashboard_url = ""
+                mock_settings.mcp_inspector_url = ""
+                mock_settings.mcp_proxy_full_address = ""
+                mock_settings.keycloak_console_url = ""
+                mock_settings.domain_name = "localtest.me"
+                mock_settings.effective_keycloak_url = "http://keycloak.localtest.me:8080"
+                mock_settings.effective_keycloak_realm = "kagenti"
+
+                response = client.get("/api/v1/config/dashboards")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["traces"] == phoenix_url

--- a/kagenti/tests/e2e/common/test_phoenix_traces.py
+++ b/kagenti/tests/e2e/common/test_phoenix_traces.py
@@ -275,7 +275,7 @@ def phoenix_client(is_openshift):
 
 
 @pytest.mark.observability
-@pytest.mark.requires_features(["otel"])
+@pytest.mark.requires_features(["otel", "phoenix"])
 class TestPhoenixConnectivity:
     """Test Phoenix service is accessible."""
 
@@ -289,7 +289,7 @@ class TestPhoenixConnectivity:
 
 @pytest.mark.observability
 @pytest.mark.openshift_only
-@pytest.mark.requires_features(["otel"])
+@pytest.mark.requires_features(["otel", "phoenix"])
 class TestWeatherAgentTracesInPhoenix:
     """
     Validate weather agent traces are captured in Phoenix.

--- a/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
+++ b/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
@@ -121,18 +121,20 @@ export const ObservabilityPage: React.FC = () => {
         )}
 
         <Grid hasGutter>
-          <GridItem md={6}>
-            <DashboardCard
-              title="Tracing & Performance"
-              description="Access detailed trace data for debugging and performance analysis. Monitor LLM calls, latency, and token usage with Phoenix/OpenTelemetry."
-              icon={<ChartLineIcon />}
-              url={tracesUrl}
-              buttonText="Open Phoenix"
-              isLoading={isLoading}
-            />
-          </GridItem>
+          {tracesUrl && (
+            <GridItem md={6}>
+              <DashboardCard
+                title="Tracing & Performance"
+                description="Access detailed trace data for debugging and performance analysis. Monitor LLM calls, latency, and token usage with Phoenix/OpenTelemetry."
+                icon={<ChartLineIcon />}
+                url={tracesUrl}
+                buttonText="Open Phoenix"
+                isLoading={isLoading}
+              />
+            </GridItem>
+          )}
 
-          <GridItem md={6}>
+          <GridItem md={tracesUrl ? 6 : 12}>
             <DashboardCard
               title="Network Traffic"
               description="Visualize service interactions, traffic flow, and service mesh health with Kiali. Monitor Istio metrics and network policies."
@@ -150,9 +152,9 @@ export const ObservabilityPage: React.FC = () => {
           isInline
           style={{ marginTop: '24px' }}
         >
-          Ensure that the observability tools (Phoenix for traces and Kiali for
+          Ensure that the observability tools ({tracesUrl ? 'Phoenix for traces and ' : ''}Kiali for
           service mesh) are properly configured and accessible from your
-          environment. Default credentials are typically <code>admin/admin</code>.
+          environment.
         </Alert>
       </PageSection>
     </>


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
[RHAIENG-3565](https://issues.redhat.com/browse/RHAIENG-3565)

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-8251de4d-7fff-4c88-412e-487473d6269a"><h2 dir="ltr" style="line-height:1.7999999999999998;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:15pt;font-family:Roboto,sans-serif;color:#151515;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Context</span></h2><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;padding:8pt 0pt 0pt 0pt;"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Phoenix (LLM observability) is currently deployed as part of the default Kagenti stack. For OpenShift AI deployments, it is not a required component and increases the stack footprint unnecessarily. There's already a partial toggle via components.otel.enabled, but Phoenix is bundled with OTEL so we can't disable it independently. The work is adding a components.phoenix.enabled flag and gating a handful of Helm templates and UI references. Phoenix will be optional for local Kind deployment as well.</span></p><h2 dir="ltr" style="line-height:1.7999999999999998;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;padding:23pt 0pt 0pt 0pt;"><span style="font-size:15pt;font-family:Roboto,sans-serif;color:#151515;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">User Stories</span></h2><ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;"><li dir="ltr" style="list-style-type:disc;font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:8pt;margin-bottom:0pt;" role="presentation"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">As a platform engineer, I want to install the Kagenti stack without Phoenix (by default), so that I only deploy what is required for core functionality.</span></p></li></ul><h2 dir="ltr" style="line-height:1.7999999999999998;background-color:#ffffff;margin-top:23pt;margin-bottom:0pt;"><span style="font-size:15pt;font-family:Roboto,sans-serif;color:#151515;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">What</span></h2><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;padding:8pt 0pt 0pt 0pt;"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Make it optional and default to off. Ensure the base Kagenti deployment works fully without Phoenix. Gate all Phoenix-related configuration (Helm values, Ansible tasks, backend config) behind a feature flag. Verify no hard dependencies on Phoenix endpoints exist in the backend or UI.</span></p><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;padding:8pt 0pt 0pt 0pt;">

</div><h2 dir="ltr" style="line-height:1.7999999999999998;background-color:#ffffff;margin-top:23pt;margin-bottom:0pt;"><span style="font-size:15pt;font-family:Roboto,sans-serif;color:#151515;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Why</span></h2><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;padding:8pt 0pt 0pt 0pt;"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Mandating Phoenix increases the stack footprint and blocks minimal deployments on OpenShift. Making it optional reduces resource requirements and simplifies the base deployment.</span></p><h2 dir="ltr" style="line-height:1.7999999999999998;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;padding:23pt 0pt 0pt 0pt;"><span style="font-size:15pt;font-family:Roboto,sans-serif;color:#151515;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Acceptance Criteria</span></h2><ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;"><li dir="ltr" style="list-style-type:disc;font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:8pt;margin-bottom:0pt;" role="presentation"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">[ ] Kagenti deploys and functions fully on OpenShift without Phoenix enabled</span></p></li><li dir="ltr" style="list-style-type:disc;font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">[ ] Phoenix can be enabled via a clear configuration flag</span></p></li><li dir="ltr" style="list-style-type:disc;font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">[ ] No backend or UI errors when Phoenix is disabled</span></p></li><li dir="ltr" style="list-style-type:disc;font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;background-color:#ffffff;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:10.5pt;font-family:Roboto,sans-serif;color:#172b4d;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">[ ] Agent chat, tool deployment, and Shipwright builds work without Phoenix</span></p></li></ul><br /></b>

## Related issue(s)

## (Optional) Testing Instructions

**1. Phoenix is disabled in cluster:**

```
(kagenti-project) ➜  kagenti git:(make-phoenix-an-optional-component) ✗ kubectl get deployments -n kagenti-system
NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
http-istio                   1/1     1            1           31m
kagenti-backend              1/1     1            1           27m
kagenti-controller-manager   1/1     1            1           27m
kagenti-ui                   1/1     1            1           27m
mcp-inspector                1/1     1            1           31m
otel-collector               1/1     1            1           31m

(kagenti-project) ➜  kagenti git:(make-phoenix-an-optional-component) ✗ kubectl get po -n kagenti-system
NAME                                          READY   STATUS    RESTARTS      AGE
http-istio-669ccc7bbc-z9vl6                   1/1     Running   0             31m
kagenti-backend-76d46db54f-k7ktb              1/1     Running   0             17m
kagenti-controller-manager-5b4867ddf7-k2lnx   1/1     Running   0             27m
kagenti-ui-6f547d5965-2fcww                   1/1     Running   0             15m
mcp-inspector-858bbb698-p96hp                 1/1     Running   0             31m
otel-collector-756bdbdd69-2t2wq               1/1     Running   0             31m
postgres-otel-0                               1/1     Running   1 (29m ago)   31m
(kagenti-project) ➜  kagenti git:(make-phoenix-an-optional-component) ✗
```

**Kagenti UI reflects changes:**

<img width="1916" height="705" alt="Screenshot 2026-03-09 at 12 36 46" src="https://github.com/user-attachments/assets/21ea120e-6807-4778-bb24-e4646caca02f" />


**Kiali confirms no Phoenix in the cluster:**

<img width="1897" height="1131" alt="Screenshot 2026-03-10 at 10 33 27" src="https://github.com/user-attachments/assets/295c22b5-e279-4efa-be3e-8c074d08f499" />


**If Phoenix is enabled, UI looks the following way:**
<img width="1917" height="766" alt="Screenshot 2026-03-06 at 17 06 01" src="https://github.com/user-attachments/assets/0302cbe1-096f-4382-864c-10de5900f6d4" />


**2. Phoenix is enabled but OTEL is disabled therefore raises the error:**

```
TASK [kagenti_installer : Install/upgrade kagenti-deps chart] ****************************************************************************************************************************************************************************************************************
Monday 09 March 2026  12:40:43 +0000 (0:00:00.026)       0:00:21.281 **********
FAILED - RETRYING: [localhost]: Install/upgrade kagenti-deps chart (3 retries left).
FAILED - RETRYING: [localhost]: Install/upgrade kagenti-deps chart (2 retries left).
FAILED - RETRYING: [localhost]: Install/upgrade kagenti-deps chart (1 retries left).
[ERROR]: Task failed: Module failed: Failure when executing Helm command. Exited 1.
stdout:
stderr: Error: UPGRADE FAILED: execution error at (kagenti-deps/templates/phoenix.yaml:3:4): components.phoenix.enabled requires components.otel.enabled (Phoenix depends on the OTEL Collector)

Origin: /Users/ianmiller/GitHub/kagenti/deployments/ansible/roles/kagenti_installer/tasks/main.yml:796:3

794     - (charts['kagenti-deps'] | default({})).get('enabled', false) | bool
795
796 - name: Install/upgrade kagenti-deps chart
      ^ column 3

fatal: [localhost]: FAILED! => {"attempts": 3, "changed": false, "command": "/opt/homebrew/opt/helm@3/bin/helm upgrade -i --reset-values --wait --timeout 1200s --create-namespace -f=/var/folders/1q/jx7s14b928n8zvstgfk98lj00000gn/T/tmp8f2d9gek.yml kagenti-deps '../../charts/kagenti-deps'", "msg": "Failure when executing Helm command. Exited 1.\nstdout: \nstderr: Error: UPGRADE FAILED: execution error at (kagenti-deps/templates/phoenix.yaml:3:4): components.phoenix.enabled requires components.otel.enabled (Phoenix depends on the OTEL Collector)\n", "stderr": "Error: UPGRADE FAILED: execution error at (kagenti-deps/templates/phoenix.yaml:3:4): components.phoenix.enabled requires components.otel.enabled (Phoenix depends on the OTEL Collector)\n", "stderr_lines": ["Error: UPGRADE FAILED: execution error at (kagenti-deps/templates/phoenix.yaml:3:4): components.phoenix.enabled requires components.otel.enabled (Phoenix depends on the OTEL Collector)"], "stdout": "", "stdout_lines": []}

PLAY RECAP *******************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=53   changed=14   unreachable=0    failed=1    skipped=68   rescued=0    ignored=0
```




Fixes #
