### PR TITLE
fix: separate UI E2E tests from backend tests in CI

### DIFF
--- a/.github/scripts/local-setup/hypershift-full-test.sh
+++ b/.github/scripts/local-setup/hypershift-full-test.sh
@@ -19,14 +19,16 @@
 #     --include-cluster-create     Include cluster creation phase
 #     --include-kagenti-install    Include Kagenti platform installation phase
 #     --include-agents             Include building/deploying test agents phase
-#     --include-test               Include E2E test phase
+#     --include-test               Include backend E2E test phase (pytest)
+#     --include-ui-tests           Include UI E2E test phase (Playwright)
 #     --include-cluster-destroy    Include cluster destruction phase
 #
 #   Skip flags (blacklist mode - run all except specified):
 #     --skip-cluster-create        Skip cluster creation (reuse existing cluster)
 #     --skip-kagenti-install       Skip Kagenti platform installation
 #     --skip-agents                Skip building/deploying test agents
-#     --skip-test                  Skip running E2E tests
+#     --skip-test                  Skip running backend E2E tests
+#     --skip-ui-tests              Skip running UI E2E tests
 #     --skip-cluster-destroy       Skip cluster destruction (keep cluster after tests)
 #
 #   Other options:
@@ -81,7 +83,8 @@ PHASES:
     cluster-create    Create HyperShift cluster (~15 min)
     kagenti-install   Install Kagenti platform via Ansible
     agents            Build and deploy test agents (weather-tool, weather-agent)
-    test              Run E2E tests
+    test              Run backend E2E tests (pytest)
+    ui-tests          Run UI E2E tests (Playwright)
     kagenti-uninstall Uninstall Kagenti (opt-in, off by default)
     cluster-destroy   Destroy HyperShift cluster (~10 min)
 
@@ -90,7 +93,8 @@ OPTIONS:
         --include-cluster-create     Include cluster creation
         --include-kagenti-install    Include Kagenti installation
         --include-agents             Include agent deployment
-        --include-test               Include E2E tests
+        --include-test               Include backend E2E tests (pytest)
+        --include-ui-tests           Include UI E2E tests (Playwright)
         --include-kagenti-uninstall  Include Kagenti uninstall
         --include-cluster-destroy    Include cluster destruction
 
@@ -98,7 +102,8 @@ OPTIONS:
         --skip-cluster-create        Skip cluster creation (use existing)
         --skip-kagenti-install       Skip Kagenti installation
         --skip-agents                Skip agent deployment
-        --skip-test                  Skip E2E tests
+        --skip-test                  Skip backend E2E tests
+        --skip-ui-tests              Skip UI E2E tests
         --skip-kagenti-uninstall     Skip Kagenti uninstall (default)
         --skip-cluster-destroy       Skip cluster destruction (keep cluster)
 
@@ -168,11 +173,13 @@ INCLUDE_CREATE=false
 INCLUDE_INSTALL=false
 INCLUDE_AGENTS=false
 INCLUDE_TEST=false
+INCLUDE_UI_TESTS=false
 INCLUDE_DESTROY=false
 SKIP_CREATE=false
 SKIP_INSTALL=false
 SKIP_AGENTS=false
 SKIP_TEST=false
+SKIP_UI_TESTS=false
 SKIP_KAGENTI_UNINSTALL=false
 SKIP_DESTROY=false
 INCLUDE_KAGENTI_UNINSTALL=false
@@ -218,6 +225,12 @@ while [[ $# -gt 0 ]]; do
             HAS_PHASE_FLAGS=true
             shift
             ;;
+        --include-ui-tests)
+            INCLUDE_UI_TESTS=true
+            WHITELIST_MODE=true
+            HAS_PHASE_FLAGS=true
+            shift
+            ;;
         --include-kagenti-uninstall)
             INCLUDE_KAGENTI_UNINSTALL=true
             WHITELIST_MODE=true
@@ -248,6 +261,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-test)
             SKIP_TEST=true
+            HAS_PHASE_FLAGS=true
+            shift
+            ;;
+        --skip-ui-tests)
+            SKIP_UI_TESTS=true
             HAS_PHASE_FLAGS=true
             shift
             ;;
@@ -320,6 +338,7 @@ if [ "$WHITELIST_MODE" = "true" ]; then
     RUN_INSTALL=$INCLUDE_INSTALL
     RUN_AGENTS=$INCLUDE_AGENTS
     RUN_TEST=$INCLUDE_TEST
+    RUN_UI_TESTS=$INCLUDE_UI_TESTS
     RUN_KAGENTI_UNINSTALL=$INCLUDE_KAGENTI_UNINSTALL
     RUN_DESTROY=$INCLUDE_DESTROY
 else
@@ -329,12 +348,14 @@ else
     RUN_INSTALL=true
     RUN_AGENTS=true
     RUN_TEST=true
+    RUN_UI_TESTS=true
     RUN_KAGENTI_UNINSTALL=false
     RUN_DESTROY=true
     [ "$SKIP_CREATE" = "true" ] && RUN_CREATE=false
     [ "$SKIP_INSTALL" = "true" ] && RUN_INSTALL=false
     [ "$SKIP_AGENTS" = "true" ] && RUN_AGENTS=false
     [ "$SKIP_TEST" = "true" ] && RUN_TEST=false
+    [ "$SKIP_UI_TESTS" = "true" ] && RUN_UI_TESTS=false
     [ "$SKIP_KAGENTI_UNINSTALL" = "true" ] && RUN_KAGENTI_UNINSTALL=false
     [ "$SKIP_DESTROY" = "true" ] && RUN_DESTROY=false
 fi
@@ -541,6 +562,7 @@ NEEDS_HOSTED_KUBECONFIG=false
 [ "$RUN_INSTALL" = "true" ] && NEEDS_HOSTED_KUBECONFIG=true
 [ "$RUN_AGENTS" = "true" ] && NEEDS_HOSTED_KUBECONFIG=true
 [ "$RUN_TEST" = "true" ] && NEEDS_HOSTED_KUBECONFIG=true
+[ "$RUN_UI_TESTS" = "true" ] && NEEDS_HOSTED_KUBECONFIG=true
 [ "$RUN_KAGENTI_UNINSTALL" = "true" ] && NEEDS_HOSTED_KUBECONFIG=true
 
 echo "Cluster: $CLUSTER_NAME"
@@ -550,6 +572,7 @@ echo "  cluster-create:     $RUN_CREATE"
 echo "  kagenti-install:    $RUN_INSTALL"
 echo "  agents:             $RUN_AGENTS"
 echo "  test:               $RUN_TEST"
+echo "  ui-tests:           $RUN_UI_TESTS"
 echo "  kagenti-uninstall:  $RUN_KAGENTI_UNINSTALL"
 echo "  cluster-destroy:    $RUN_DESTROY"
 echo ""
@@ -1040,15 +1063,24 @@ if [ "$RUN_TEST" = "true" ]; then
 
     # Backend E2E tests (pytest)
     ./.github/scripts/kagenti-operator/90-run-e2e-tests.sh
+else
+    log_phase "PHASE 4: Skipping E2E Tests"
+fi
 
-    # UI E2E tests (Playwright)
+# ============================================================================
+# PHASE 4b: Run UI E2E Tests (Playwright)
+# ============================================================================
+
+if [ "$RUN_UI_TESTS" = "true" ]; then
+    log_phase "PHASE 4b: Run UI E2E Tests (Playwright)"
+
     if [ -f "./.github/scripts/common/92-run-ui-tests.sh" ]; then
         ./.github/scripts/common/92-run-ui-tests.sh
     else
         log_step "Skipping UI tests (script not found)"
     fi
 else
-    log_phase "PHASE 4: Skipping E2E Tests"
+    log_phase "PHASE 4b: Skipping UI E2E Tests"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add `--include-ui-tests` / `--skip-ui-tests` flags to `hypershift-full-test.sh`
- `--include-test` now only runs backend pytest (no longer includes Playwright UI tests)
- UI tests are a new independent phase (4b) controllable separately from backend tests

## Problem

The "Run backend E2E tests" CI step (step 19) calls `hypershift-full-test.sh --include-test`,
which was running **both** backend pytest and Playwright UI tests in a single phase. When
`agent-catalog.spec.ts` Playwright tests failed (flaky timeouts), they caused the entire
"backend E2E tests" step to fail, which then **skipped** the dedicated "Run UI E2E tests"
step (step 20) due to `if: success()`.

This created a confusing situation where:
1. Backend tests passed (51/51) but the step was marked as failed
2. The dedicated UI test step never ran
3. UI test flakiness blocked the entire E2E pipeline

## Fix

Removed the `92-run-ui-tests.sh` call from inside `hypershift-full-test.sh`'s test phase.
The workflow already has a dedicated step 20 that calls `92-run-ui-tests.sh` directly, so
the embedded call was redundant and harmful.

For local/manual use, added `--include-ui-tests` and `--skip-ui-tests` flags so users can
still run UI tests through `hypershift-full-test.sh` when desired.

## Test plan

- [ ] Verify `hypershift-full-test.sh --include-test` only runs pytest (no Playwright)
- [ ] Verify `hypershift-full-test.sh --include-ui-tests` runs Playwright tests
- [ ] Verify `hypershift-full-test.sh --skip-cluster-destroy` runs both backend and UI tests
- [ ] CI: backend test step passes even if UI tests would fail
- [ ] CI: UI test step runs independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)