### PR TITLE
feat: update skills with portable LOG_DIR and sandbox test selectors

### DIFF
--- a/.claude/skills/ci:monitoring/SKILL.md
+++ b/.claude/skills/ci:monitoring/SKILL.md
@@ -12,8 +12,8 @@ Monitor running CI pipelines and report results. Creates task items for each CI 
 **CI log downloads MUST go to files.** Status checks (`gh pr checks`) are small and OK inline.
 
 ```bash
-export LOG_DIR=/tmp/kagenti/ci/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-ci}"
+mkdir -p "$LOG_DIR"
 
 # When downloading logs after completion:
 gh run view <run-id> --log-failed > $LOG_DIR/ci-run-<run-id>.log 2>&1; echo "EXIT:$?"

--- a/.claude/skills/ci:status/SKILL.md
+++ b/.claude/skills/ci:status/SKILL.md
@@ -13,8 +13,8 @@ Check the current CI status for a PR and create task items for any failures.
 `gh run view --log-failed` and artifact downloads MUST redirect:
 
 ```bash
-export LOG_DIR=/tmp/kagenti/ci/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-ci}"
+mkdir -p "$LOG_DIR"
 
 # Small output OK inline:
 gh pr checks <PR-number>

--- a/.claude/skills/github:pr-review/SKILL.md
+++ b/.claude/skills/github:pr-review/SKILL.md
@@ -47,8 +47,8 @@ comments, and posts a GitHub review after user approval.
 PR diffs can be very large. **Always redirect diff output to files and analyze with subagents.**
 
 ```bash
-export LOG_DIR=/tmp/kagenti/review/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-review}"
+mkdir -p "$LOG_DIR"
 ```
 
 Small output OK inline: `gh pr checks`, `gh pr view --json` (metadata only).

--- a/.claude/skills/helm:debug/SKILL.md
+++ b/.claude/skills/helm:debug/SKILL.md
@@ -10,8 +10,8 @@ description: Debug Helm chart issues - template rendering, value overrides, hook
 **Helm template output can be hundreds of lines.** Always redirect to files:
 
 ```bash
-export LOG_DIR=/tmp/kagenti/helm/${WORKTREE:-$(basename $(git rev-parse --show-toplevel))}
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-helm}"
+mkdir -p "$LOG_DIR"
 
 # Redirect helm template output
 helm template kagenti charts/kagenti -n kagenti-system > $LOG_DIR/rendered.yaml 2>&1 && echo "OK" || echo "FAIL"

--- a/.claude/skills/kagenti:deploy/SKILL.md
+++ b/.claude/skills/kagenti:deploy/SKILL.md
@@ -12,8 +12,8 @@ This skill guides you through deploying or redeploying the Kagenti Kind cluster 
 **Deploy scripts produce hundreds of lines.** Always redirect to files:
 
 ```bash
-export LOG_DIR=/tmp/kagenti/deploy/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-deploy}"
+mkdir -p "$LOG_DIR"
 
 # Pattern: redirect deploy output
 ./.github/scripts/local-setup/kind-full-test.sh ... > $LOG_DIR/deploy.log 2>&1; echo "EXIT:$?"

--- a/.claude/skills/kagenti:operator/SKILL.md
+++ b/.claude/skills/kagenti:operator/SKILL.md
@@ -12,8 +12,8 @@ Deploy and manage Kagenti operator, agents, and tools on Kubernetes clusters.
 **Deploy/build commands produce large output.** Always redirect to files:
 
 ```bash
-export LOG_DIR=/tmp/kagenti/deploy/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-deploy}"
+mkdir -p "$LOG_DIR"
 
 # Pattern: redirect build/deploy output
 command > $LOG_DIR/<name>.log 2>&1; echo "EXIT:$?"

--- a/.claude/skills/rca/SKILL.md
+++ b/.claude/skills/rca/SKILL.md
@@ -37,8 +37,8 @@ the main conversation context.
 
 ```bash
 # Session-scoped log directory
-export LOG_DIR=/tmp/kagenti/rca/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-rca}"
+mkdir -p "$LOG_DIR"
 ```
 
 **Rules:**

--- a/.claude/skills/rca:ci/SKILL.md
+++ b/.claude/skills/rca:ci/SKILL.md
@@ -14,8 +14,9 @@ can dump thousands of lines into context. ALL CI log analysis MUST happen in sub
 
 ```bash
 # Session-scoped log directory
-export LOG_DIR=/tmp/kagenti/rca/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+# Works in both Claude Code (local) and sandbox agent (container)
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-rca}"
+mkdir -p "$LOG_DIR"
 ```
 
 **Rules:**
@@ -209,11 +210,32 @@ Escalate when:
 rca:ci inconclusive? → Create cluster → rca:hypershift
 ```
 
+## gh CLI Flag Reference (use ONLY these — do NOT invent flags)
+
+### `gh run list`
+Valid: `--branch <name>`, `--status <state>`, `--event <type>`, `--limit <n>`,
+       `--workflow <name>`, `--json <fields>`, `--commit <sha>`
+INVALID (do NOT use): `--head`, `--head-ref`, `--pr`, `--pull-request`
+To filter by PR: use `gh pr checks <pr-number>` or `--branch <pr-branch-name>`
+
+### `gh run view <run_id>`
+Valid: `--log`, `--log-failed`, `--job <id>`, `--web`
+Always redirect large output: `gh run view <id> --log-failed > $LOG_DIR/ci.log`
+
+### `gh pr`
+- `gh pr checks <number>` — CI status for a specific PR
+- `gh pr view <number> --json checks` — JSON CI check data
+- `gh pr list --state open|closed|merged`
+
+### If a flag fails
+Run `gh <command> --help` to see valid flags. Do NOT guess.
+
 ## Quick Reference
 
 | Task | Command |
 |------|---------|
-| List failed runs | `gh run list --status failure` |
+| List failed runs | `gh run list --status failure --limit 5` |
+| CI for specific PR | `gh pr checks <pr-number>` |
 | View failed logs | `gh run view <id> --log-failed` |
 | Download artifacts | `gh run download <id>` |
 | Open in browser | `gh run view <id> --web` |

--- a/.claude/skills/rca:kind/SKILL.md
+++ b/.claude/skills/rca:kind/SKILL.md
@@ -12,8 +12,8 @@ Root cause analysis workflow for failures on local Kind clusters.
 **All diagnostic commands MUST redirect output to files.**
 
 ```bash
-export LOG_DIR=/tmp/kagenti/rca/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-rca}"
+mkdir -p "$LOG_DIR"
 ```
 
 **Rules:**

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -320,8 +320,8 @@ and being re-read on every subsequent turn.
 
 ```bash
 # Session-scoped log directory — ALWAYS set before running commands
-export LOG_DIR=/tmp/kagenti/tdd/$WORKTREE   # or $(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-tdd}"
+mkdir -p "$LOG_DIR"
 ```
 
 **Rules:**

--- a/.claude/skills/tdd:ci/SKILL.md
+++ b/.claude/skills/tdd:ci/SKILL.md
@@ -34,8 +34,8 @@ Iterative development workflow using CI as the test environment. Commit changes,
 
 ```bash
 # Session-scoped log directory — use worktree name to avoid collisions
-export LOG_DIR=/tmp/kagenti/tdd/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-tdd}"
+mkdir -p "$LOG_DIR"
 ```
 
 ### Key Patterns
@@ -490,7 +490,7 @@ After **3+ failed CI iterations**, consider switching to `tdd:hypershift` for re
 
 ```bash
 # Check if cluster exists for current worktree
-WORKTREE=$(basename $(git rev-parse --show-toplevel))
+WORKTREE=$(basename "${WORKSPACE_DIR:-$(pwd)}")
 ls ~/clusters/hcp/kagenti-hypershift-custom-*/auth/kubeconfig 2>/dev/null
 ```
 

--- a/.claude/skills/tdd:ci/SKILL.md
+++ b/.claude/skills/tdd:ci/SKILL.md
@@ -33,7 +33,8 @@ Iterative development workflow using CI as the test environment. Commit changes,
 **Every command that produces more than ~5 lines of output MUST redirect to a file.**
 
 ```bash
-# Session-scoped log directory — use worktree name to avoid collisions
+# Session-scoped log directory — use worktree/repo name to avoid collisions
+# For parallel worktree sessions, pre-set LOG_DIR to a unique path
 export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-tdd}"
 mkdir -p "$LOG_DIR"
 ```
@@ -490,7 +491,7 @@ After **3+ failed CI iterations**, consider switching to `tdd:hypershift` for re
 
 ```bash
 # Check if cluster exists for current worktree
-WORKTREE=$(basename "${WORKSPACE_DIR:-$(pwd)}")
+WORKTREE=$(basename "${WORKSPACE_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}")
 ls ~/clusters/hcp/kagenti-hypershift-custom-*/auth/kubeconfig 2>/dev/null
 ```
 

--- a/.claude/skills/tdd:kind/SKILL.md
+++ b/.claude/skills/tdd:kind/SKILL.md
@@ -101,8 +101,8 @@ This gate runs once per session, not on every iteration.
 
 ```bash
 # Session-scoped log directory — use worktree name to avoid collisions
-export LOG_DIR=/tmp/kagenti/tdd/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-tdd}"
+mkdir -p "$LOG_DIR"
 ```
 
 ### Log Analysis Rule

--- a/.claude/skills/tdd:ui-hypershift/SKILL.md
+++ b/.claude/skills/tdd:ui-hypershift/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: tdd:ui-hypershift
+description: Rapid UI/backend iteration on HyperShift — edit, build, deploy, Playwright test in under 3 minutes
+---
+
+# TDD UI+Backend on HyperShift
+
+Fast iteration loop for Kagenti UI and backend development on a live HyperShift cluster.
+Covers the full cycle: edit → commit → push → build → rollout → Playwright test.
+
+## When to Use
+
+- Fixing UI rendering bugs (SandboxPage, ChatBubble, etc.)
+- Fixing backend API issues (sandbox_deploy, chat streaming)
+- Adding new UI features and testing on live cluster
+- Iterating on Playwright E2E tests
+
+## Setup (once per session)
+
+```bash
+# Cluster config
+export CLUSTER=sbox42
+export MANAGED_BY_TAG=kagenti-team
+export KUBECONFIG=~/clusters/hcp/${MANAGED_BY_TAG}-${CLUSTER}/auth/kubeconfig
+export LOG_DIR=/tmp/kagenti/tdd/ui-${CLUSTER}
+mkdir -p $LOG_DIR
+
+# Keycloak password (stored in K8s secret, not hardcoded)
+export KEYCLOAK_PASSWORD=$(kubectl -n keycloak get secret kagenti-test-users \
+  -o jsonpath='{.data.admin-password}' | base64 -d)
+
+# UI URL from OpenShift route
+export KAGENTI_UI_URL="https://$(kubectl get route kagenti-ui -n kagenti-system \
+  -o jsonpath='{.spec.host}')"
+
+# Working directory
+cd .worktrees/sandbox-agent/kagenti/ui-v2
+```
+
+## Iteration Levels (fastest first)
+
+### Level 0: Test-only change (~30s)
+
+Test file changed, no build needed:
+
+```bash
+KUBECONFIG=$KUBECONFIG KAGENTI_UI_URL=$KAGENTI_UI_URL \
+  KEYCLOAK_USER=admin KEYCLOAK_PASSWORD=$KEYCLOAK_PASSWORD \
+  npx playwright test e2e/<spec>.spec.ts --reporter=list \
+  > $LOG_DIR/test.log 2>&1; echo "EXIT:$?"
+```
+
+### Level 1: UI-only change (~2min)
+
+Frontend code changed (components, pages, styles):
+
+```bash
+# 1. Commit + push
+git add -u && git commit -s -m "fix(ui): <description>" && git push
+
+# 2. Build UI image (~90s)
+oc -n kagenti-system start-build kagenti-ui > $LOG_DIR/ui-build.log 2>&1
+# Poll until complete:
+while ! oc -n kagenti-system get build kagenti-ui-$(oc -n kagenti-system get bc kagenti-ui -o jsonpath='{.status.lastVersion}') -o jsonpath='{.status.phase}' 2>/dev/null | grep -qE 'Complete|Failed'; do sleep 10; done
+echo "Build: $(oc -n kagenti-system get build kagenti-ui-$(oc -n kagenti-system get bc kagenti-ui -o jsonpath='{.status.lastVersion}') -o jsonpath='{.status.phase}')"
+
+# 3. Rollout (~15s)
+oc -n kagenti-system rollout restart deploy/kagenti-ui
+oc -n kagenti-system rollout status deploy/kagenti-ui --timeout=60s
+
+# 4. Test
+npx playwright test e2e/<spec>.spec.ts --reporter=list > $LOG_DIR/test.log 2>&1; echo "EXIT:$?"
+```
+
+### Level 2: Backend-only change (~90s)
+
+Backend Python code changed (routers, services):
+
+```bash
+# 1. Commit + push
+git add -u && git commit -s -m "fix(backend): <description>" && git push
+
+# 2. Build backend image (~30s — Python, no npm)
+oc -n kagenti-system start-build kagenti-backend > $LOG_DIR/be-build.log 2>&1
+# Wait for completion (same polling pattern as UI)
+
+# 3. Rollout
+oc -n kagenti-system rollout restart deploy/kagenti-backend
+oc -n kagenti-system rollout status deploy/kagenti-backend --timeout=90s
+
+# 4. Test
+npx playwright test e2e/<spec>.spec.ts --reporter=list > $LOG_DIR/test.log 2>&1; echo "EXIT:$?"
+```
+
+### Level 3: Both UI + backend (~3min)
+
+```bash
+git add -u && git commit -s -m "fix: <description>" && git push
+
+# Build both in parallel
+oc -n kagenti-system start-build kagenti-backend &
+oc -n kagenti-system start-build kagenti-ui &
+wait
+# Poll both until complete, then:
+
+oc -n kagenti-system rollout restart deploy/kagenti-backend deploy/kagenti-ui
+oc -n kagenti-system rollout status deploy/kagenti-backend --timeout=90s
+oc -n kagenti-system rollout status deploy/kagenti-ui --timeout=90s
+
+# Test
+npx playwright test e2e/<spec>.spec.ts --reporter=list > $LOG_DIR/test.log 2>&1; echo "EXIT:$?"
+```
+
+## Common Patterns
+
+### Agent cleanup before test
+
+```bash
+oc -n team1 delete deploy ${AGENT_NAME} --ignore-not-found
+oc -n team1 delete svc ${AGENT_NAME} --ignore-not-found
+```
+
+### Check pod crash reason
+
+```bash
+oc -n kagenti-system logs deploy/kagenti-backend -c backend --tail=20
+oc -n team1 describe pod -l app.kubernetes.io/name=${AGENT_NAME} | grep -A5 "Events\|Error"
+```
+
+### Build failure diagnosis
+
+```bash
+oc -n kagenti-system logs build/kagenti-ui-$(oc -n kagenti-system get bc kagenti-ui -o jsonpath='{.status.lastVersion}') | tail -20
+```
+
+### SPA routing for session reload (Keycloak redirect workaround)
+
+In Playwright tests, navigating to `/sandbox?session=<id>` via `page.goto()` triggers
+Keycloak re-auth which redirects to `/`. Use SPA routing instead:
+
+```typescript
+// Login first on /
+await page.goto('/');
+await loginIfNeeded(page);
+// Then SPA-navigate (no full page reload, no Keycloak redirect)
+await page.evaluate((sid) => {
+  window.history.pushState({}, '', `/sandbox?session=${sid}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}, sessionId);
+```
+
+## Checklist
+
+Before each iteration:
+- [ ] Changes committed and pushed (build configs pull from git)
+- [ ] Correct KUBECONFIG exported
+- [ ] KEYCLOAK_PASSWORD refreshed (passwords rotate)
+- [ ] Previous test agent cleaned up (if applicable)
+
+After green tests:
+- [ ] Push final commit
+- [ ] Run full suite: `npx playwright test --reporter=list`
+- [ ] Check for regressions in other spec files
+
+## Related Skills
+
+- `test:ui` — Playwright test writing patterns and selectors
+- `tdd:hypershift` — Python E2E tests via hypershift-full-test.sh
+- `kagenti:ui-debug` — Debug 502s, proxy issues, auth problems
+- `k8s:live-debugging` — Debug pods, logs, configs on live cluster

--- a/.claude/skills/tdd:ui-hypershift/SKILL.md
+++ b/.claude/skills/tdd:ui-hypershift/SKILL.md
@@ -22,8 +22,8 @@ Covers the full cycle: edit → commit → push → build → rollout → Playwr
 export CLUSTER=sbox42
 export MANAGED_BY_TAG=kagenti-team
 export KUBECONFIG=~/clusters/hcp/${MANAGED_BY_TAG}-${CLUSTER}/auth/kubeconfig
-export LOG_DIR=/tmp/kagenti/tdd/ui-${CLUSTER}
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-/tmp/kagenti/tdd/ui-${CLUSTER}}"
+mkdir -p "$LOG_DIR"
 
 # Keycloak password (stored in K8s secret, not hardcoded)
 export KEYCLOAK_PASSWORD=$(kubectl -n keycloak get secret kagenti-test-users \
@@ -34,7 +34,7 @@ export KAGENTI_UI_URL="https://$(kubectl get route kagenti-ui -n kagenti-system 
   -o jsonpath='{.spec.host}')"
 
 # Working directory
-cd .worktrees/sandbox-agent/kagenti/ui-v2
+cd "${WORKTREE_DIR:-.worktrees/sandbox-agent}"/kagenti/ui-v2
 ```
 
 ## Iteration Levels (fastest first)

--- a/.claude/skills/test:run-kind/SKILL.md
+++ b/.claude/skills/test:run-kind/SKILL.md
@@ -12,8 +12,8 @@ description: Run E2E tests on local Kind cluster
 **Test output MUST go to files.** Test runs produce hundreds of lines.
 
 ```bash
-export LOG_DIR=/tmp/kagenti/tdd/$(basename $(git rev-parse --show-toplevel))
-mkdir -p $LOG_DIR
+export LOG_DIR="${LOG_DIR:-${WORKSPACE_DIR:-/tmp}/kagenti-tdd}"
+mkdir -p "$LOG_DIR"
 
 # Pattern: redirect test output
 command > $LOG_DIR/test-run.log 2>&1; echo "EXIT:$?"

--- a/.claude/skills/test:ui-sandbox/SKILL.md
+++ b/.claude/skills/test:ui-sandbox/SKILL.md
@@ -96,7 +96,8 @@ await page.evaluate((s) => {
   window.history.pushState({}, '', `/sandbox?session=${s}`);
   window.dispatchEvent(new PopStateEvent('popstate'));
 }, sid);
-await page.waitForTimeout(5000);
+// pushState triggers sync React re-render — no DOM indicator to await
+    await page.waitForTimeout(5000);
 ```
 
 ## History Loading (toMessage conversion)

--- a/.claude/skills/test:ui-sandbox/SKILL.md
+++ b/.claude/skills/test:ui-sandbox/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: test:ui-sandbox
+description: Playwright selector patterns for sandbox agent chat — proven selectors for sessions, agents, messages, tool calls
+---
+
+# Sandbox UI Test Patterns
+
+Proven Playwright selectors and patterns for testing the Kagenti sandbox agent chat UI.
+Based on 20+ iterations of debugging on live HyperShift clusters.
+
+## Agent Selection
+
+```typescript
+// Select an agent in the Sandboxes sidebar (proven pattern from sandbox-variants)
+const agentEntry = page.locator('div[role="button"]').filter({
+  hasText: agentName,
+}).filter({
+  hasText: /session/i,  // Agents show "N sessions" text
+});
+await expect(agentEntry.first()).toBeVisible({ timeout: 30000 });
+await agentEntry.first().click();
+```
+
+## Chat Input
+
+```typescript
+// Message input (SandboxPage)
+const input = page.locator('textarea[aria-label="Message input"]');
+await input.fill('my message');
+await input.press('Enter');  // Enter sends (not click Send button)
+
+// Or via Send button
+await page.getByRole('button', { name: /Send/i }).click();
+```
+
+## Agent Response Detection
+
+The agent may respond with **text** (`.sandbox-markdown`) or **tool calls** (ToolCallStep divs).
+Always check for both:
+
+```typescript
+// Wait for ANY agent output (text or tool calls)
+const agentOutput = page.locator('.sandbox-markdown')
+  .or(page.locator('text=/Tool Call:|Result:/i'));
+await expect(agentOutput.first()).toBeVisible({ timeout: 180000 });
+
+// Count each type
+const mdCount = await page.locator('.sandbox-markdown').count();
+const toolCount = await page.locator('text=/Tool Call:|Result:/i').count();
+```
+
+### .sandbox-markdown
+
+Renders for assistant messages with text content (not tool calls):
+```html
+<div class="sandbox-markdown">
+  <ReactMarkdown>response text here</ReactMarkdown>
+</div>
+```
+
+### ToolCallStep
+
+Renders for tool_call and tool_result events. Uses `<div>` with click handler, NOT `<details>`:
+```html
+<div style="border-left: 3px solid ...">
+  <div style="font-weight: 600">▶ Tool Call: web_fetch</div>
+</div>
+```
+
+Selector: `page.locator('text=/Tool Call:|Result:/i')`
+
+## Session URL & Navigation
+
+### Capture session URL from test 3 for reuse in tests 4-6:
+```typescript
+let sessionUrl: string | null = null;
+
+// After sending message and getting response:
+sessionUrl = page.url();
+// URL format: /sandbox?session=<context_id>
+```
+
+### Navigate to session (avoiding Keycloak re-auth redirect):
+
+**WRONG** — triggers full page load through Keycloak, redirects to `/`:
+```typescript
+await page.goto(sessionUrl); // Keycloak redirects to /
+```
+
+**RIGHT** — SPA routing via pushState:
+```typescript
+await page.goto('/');
+await loginIfNeeded(page);
+const sid = sessionUrl.match(/session=([a-f0-9]+)/)?.[1];
+await page.evaluate((s) => {
+  window.history.pushState({}, '', `/sandbox?session=${s}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}, sid);
+await page.waitForTimeout(5000);
+```
+
+## History Loading (toMessage conversion)
+
+When a session reloads from history, the backend's paginated history API converts
+agent messages into `kind: "data"` parts. The frontend `toMessage()` function
+must distinguish tool calls from text:
+
+- `kind: "data"` + `type: "tool_call"` → renders as ToolCallStep
+- `kind: "data"` + `type: "tool_result"` → renders as ToolCallStep
+- `kind: "data"` + `type: "llm_response"` → should render as .sandbox-markdown
+- `kind: "text"` → always renders as .sandbox-markdown
+
+## Known Issues
+
+1. **rca-agent shows "0 sessions"** — sessions not tagged with agent name in metadata
+2. **TOFU PermissionError** — agent Dockerfile needs `chmod g+w /app` for OCP arbitrary UID
+3. **SSE rendering flaky** — `.sandbox-markdown` sometimes doesn't appear during streaming
+   (tool calls render, but final text may not). Workaround: poll with retry.
+
+## Test Structure for Serial Agent Tests
+
+```typescript
+test.describe('Agent Workflow', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(300000);
+  let sessionUrl: string | null = null;
+
+  test.beforeAll(() => { /* cleanup agent */ });
+
+  test('1 — deploy', async ({ page }) => { /* wizard + patch */ });
+  test('2 — verify card', async ({ page }) => { /* kubectl exec httpx */ });
+  test('3 — send message', async ({ page }) => {
+    // ... send and wait for response ...
+    sessionUrl = page.url();
+  });
+  test('4 — reload session', async ({ page }) => {
+    // Login first, then SPA-navigate to sessionUrl
+  });
+});
+```


### PR DESCRIPTION
## Summary
- Update LOG_DIR pattern across 12 skills to portable env-based defaults
- Add tdd:ui-hypershift skill for rapid UI/backend iteration
- Add test:ui-sandbox skill with proven Playwright selectors
- Update rca:ci with gh CLI flag reference

15 files | Part of Sandbox Agent streaming PR series