### PR TITLE
fix: Kagenti deployment on OpenShift: shared trust, MLflow OIDC, installer resilience

### DIFF
--- a/charts/kagenti-deps/templates/mlflow.yaml
+++ b/charts/kagenti-deps/templates/mlflow.yaml
@@ -134,11 +134,12 @@ spec:
           pip install --no-cache-dir --quiet "mlflow-oidc-auth" && \
           {{- end }}
           {{- if and .Values.openshift .Values.mlflow.auth.enabled }}
-          # Set CA bundle for JWKS verification AFTER pip install
-          # The ingress CA is only for OpenShift routes, not PyPI
-          # SSL_CERT_FILE for httpx/authlib (OIDC), REQUESTS_CA_BUNDLE for requests
-          export SSL_CERT_FILE=/etc/pki/ingress-ca/ingress-ca.pem && \
-          export REQUESTS_CA_BUNDLE=/etc/pki/ingress-ca/ingress-ca.pem && \
+          # Combine system CAs with the ingress CA so Python can verify both
+          # public CAs (e.g. Let's Encrypt on ROSA) and custom OpenShift CAs
+          SYS_CA=$(find /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem -maxdepth 0 2>/dev/null | head -1) && \
+          cat "${SYS_CA:-/dev/null}" /etc/pki/ingress-ca/ingress-ca.pem > /tmp/combined-ca.pem && \
+          export SSL_CERT_FILE=/tmp/combined-ca.pem && \
+          export REQUESTS_CA_BUNDLE=/tmp/combined-ca.pem && \
           {{- end }}
           {{- if .Values.openshift }}
           # Read auto-detected route hostname if available

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -11,6 +11,14 @@ metadata:
     # OpenShift injects trusted CA bundle into ConfigMaps with this label
     config.openshift.io/inject-trusted-cabundle: "true"
     {{- include "kagenti.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    # Retain on helm uninstall: OpenShift asynchronously injects the trusted CA bundle
+    # into this ConfigMap. Deleting it causes a race on reinstall where the OTel collector
+    # mounts an empty ConfigMap before OpenShift re-injects the CAs, breaking TLS verification.
+    "helm.sh/resource-policy": keep
 data: {}
 {{- end }}
 ---
@@ -103,10 +111,12 @@ spec:
           configMap:
             name: otel-collector-config
         {{- if and $.Values.openshift $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled }}
-        # Use OpenShift's pre-existing trusted CA bundle ConfigMap
+        # OpenShift trusted CA bundle — created by Tekton/platform operators.
+        # Optional so the pod starts while waiting for the ConfigMap to appear.
         - name: trusted-ca
           configMap:
             name: config-trusted-cabundle
+            optional: true
             items:
               - key: ca-bundle.crt
                 path: tls-ca-bundle.pem

--- a/charts/kagenti-deps/templates/rhoai-shared-trust.yaml
+++ b/charts/kagenti-deps/templates/rhoai-shared-trust.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.components.rhoai.enabled .Values.openshift (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "certificates.cert-manager.io") }}
+{{- if and .Values.components.rhoai.enabled .Values.openshift (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "certificates.cert-manager.io") (lookup "v1" "Service" "cert-manager" "cert-manager-webhook") }}
 {{- /*
   Istio Multi-Mesh Shared Trust via cert-manager
 

--- a/deployments/ansible/roles/kagenti_installer/tasks/05_install_rhoai.yaml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/05_install_rhoai.yaml
@@ -63,10 +63,12 @@
     # oauth-proxy). The operator defaults to 3 replicas at 500m each. On small clusters
     # (2-3 nodes), this exhausts CPU and blocks other pods from scheduling.
     # Scale operator FIRST (prevents it from reconciling replicas back up), then dashboard.
+    # Only runs when rhoai.scale_down is explicitly set to true.
     - name: Scale down RHOAI operator to 1 replica for test cluster
       command: kubectl scale deployment rhods-operator -n redhat-ods-operator --replicas=1
       failed_when: false
       changed_when: false
+      when: (rhoai | default({})).get('scale_down', false) | bool
 
     - name: Scale down RHOAI dashboard for test cluster
       shell: |
@@ -82,6 +84,7 @@
         echo "Dashboard deployment not found (may not be created yet)"
       failed_when: false
       changed_when: false
+      when: (rhoai | default({})).get('scale_down', false) | bool
 
     - name: Delete pending dashboard pods to free CPU
       shell: |
@@ -89,6 +92,7 @@
         kubectl delete pod -n redhat-ods-operator --field-selector=status.phase=Pending 2>/dev/null || true
       failed_when: false
       changed_when: false
+      when: (rhoai | default({})).get('scale_down', false) | bool
 
     - name: Wait for DataScienceCluster to be Ready
       shell: |
@@ -120,6 +124,15 @@
       delay: 10
       until: certmanager_crd_ready.rc == 0
       changed_when: false
+
+    - name: Wait for cert-manager webhook to be ready
+      command: >-
+        kubectl rollout status deployment/cert-manager-webhook
+        -n cert-manager --timeout=60s
+      register: certmanager_webhook_ready
+      retries: 12
+      delay: 15
+      until: certmanager_webhook_ready.rc == 0
 
     - name: Create shared trust cert-manager resources (fallback if Helm skipped)
       shell: |
@@ -232,6 +245,62 @@
       until: rhoai_cacert_check.rc == 0 and rhoai_cacert_check.stdout | length > 0
       changed_when: false
 
+    # When the root CA is regenerated (e.g. after Helm reinstall), cert-manager
+    # does NOT re-sign existing valid intermediates. Detect the mismatch and
+    # force re-issuance by deleting stale intermediate secrets.
+    - name: Get current root CA fingerprint
+      shell: >-
+        kubectl get secret istio-mesh-root-ca-secret -n cert-manager
+        -o jsonpath='{.data.tls\.crt}' | base64 -d |
+        openssl x509 -noout -fingerprint -sha256 2>/dev/null |
+        sed 's/.*=//'
+      register: root_ca_fingerprint
+      args:
+        executable: /bin/bash
+
+    - name: Check intermediate CA root consistency
+      shell: |
+        ROOT_FP="{{ root_ca_fingerprint.stdout }}"
+        CHANGED=false
+        for item in "istio-cacerts-default-cert:istio-system" "istio-cacerts-og-cert:openshift-ingress"; do
+          SECRET="${item%%:*}"
+          NS="${item##*:}"
+          INTER_FP=$(kubectl get secret "$SECRET" -n "$NS" \
+            -o jsonpath='{.data.ca\.crt}' | base64 -d | \
+            openssl x509 -noout -fingerprint -sha256 2>/dev/null | sed 's/.*=//')
+          if [ "$ROOT_FP" != "$INTER_FP" ]; then
+            echo "Root CA mismatch in $NS/$SECRET — forcing re-issuance"
+            kubectl delete secret "$SECRET" -n "$NS"
+            CHANGED=true
+          fi
+        done
+        echo "$CHANGED"
+      register: ca_consistency_check
+      args:
+        executable: /bin/bash
+
+    - name: Wait for re-issued Kagenti intermediate CA
+      command: >-
+        kubectl get secret istio-cacerts-default-cert -n istio-system
+        -o jsonpath='{.data.tls\.crt}'
+      register: kagenti_reissued
+      retries: 30
+      delay: 10
+      until: kagenti_reissued.rc == 0 and kagenti_reissued.stdout | length > 0
+      changed_when: false
+      when: "'true' in ca_consistency_check.stdout"
+
+    - name: Wait for re-issued RHOAI intermediate CA
+      command: >-
+        kubectl get secret istio-cacerts-og-cert -n openshift-ingress
+        -o jsonpath='{.data.tls\.crt}'
+      register: rhoai_reissued
+      retries: 30
+      delay: 10
+      until: rhoai_reissued.rc == 0 and rhoai_reissued.stdout | length > 0
+      changed_when: false
+      when: "'true' in ca_consistency_check.stdout"
+
     - name: Create cacerts secret for Kagenti istiod (istio-system)
       shell: |
         CA_CERT=$(kubectl get secret istio-cacerts-default-cert -n istio-system -o jsonpath='{.data.tls\.crt}' | base64 -d)
@@ -264,8 +333,15 @@
       args:
         executable: /bin/bash
 
+    - name: Check if Kagenti istiod deployment exists
+      command: kubectl get deployment/istiod -n istio-system --no-headers
+      register: kagenti_istiod_exists
+      failed_when: false
+      changed_when: false
+
     - name: Restart Kagenti istiod to pick up shared CA
       command: kubectl rollout restart deployment/istiod -n istio-system
+      when: kagenti_istiod_exists.rc == 0
 
     - name: Restart RHOAI istiod to pick up shared CA
       command: kubectl rollout restart deployment/istiod-openshift-gateway -n openshift-ingress
@@ -273,6 +349,15 @@
 
     - name: Wait for Kagenti istiod rollout
       command: kubectl rollout status deployment/istiod -n istio-system --timeout=120s
+      when: kagenti_istiod_exists.rc == 0
+
+    - name: Warn if Kagenti istiod not found for shared CA restart
+      debug:
+        msg: >-
+          WARNING: deployment/istiod not found in istio-system.
+          The kagenti-deps Helm post-install hooks may not have created the Istio CR.
+          Check 'helm history kagenti-deps -n kagenti-system' for errors.
+      when: kagenti_istiod_exists.rc != 0
 
     - name: Wait for RHOAI istiod rollout
       command: kubectl rollout status deployment/istiod-openshift-gateway -n openshift-ingress --timeout=120s

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -844,25 +844,6 @@
 - name: Wait for RHOAI operator and create DataScienceCluster
   ansible.builtin.import_tasks: 05_install_rhoai.yaml
 
-# Create ConfigMap for OpenShift trusted CA bundle injection
-# OpenShift's cluster network operator injects the trusted CA bundle into
-# ConfigMaps that have the label config.openshift.io/inject-trusted-cabundle=true
-- name: Create trusted CA bundle ConfigMap for OpenShift
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: config-trusted-cabundle
-        namespace: "{{ (charts['kagenti-deps'] | default({})).get('namespace', 'kagenti-system') }}"
-        labels:
-          config.openshift.io/inject-trusted-cabundle: "true"
-      data: {}
-  when:
-    - openshift | default(false) | bool
-    - (charts['kagenti-deps'] | default({})).get('enabled', false) | bool
-
 # Wait for cert-manager CRDs to be available on OpenShift.
 # The cert-manager operator is installed via OLM subscription in kagenti-deps,
 # but the CRDs take time to be created by the operator. The kagenti chart
@@ -1394,8 +1375,19 @@
 # Wait for Istio ambient mesh components to be ready on OpenShift.
 # The Istio, IstioCNI, and ZTunnel CRs are created as helm post-install hooks,
 # and ztunnel pods may start before istiod is ready, causing certificate issues.
+# Guard: check that the istiod deployment actually exists before waiting,
+# since a failed kagenti-deps install may have prevented the hooks from running.
 - name: Wait for Istio ambient mesh to be ready on OpenShift
   block:
+    - name: Check if istiod deployment exists
+      command: >-
+        kubectl get deployment/istiod
+        -n {{ (charts['kagenti-deps'] | default({})).get('values', {}).get('istio', {}).get('namespace', 'istio-system') }}
+        --no-headers
+      register: istiod_exists
+      failed_when: false
+      changed_when: false
+
     - name: Wait for istiod deployment to be ready
       command: >-
         kubectl rollout status deployment/istiod
@@ -1405,6 +1397,16 @@
       retries: 3
       delay: 30
       until: istiod_ready.rc == 0
+      when: istiod_exists.rc == 0
+
+    - name: Warn if istiod deployment was not found
+      debug:
+        msg: >-
+          WARNING: istiod deployment not found in
+          {{ (charts['kagenti-deps'] | default({})).get('values', {}).get('istio', {}).get('namespace', 'istio-system') }}.
+          The kagenti-deps Helm post-install hooks may not have run.
+          Check 'helm history kagenti-deps -n kagenti-system' for errors.
+      when: istiod_exists.rc != 0
   when:
     - enable_openshift | default(false)
     - (charts['kagenti-deps'] | default({})).get('values', {}).get('components', {}).get('istio', {}).get('enabled', false) | bool
@@ -1697,4 +1699,24 @@
   when:
     - enable_openshift | default(false)
     - (charts['kagenti'] | default({})).get('enabled', false) | bool
+
+- name: Verify Helm release status
+  shell: |
+    NS={{ (charts['kagenti'] | default({})).get('namespace', 'kagenti-system') }}
+    FAILED=""
+    for RELEASE in kagenti-deps kagenti; do
+      STATUS=$(helm history "$RELEASE" -n "$NS" --max 1 -o json 2>/dev/null | {{ ansible_python_interpreter | default('python3', true) }} -c "import sys,json; h=json.load(sys.stdin); print(h[0]['status'])" 2>/dev/null || echo "not-found")
+      echo "$RELEASE: $STATUS"
+      if [ "$STATUS" != "deployed" ] && [ "$STATUS" != "not-found" ]; then
+        FAILED="$FAILED $RELEASE($STATUS)"
+      fi
+    done
+    if [ -n "$FAILED" ]; then
+      echo "ERROR: Helm releases not healthy:$FAILED"
+      helm list -n "$NS" -a
+      exit 1
+    fi
+    echo "All Helm releases healthy."
+  args:
+    executable: /bin/bash
 

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -127,3 +127,4 @@ rhoai:
   profile: minimal    # minimal or full
   channel: fast-3.x
   kserve_mode: raw    # raw (no mesh needed) or serverless (deprecated)
+  scale_down: false    # Scale RHOAI operator/dashboard to 1 replica (test/dev clusters only)


### PR DESCRIPTION
## Summary

Fix multiple issues where Kagenti deployment completed on RHOAI/OpenShift clusters but services silently failed — MLflow couldn't connect to PostgreSQL, OIDC login returned 500 errors, istiod deployment not made, and the installer didn't surface Helm failures.

Key changes:

- **Istio multi-mesh shared trust: detect stale intermediate CAs** — When the cert-manager root CA is regenerated (e.g. after Helm reinstall), cert-manager does not re-sign existing valid intermediate certificates. This caused Kagenti's and RHOAI's istiods to use different root CAs, making ztunnel fail with `BadSignature` errors and breaking all pod-to-pod mTLS in ambient mode. The installer now compares root CA fingerprints against each intermediate and forces re-issuance on mismatch.

- **MLflow OIDC login: combine system CAs with ingress CA** — `SSL_CERT_FILE` was set to only the OpenShift ingress CA, which replaced the system trust store entirely. On ROSA (Let's Encrypt), the ISRG Root X1 was missing, causing `CERTIFICATE_VERIFY_FAILED` when MLflow contacted Keycloak. The fix combines the system CA bundle with the ingress CA at runtime, supporting both public and custom CA environments.

- **Guard RHOAI scale-down behind `rhoai.scale_down` flag** — The RHOAI operator/dashboard scale-down was running unconditionally, which is inappropriate for production clusters. Now requires explicit opt-in via `rhoai.scale_down: true`.

- **Wait for cert-manager webhook before creating certificates** — The shared trust resources could fail silently if cert-manager's webhook wasn't ready. Added explicit readiness check.

- **Guard istiod rollout waits behind existence checks** — If kagenti-deps Helm hooks failed to create the Istio CR, the installer would hang waiting for a deployment that doesn't exist. Now checks first and warns.

- **Add Helm release health verification at end of install** — Catches silent Helm failures (e.g. `failed` status) that previously went unnoticed.

- **Make `config-trusted-cabundle` ConfigMap a Helm pre-install hook** — Ensures the OpenShift trusted CA bundle ConfigMap exists before any pod that needs it. Also mark the volume `optional: true` so the OTel collector starts while waiting for the ConfigMap.

- **Add cert-manager-webhook service lookup to `rhoai-shared-trust.yaml`** — Prevents Helm from rendering cert-manager Certificate resources when the webhook isn't available yet.


## Verification
All pods are running and working as expected on OpenShift. This includes MLFlow, Kagenti UI, Istiod, and keycloak, etc. - All Routes are accessible.