### PR TITLE
fix: Set serviceAccountName in workload manifests for correct SPIFFE identity

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -1083,6 +1083,7 @@ async def migrate_agent(
     else:
         # Create new Deployment from Agent CRD spec
         deployment_manifest = _build_deployment_from_agent_crd(agent)
+        kube.ensure_service_account(namespace=namespace, name=name)
         try:
             kube.create_deployment(namespace=namespace, body=deployment_manifest)
             deployment_created = True
@@ -1288,6 +1289,7 @@ def _build_deployment_from_agent_crd(agent: dict) -> dict:
             )
 
         pod_spec = {
+            "serviceAccountName": name,
             "containers": [
                 {
                     "name": "agent",
@@ -1315,6 +1317,10 @@ def _build_deployment_from_agent_crd(agent: dict) -> dict:
                 {"name": "shared-data", "emptyDir": {}},
             ],
         }
+
+    # Ensure serviceAccountName is set so the webhook's SPIFFE identity
+    # derivation uses the workload name rather than the ReplicaSet hash.
+    pod_spec.setdefault("serviceAccountName", name)
 
     # Build selector labels
     selector_labels = {
@@ -1987,6 +1993,7 @@ def _build_deployment_manifest(
                     },
                 },
                 "spec": {
+                    "serviceAccountName": request.name,
                     "containers": [
                         {
                             "name": "agent",
@@ -2140,6 +2147,7 @@ def _build_statefulset_manifest(
                     },
                 },
                 "spec": {
+                    "serviceAccountName": request.name,
                     "containers": [
                         {
                             "name": "agent",
@@ -2237,6 +2245,7 @@ def _build_job_manifest(
                     },
                 },
                 "spec": {
+                    "serviceAccountName": request.name,
                     "restartPolicy": "OnFailure",
                     "containers": [
                         {
@@ -2313,6 +2322,10 @@ async def create_agent(
                     status_code=400,
                     detail="containerImage is required for image deployment",
                 )
+
+            # Ensure a dedicated ServiceAccount exists so the webhook's
+            # SPIFFE identity uses the workload name, not the ReplicaSet hash.
+            kube.ensure_service_account(namespace=request.namespace, name=request.name)
 
             # Create workload based on workloadType
             if request.workloadType == WORKLOAD_TYPE_DEPLOYMENT:
@@ -2697,6 +2710,10 @@ async def finalize_shipwright_build(
             authBridgeEnabled=final_auth_bridge,
             spireEnabled=final_spire_enabled,
         )
+
+        # Ensure a dedicated ServiceAccount exists so the webhook's
+        # SPIFFE identity uses the workload name, not the ReplicaSet hash.
+        kube.ensure_service_account(namespace=namespace, name=name)
 
         # Create workload based on workloadType
         if final_workload_type == WORKLOAD_TYPE_DEPLOYMENT:

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -924,6 +924,7 @@ def _build_tool_deployment_manifest(
                     "labels": pod_labels,
                 },
                 "spec": {
+                    "serviceAccountName": name,
                     "securityContext": {
                         "runAsNonRoot": True,
                         "seccompProfile": {"type": "RuntimeDefault"},
@@ -1073,6 +1074,7 @@ def _build_tool_statefulset_manifest(
                     "labels": pod_labels,
                 },
                 "spec": {
+                    "serviceAccountName": name,
                     "securityContext": {
                         "runAsNonRoot": True,
                         "seccompProfile": {"type": "RuntimeDefault"},
@@ -1300,6 +1302,10 @@ async def create_tool(
                 description = (
                     f"Tool '{request.name}' deployed from existing image '{request.containerImage}'"
                 )
+
+            # Ensure a dedicated ServiceAccount exists so the webhook's
+            # SPIFFE identity uses the workload name, not the ReplicaSet hash.
+            kube.ensure_service_account(namespace=request.namespace, name=request.name)
 
             # Create workload (Deployment or StatefulSet)
             if request.workloadType == WORKLOAD_TYPE_STATEFULSET:
@@ -1685,6 +1691,10 @@ async def finalize_tool_shipwright_build(
 
         # Propagate SPIRE identity setting from stored config
         spire_enabled = tool_config_dict.get("spireEnabled", False)
+
+        # Ensure a dedicated ServiceAccount exists so the webhook's
+        # SPIFFE identity uses the workload name, not the ReplicaSet hash.
+        kube.ensure_service_account(namespace=namespace, name=name)
 
         # Create workload (Deployment or StatefulSet)
         if workload_type == WORKLOAD_TYPE_STATEFULSET:

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -200,6 +200,35 @@ class KubernetesService:
             raise
 
     # -------------------------------------------------------------------------
+    # ServiceAccount Operations
+    # -------------------------------------------------------------------------
+
+    def ensure_service_account(self, namespace: str, name: str) -> None:
+        """Create a ServiceAccount if it does not already exist.
+
+        This is needed so that the webhook's SPIFFE identity derivation uses
+        the workload name (e.g. ``git-issue-agent``) rather than falling back
+        to the ReplicaSet hash.
+        """
+        try:
+            self.core_api.read_namespaced_service_account(name=name, namespace=namespace)
+            logger.debug(f"ServiceAccount '{name}' already exists in {namespace}")
+        except ApiException as e:
+            if e.status == 404:
+                sa = kubernetes.client.V1ServiceAccount(
+                    metadata=kubernetes.client.V1ObjectMeta(
+                        name=name,
+                        namespace=namespace,
+                        labels={"kagenti.io/managed-by": "kagenti-ui"},
+                    ),
+                )
+                self.core_api.create_namespaced_service_account(namespace=namespace, body=sa)
+                logger.info(f"Created ServiceAccount '{name}' in {namespace}")
+            else:
+                logger.error(f"Error checking ServiceAccount '{name}' in {namespace}: {e}")
+                raise
+
+    # -------------------------------------------------------------------------
     # Deployment Operations
     # -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Set `serviceAccountName` to the workload name in all manifest builders (Deployment, StatefulSet, Job) for both agents and tools
- Add `ensure_service_account()` to `KubernetesService` to idempotently create the SA before the workload
- Call `ensure_service_account()` in all creation endpoints (image deploy, Shipwright finalize, CRD migration)

Without this fix, the webhook's `deriveWorkloadName()` falls back to the ReplicaSet name (which includes a hash suffix), producing incorrect SPIFFE IDs, Keycloak client registrations, and audience scopes.

Fixes #958

## Files Changed

| File | Change |
|------|--------|
| `kubernetes.py` | New `ensure_service_account()` method (read-or-create, idempotent) |
| `agents.py` | `serviceAccountName` in 4 manifest builders + `ensure_service_account()` in 3 creation paths |
| `tools.py` | `serviceAccountName` in 2 manifest builders + `ensure_service_account()` in 2 creation paths |

## Test plan

- [ ] Deploy an agent via UI (Build from Source) and verify `kubectl logs -c kagenti-client-registration` shows the correct SPIFFE ID (no ReplicaSet hash)
- [ ] Run the github-issue demo Step 9d CLI test end-to-end
- [ ] Deploy a tool via UI and verify its ServiceAccount name matches the tool name
- [ ] Verify re-deploying an existing agent does not fail (SA creation is idempotent)
- [ ] Verify the CRD migration path sets serviceAccountName correctly