### PR TITLE
fix: replace broken Kubestellar link with inline inotify guidance

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -240,7 +240,12 @@ To ensure Kagenti installs correctly, configure Rancher Desktop with the followi
 ---
 
 ### 3. Increase Resource Limits
-- Follow the guidance in [Kubestellar Known Issue Docs](https://docs.kubestellar.io/release-0.25.1/direct/knownissue-kind-config/) to adjust limits for Kind clusters.
+- Kind clusters on Rancher Desktop may fail if Linux inotify limits are too low. Inside the Rancher Desktop VM, ensure:
+  ```bash
+  sudo sysctl fs.inotify.max_user_watches=524288
+  sudo sysctl fs.inotify.max_user_instances=512
+  ```
+  To make these persistent, add them to `/etc/sysctl.conf` inside the VM.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace broken Kubestellar docs link (`docs.kubestellar.io/release-0.25.1/direct/knownissue-kind-config/`) with inline `sysctl` commands
- The original page described setting `fs.inotify.max_user_watches=524288` and `fs.inotify.max_user_instances=512` inside the Rancher Desktop VM
- The KubeStellar docs site was restructured and the page no longer exists (returns 404)

Fixes #939

## Test plan

- [x] Verify the broken link is removed
- [x] Verify the inline guidance matches the original page content (inotify settings)
- [ ] Rendered markdown looks correct in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)