### PR TITLE
feat: sandbox agent infrastructure — CI, Helm, Ansible, scripts

### DIFF
--- a/.github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
+++ b/.github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
@@ -612,20 +612,16 @@ if [ "$HC_EXISTS" = "true" ] || [ "$NS_EXISTS" = "true" ]; then
             sleep 5
         done
 
-        # Fail if namespace still exists - don't allow create step to run with conflicting resources
-        # A namespace with leftover resources causes the new cluster to be in a broken state
+        # Warn if namespace still exists — proceed anyway since the cluster name
+        # is unique per PR and the HyperShift operator will handle the stale
+        # namespace eventually. Blocking here causes CI deadlocks when multiple
+        # E2E runs overlap.
         if [ "$NS_DELETED" = "false" ]; then
-            echo "::error::Namespace $CONTROL_PLANE_NS still exists after 5 minutes"
-            echo "Cannot proceed with cluster creation while old resources exist."
+            echo "::warning::Namespace $CONTROL_PLANE_NS still exists after 5 minutes — proceeding anyway"
+            echo "The HyperShift operator will clean it up asynchronously."
             echo ""
-            echo "Debug info:"
-            oc get all -n "$CONTROL_PLANE_NS" 2>/dev/null || true
-            echo ""
-            echo "Finalizers on remaining resources:"
-            for resource in hostedcontrolplane clusters.cluster.x-k8s.io deployment statefulset secret; do
-                oc get "$resource" -n "$CONTROL_PLANE_NS" -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}: {.metadata.finalizers}{"\n"}{end}' 2>/dev/null || true
-            done
-            exit 1
+            echo "Remaining resources (for debugging):"
+            oc get pods -n "$CONTROL_PLANE_NS" 2>/dev/null || true
         fi
     fi
 

--- a/.github/scripts/kagenti-operator/36-fix-keycloak-admin.sh
+++ b/.github/scripts/kagenti-operator/36-fix-keycloak-admin.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Fix Keycloak Admin After RHBK Operator Deploy
+#
+# The RHBK operator creates keycloak-initial-admin with temp-admin + random
+# password. This script:
+#   1. Reads the operator-generated credentials from the secret
+#   2. Logs in with those credentials
+#   3. Creates a permanent admin/admin user (if not exists)
+#   4. Creates the demo realm (if not exists)
+#   5. Updates the keycloak-initial-admin secret to admin/admin
+#
+# Idempotent — safe to run multiple times.
+#
+# Usage:
+#   ./.github/scripts/kagenti-operator/36-fix-keycloak-admin.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/logging.sh" 2>/dev/null || {
+    log_step() { echo "==> [$1] $2"; }
+    log_info() { echo "  INFO: $*"; }
+    log_success() { echo "  OK: $*"; }
+    log_warn() { echo "  WARN: $*"; }
+    log_error() { echo "  ERROR: $*"; }
+}
+
+log_step "36" "Fix Keycloak Admin (RHBK operator workaround)"
+
+KC_NS="${KEYCLOAK_NAMESPACE:-keycloak}"
+KC_POD="keycloak-0"
+KCADM="/opt/keycloak/bin/kcadm.sh"
+DESIRED_USER="admin"
+# Generate random password unless KEYCLOAK_ADMIN_PASSWORD is set
+# The password is stored in the keycloak-initial-admin K8s secret
+# and displayed by show-services.sh — NEVER hardcode admin/admin
+DESIRED_PASS="${KEYCLOAK_ADMIN_PASSWORD:-$(openssl rand -base64 12 | tr -dc 'a-zA-Z0-9' | head -c 16)}"
+
+# ── Step 1: Wait for Keycloak pod ────────────────────────────────────────────
+log_info "Waiting for Keycloak pod to be ready..."
+kubectl wait --for=condition=Ready pod/$KC_POD -n "$KC_NS" --timeout=120s
+
+# ── Step 2: Read current credentials from secret ────────────────────────────
+log_info "Reading current credentials from keycloak-initial-admin secret..."
+CURRENT_USER=$(kubectl get secret keycloak-initial-admin -n "$KC_NS" \
+    -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+CURRENT_PASS=$(kubectl get secret keycloak-initial-admin -n "$KC_NS" \
+    -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+
+if [ -z "$CURRENT_USER" ] || [ -z "$CURRENT_PASS" ]; then
+    log_error "Could not read keycloak-initial-admin secret"
+    exit 1
+fi
+log_info "Current admin: $CURRENT_USER"
+
+# ── Step 3: Try logging in ───────────────────────────────────────────────────
+# Try desired credentials first (idempotent case), then current secret
+LOGIN_OK=false
+for TRY_USER in "$DESIRED_USER" "$CURRENT_USER"; do
+    for TRY_PASS in "$DESIRED_PASS" "$CURRENT_PASS"; do
+        if kubectl exec -n "$KC_NS" "$KC_POD" -- bash -c \
+            "$KCADM config credentials --server http://localhost:8080 --realm master \
+             --user '$TRY_USER' --password '$TRY_PASS' --config /tmp/kc/kcadm.config" \
+            >/dev/null 2>&1; then
+            log_info "Logged in as $TRY_USER"
+            LOGIN_OK=true
+            break 2
+        fi
+    done
+done
+
+if [ "$LOGIN_OK" != "true" ]; then
+    log_error "Could not login to Keycloak with any known credentials"
+    exit 1
+fi
+
+# ── Step 4: Create permanent admin user ──────────────────────────────────────
+log_info "Ensuring permanent admin user exists..."
+kubectl exec -n "$KC_NS" "$KC_POD" -- bash -c "
+$KCADM create users --config /tmp/kc/kcadm.config -r master \
+    -s username=$DESIRED_USER -s enabled=true 2>/dev/null && echo 'Created user' || echo 'User exists'
+
+$KCADM set-password --config /tmp/kc/kcadm.config -r master \
+    --username $DESIRED_USER --new-password $DESIRED_PASS 2>/dev/null && echo 'Password set'
+
+# Grant admin role
+ADMIN_ROLE_ID=\$($KCADM get roles --config /tmp/kc/kcadm.config -r master \
+    -q name=admin --fields id --format csv --noquotes 2>/dev/null || echo '')
+USER_ID=\$($KCADM get users --config /tmp/kc/kcadm.config -r master \
+    -q username=$DESIRED_USER --fields id --format csv --noquotes 2>/dev/null || echo '')
+if [ -n \"\$ADMIN_ROLE_ID\" ] && [ -n \"\$USER_ID\" ]; then
+    $KCADM add-roles --config /tmp/kc/kcadm.config -r master \
+        --uusername $DESIRED_USER --rolename admin 2>/dev/null && echo 'Admin role assigned' || echo 'Role already assigned'
+fi
+"
+log_success "Permanent admin user ensured: $DESIRED_USER/$DESIRED_PASS"
+
+# ── Step 5: Create demo realm ────────────────────────────────────────────────
+log_info "Ensuring demo realm exists..."
+kubectl exec -n "$KC_NS" "$KC_POD" -- bash -c "
+$KCADM create realms --config /tmp/kc/kcadm.config \
+    -s realm=demo -s enabled=true 2>/dev/null && echo 'Created demo realm' || echo 'Demo realm exists'
+"
+log_success "Demo realm ensured"
+
+# ── Step 6: Update secret to known credentials ──────────────────────────────
+if [ "$CURRENT_USER" != "$DESIRED_USER" ] || [ "$CURRENT_PASS" != "$DESIRED_PASS" ]; then
+    log_info "Updating keycloak-initial-admin secret to $DESIRED_USER/$DESIRED_PASS..."
+    kubectl patch secret keycloak-initial-admin -n "$KC_NS" --type merge \
+        -p "{\"data\":{\"username\":\"$(echo -n $DESIRED_USER | base64)\",\"password\":\"$(echo -n $DESIRED_PASS | base64)\"}}"
+    log_success "Secret updated"
+else
+    log_info "Secret already has correct credentials"
+fi
+
+log_success "Keycloak admin fix complete"

--- a/.github/scripts/kagenti-operator/36-fix-keycloak-admin.sh
+++ b/.github/scripts/kagenti-operator/36-fix-keycloak-admin.sh
@@ -91,7 +91,7 @@ USER_ID=\$($KCADM get users --config /tmp/kc/kcadm.config -r master \
     -q username=$DESIRED_USER --fields id --format csv --noquotes 2>/dev/null || echo '')
 if [ -n \"\$ADMIN_ROLE_ID\" ] && [ -n \"\$USER_ID\" ]; then
     $KCADM add-roles --config /tmp/kc/kcadm.config -r master \
-        --uusername $DESIRED_USER --rolename admin 2>/dev/null && echo 'Admin role assigned' || echo 'Role already assigned'
+        --username $DESIRED_USER --rolename admin 2>/dev/null && echo 'Admin role assigned' || echo 'Role already assigned'
 fi
 "
 log_success "Permanent admin user ensured: $DESIRED_USER/$DESIRED_PASS"

--- a/.github/scripts/kagenti-operator/37-build-platform-images.sh
+++ b/.github/scripts/kagenti-operator/37-build-platform-images.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Build Kagenti backend and UI images from source
+#
+# Builds backend and UI container images on-cluster using OpenShift BuildConfig,
+# then patches the deployments to use the freshly built images. This ensures
+# E2E tests run against the actual code from the current branch, not stock images.
+#
+# Prerequisites:
+#   - OpenShift cluster with Build API available
+#   - KUBECONFIG set to the hosted cluster
+#
+# Usage:
+#   ./.github/scripts/kagenti-operator/37-build-platform-images.sh
+#
+# Environment:
+#   GIT_REPO_URL:    Git repo URL (default: auto-detect from git remote)
+#   GIT_BRANCH:      Branch to build (default: auto-detect from current branch)
+#   SKIP_BUILD:      Set to "true" to skip (uses stock images)
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+source "$SCRIPT_DIR/../lib/logging.sh"
+source "$SCRIPT_DIR/../lib/k8s-utils.sh"
+
+log_step "37" "Building platform images from source"
+
+if [ "${SKIP_BUILD:-false}" = "true" ]; then
+    log_info "SKIP_BUILD=true — using stock images"
+    exit 0
+fi
+
+if [ "$IS_OPENSHIFT" != "true" ]; then
+    log_info "Not OpenShift — skipping on-cluster build (use stock images)"
+    exit 0
+fi
+
+NS="kagenti-system"
+REGISTRY="image-registry.openshift-image-registry.svc:5000/$NS"
+
+# Auto-detect git repo and branch
+GIT_REPO_URL="${GIT_REPO_URL:-}"
+GIT_BRANCH="${GIT_BRANCH:-}"
+
+if [ -z "$GIT_REPO_URL" ]; then
+    # Try to get the push URL from git remote
+    GIT_REPO_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null | sed 's|git@github.com:|https://github.com/|' || echo "")
+    if [ -z "$GIT_REPO_URL" ]; then
+        log_info "Could not detect git remote — skipping source build"
+        exit 0
+    fi
+fi
+
+if [ -z "$GIT_BRANCH" ]; then
+    GIT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo "main")
+fi
+
+log_info "Building from: $GIT_REPO_URL @ $GIT_BRANCH"
+
+# Components to build: name:dockerfile:tag
+# Dockerfiles expect context=kagenti/ (e.g. COPY backend/pyproject.toml)
+CONTEXT_DIR="kagenti"
+COMPONENTS=(
+    "kagenti-backend:backend/Dockerfile:worktree"
+    "kagenti-ui:ui-v2/Dockerfile:worktree"
+)
+
+for COMPONENT_SPEC in "${COMPONENTS[@]}"; do
+    IFS=: read -r NAME DOCKERFILE TAG <<< "$COMPONENT_SPEC"
+
+    log_info "Building $NAME..."
+
+    # Create ImageStream if needed
+    oc create imagestream "$NAME" -n "$NS" 2>/dev/null || true
+
+    # Create/update BuildConfig
+    cat <<EOF | kubectl apply -f -
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: $NAME
+  namespace: $NS
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: $NAME:$TAG
+  source:
+    type: Git
+    git:
+      uri: $GIT_REPO_URL
+      ref: $GIT_BRANCH
+    contextDir: $CONTEXT_DIR
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: $DOCKERFILE
+EOF
+
+    # Start build
+    BUILD_NAME=$(oc start-build "$NAME" -n "$NS" -o name 2>&1)
+    log_info "$BUILD_NAME started"
+
+    # Wait for build to complete
+    run_with_timeout 600 "oc wait --for=jsonpath='{.status.phase}'=Complete $BUILD_NAME -n $NS --timeout=600s" || {
+        log_error "$NAME build failed"
+        oc logs "$BUILD_NAME" -n "$NS" 2>&1 | tail -30 || true
+        exit 1
+    }
+    log_success "$NAME image built"
+
+    # Patch deployment to use the new image
+    CONTAINER_NAME=$(kubectl get deployment "$NAME" -n "$NS" -o jsonpath='{.spec.template.spec.containers[0].name}' 2>/dev/null || echo "")
+    if [ -n "$CONTAINER_NAME" ]; then
+        kubectl set image "deployment/$NAME" -n "$NS" "$CONTAINER_NAME=$REGISTRY/$NAME:$TAG"
+        # Force pull to avoid node-level image cache serving stale layers
+        kubectl patch deployment "$NAME" -n "$NS" --type=json \
+            -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/imagePullPolicy\",\"value\":\"Always\"}]" 2>/dev/null || true
+        log_info "Patched $NAME deployment → $REGISTRY/$NAME:$TAG (Always pull)"
+    else
+        log_warn "Deployment $NAME not found — skipping patch"
+    fi
+done
+
+# Restart and wait for rollouts
+for COMPONENT_SPEC in "${COMPONENTS[@]}"; do
+    IFS=: read -r NAME _ _ <<< "$COMPONENT_SPEC"
+    if kubectl get deployment "$NAME" -n "$NS" &>/dev/null; then
+        kubectl rollout restart "deployment/$NAME" -n "$NS"
+    fi
+done
+
+for COMPONENT_SPEC in "${COMPONENTS[@]}"; do
+    IFS=: read -r NAME _ _ <<< "$COMPONENT_SPEC"
+    if kubectl get deployment "$NAME" -n "$NS" &>/dev/null; then
+        kubectl rollout status "deployment/$NAME" -n "$NS" --timeout=120s || {
+            log_error "$NAME rollout failed"
+            kubectl get pods -n "$NS" -l "app.kubernetes.io/name=$NAME" 2>&1
+            exit 1
+        }
+    fi
+done
+
+log_success "Platform images built and deployed from source"

--- a/.github/scripts/kagenti-operator/38-deploy-litellm.sh
+++ b/.github/scripts/kagenti-operator/38-deploy-litellm.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+#
+# Deploy LiteLLM Proxy
+#
+# Deploys LiteLLM as a centralized model gateway in kagenti-system.
+# Reads model credentials from .env.maas and creates:
+#   - litellm-config ConfigMap (model routing config)
+#   - litellm-model-keys Secret (MAAS API keys as env vars)
+#   - litellm-proxy-secret Secret (master key + DB URL)
+#   - litellm-proxy Deployment + Service
+#
+# Prerequisites:
+#   - postgres-otel StatefulSet running in kagenti-system
+#   - .env.maas file in main repo root (or MAIN_REPO_ROOT)
+#
+# Usage:
+#   ./.github/scripts/kagenti-operator/38-deploy-litellm.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+source "$SCRIPT_DIR/../lib/logging.sh"
+source "$SCRIPT_DIR/../lib/k8s-utils.sh"
+
+log_step "38" "Deploying LiteLLM Proxy"
+
+NAMESPACE="kagenti-system"
+LITELLM_DIR="$REPO_ROOT/deployments/litellm"
+LITELLM_DB_NAME="${LITELLM_DB_NAME:-litellm}"
+LITELLM_DB_SECRET="${LITELLM_DB_SECRET:-otel-db-secret}"
+LITELLM_DB_HOST="${LITELLM_DB_HOST:-postgres.${NAMESPACE}.svc}"
+LITELLM_DB_PORT="${LITELLM_DB_PORT:-5432}"
+
+# ============================================================================
+# Step 0: Create ServiceAccount and grant anyuid SCC
+# ============================================================================
+# TODO: Remove anyuid SCC requirement by building a custom LiteLLM image
+# that relocates Prisma binaries from /root/.cache to a non-root path.
+# The upstream litellm-database image bakes Prisma query engine binaries
+# under /root/.cache during docker build (as root). On OpenShift, pods
+# run with an arbitrary UID from the restricted SCC range, which cannot
+# read root-owned files. Options to eliminate this:
+#   1. Custom Dockerfile: RUN chmod -R a+rX /root/.cache
+#   2. Upstream PR to use non-root user in LiteLLM Dockerfile
+#   3. Init container that copies binaries to emptyDir with world-read
+
+log_info "Creating ServiceAccount for litellm-proxy..."
+kubectl create serviceaccount litellm-proxy -n "$NAMESPACE" 2>/dev/null || true
+
+if [ "$IS_OPENSHIFT" = "true" ]; then
+    log_info "Granting anyuid SCC to litellm-proxy ServiceAccount..."
+    oc adm policy add-scc-to-user anyuid -z litellm-proxy -n "$NAMESPACE" 2>/dev/null || true
+    log_success "anyuid SCC granted"
+fi
+
+# ============================================================================
+# Step 1: Load model credentials from .env.maas
+# ============================================================================
+
+MAAS_ENV="$MAIN_REPO_ROOT/.env.maas"
+if [ ! -f "$MAAS_ENV" ]; then
+    log_error ".env.maas not found at $MAAS_ENV"
+    log_info "Create .env.maas with MAAS_*_API_BASE, MAAS_*_API_KEY, MAAS_*_MODEL vars"
+    exit 1
+fi
+
+log_info "Loading model credentials from $MAAS_ENV..."
+# Source in subshell to capture without polluting this shell
+eval "$(grep -E '^export MAAS_' "$MAAS_ENV")"
+
+# Validate required vars
+for var in MAAS_LLAMA4_API_BASE MAAS_LLAMA4_API_KEY MAAS_LLAMA4_MODEL \
+           MAAS_MISTRAL_API_BASE MAAS_MISTRAL_API_KEY MAAS_MISTRAL_MODEL \
+           MAAS_DEEPSEEK_API_BASE MAAS_DEEPSEEK_API_KEY MAAS_DEEPSEEK_MODEL; do
+    if [ -z "${!var:-}" ]; then
+        log_error "Missing $var in .env.maas"
+        exit 1
+    fi
+done
+log_success "MAAS model credentials loaded (3 models)"
+
+# ============================================================================
+# Step 1b: Load OpenAI credentials (optional)
+# ============================================================================
+# Try sources in order: env var > K8s secret (team1) > K8s secret (kagenti-system)
+OPENAI_API_KEY="${OPENAI_API_KEY:-}"
+OPENAI_ENABLED=false
+
+if [ -n "$OPENAI_API_KEY" ]; then
+    log_info "OpenAI key loaded from env var"
+    OPENAI_ENABLED=true
+else
+    for ns in team1 "$NAMESPACE"; do
+        KEY=$(kubectl get secret openai-secret -n "$ns" \
+            -o jsonpath='{.data.apikey}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+        if [ -n "$KEY" ]; then
+            OPENAI_API_KEY="$KEY"
+            OPENAI_ENABLED=true
+            log_info "OpenAI key loaded from openai-secret in $ns"
+            break
+        fi
+    done
+fi
+
+if [ "$OPENAI_ENABLED" = "true" ]; then
+    log_success "OpenAI credentials loaded (gpt-4o-mini, gpt-4o)"
+else
+    log_warn "No OpenAI key found — OpenAI models will not be available"
+    log_info "To enable: kubectl create secret generic openai-secret -n team1 --from-literal=apikey=sk-..."
+fi
+
+# ============================================================================
+# Step 2: Get postgres credentials from existing otel-db-secret
+# ============================================================================
+
+log_info "Reading postgres credentials from $LITELLM_DB_SECRET..."
+DB_USER=$(kubectl get secret "$LITELLM_DB_SECRET" -n "$NAMESPACE" \
+    -o jsonpath='{.data.username}' | base64 -d)
+DB_PASS=$(kubectl get secret "$LITELLM_DB_SECRET" -n "$NAMESPACE" \
+    -o jsonpath='{.data.password}' | base64 -d)
+
+if [ -z "$DB_USER" ] || [ -z "$DB_PASS" ]; then
+    log_error "Could not read $LITELLM_DB_SECRET credentials"
+    exit 1
+fi
+
+# Create litellm database if it doesn't exist
+# Uses postgres superuser for CREATE DATABASE (application user may lack CREATEDB)
+log_info "Ensuring $LITELLM_DB_NAME database exists..."
+POSTGRES_POD=$(kubectl get pod -n "$NAMESPACE" -l app.kubernetes.io/name=postgres-otel \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "postgres-otel-0")
+kubectl exec -n "$NAMESPACE" "$POSTGRES_POD" -- bash -c \
+    "psql -U postgres -d postgres -tc \"SELECT 1 FROM pg_database WHERE datname='$LITELLM_DB_NAME'\" | grep -q 1 || \
+     psql -U postgres -d postgres -c 'CREATE DATABASE $LITELLM_DB_NAME OWNER $DB_USER'" 2>/dev/null || {
+    log_warn "Could not create $LITELLM_DB_NAME DB (may already exist or psql not available)"
+}
+
+DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@${LITELLM_DB_HOST}:${LITELLM_DB_PORT}/${LITELLM_DB_NAME}"
+log_success "Database URL configured"
+
+# ============================================================================
+# Step 3: Generate master key
+# ============================================================================
+
+# Use existing master key if secret exists, otherwise generate new one
+EXISTING_KEY=$(kubectl get secret litellm-proxy-secret -n "$NAMESPACE" \
+    -o jsonpath='{.data.master-key}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+
+if [ -n "$EXISTING_KEY" ]; then
+    MASTER_KEY="$EXISTING_KEY"
+    log_info "Using existing master key from litellm-proxy-secret"
+else
+    MASTER_KEY="sk-kagenti-$(openssl rand -hex 16)"
+    log_info "Generated new master key"
+fi
+
+# ============================================================================
+# Step 4: Create secrets
+# ============================================================================
+
+log_info "Creating litellm-proxy-secret..."
+kubectl create secret generic litellm-proxy-secret \
+    -n "$NAMESPACE" \
+    --from-literal=master-key="$MASTER_KEY" \
+    --from-literal=database-url="$DATABASE_URL" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+log_info "Creating litellm-model-keys secret (API keys)..."
+MODEL_KEY_ARGS=(
+    --from-literal=MAAS_LLAMA4_API_KEY="$MAAS_LLAMA4_API_KEY"
+    --from-literal=MAAS_MISTRAL_API_KEY="$MAAS_MISTRAL_API_KEY"
+    --from-literal=MAAS_DEEPSEEK_API_KEY="$MAAS_DEEPSEEK_API_KEY"
+)
+if [ "$OPENAI_ENABLED" = "true" ]; then
+    MODEL_KEY_ARGS+=(--from-literal=OPENAI_API_KEY="$OPENAI_API_KEY")
+fi
+kubectl create secret generic litellm-model-keys \
+    -n "$NAMESPACE" \
+    "${MODEL_KEY_ARGS[@]}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+log_success "Secrets created"
+
+# ============================================================================
+# Step 5: Generate and apply ConfigMap
+# ============================================================================
+
+log_info "Generating LiteLLM config..."
+
+# Build OpenAI model entries if key is available
+OPENAI_MODEL_ENTRIES=""
+if [ "$OPENAI_ENABLED" = "true" ]; then
+    OPENAI_MODEL_ENTRIES="
+      - model_name: gpt-4o-mini
+        litellm_params:
+          model: gpt-4o-mini
+          api_key: os.environ/OPENAI_API_KEY
+
+      - model_name: gpt-4o
+        litellm_params:
+          model: gpt-4o
+          api_key: os.environ/OPENAI_API_KEY"
+fi
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: $NAMESPACE
+  labels:
+    app.kubernetes.io/name: litellm-proxy
+    app.kubernetes.io/part-of: kagenti
+data:
+  config.yaml: |
+    model_list:
+      - model_name: llama-4-scout
+        litellm_params:
+          model: openai/$MAAS_LLAMA4_MODEL
+          api_base: $MAAS_LLAMA4_API_BASE
+          api_key: os.environ/MAAS_LLAMA4_API_KEY
+
+      - model_name: mistral-small
+        litellm_params:
+          model: openai/$MAAS_MISTRAL_MODEL
+          api_base: $MAAS_MISTRAL_API_BASE
+          api_key: os.environ/MAAS_MISTRAL_API_KEY
+
+      - model_name: deepseek-r1
+        litellm_params:
+          model: openai/$MAAS_DEEPSEEK_MODEL
+          api_base: $MAAS_DEEPSEEK_API_BASE
+          api_key: os.environ/MAAS_DEEPSEEK_API_KEY
+${OPENAI_MODEL_ENTRIES}
+
+    general_settings:
+      master_key: os.environ/LITELLM_MASTER_KEY
+      database_url: os.environ/DATABASE_URL
+EOF
+
+log_success "ConfigMap created"
+
+# ============================================================================
+# Step 6: Apply deployment and service
+# ============================================================================
+
+log_info "Applying LiteLLM deployment and service..."
+kubectl apply -f "$LITELLM_DIR/deployment.yaml"
+kubectl apply -f "$LITELLM_DIR/service.yaml"
+
+# ============================================================================
+# Step 7: Wait for rollout
+# ============================================================================
+
+log_info "Waiting for litellm-proxy deployment to be ready..."
+if run_with_timeout 120 "kubectl rollout status deployment/litellm-proxy -n $NAMESPACE --timeout=120s"; then
+    log_success "litellm-proxy is running"
+else
+    log_error "litellm-proxy did not become ready"
+    kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=litellm-proxy
+    kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/name=litellm-proxy --tail=30 || true
+    exit 1
+fi
+
+# ============================================================================
+# Step 8: Verify health and create virtual keys
+# ============================================================================
+
+log_info "Verifying LiteLLM proxy health via port-forward..."
+
+# Start temporary port-forward for health check and key generation
+LITELLM_PF_PORT=14099
+lsof -ti:${LITELLM_PF_PORT} 2>/dev/null | xargs kill 2>/dev/null || true
+sleep 1
+kubectl port-forward -n "$NAMESPACE" svc/litellm-proxy \
+    "${LITELLM_PF_PORT}:4000" &>/tmp/litellm-deploy-pf.log &
+PF_PID=$!
+trap "kill $PF_PID 2>/dev/null || true" EXIT
+
+# Wait for port-forward
+for i in $(seq 1 15); do
+    if curl -s -o /dev/null -w "%{http_code}" "http://localhost:${LITELLM_PF_PORT}/health/readiness" 2>/dev/null | grep -q "200"; then
+        break
+    fi
+    sleep 2
+done
+
+HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${LITELLM_PF_PORT}/health/readiness" 2>/dev/null || echo "000")
+if [ "$HEALTH" = "200" ]; then
+    log_success "LiteLLM proxy health check passed"
+else
+    log_warn "Health check returned $HEALTH (proxy may still be starting)"
+fi
+
+# List available models
+log_info "Available models:"
+curl -s "http://localhost:${LITELLM_PF_PORT}/v1/models" \
+    -H "Authorization: Bearer $MASTER_KEY" 2>/dev/null | \
+    jq -r '.data[]?.id // empty' 2>/dev/null | sed 's/^/  - /' || \
+    log_warn "Could not list models (proxy may still be initializing)"
+
+# Create virtual key for team1 namespace
+log_info "Creating virtual API key for team1..."
+TEAM1_KEY_RESPONSE=$(curl -s "http://localhost:${LITELLM_PF_PORT}/key/generate" \
+    -H "Authorization: Bearer $MASTER_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"key_alias": "team1-agents", "metadata": {"namespace": "team1"}, "max_budget": 100}' \
+    2>/dev/null || echo '{}')
+
+TEAM1_VIRTUAL_KEY=$(echo "$TEAM1_KEY_RESPONSE" | jq -r '.key // empty' 2>/dev/null || echo "")
+
+if [ -n "$TEAM1_VIRTUAL_KEY" ]; then
+    # Store virtual key in a secret for agent deployments to use
+    kubectl create secret generic litellm-virtual-keys \
+        -n team1 \
+        --from-literal=api-key="$TEAM1_VIRTUAL_KEY" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    log_success "Virtual key created for team1 and stored in litellm-virtual-keys secret"
+else
+    log_warn "Could not create virtual key (will retry on next deploy)"
+fi
+
+# Clean up port-forward
+kill "$PF_PID" 2>/dev/null || true
+
+log_success "LiteLLM proxy deployment complete"
+log_info "Proxy endpoint: http://litellm-proxy.${NAMESPACE}.svc:4000/v1"
+log_info "Master key stored in: litellm-proxy-secret (namespace: $NAMESPACE)"

--- a/.github/scripts/kagenti-operator/39-setup-llm-teams.sh
+++ b/.github/scripts/kagenti-operator/39-setup-llm-teams.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Setup LLM Teams via Backend API
+#
+# Creates litellm teams + default virtual keys for agent namespaces
+# by calling the kagenti backend API. Must run AFTER:
+#   - 30-run-installer.sh (platform + keycloak)
+#   - 38-deploy-litellm.sh (litellm proxy)
+#   - 37-build-platform-images.sh (backend with llm_keys router)
+#
+# Usage:
+#   ./.github/scripts/kagenti-operator/39-setup-llm-teams.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+source "$SCRIPT_DIR/../lib/logging.sh"
+
+log_step "39" "Setting up LLM teams via backend API"
+
+NAMESPACES="${AGENT_NAMESPACES:-team1 team2}"
+MAX_BUDGET="${LLM_TEAM_BUDGET:-500}"
+
+# Get backend URL
+if [ "$IS_OPENSHIFT" = "true" ]; then
+    BACKEND_ROUTE=$(kubectl get route kagenti-ui -n kagenti-system -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+    if [ -n "$BACKEND_ROUTE" ]; then
+        BACKEND_URL="https://$BACKEND_ROUTE"
+    fi
+fi
+
+if [ -z "${BACKEND_URL:-}" ]; then
+    log_info "Using port-forward to backend..."
+    BACKEND_PF_PORT=18099
+    lsof -ti:${BACKEND_PF_PORT} 2>/dev/null | xargs kill 2>/dev/null || true
+    sleep 1
+    kubectl port-forward -n kagenti-system svc/kagenti-backend \
+        "${BACKEND_PF_PORT}:8080" &>/tmp/kagenti-backend-pf.log &
+    PF_PID=$!
+    trap "kill $PF_PID 2>/dev/null || true" EXIT
+
+    for i in $(seq 1 15); do
+        if curl -s -o /dev/null -w "%{http_code}" "http://localhost:${BACKEND_PF_PORT}/health" 2>/dev/null | grep -q "200"; then
+            break
+        fi
+        sleep 2
+    done
+    BACKEND_URL="http://localhost:${BACKEND_PF_PORT}"
+fi
+
+# Get auth token from Keycloak
+KEYCLOAK_URL=$(kubectl get configmap kagenti-ui-config -n kagenti-system -o jsonpath='{.data.KEYCLOAK_CONSOLE_URL}' 2>/dev/null || echo "")
+if [ -z "$KEYCLOAK_URL" ]; then
+    KEYCLOAK_URL="http://keycloak-service.keycloak.svc:8080"
+fi
+
+CLIENT_SECRET=$(kubectl get secret kagenti-ui-oauth-secret -n kagenti-system \
+    -o jsonpath='{.data.CLIENT_SECRET}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+
+KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-admin}"
+
+TOKEN=$(curl -sk "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" \
+    -d "client_id=kagenti" \
+    -d "client_secret=$CLIENT_SECRET" \
+    -d "username=admin" \
+    -d "password=$KEYCLOAK_PASSWORD" \
+    -d "grant_type=password" \
+    -d "scope=openid" 2>/dev/null | jq -r '.access_token // empty' 2>/dev/null || echo "")
+
+if [ -z "$TOKEN" ]; then
+    log_warn "Could not get auth token — skipping team setup"
+    log_info "Teams can be created manually: POST /api/v1/llm/teams"
+    exit 0
+fi
+
+# Create teams
+for ns in $NAMESPACES; do
+    log_info "Creating LLM team for $ns..."
+    RESULT=$(curl -sk -X POST "$BACKEND_URL/api/v1/llm/teams" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"namespace\": \"$ns\", \"max_budget\": $MAX_BUDGET}" 2>/dev/null || echo '{"error": "request failed"}')
+
+    if echo "$RESULT" | jq -e '.team_id // empty' >/dev/null 2>&1; then
+        log_success "Team created for $ns"
+    elif echo "$RESULT" | grep -q "503"; then
+        log_warn "LiteLLM master key not configured — skipping"
+        break
+    else
+        log_warn "Team setup for $ns: $RESULT"
+    fi
+done
+
+log_success "LLM team setup complete"

--- a/.github/scripts/kagenti-operator/71-build-weather-tool.sh
+++ b/.github/scripts/kagenti-operator/71-build-weather-tool.sh
@@ -15,7 +15,7 @@ else
     log_info "Using Kind/Kubernetes Shipwright Build"
 fi
 
-AGENT_EXAMPLES_BRANCH="${AGENT_EXAMPLES_BRANCH:-fix/weather-tool-resilience}"
+AGENT_EXAMPLES_BRANCH="${AGENT_EXAMPLES_BRANCH:-main}"
 
 if [ "$IS_OPENSHIFT" = "true" ]; then
     # OpenShift: Use BuildConfig (native OpenShift builds)

--- a/.github/scripts/kagenti-operator/71-build-weather-tool.sh
+++ b/.github/scripts/kagenti-operator/71-build-weather-tool.sh
@@ -15,11 +15,19 @@ else
     log_info "Using Kind/Kubernetes Shipwright Build"
 fi
 
+AGENT_EXAMPLES_BRANCH="${AGENT_EXAMPLES_BRANCH:-fix/weather-tool-resilience}"
+
 if [ "$IS_OPENSHIFT" = "true" ]; then
     # OpenShift: Use BuildConfig (native OpenShift builds)
     # This avoids Tekton pipeline issues on OpenShift
 
-    kubectl apply -f "$REPO_ROOT/kagenti/examples/mcpservers/weather_tool_buildconfig.yaml"
+    if [ "$AGENT_EXAMPLES_BRANCH" != "main" ]; then
+        log_info "Using agent-examples branch: $AGENT_EXAMPLES_BRANCH"
+        sed "s|ref: main|ref: $AGENT_EXAMPLES_BRANCH|" \
+            "$REPO_ROOT/kagenti/examples/mcpservers/weather_tool_buildconfig.yaml" | kubectl apply -f -
+    else
+        kubectl apply -f "$REPO_ROOT/kagenti/examples/mcpservers/weather_tool_buildconfig.yaml"
+    fi
 
     # Wait for BuildConfig to exist
     run_with_timeout 60 'until kubectl get buildconfig weather-tool -n team1 &> /dev/null; do sleep 2; done' || {
@@ -65,7 +73,13 @@ else
 
     # Apply build manifest
     log_info "Creating Shipwright Build..."
-    kubectl apply -f "$REPO_ROOT/kagenti/examples/tools/weather_tool_shipwright_build.yaml"
+    if [ "$AGENT_EXAMPLES_BRANCH" != "main" ]; then
+        log_info "Using agent-examples branch: $AGENT_EXAMPLES_BRANCH"
+        sed "s|revision: main|revision: $AGENT_EXAMPLES_BRANCH|" \
+            "$REPO_ROOT/kagenti/examples/tools/weather_tool_shipwright_build.yaml" | kubectl apply -f -
+    else
+        kubectl apply -f "$REPO_ROOT/kagenti/examples/tools/weather_tool_shipwright_build.yaml"
+    fi
 
     # Wait for Shipwright Build to be registered
     run_with_timeout 60 'until kubectl get builds.shipwright.io weather-tool -n team1 &> /dev/null; do sleep 2; done' || {

--- a/.github/scripts/kagenti-operator/76-deploy-sandbox-agents.sh
+++ b/.github/scripts/kagenti-operator/76-deploy-sandbox-agents.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# Deploy Sandbox Agents
+#
+# Builds one shared image, then deploys all sandbox agent variants:
+#   - sandbox-agent:  basic variant (in-memory, stateless)
+#   - sandbox-legion: persistent variant (PostgreSQL sessions, sub-agents)
+#
+# Shared infrastructure (deployed once):
+#   - postgres-sessions StatefulSet (used by sandbox-legion)
+#
+# To add a new variant: create its *_deployment.yaml and *_service.yaml,
+# then add it to the VARIANTS array below.
+#
+# Usage:
+#   ./.github/scripts/kagenti-operator/76-deploy-sandbox-agents.sh
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+source "$SCRIPT_DIR/../lib/logging.sh"
+source "$SCRIPT_DIR/../lib/k8s-utils.sh"
+
+log_step "76" "Deploying Sandbox Agents"
+
+NAMESPACE="${SANDBOX_NAMESPACE:-team1}"
+AGENTS_DIR="$REPO_ROOT/kagenti/examples/agents"
+
+# ============================================================================
+# Step 1: Deploy shared infrastructure (postgres-sessions)
+# ============================================================================
+
+log_info "Deploying postgres-sessions StatefulSet..."
+kubectl apply -f "$REPO_ROOT/deployments/sandbox/postgres-sessions.yaml"
+
+run_with_timeout 120 "kubectl rollout status statefulset/postgres-sessions -n $NAMESPACE --timeout=120s" || {
+    log_error "postgres-sessions did not become ready"
+    kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=postgres-sessions
+    exit 1
+}
+log_success "postgres-sessions running"
+
+# ============================================================================
+# Step 1b: Deploy LLM budget proxy (per-namespace, shared by all agents)
+# ============================================================================
+
+log_info "Building llm-budget-proxy image..."
+if [ "$IS_OPENSHIFT" = "true" ] && oc api-resources --api-group=build.openshift.io 2>/dev/null | grep -q BuildConfig; then
+    oc create imagestream llm-budget-proxy -n "$NAMESPACE" 2>/dev/null || true
+    cat <<BPEOF | kubectl apply -f -
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: llm-budget-proxy
+  namespace: $NAMESPACE
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: llm-budget-proxy:v0.0.1
+  source:
+    type: Git
+    git:
+      uri: $(git remote get-url origin 2>/dev/null || echo "https://github.com/kagenti/kagenti.git")
+      ref: $(git rev-parse HEAD 2>/dev/null || echo "main")
+    contextDir: kagenti
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: llm-budget-proxy/Dockerfile
+      noCache: true
+BPEOF
+    BUILD_NAME=$(oc start-build llm-budget-proxy -n "$NAMESPACE" -o name 2>&1) || {
+        log_error "Failed to start llm-budget-proxy build"
+        exit 1
+    }
+    log_info "Build: $BUILD_NAME"
+    run_with_timeout 300 "oc wait --for=jsonpath='{.status.phase}'=Complete --timeout=300s $BUILD_NAME -n $NAMESPACE" || {
+        BUILD_PHASE=$(oc get "$BUILD_NAME" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+        if [ "$BUILD_PHASE" != "Complete" ]; then
+            log_error "llm-budget-proxy build failed (phase: $BUILD_PHASE)"
+            oc logs "$BUILD_NAME" -n "$NAMESPACE" 2>&1 | tail -20 || true
+            exit 1
+        fi
+    }
+    log_success "llm-budget-proxy image built"
+else
+    log_warn "OpenShift builds not available — skipping llm-budget-proxy build"
+    log_info "Pre-build the image and push to the registry manually"
+fi
+
+log_info "Deploying llm-budget-proxy..."
+
+# Create the llm_budget database in postgres-sessions
+POSTGRES_POD=$(kubectl get pod -n "$NAMESPACE" -l app.kubernetes.io/name=postgres-sessions \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "postgres-sessions-0")
+kubectl exec -n "$NAMESPACE" "$POSTGRES_POD" -- bash -c \
+    "psql -U kagenti -d postgres -tc \"SELECT 1 FROM pg_database WHERE datname='llm_budget'\" | grep -q 1 || \
+     psql -U kagenti -d postgres -c 'CREATE DATABASE llm_budget'" 2>/dev/null || {
+    log_warn "Could not create llm_budget DB (may already exist)"
+}
+
+kubectl apply -f "$REPO_ROOT/deployments/sandbox/llm-budget-proxy.yaml"
+
+run_with_timeout 120 "kubectl rollout status deployment/llm-budget-proxy -n $NAMESPACE --timeout=120s" || {
+    log_error "llm-budget-proxy did not become ready"
+    kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=llm-budget-proxy
+    kubectl describe pods -n "$NAMESPACE" -l app.kubernetes.io/name=llm-budget-proxy 2>&1 | tail -20 || true
+    exit 1
+}
+log_success "llm-budget-proxy running"
+
+# ============================================================================
+# Step 2: Build shared sandbox-agent image
+# ============================================================================
+# Uses OpenShift BuildConfig (Docker strategy with noCache: true) to avoid
+# buildah layer caching issues. Falls back to Shipwright if OCP builds
+# are not available.
+
+log_info "Building sandbox-agent image (shared by all variants)..."
+
+if [ "$IS_OPENSHIFT" = "true" ] && oc api-resources --api-group=build.openshift.io 2>/dev/null | grep -q BuildConfig; then
+    # ── OpenShift BuildConfig (preferred — no layer caching) ──
+    log_info "Using OpenShift BuildConfig (Docker strategy, noCache)..."
+
+    # Create ImageStream if it doesn't exist
+    oc create imagestream sandbox-agent -n "$NAMESPACE" 2>/dev/null || true
+
+    # Apply BuildConfig
+    kubectl apply -f "$AGENTS_DIR/sandbox_agent_buildconfig_ocp.yaml"
+
+    # Start build and follow logs
+    log_info "Starting build (this may take a few minutes)..."
+    BUILD_NAME=$(oc start-build sandbox-agent -n "$NAMESPACE" -o name 2>&1) || {
+        log_error "Failed to start build"
+        exit 1
+    }
+    log_info "Build: $BUILD_NAME"
+
+    # Wait for build to complete
+    run_with_timeout 600 "oc wait --for=jsonpath='{.status.phase}'=Complete --timeout=600s $BUILD_NAME -n $NAMESPACE" || {
+        BUILD_PHASE=$(oc get "$BUILD_NAME" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+        if [ "$BUILD_PHASE" = "Complete" ]; then
+            log_info "Build completed (status race condition). Proceeding..."
+        else
+            log_error "Build did not complete (phase: $BUILD_PHASE)"
+            oc logs "$BUILD_NAME" -n "$NAMESPACE" 2>&1 | tail -30 || true
+            exit 1
+        fi
+    }
+    log_success "sandbox-agent image built (OpenShift BuildConfig)"
+
+else
+    # ── Shipwright fallback (non-OpenShift or no Build API) ──
+    log_info "Using Shipwright Build (fallback)..."
+    kubectl delete build sandbox-agent -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+    sleep 2
+    kubectl apply -f "$AGENTS_DIR/sandbox_agent_shipwright_build_ocp.yaml"
+
+    run_with_timeout 60 "kubectl get builds.shipwright.io sandbox-agent -n $NAMESPACE" || {
+        log_error "Shipwright Build not found after 60 seconds"
+        exit 1
+    }
+
+    log_info "Triggering BuildRun..."
+    BUILDRUN_NAME=$(kubectl create -f - -o jsonpath='{.metadata.name}' <<EOF
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+metadata:
+  generateName: sandbox-agent-run-
+  namespace: $NAMESPACE
+spec:
+  build:
+    name: sandbox-agent
+EOF
+    )
+    log_info "BuildRun: $BUILDRUN_NAME"
+
+    log_info "Waiting for build..."
+    run_with_timeout 600 "kubectl wait --for=condition=Succeeded --timeout=600s buildrun/$BUILDRUN_NAME -n $NAMESPACE" || {
+        log_error "BuildRun did not succeed"
+        BUILD_POD=$(kubectl get pods -n "$NAMESPACE" -l build.shipwright.io/name=sandbox-agent --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || echo "")
+        [ -n "$BUILD_POD" ] && kubectl logs -n "$NAMESPACE" "$BUILD_POD" --all-containers=true 2>&1 | tail -30 || true
+        exit 1
+    }
+    log_success "sandbox-agent image built (Shipwright)"
+fi
+
+# ============================================================================
+# Step 3: Deploy all sandbox agent variants
+# ============================================================================
+
+# Each variant is defined by its deployment + service YAML files.
+# All variants use the same sandbox-agent:v0.0.1 image.
+VARIANTS=(
+    "sandbox-agent"
+    "sandbox-legion"
+    "sandbox-hardened"
+    "sandbox-basic"
+    "sandbox-restricted"
+)
+
+for VARIANT in "${VARIANTS[@]}"; do
+    log_info "Deploying $VARIANT..."
+
+    DEPLOYMENT_FILE="$AGENTS_DIR/${VARIANT//-/_}_deployment.yaml"
+    SERVICE_FILE="$AGENTS_DIR/${VARIANT//-/_}_service.yaml"
+
+    if [ ! -f "$DEPLOYMENT_FILE" ]; then
+        log_error "Missing deployment manifest: $DEPLOYMENT_FILE"
+        exit 1
+    fi
+
+    kubectl apply -f "$DEPLOYMENT_FILE"
+    kubectl apply -f "$SERVICE_FILE"
+
+    kubectl wait --for=condition=available --timeout=300s "deployment/$VARIANT" -n "$NAMESPACE" || {
+        log_error "$VARIANT deployment not available"
+        kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=$VARIANT"
+        kubectl describe pods -n "$NAMESPACE" -l "app.kubernetes.io/name=$VARIANT" 2>&1 | tail -20 || true
+        exit 1
+    }
+
+    # Create OpenShift Route with streaming-friendly timeout
+    if [ "$IS_OPENSHIFT" = "true" ]; then
+        log_info "Creating route for $VARIANT..."
+        cat <<EOF | kubectl apply -f -
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: $VARIANT
+  namespace: $NAMESPACE
+  annotations:
+    openshift.io/host.generated: "true"
+    haproxy.router.openshift.io/timeout: 300s
+spec:
+  port:
+    targetPort: 8000
+  to:
+    kind: Service
+    name: $VARIANT
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+EOF
+
+        # Wait for route and agent readiness
+        for i in {1..30}; do
+            ROUTE_HOST=$(oc get route -n "$NAMESPACE" "$VARIANT" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+            if [ -n "$ROUTE_HOST" ]; then
+                log_info "Route: https://$ROUTE_HOST"
+                break
+            fi
+            sleep 2
+        done
+
+        if [ -n "${ROUTE_HOST:-}" ]; then
+            for i in {1..40}; do
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -k --connect-timeout 5 "https://$ROUTE_HOST/.well-known/agent-card.json" 2>/dev/null || echo "000")
+                if [ "$HTTP_CODE" = "200" ]; then
+                    log_success "$VARIANT ready (HTTP 200)"
+                    break
+                fi
+                [ "$i" -lt 40 ] && sleep 3
+            done
+        fi
+    fi
+
+    log_success "$VARIANT deployed"
+done
+
+log_success "All sandbox agents deployed: ${VARIANTS[*]}"

--- a/.github/scripts/kagenti-operator/91-test-litellm.sh
+++ b/.github/scripts/kagenti-operator/91-test-litellm.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Test LiteLLM Proxy
+#
+# Port-forwards to the LiteLLM proxy and runs E2E tests against it.
+# Designed to run as part of the CI/fulltest pipeline or standalone.
+#
+# What it tests:
+#   - LiteLLM health endpoints (readiness, liveliness)
+#   - Model listing via /v1/models
+#   - Chat completions through each configured model
+#   - Virtual key authentication
+#   - Spend tracking (if DB is enabled)
+#
+# Prerequisites:
+#   - LiteLLM proxy deployed (38-deploy-litellm.sh)
+#   - KUBECONFIG set to target cluster
+#
+# Usage:
+#   ./.github/scripts/kagenti-operator/91-test-litellm.sh
+#
+#   # Run only specific tests:
+#   PYTEST_FILTER="test_health" ./.github/scripts/kagenti-operator/91-test-litellm.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+source "$SCRIPT_DIR/../lib/logging.sh"
+source "$SCRIPT_DIR/../lib/k8s-utils.sh"
+
+log_step "91" "Testing LiteLLM Proxy"
+
+NAMESPACE="kagenti-system"
+LITELLM_LOCAL_PORT="${LITELLM_LOCAL_PORT:-14000}"
+
+# ============================================================================
+# Step 1: Verify LiteLLM is deployed
+# ============================================================================
+
+log_info "Checking LiteLLM proxy deployment..."
+if ! kubectl get deployment litellm-proxy -n "$NAMESPACE" &>/dev/null; then
+    log_error "litellm-proxy deployment not found in $NAMESPACE"
+    log_info "Run 38-deploy-litellm.sh first"
+    exit 1
+fi
+
+READY=$(kubectl get deployment litellm-proxy -n "$NAMESPACE" \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+if [ "${READY:-0}" -lt 1 ]; then
+    log_error "litellm-proxy has no ready replicas (ready: ${READY:-0})"
+    kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=litellm-proxy
+    exit 1
+fi
+log_success "litellm-proxy deployment ready"
+
+# ============================================================================
+# Step 2: Read secrets for test configuration
+# ============================================================================
+
+log_info "Reading LiteLLM master key..."
+LITELLM_MASTER_KEY=$(kubectl get secret litellm-proxy-secret -n "$NAMESPACE" \
+    -o jsonpath='{.data.master-key}' | base64 -d)
+
+if [ -z "$LITELLM_MASTER_KEY" ]; then
+    log_error "Could not read master key from litellm-proxy-secret"
+    exit 1
+fi
+
+# Read virtual key for team1 (if exists)
+LITELLM_VIRTUAL_KEY=$(kubectl get secret litellm-virtual-keys -n team1 \
+    -o jsonpath='{.data.api-key}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+
+log_success "Secrets loaded"
+
+# ============================================================================
+# Step 3: Start port-forward
+# ============================================================================
+
+log_info "Starting port-forward to litellm-proxy on localhost:${LITELLM_LOCAL_PORT}..."
+
+# Kill any existing port-forward on this port
+lsof -ti:${LITELLM_LOCAL_PORT} 2>/dev/null | xargs kill 2>/dev/null || true
+sleep 1
+
+kubectl port-forward -n "$NAMESPACE" svc/litellm-proxy \
+    "${LITELLM_LOCAL_PORT}:4000" &>/tmp/litellm-pf.log &
+PF_PID=$!
+
+# Ensure port-forward is cleaned up on exit
+cleanup_pf() {
+    log_info "Cleaning up port-forward (PID: $PF_PID)..."
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup_pf EXIT
+
+# Wait for port-forward to be ready
+log_info "Waiting for port-forward..."
+for i in $(seq 1 15); do
+    if curl -s -o /dev/null -w "%{http_code}" "http://localhost:${LITELLM_LOCAL_PORT}/health/readiness" 2>/dev/null | grep -q "200"; then
+        break
+    fi
+    if ! kill -0 "$PF_PID" 2>/dev/null; then
+        log_error "Port-forward process died. Check /tmp/litellm-pf.log"
+        cat /tmp/litellm-pf.log
+        exit 1
+    fi
+    sleep 2
+done
+
+# Final health check
+HEALTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${LITELLM_LOCAL_PORT}/health/readiness" 2>/dev/null || echo "000")
+if [ "$HEALTH_CODE" != "200" ]; then
+    log_error "LiteLLM not healthy after port-forward (HTTP $HEALTH_CODE)"
+    cat /tmp/litellm-pf.log
+    exit 1
+fi
+log_success "Port-forward active, LiteLLM healthy"
+
+# ============================================================================
+# Step 4: Run pytest E2E tests
+# ============================================================================
+
+log_info "Running LiteLLM E2E tests..."
+
+cd "$REPO_ROOT/kagenti"
+
+# Export test configuration as env vars
+export LITELLM_PROXY_URL="http://localhost:${LITELLM_LOCAL_PORT}"
+export LITELLM_MASTER_KEY
+export LITELLM_VIRTUAL_KEY
+
+# Ensure test dependencies
+if command -v uv &>/dev/null; then
+    PYTEST_CMD="uv run pytest"
+else
+    PYTEST_CMD="pytest"
+fi
+
+PYTEST_TARGETS="tests/e2e/kagenti_operator/test_litellm_proxy.py"
+PYTEST_OPTS="-v --timeout=120 --tb=short"
+
+if [ -n "${PYTEST_FILTER:-}" ]; then
+    PYTEST_OPTS="$PYTEST_OPTS -k \"$PYTEST_FILTER\""
+fi
+
+if [ -n "${PYTEST_ARGS:-}" ]; then
+    PYTEST_OPTS="$PYTEST_OPTS $PYTEST_ARGS"
+fi
+
+log_info "Running: $PYTEST_CMD $PYTEST_TARGETS $PYTEST_OPTS"
+eval "$PYTEST_CMD $PYTEST_TARGETS $PYTEST_OPTS" || {
+    log_error "LiteLLM E2E tests failed"
+    exit 1
+}
+
+log_success "LiteLLM E2E tests passed"

--- a/charts/kagenti-deps/templates/keycloak-realm-init.yaml
+++ b/charts/kagenti-deps/templates/keycloak-realm-init.yaml
@@ -1,0 +1,161 @@
+{{- if .Values.components.keycloak.enabled }}
+{{- $realm := .Values.keycloak.realm | default "demo" }}
+{{- $ns := .Values.keycloak.namespace }}
+{{- /*
+  Keycloak Realm Initialization
+  Creates the demo realm with roles and test users (admin, dev-user, ns-admin).
+
+  Kind:      ConfigMap mounted into Keycloak pod via --import-realm
+  OpenShift: KeycloakRealmImport CR managed by RHBK operator
+
+  NOTE: The UI OAuth client is currently registered in the MASTER realm.
+  These demo realm users are for future use when the backend migrates to
+  the demo realm. For current UI login, run kagenti/auth/create-test-users.sh
+  to create users in the master realm.
+*/ -}}
+
+{{- /* Generate random passwords for demo realm test users */ -}}
+{{- $testUsers := .Values.keycloak.testUsers | default dict }}
+{{- $adminPass := $testUsers.adminPassword | default (randAlphaNum 16) }}
+{{- $devPass := $testUsers.devUserPassword | default (randAlphaNum 16) }}
+{{- $nsAdminPass := $testUsers.nsAdminPassword | default (randAlphaNum 16) }}
+
+{{- if .Values.openshift }}
+---
+# Store test user passwords in a K8s secret so show-services.sh can read them
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kagenti-test-users
+  namespace: {{ $ns }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/resource-policy": keep
+type: Opaque
+stringData:
+  admin-password: {{ $adminPass | quote }}
+  dev-user-password: {{ $devPass | quote }}
+  ns-admin-password: {{ $nsAdminPass | quote }}
+---
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: {{ $realm }}-realm-import
+  namespace: {{ $ns }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "2"
+spec:
+  keycloakCRName: keycloak
+  realm:
+    realm: {{ $realm }}
+    enabled: true
+    registrationAllowed: false
+    roles:
+      realm:
+        - name: admin
+          description: "Platform administrator"
+        - name: developer
+          description: "Developer with namespace-scoped access"
+        - name: ns-admin
+          description: "Namespace administrator"
+    users:
+      - username: admin
+        enabled: true
+        emailVerified: true
+        firstName: Admin
+        lastName: User
+        email: admin@kagenti.local
+        credentials:
+          - type: password
+            value: {{ $adminPass | quote }}
+            temporary: false
+        realmRoles:
+          - admin
+      - username: dev-user
+        enabled: true
+        emailVerified: true
+        firstName: Dev
+        lastName: User
+        email: dev-user@kagenti.local
+        credentials:
+          - type: password
+            value: {{ $devPass | quote }}
+            temporary: false
+        realmRoles:
+          - developer
+      - username: ns-admin
+        enabled: true
+        emailVerified: true
+        firstName: Namespace
+        lastName: Admin
+        email: ns-admin@kagenti.local
+        credentials:
+          - type: password
+            value: {{ $nsAdminPass | quote }}
+            temporary: false
+        realmRoles:
+          - ns-admin
+{{- else }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm-import
+  namespace: {{ $ns }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+    app: keycloak
+data:
+  {{ $realm }}-realm.json: |
+    {
+      "realm": {{ $realm | quote }},
+      "enabled": true,
+      "registrationAllowed": false,
+      "roles": {
+        "realm": [
+          { "name": "admin", "description": "Platform administrator" },
+          { "name": "developer", "description": "Developer with namespace-scoped access" },
+          { "name": "ns-admin", "description": "Namespace administrator" }
+        ]
+      },
+      "users": [
+        {
+          "username": "admin",
+          "enabled": true,
+          "emailVerified": true,
+          "firstName": "Admin",
+          "lastName": "User",
+          "email": "admin@kagenti.local",
+          "credentials": [{ "type": "password", "value": "admin", "temporary": false }],
+          "realmRoles": ["admin"]
+        },
+        {
+          "username": "dev-user",
+          "enabled": true,
+          "emailVerified": true,
+          "firstName": "Dev",
+          "lastName": "User",
+          "email": "dev-user@kagenti.local",
+          "credentials": [{ "type": "password", "value": "dev-user", "temporary": false }],
+          "realmRoles": ["developer"]
+        },
+        {
+          "username": "ns-admin",
+          "enabled": true,
+          "emailVerified": true,
+          "firstName": "Namespace",
+          "lastName": "Admin",
+          "email": "ns-admin@kagenti.local",
+          "credentials": [{ "type": "password", "value": "ns-admin", "temporary": false }],
+          "realmRoles": ["ns-admin"]
+        }
+      ]
+    }
+{{- end }}
+{{- end }}

--- a/charts/kagenti/templates/integration-crd.yaml
+++ b/charts/kagenti/templates/integration-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.featureFlags.integrations }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -144,3 +145,4 @@ spec:
     kind: Integration
     shortNames:
       - intg
+{{- end }}

--- a/charts/kagenti/templates/integration-crd.yaml
+++ b/charts/kagenti/templates/integration-crd.yaml
@@ -1,0 +1,146 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: integrations.kagenti.io
+  labels:
+    app.kubernetes.io/part-of: kagenti
+spec:
+  group: kagenti.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                repository:
+                  type: object
+                  required: [url, provider]
+                  properties:
+                    url:
+                      type: string
+                    provider:
+                      type: string
+                      enum: [github, gitlab, bitbucket]
+                    branch:
+                      type: string
+                      default: main
+                    credentialsSecret:
+                      type: string
+                agents:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, namespace]
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                webhooks:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, events]
+                    properties:
+                      name:
+                        type: string
+                      events:
+                        type: array
+                        items:
+                          type: string
+                      secret:
+                        type: string
+                      filters:
+                        type: object
+                        properties:
+                          branches:
+                            type: array
+                            items:
+                              type: string
+                          actions:
+                            type: array
+                            items:
+                              type: string
+                schedules:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, cron, skill, agent]
+                    properties:
+                      name:
+                        type: string
+                      cron:
+                        type: string
+                      skill:
+                        type: string
+                      agent:
+                        type: string
+                      enabled:
+                        type: boolean
+                        default: true
+                alerts:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, source, agent]
+                    properties:
+                      name:
+                        type: string
+                      source:
+                        type: string
+                        enum: [prometheus, pagerduty]
+                      matchLabels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      agent:
+                        type: string
+            status:
+              type: object
+              properties:
+                webhookUrl:
+                  type: string
+                webhookRegistered:
+                  type: boolean
+                lastWebhookEvent:
+                  type: string
+                lastScheduleRun:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Provider
+          type: string
+          jsonPath: .spec.repository.provider
+        - name: URL
+          type: string
+          jsonPath: .spec.repository.url
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: integrations
+    singular: integration
+    kind: Integration
+    shortNames:
+      - intg

--- a/deployments/litellm/deployment.yaml
+++ b/deployments/litellm/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: litellm
-        # TODO: Build a custom LiteLLM image that relocates Prisma cache from
+        # TODO(#1126): Build custom LiteLLM image to remove anyuid SCC requirement
         # /root/.cache to a non-root path, so we can drop the anyuid SCC.
         image: ghcr.io/berriai/litellm-database:main-v1.63.14-stable
         securityContext:

--- a/deployments/litellm/deployment.yaml
+++ b/deployments/litellm/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: litellm
-        # TODO(#1126): Build custom LiteLLM image to remove anyuid SCC requirement
+        # TODO: Build a custom LiteLLM image that relocates Prisma cache from
         # /root/.cache to a non-root path, so we can drop the anyuid SCC.
         image: ghcr.io/berriai/litellm-database:main-v1.63.14-stable
         securityContext:
@@ -62,7 +62,7 @@ spec:
         - name: STORE_MODEL_IN_DB
           value: "True"
         - name: LITELLM_LOG
-          value: "DEBUG"
+          value: "INFO"
         envFrom:
         - secretRef:
             name: litellm-model-keys

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,11 +50,14 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "http://dockerhost:11434/v1"
+          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
         - name: LLM_API_KEY
-          value: "dummy"
+          valueFrom:
+            secretKeyRef:
+              name: openai-secret
+              key: apikey
         - name: LLM_MODEL
-          value: "qwen2.5:3b"
+          value: "llama-scout-17b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,14 +50,11 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
+          value: "http://dockerhost:11434/v1"
         - name: LLM_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: openai-secret
-              key: apikey
+          value: "dummy"
         - name: LLM_MODEL
-          value: "llama-scout-17b"
+          value: "qwen2.5:3b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:


### PR DESCRIPTION
## Summary
- CI scripts for sandbox agent deployment, LiteLLM, platform image builds
- Helm chart updates: Keycloak realm init, random admin password, container registry
- Ansible installer: post-install tasks, pipeline templates, operator workarounds
- Integration CRD template, expanded RBAC, HyperShift gVisor support

22 files | Part of Sandbox Agent streaming PR series

## Test plan
- [ ] helm template renders cleanly
- [ ] CI scripts run without errors on HyperShift cluster