### PR TITLE
Feat: Add issue self-assign caller workflow

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,22 @@
+# Issue Self-Assign
+#
+# Thin caller for the org-wide reusable self-assign workflow.
+# Configuration and defaults are managed centrally in kagenti/.github.
+#
+# Reference: https://github.com/kagenti/.github/blob/main/.github/workflows/self-assign-reusable.yml
+#
+name: Issue self-assign
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  self-assign:
+    uses: kagenti/.github/.github/workflows/self-assign-reusable.yml@main
+    secrets:
+      ISSUE_ASSIGN_TOKEN: ${{ secrets.ISSUE_ASSIGN_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ Your assistance in improving documentation is highly valued, regardless of your 
 
 To claim an issue that you are interested in, kindly leave a comment on the issue and request the maintainers to assign it to you.
 
+Alternatively, comment `/claim` on the issue to have it automatically assigned to you. Issues labeled `blocked` or `in-progress` cannot be claimed this way.
+
 ### Committing
 
 We encourage all contributors to adopt [best practices in git commit management](https://www.futurelearn.com/info/blog/telling-stories-with-your-git-history) to facilitate efficient reviews and retrospective analysis. Your git commits should provide ample context for reviewers and future codebase readers.


### PR DESCRIPTION
## Summary
- Adds caller workflow for org-wide issue self-assign (`/claim`)
- Updates CONTRIBUTING.md with `/claim` instructions

## Test plan
- [x] Depends on kagenti/.github reusable workflow being merged first
- [x] Comment `/claim` on an issue from a non-member account
- [x] Verify assignment and bot reply

closes https://github.com/kagenti/kagenti/issues/881