### PR TITLE
fix: ensure UTF-8 locale for Ansible in WSL environments

### DIFF
--- a/deployments/ansible/run-install.sh
+++ b/deployments/ansible/run-install.sh
@@ -242,13 +242,34 @@ if [[ "$(uname)" == "Darwin" ]]; then
   fi
 fi
 
+# Ensure UTF-8 locale is set for Ansible (required by Ansible)
+# This is especially important in WSL environments where locale may not be inherited properly
+# Respect existing UTF-8 locales, but fix non-UTF-8 ones (like C or POSIX)
+if [[ "${LC_ALL:-}" != *.UTF-8 && "${LC_ALL:-}" != *.utf8 ]]; then
+  # LC_ALL is not UTF-8 (or unset), check LANG
+  if [[ "${LANG:-}" == *.UTF-8 || "${LANG:-}" == *.utf8 ]]; then
+    # LANG is UTF-8, use it for LC_ALL
+    export LC_ALL="${LANG}"
+  else
+    # Neither is UTF-8, default to en_US.UTF-8
+    export LANG="en_US.UTF-8"
+    export LC_ALL="en_US.UTF-8"
+  fi
+else
+  # LC_ALL is already UTF-8, ensure LANG is also UTF-8
+  if [[ "${LANG:-}" != *.UTF-8 && "${LANG:-}" != *.utf8 ]]; then
+    export LANG="${LC_ALL}"
+  fi
+fi
+
 # Enable task timing — shows duration of each task in the output
 export ANSIBLE_CALLBACKS_ENABLED=ansible.posix.profile_tasks
 
 # Call ansible-playbook via the 'uv' wrapper when available so uv manages deps/venv.
 # Fall back to ansible-playbook if uv is not present.
 if command -v uv >/dev/null 2>&1; then
-  ANSIBLE_CMD=(uv run ansible-playbook -i localhost, -c local "$PLAYBOOK")
+  # Pass locale environment variables explicitly to uv run to ensure Ansible receives them
+  ANSIBLE_CMD=(env LANG="${LANG}" LC_ALL="${LC_ALL}" uv run ansible-playbook -i localhost, -c local "$PLAYBOOK")
 else
   echo "WARNING: 'uv' not found in PATH; falling back to 'ansible-playbook'. To use uv ensure it's installed and on PATH." >&2
   ANSIBLE_CMD=(ansible-playbook -i localhost, -c local "$PLAYBOOK")


### PR DESCRIPTION
## Problem
Ansible installer was failing in WSL environments with error:
```
ERROR: Ansible requires the locale encoding to be UTF-8; Detected None.
```

This occurred because `LC_ALL` was set to `C` in WSL, and `uv run` wasn't properly inheriting locale environment variables.

## Solution
Added intelligent locale detection in `run-install.sh`:
- Respects existing UTF-8 locales (any language/region)
- Fixes non-UTF-8 locales (C, POSIX) that cause Ansible errors
- Passes locale variables explicitly to uv run command
- Only defaults to en_US.UTF-8 when no UTF-8 locale is available

## Testing
Tested in WSL environment where LC_ALL=C was causing the original error.

## Changes
- Modified deployments/ansible/run-install.sh