### PR TITLE
fix: Move KEYCLOAK_URL and KEYCLOAK_REALM into authbridge-config ConfigMap

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -198,8 +198,6 @@ data:
       }
     ]
   SPIRE_ENABLED: {{ if $root.Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
-  KEYCLOAK_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
-  KEYCLOAK_REALM: {{ $root.Values.keycloak.realm | quote }}
 ---
 {{- if not $root.Values.keycloak.adminExistingSecret }}
 # ——————————————————————————————————————————————————————————————————————————————
@@ -222,6 +220,10 @@ stringData:
 
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for AuthBridge in Namespace: {{ . }}
+#  Unified config for both client-registration and envoy-proxy (go-processor).
+#  client-registration reads: KEYCLOAK_URL, KEYCLOAK_REALM, PLATFORM_CLIENT_IDS
+#  go-processor reads: KEYCLOAK_URL, KEYCLOAK_REALM (to derive TOKEN_URL/ISSUER),
+#                      ISSUER (explicit override for split-horizon DNS)
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: v1
 kind: ConfigMap
@@ -229,10 +231,12 @@ metadata:
   name: authbridge-config
   namespace: {{ . }}
 data:
-  TOKEN_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080/realms/{{ $root.Values.keycloak.realm }}/protocol/openid-connect/token"
+  KEYCLOAK_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
+  KEYCLOAK_REALM: {{ $root.Values.keycloak.realm | quote }}
+  # ISSUER: Optional. Auto-derived from KEYCLOAK_URL + KEYCLOAK_REALM if not set.
+  # Set explicitly when the internal KEYCLOAK_URL differs from the frontend URL
+  # that appears in token "iss" claims (split-horizon DNS).
   ISSUER: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
-  TARGET_AUDIENCE: "auth-target"
-  TARGET_SCOPES: "openid auth-target-aud"
 ---
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for Envoy in Namespace: {{ . }}


### PR DESCRIPTION
## Summary

- Move `KEYCLOAK_URL` and `KEYCLOAK_REALM` from the `environments` ConfigMap into `authbridge-config`
- Remove obsolete `TOKEN_URL`, `TARGET_AUDIENCE`, and `TARGET_SCOPES` keys from `authbridge-config`
- Keep `ISSUER` for split-horizon DNS deployments

## Context

The kagenti-extensions webhook [consolidated](https://github.com/kagenti/kagenti-extensions/commit/6256f8b) the `environments` and `authbridge-config` ConfigMaps into a single `authbridge-config` ConfigMap. The webhook now reads `KEYCLOAK_URL` and `KEYCLOAK_REALM` from `authbridge-config`, but the kagenti Helm chart still had these keys only in the `environments` ConfigMap.

This caused the `kagenti-client-registration` sidecar to start without `KEYCLOAK_URL`, skip Keycloak registration, and never start its gRPC server on `:9090` — making Envoy ext_proc get "Connection refused" and all outbound HTTP traffic from injected pods fail.

`TOKEN_URL` is removed because go-processor now auto-derives it from `KEYCLOAK_URL + KEYCLOAK_REALM`. `TARGET_AUDIENCE` and `TARGET_SCOPES` are removed because target audience and scopes are now configured per-route in the `authproxy-routes` ConfigMap, not globally.

Fixes #969

## Test plan

- [ ] Deploy with updated Helm chart and verify `authbridge-config` contains `KEYCLOAK_URL` and `KEYCLOAK_REALM`
- [ ] Verify `kagenti-client-registration` sidecar starts successfully and registers with Keycloak
- [ ] Verify outbound HTTP traffic from injected pods works (no "Connection refused" on `:9090`)
- [ ] Verify `environments` ConfigMap still contains LLM/MCP environment presets
