### PR TITLE
docs: fix broken Architecture header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kagenti is designed to support a broad range of AI‑agent deployment patterns, 
 
 See the full list and definitions in the **[Kagenti Use Cases](./docs/use-case-types.md)** document.
 
-## Architecturegit push --set-upstream origin
+## Architecture
 
 The goal of Kagenti is to provide a pluggable agentic platform blueprint. Key functionalities are currently organized into four key pillars:
 1. Lifecycle Orchestration


### PR DESCRIPTION
## Summary
- Fix garbled `## Architecture` heading in README.md that was introduced by commit e60337b
- The header contained an accidental `git push --set-upstream origin` appended to it

Fixes #914

## Test plan
- [ ] Verify the rendered README shows `## Architecture` correctly

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>