### PR TITLE
chore: Bump UI and backend image tags to v0.5.0-alpha.11

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -61,7 +61,7 @@ ui:
   # Frontend (UI v2) configuration
   frontend:
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.5.0-alpha.10
+    tag: v0.5.0-alpha.11
     resources:
       limits:
         cpu: 100m
@@ -75,7 +75,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.5.0-alpha.10
+    tag: v0.5.0-alpha.11
     resources:
       limits:
         cpu: 250m

--- a/deployments/ansible/kind/preload-images.txt
+++ b/deployments/ansible/kind/preload-images.txt
@@ -17,6 +17,6 @@ quay.io/containers/buildah:v1.37.5
 quay.io/keycloak/keycloak:26.3.3
 ghcr.io/shipwright-io/build/shipwright-build-controller:v0.14.0
 ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.14.0
-ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.10
+ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.11
 ghcr.io/kagenti/kagenti-operator/kagenti-operator:0.2.0-alpha.19
-ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.10
+ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.11


### PR DESCRIPTION
## Summary
- Update `ui-v2` and `backend` image tags from `v0.5.0-alpha.10` to `v0.5.0-alpha.11` in the Helm chart values (`charts/kagenti/values.yaml`)
- Update the Kind preload images list (`deployments/ansible/kind/preload-images.txt`) to match

## Test plan
- [ ] Verify the new images `ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.11` and `ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.11` exist in the registry
- [ ] Deploy with updated Helm chart and confirm UI and backend start correctly