### PR TITLE
chore: Bump kagenti-webhook-chart to v0.4.0-alpha.8

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.2.0-alpha.21
 - name: kagenti-webhook-chart
   repository: oci://ghcr.io/kagenti/kagenti-extensions
-  version: 0.4.0-alpha.5
-digest: sha256:88e98f9ae2b96a8e5a6644c663ff81b7ae97cd568077df963b8c89be4d9cc953
-generated: "2026-03-02T10:48:11.442622Z"
+  version: 0.4.0-alpha.8
+digest: sha256:66cc54b5ba694f86a66af68dbc658c75f4e55d60073e95981a58b7fde42865aa
+generated: "2026-03-15T10:52:35.566834-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -11,6 +11,6 @@ dependencies:
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 - name: kagenti-webhook-chart
-  version: 0.4.0-alpha.5
+  version: 0.4.0-alpha.8
   repository: oci://ghcr.io/kagenti/kagenti-extensions
   condition: components.platformWebhook.enabled


### PR DESCRIPTION
## Summary

- Bump `kagenti-webhook-chart` dependency from `v0.4.0-alpha.5` to `v0.4.0-alpha.8`
- Key fixes in this version:
  - `authproxy-routes` ConfigMap is now mounted into envoy-proxy at `/etc/authproxy`, enabling per-route token exchange without manual patching
  - Default outbound policy set to `passthrough`, preventing token exchange failures for LLM and telemetry traffic
  - `ISSUER` env var made optional to allow pods to start without `authbridge-config`
  - Redundant env vars (`TARGET_AUDIENCE`, `TARGET_SCOPES`) and dead code removed

## Test plan

- [ ] `helm dependency update` succeeds
- [ ] Fresh install deploys webhook `v0.4.0-alpha.8`
- [ ] AuthBridge sidecar injection includes `authproxy-routes` volume mount
- [ ] GitHub issue agent demo works with token exchange