### PR TITLE
chore: Block keycloak-js major version bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,14 @@ updates:
       minor-and-patch:
         update-types: [minor, patch]
     ignore:
+      # keycloak-js 26.x requires Web Crypto API (crypto.randomUUID, crypto.subtle)
+      # which is unavailable over plain HTTP. Block until all environments use HTTPS.
+      - dependency-name: "keycloak-js"
+        update-types: [version-update:semver-major]
+      # keycloak-js 26.x requires Web Crypto API (crypto.randomUUID, crypto.subtle)
+      # which is unavailable over plain HTTP. Block until all environments use HTTPS.
+      - dependency-name: "keycloak-js"
+        update-types: [version-update:semver-major]
       # PatternFly packages must be upgraded together (PF5→PF6).
       # Block major version bumps to prevent partial upgrades.
       - dependency-name: "@patternfly/*"


### PR DESCRIPTION
## Summary
- Add Dependabot ignore rule to block `keycloak-js` major version bumps (26.x+)

Follow-up to PR #945 which reverted keycloak-js from 26.x to 25.x. This prevents Dependabot from re-proposing the same breaking upgrade.

## Context
`keycloak-js` 26.x requires the Web Crypto API (`crypto.randomUUID`, `crypto.subtle`) which is only available in secure contexts (HTTPS or localhost). Kind dev environments serve over plain HTTP, causing `Login failed: Web Crypto API is not available`. Version 25.x has JavaScript fallbacks.

## Test plan
- [ ] Verify Dependabot does not propose keycloak-js 26.x bumps on the next weekly run
