### PR TITLE
fix: Revert keycloak-js from 26.x to 25.x for HTTP compatibility

### DIFF
--- a/kagenti/ui-v2/package-lock.json
+++ b/kagenti/ui-v2/package-lock.json
@@ -14,7 +14,7 @@
         "@patternfly/react-table": "^5.4.0",
         "@tanstack/react-query": "^5.90.21",
         "js-yaml": "^4.1.0",
-        "keycloak-js": "^26.2.3",
+        "keycloak-js": "~25.0.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -3242,6 +3242,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3307,14 +3313,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keycloak-js": {
-      "version": "26.2.3",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.3.tgz",
-      "integrity": "sha512-widjzw/9T6bHRgEp6H/Se3NCCarU7u5CwFKBcwtu7xfA1IfdZb+7Q7/KGusAnBo34Vtls8Oz9vzSqkQvQ7+b4Q==",
+      "version": "25.0.6",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-25.0.6.tgz",
+      "integrity": "sha512-Km+dc+XfNvY6a4az5jcxTK0zPk52ns9mAxLrHj7lF3V+riVYvQujfHmhayltJDjEpSOJ4C8a57LFNNKnNnRP2g==",
       "license": "Apache-2.0",
-      "workspaces": [
-        "test"
-      ]
+      "dependencies": {
+        "js-sha256": "^0.11.0",
+        "jwt-decode": "^4.0.0"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/kagenti/ui-v2/package.json
+++ b/kagenti/ui-v2/package.json
@@ -21,7 +21,7 @@
     "@patternfly/react-table": "^5.4.0",
     "@tanstack/react-query": "^5.90.21",
     "js-yaml": "^4.1.0",
-    "keycloak-js": "^26.2.3",
+    "keycloak-js": "~25.0.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary
- Pin `keycloak-js` to `~25.0.6` (was `^26.2.3` after Dependabot PR #903)

## Root cause
`keycloak-js` 26.x requires the Web Crypto API (`crypto.randomUUID`, `crypto.subtle`) for generating nonces and PKCE challenges. The Web Crypto API is only available in secure contexts (HTTPS or `localhost`). Kind dev environments serve the UI over `http://kagenti-ui.localtest.me:8080`, which browsers do **not** treat as a secure context despite resolving to 127.0.0.1. This causes `Login failed: Web Crypto API is not available`.

`keycloak-js` 25.x has JavaScript fallbacks for all crypto operations and works over plain HTTP.

## What changed
| File | Change |
|---|---|
| `kagenti/ui-v2/package.json` | `keycloak-js`: `^26.2.3` -> `~25.0.6` |
| `kagenti/ui-v2/package-lock.json` | Lock file updated |

## Test plan
- [x] Login works on Kind cluster over `http://kagenti-ui.localtest.me:8080`
- [ ] Login works on HTTPS/OpenShift environments
