### PR TITLE
fix: Resolve TypeScript build errors in ui-v2

### DIFF
--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -188,6 +188,7 @@ export interface ToolDetail {
   };
   // Deployment/StatefulSet spec
   spec: {
+    description?: string;
     replicas?: number;
     selector?: {
       matchLabels?: Record<string, string>;

--- a/kagenti/ui-v2/vite.config.ts
+++ b/kagenti/ui-v2/vite.config.ts
@@ -1,5 +1,4 @@
-/// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 


### PR DESCRIPTION
## Summary
- Fix `TS2769` in `vite.config.ts`: import `defineConfig` from `vitest/config` instead of `vite` so the `test` property is properly typed (vitest v4 + vite v7 no longer support the `/// <reference types="vitest" />` augmentation)
- Fix `TS2339` in `ToolDetailPage.tsx`: add `description?: string` to the `ToolDetail.spec` interface so `spec.description` compiles

These two errors broke the `v0.5.0-alpha.11` Build-Publish workflow, preventing all images from being pushed to ghcr.io.

## Test plan
- [x] `tsc -b` passes locally with zero errors
- [ ] Build-Publish workflow succeeds after merge and tag re-creation