### PR TITLE
chore: Bump OpenShift version from 4.20.11 to 4.20.21

### DIFF
--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -107,7 +107,7 @@ HYPERSHIFT_AUTOMATION_DIR=$(find_hypershift_automation)
 # Configuration with defaults
 REPLICAS="${REPLICAS:-2}"
 INSTANCE_TYPE="${INSTANCE_TYPE:-m5.xlarge}"
-OCP_VERSION="${OCP_VERSION:-4.20.11}"
+OCP_VERSION="${OCP_VERSION:-4.20.13}"
 
 # NodePool autoscaling (enabled by default)
 # Override AUTOSCALE_MIN and AUTOSCALE_MAX to adjust limits, or set to empty to disable

--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -107,7 +107,7 @@ HYPERSHIFT_AUTOMATION_DIR=$(find_hypershift_automation)
 # Configuration with defaults
 REPLICAS="${REPLICAS:-2}"
 INSTANCE_TYPE="${INSTANCE_TYPE:-m5.xlarge}"
-OCP_VERSION="${OCP_VERSION:-4.20.13}"
+OCP_VERSION="${OCP_VERSION:-4.20.21}"
 
 # NodePool autoscaling (enabled by default)
 # Override AUTOSCALE_MIN and AUTOSCALE_MAX to adjust limits, or set to empty to disable

--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -16,7 +16,7 @@
 #   - Label serves as visual indicator of approval status
 #   - New commits require re-approval (TOCTOU protection)
 #
-name: E2E OCP 4.20.11 (HyperShift PR)
+name: E2E OCP 4.20.13 (HyperShift PR)
 
 on:
   issue_comment:
@@ -27,7 +27,7 @@ permissions: {}
 
 # Version tracking - keep workflow name in sync with OCP_VERSION
 env:
-  OCP_VERSION: '4.20.11'  # Update workflow name when changing default
+  OCP_VERSION: '4.20.13'  # Update workflow name when changing default
   MAX_SLOTS: '6'
   SLOT_TIMEOUT: '60'
 

--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -16,7 +16,7 @@
 #   - Label serves as visual indicator of approval status
 #   - New commits require re-approval (TOCTOU protection)
 #
-name: E2E OCP 4.20.13 (HyperShift PR)
+name: E2E OCP 4.20.21 (HyperShift PR)
 
 on:
   issue_comment:
@@ -27,7 +27,7 @@ permissions: {}
 
 # Version tracking - keep workflow name in sync with OCP_VERSION
 env:
-  OCP_VERSION: '4.20.13'  # Update workflow name when changing default
+  OCP_VERSION: '4.20.21'  # Update workflow name when changing default
   MAX_SLOTS: '6'
   SLOT_TIMEOUT: '60'
 

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -1,4 +1,4 @@
-name: E2E OCP 4.20.11 (HyperShift)
+name: E2E OCP 4.20.13 (HyperShift)
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
       ocp_version:
         description: 'OpenShift version'
         required: false
-        default: '4.20.11'
+        default: '4.20.13'
       skip_destroy:
         description: 'Skip cluster destruction (for debugging)'
         required: false
@@ -52,7 +52,7 @@ env:
   # Cluster suffix - for push to main uses run number, for workflow_dispatch uses user input
   # For PR testing, use /run-e2e comment trigger (see e2e-hypershift-pr.yaml)
   CLUSTER_SUFFIX: ${{ inputs.cluster_name || github.run_number }}
-  OCP_VERSION: ${{ inputs.ocp_version || '4.20.11' }}  # Update workflow name when changing default
+  OCP_VERSION: ${{ inputs.ocp_version || '4.20.13' }}  # Update workflow name when changing default
   # Slot management for parallel CI runs
   MAX_SLOTS: ${{ inputs.max_parallel || '6' }}
   SLOT_TIMEOUT: '60'  # Minutes to wait for an available slot

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -1,4 +1,4 @@
-name: E2E OCP 4.20.13 (HyperShift)
+name: E2E OCP 4.20.21 (HyperShift)
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
       ocp_version:
         description: 'OpenShift version'
         required: false
-        default: '4.20.13'
+        default: '4.20.21'
       skip_destroy:
         description: 'Skip cluster destruction (for debugging)'
         required: false
@@ -52,7 +52,7 @@ env:
   # Cluster suffix - for push to main uses run number, for workflow_dispatch uses user input
   # For PR testing, use /run-e2e comment trigger (see e2e-hypershift-pr.yaml)
   CLUSTER_SUFFIX: ${{ inputs.cluster_name || github.run_number }}
-  OCP_VERSION: ${{ inputs.ocp_version || '4.20.13' }}  # Update workflow name when changing default
+  OCP_VERSION: ${{ inputs.ocp_version || '4.20.21' }}  # Update workflow name when changing default
   # Slot management for parallel CI runs
   MAX_SLOTS: ${{ inputs.max_parallel || '6' }}
   SLOT_TIMEOUT: '60'  # Minutes to wait for an available slot

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![CI](https://github.com/kagenti/kagenti/actions/workflows/ci.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/ci.yaml)
 [![E2E K8s 1.35.0 (Kind)](https://github.com/kagenti/kagenti/actions/workflows/e2e-kind.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/e2e-kind.yaml)
-[![E2E OCP 4.20.11 (HyperShift)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml)
+[![E2E OCP 4.20.13 (HyperShift)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kagenti/kagenti/badge)](https://scorecard.dev/viewer/?uri=github.com/kagenti/kagenti)
 [![GitHub Release](https://img.shields.io/github/v/release/kagenti/kagenti)](https://github.com/kagenti/kagenti/releases/latest)
 [![License](https://img.shields.io/github/license/kagenti/kagenti)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![CI](https://github.com/kagenti/kagenti/actions/workflows/ci.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/ci.yaml)
 [![E2E K8s 1.35.0 (Kind)](https://github.com/kagenti/kagenti/actions/workflows/e2e-kind.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/e2e-kind.yaml)
-[![E2E OCP 4.20.13 (HyperShift)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml)
+[![E2E OCP 4.20.21 (HyperShift)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml/badge.svg)](https://github.com/kagenti/kagenti/actions/workflows/e2e-hypershift.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kagenti/kagenti/badge)](https://scorecard.dev/viewer/?uri=github.com/kagenti/kagenti)
 [![GitHub Release](https://img.shields.io/github/v/release/kagenti/kagenti)](https://github.com/kagenti/kagenti/releases/latest)
 [![License](https://img.shields.io/github/license/kagenti/kagenti)](LICENSE)

--- a/terraform/management-cluster/variables.tf
+++ b/terraform/management-cluster/variables.tf
@@ -21,7 +21,7 @@ variable "aws_region" {
 variable "ocp_version" {
   description = "OpenShift version for the management cluster"
   type        = string
-  default     = "4.20.11"
+  default     = "4.20.13"
 }
 
 variable "vpc_cidr" {

--- a/terraform/management-cluster/variables.tf
+++ b/terraform/management-cluster/variables.tf
@@ -21,7 +21,7 @@ variable "aws_region" {
 variable "ocp_version" {
   description = "OpenShift version for the management cluster"
   type        = string
-  default     = "4.20.13"
+  default     = "4.20.21"
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
● Summary                  

  Updates OpenShift version from 4.20.11 to 4.20.21 across all configurations.                                         
   
  Changes                                                                                                              
                                         
  - CI Workflows: Updated default version and workflow names
    - e2e-hypershift.yaml
    - e2e-hypershift-pr.yaml
  - Scripts: Updated create-cluster.sh default OCP_VERSION
  - Terraform: Updated default ocp_version in variables.tf
  - Documentation: Updated README badge

  Compatibility

  - 4.20.21 available in OpenShift mirrors
  - HyperShift CLI supports 4.20.0+
  - Minor patch release (low risk)
  - Ansible roles auto-detect version (no hardcoded constraints)

  Testing

  Version bump should be tested via CI before merging to ensure:
  - Cluster creation works with 4.20.21
  - E2E tests pass on new version