### PR TITLE
chore: clean up Ansible installer dead code and stale references

### DIFF
--- a/.github/scripts/local-setup/hypershift-full-test.sh
+++ b/.github/scripts/local-setup/hypershift-full-test.sh
@@ -16,18 +16,18 @@
 #
 # OPTIONS:
 #   Include flags (whitelist mode - only run specified phases):
-#     --include-create   Include cluster creation phase
-#     --include-install  Include Kagenti platform installation phase
-#     --include-agents   Include building/deploying test agents phase
-#     --include-test     Include E2E test phase
-#     --include-destroy  Include cluster destruction phase
+#     --include-cluster-create     Include cluster creation phase
+#     --include-kagenti-install    Include Kagenti platform installation phase
+#     --include-agents             Include building/deploying test agents phase
+#     --include-test               Include E2E test phase
+#     --include-cluster-destroy    Include cluster destruction phase
 #
 #   Skip flags (blacklist mode - run all except specified):
-#     --skip-create      Skip cluster creation (reuse existing cluster)
-#     --skip-install     Skip Kagenti platform installation
-#     --skip-agents      Skip building/deploying test agents
-#     --skip-test        Skip running E2E tests
-#     --skip-destroy     Skip cluster destruction (keep cluster after tests)
+#     --skip-cluster-create        Skip cluster creation (reuse existing cluster)
+#     --skip-kagenti-install       Skip Kagenti platform installation
+#     --skip-agents                Skip building/deploying test agents
+#     --skip-test                  Skip running E2E tests
+#     --skip-cluster-destroy       Skip cluster destruction (keep cluster after tests)
 #
 #   Other options:
 #     --clean-kagenti    Uninstall Kagenti before installing (fresh install)
@@ -42,22 +42,22 @@
 #   ./.github/scripts/local-setup/hypershift-full-test.sh
 #
 #   # First dev run - everything except destroy (blacklist mode)
-#   ./.github/scripts/local-setup/hypershift-full-test.sh --skip-destroy
+#   ./.github/scripts/local-setup/hypershift-full-test.sh --skip-cluster-destroy
 #
 #   # CI deploy step - only install + agents (whitelist mode)
-#   ./.github/scripts/local-setup/hypershift-full-test.sh --include-install --include-agents
+#   ./.github/scripts/local-setup/hypershift-full-test.sh --include-kagenti-install --include-agents
 #
 #   # CI test step - only tests (whitelist mode)
 #   ./.github/scripts/local-setup/hypershift-full-test.sh --include-test
 #
 #   # Iterate on existing cluster (blacklist mode)
-#   ./.github/scripts/local-setup/hypershift-full-test.sh --skip-create --skip-destroy
+#   ./.github/scripts/local-setup/hypershift-full-test.sh --skip-cluster-create --skip-cluster-destroy
 #
 #   # Fresh kagenti on existing cluster (whitelist mode)
-#   ./.github/scripts/local-setup/hypershift-full-test.sh --include-install --include-agents --include-test --clean-kagenti
+#   ./.github/scripts/local-setup/hypershift-full-test.sh --include-kagenti-install --include-agents --include-test --clean-kagenti
 #
 #   # Final cleanup - only destroy (whitelist mode)
-#   ./.github/scripts/local-setup/hypershift-full-test.sh --include-destroy
+#   ./.github/scripts/local-setup/hypershift-full-test.sh --include-cluster-destroy
 #
 
 set -euo pipefail

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1017,12 +1017,12 @@
     - skip_cert_manager_operator | default(false)
     - cert_manager_existing_check.rc == 0
 
-# TODO: Move TektonConfig patching to kagenti-operator
-# The kagenti-operator manages Shipwright builds, so it has the
-# context to know what Tekton settings are needed. The operator should:
-# 1. Check if running on OpenShift (detect TektonConfig CRD)
-# 2. Patch TektonConfig to set pipeline.set-security-context: true
-# 3. This ensures proper fsGroup handling for PVC permissions in build pods
+# TODO: Move TektonConfig patching to kagenti-operator.
+# Shipwright (managed by OpenShift Builds operator) depends on TektonConfig
+# being correctly configured. The operator should reconcile TektonConfig:
+# 1. Watch for TektonConfig creation (detect TektonConfig CRD)
+# 2. Patch SCC defaults and set pipeline.set-security-context: true
+# 3. Re-patch after upgrades if the config is reset
 # For now, we patch it in the installer as a workaround.
 #
 # IMPORTANT: On HyperShift clusters, TektonConfig may be created without
@@ -1655,73 +1655,6 @@
   - (charts['kagenti'] | default({})).get('enabled', false) | bool
   - (charts['kagenti'] | default({})).get('chart') is defined
 
-# TODO: Move internal-registry-secret creation to kagenti-operator or kagenti helm chart.
-# Shipwright builds (triggered by UI/backend) push images to the OpenShift internal
-# registry. The buildah step needs a dockerconfigjson-format secret with registry
-# credentials. OpenShift auto-creates builder-dockercfg secrets but in dockercfg
-# format, which buildah cannot use directly.
-# For now, we create the internal-registry-secret in each agent namespace as a workaround.
-- name: Create internal-registry-secret in agent namespaces for OpenShift
-  block:
-    - name: Create internal-registry-secret from builder SA token
-      shell: |
-        for ns in {{ (((charts['kagenti'] | default({})).get('values')) | default({})).get('agentNamespaces', []) | join(' ') }}; do
-          # Get builder dockercfg and convert to dockerconfigjson format
-          DOCKERCFG=$(kubectl get secret -n $ns -o name | grep builder-dockercfg | head -1 | xargs -I {} kubectl get {} -n $ns -o jsonpath='{.data.\.dockercfg}' | base64 -d)
-          if [ -n "$DOCKERCFG" ]; then
-            DOCKERCONFIGJSON=$(echo "{\"auths\": $DOCKERCFG}" | base64 | tr -d '\n')
-            kubectl apply -f - <<EOF
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: internal-registry-secret
-          namespace: $ns
-        type: kubernetes.io/dockerconfigjson
-        data:
-          .dockerconfigjson: $DOCKERCONFIGJSON
-        EOF
-            echo "Created internal-registry-secret in $ns"
-          else
-            echo "No builder-dockercfg found in $ns, skipping"
-          fi
-        done
-      args:
-        executable: /bin/bash
-  when:
-    - enable_openshift | default(false)
-    - (((charts['kagenti'] | default({})).get('values')) | default({})).get('agentNamespaces', []) | length > 0
-
-# TODO: Move spiffe-helper-config ConfigMap creation to kagenti-operator.
-# Agent/tool workloads with SPIFFE identity injection expect this ConfigMap for the spiffe-helper sidecar.
-# For now, we create it in each agent namespace.
-- name: Create spiffe-helper-config ConfigMap in agent namespaces
-  block:
-    - name: Apply spiffe-helper-config ConfigMap
-      shell: |
-        for ns in {{ (((charts['kagenti'] | default({})).get('values')) | default({})).get('agentNamespaces', []) | join(' ') }}; do
-          kubectl apply -n $ns -f - <<EOF
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: spiffe-helper-config
-        data:
-          helper.conf: |
-            agent_address = "/spiffe-workload-api/spire-agent.sock"
-            cmd = ""
-            cmd_args = ""
-            svid_file_name = "/opt/svid.pem"
-            svid_key_file_name = "/opt/svid_key.pem"
-            svid_bundle_file_name = "/opt/svid_bundle.pem"
-            jwt_svids = [{jwt_audience="kagenti", jwt_svid_file_name="/opt/jwt_svid.token"}]
-            jwt_svid_file_mode = 0644
-            include_federated_domains = true
-        EOF
-          echo "Created spiffe-helper-config in $ns"
-        done
-      args:
-        executable: /bin/bash
-  when:
-    - (((charts['kagenti'] | default({})).get('values')) | default({})).get('agentNamespaces', []) | length > 0
 
 # TODO: Move OAuth secret job ordering to kagenti helm chart.
 # The kagenti-ui-oauth-secret-job needs the OpenShift Route to exist before it runs,

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -102,7 +102,6 @@ charts:
         useServiceAccountCA: true
       keycloak:
         url: http://keycloak-service.keycloak:8080
-      # List of agent namespaces for Ansible installer to create internal-registry-secret
       agentNamespaces:
         - team1
         - team2

--- a/kagenti/examples/agents/weather_agent_shipwright_build.yaml
+++ b/kagenti/examples/agents/weather_agent_shipwright_build.yaml
@@ -23,10 +23,8 @@ spec:
   source:
     type: Git
     git:
-      # TODO: Change back to kagenti/agent-examples after PR merged
-      # PR: https://github.com/kagenti/agent-examples/pull/XXX
-      url: https://github.com/ladas/agent-examples
-      revision: genai-autoinstrumentation
+      url: https://github.com/kagenti/agent-examples
+      revision: main
     contextDir: a2a/weather_service
   strategy:
     name: buildah-insecure-push

--- a/kagenti/examples/agents/weather_agent_shipwright_build_ocp.yaml
+++ b/kagenti/examples/agents/weather_agent_shipwright_build_ocp.yaml
@@ -23,10 +23,8 @@ spec:
   source:
     type: Git
     git:
-      # TODO: Change back to kagenti/agent-examples after PR merged
-      # PR: https://github.com/kagenti/agent-examples/pull/XXX
-      url: https://github.com/ladas/agent-examples
-      revision: genai-autoinstrumentation
+      url: https://github.com/kagenti/agent-examples
+      revision: main
     contextDir: a2a/weather_service
   strategy:
     name: buildah

--- a/kagenti/examples/mcpservers/weather_tool_buildconfig.yaml
+++ b/kagenti/examples/mcpservers/weather_tool_buildconfig.yaml
@@ -26,10 +26,8 @@ spec:
   source:
     type: Git
     git:
-      # TODO: Revert to kagenti/agent-examples after Dockerfile fix merged
-      # TODO: Revert to kagenti/agent-examples after PR#114 merged
-      uri: https://github.com/Ladas/agent-examples
-      ref: genai-autoinstrumentation
+      uri: https://github.com/kagenti/agent-examples
+      ref: main
     contextDir: mcp/weather_tool
   strategy:
     type: Docker


### PR DESCRIPTION
## Summary

Clean up the Ansible installer by removing redundant tasks verified as unnecessary, updating stale TODO comments to reflect the current operator migration plan, and fixing documentation inconsistencies.

## Changes

### 1. Remove `internal-registry-secret` creation task (`main.yml`)

**Removed:** The Ansible task that created `internal-registry-secret` in each agent namespace for Shipwright builds to push to the OpenShift internal registry.

**Reasoning:** Tested on a live OpenShift (HyperShift) cluster by deleting the secret and re-running a Shipwright BuildRun — the build succeeded without it. OpenShift's `system:image-builder` ClusterRole, bound to the `builder` ServiceAccount via the `system:image-builders` RoleBinding, already grants push access to the internal registry. The `dockerconfigjson`-format secret was redundant.

### 2. Remove `spiffe-helper-config` ConfigMap creation task (`main.yml`)

**Removed:** The Ansible task that created `spiffe-helper-config` ConfigMap in each agent namespace.

**Reasoning:** The Helm chart (`charts/kagenti/templates/spiffe-namespaces-config.yaml`) already creates this ConfigMap during install/upgrade. The Ansible task was duplicating what Helm handles.

### 3. Update ` TODO (`main.yml`)

**Updated:** Clarified the TODO comment to reflect the actual intent — the operator should reconcile TektonConfig (watch for creation, patch SCC defaults, re-patch after upgrades) rather than the previous vague description.


### 3. Update OAuth secret management and TektonConfig patching TODO (`main.yml`)

> **Note:** Moving TektonConfig patching to kagenti-operator is in progress and will be addressed in a separate PR.

### 4. Fix `hypershift-full-test.sh` header documentation

**Fixed:** The script header comments and examples referenced old flag names (`--include-install`, `--skip-create`, `--include-destroy`, etc.) that don't match the actual `case` statement flags (`--include-kagenti-install`, `--skip-cluster-create`, `--include-cluster-destroy`, etc.). Updated all references to match.

### 5. Point example builds to `kagenti/agent-examples` (`examples/`)

**Fixed:** Three example YAML files (`weather_agent_shipwright_build.yaml`, `weather_agent_shipwright_build_ocp.yaml`, `weather_tool_buildconfig.yaml`) referenced a personal fork (`ladas/agent-examples`) with TODO comments to revert. Updated to point to the upstream `kagenti/agent-examples` repository.

## Test Plan
- [x] Run full Kind E2E test to verify no regressions
- [x] Run HyperShift E2E test to verify no regressions