### PR TITLE
fix: use JSON output for preflight container runtime detection

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/00_preflight.yaml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/00_preflight.yaml
@@ -100,6 +100,7 @@
     - create_kind_cluster | default(false)
     - not (enable_openshift | default(false))
     - runtime_memory_gb is defined
+    - runtime_memory_gb | float > 0
     - (runtime_memory_gb | float) < (kind_min_memory_gb | float)
 
 - name: Preflight - Fail if container runtime has insufficient CPUs
@@ -113,4 +114,5 @@
     - create_kind_cluster | default(false)
     - not (enable_openshift | default(false))
     - runtime_cpus is defined
+    - (runtime_cpus | int) > 0
     - (runtime_cpus | int) < (kind_min_cpus | int)


### PR DESCRIPTION
## Summary

- Replace Go template format strings with JSON output (`{{json .}}`) for container runtime resource detection in the Ansible preflight check
- Extract memory/CPU using Ansible's `from_json` filter with fallback paths for Docker (`MemTotal`/`NCPU`) and Podman (`Host.MemTotal`/`Host.CPUs`)
- Remove the fragile two-step "detect Podman masquerading as Docker" fallback in favor of a single unified JSON approach

## Problem

The preflight check (#724) uses Go template fields (`{{.MemTotal}}`, `{{.NCPU}}`) that don't exist in Podman's `system.infoReport` struct. On environments where Podman is aliased as `docker` (Fedora, RHEL, macOS with `podman-docker`), the check fails with:

```
Container runtime 'docker' is not available or not running.
Error: template: info:1:2: executing "info" at <.MemTotal>:
can't evaluate field MemTotal in type system.infoReport
```

The error is misleading — the runtime IS running, but the format string is incompatible.

## Test plan

- [ ] Verify on Docker Desktop: `docker info --format '{{json .}}' | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['MemTotal'], d['NCPU'])"`
- [ ] Verify on Podman: `podman info --format '{{json .}}' | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Host']['MemTotal'], d['Host']['CPUs'])"`
- [ ] Run Kind deployment with Docker: `.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy`
- [ ] Run Kind deployment on Podman-as-Docker environment

Fixes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)