### PR TITLE
feat: add sandbox, integration, and analytics API routes

### DIFF
--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -345,17 +345,15 @@ async def _stream_a2a_response(
 
                         try:
                             chunk = json.loads(data)
-                            logger.info(f"Parsed chunk keys: {list(chunk.keys())}")
-                            if "result" in chunk:
-                                logger.info(f"Result keys: {list(chunk['result'].keys())}")
 
-                            # Fan out event to sidecar manager
-                            try:
-                                from app.services.sidecar_manager import get_sidecar_manager
+                            # Fan out event to sidecars (only when sandbox flag is on)
+                            if settings.kagenti_feature_flag_sidecars:
+                                try:
+                                    from app.services.sidecar_manager import get_sidecar_manager
 
-                                get_sidecar_manager().fan_out_event(session_id, chunk)
-                            except Exception:
-                                pass  # Sidecar fan-out is best-effort
+                                    get_sidecar_manager().fan_out_event(session_id, chunk)
+                                except Exception:
+                                    logger.debug("Sidecar fan-out failed", exc_info=True)
 
                             if "result" not in chunk:
                                 logger.info("Skipping chunk - no 'result' field")

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -61,18 +61,6 @@ class ChatResponse(BaseModel):
     username: Optional[str] = None
 
 
-def _get_agent_url_with_port(name: str, namespace: str, port: int = 8080) -> str:
-    """Get agent URL with custom port (for sandbox agents on port 8000).
-
-    For standard agents, use get_agent_url() from app.utils.routes instead.
-    """
-    if settings.is_running_in_cluster:
-        return f"http://{name}.{namespace}.svc.cluster.local:{port}"
-    else:
-        domain = settings.domain_name
-        return f"http://{name}.{namespace}.{domain}:{port}"
-
-
 @router.get(
     "/{namespace}/{name}/agent-card",
     response_model=AgentCardResponse,
@@ -85,23 +73,15 @@ async def get_agent_card(
     Fetch the A2A agent card for an agent.
 
     The agent card describes the agent's capabilities, skills, and metadata.
+    All agents (including sandbox) go through AuthBridge on port 8080.
     """
-    # Try port 8080 first (AuthBridge agents), fallback to 8000 (direct agents)
-    # TODO: discover port from K8s Service spec
     agent_url = get_agent_url(name, namespace)
     card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            try:
-                response = await client.get(card_url)
-                response.raise_for_status()
-            except (httpx.ConnectError, httpx.HTTPStatusError):
-                # Fallback to port 8000 (sandbox agents without AuthBridge)
-                agent_url = _get_agent_url_with_port(name, namespace, port=8000)
-                card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
-                response = await client.get(card_url)
-                response.raise_for_status()
+            response = await client.get(card_url)
+            response.raise_for_status()
             card_data = response.json()
 
             # Parse capabilities
@@ -170,7 +150,6 @@ async def send_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    # TODO: discover port from K8s Service. Try 8080 (AuthBridge), fallback 8000 (direct)
     agent_url = get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 
@@ -537,7 +516,6 @@ async def stream_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    # TODO: discover port from K8s Service. Try 8080 (AuthBridge), fallback 8000 (direct)
     agent_url = get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -16,9 +16,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from app.core.auth import require_roles, ROLE_VIEWER, ROLE_OPERATOR
+from app.core.auth import require_roles, get_required_user, ROLE_VIEWER, ROLE_OPERATOR, TokenData
 from app.core.config import settings
-from app.utils.routes import get_agent_url
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -58,12 +57,31 @@ class ChatResponse(BaseModel):
     content: str
     session_id: str
     is_complete: bool = True
+    username: Optional[str] = None
+
+
+def _get_agent_url(name: str, namespace: str, port: int = 8080) -> str:
+    """Get the URL for an A2A agent.
+
+    Returns different URL formats based on deployment context:
+    - In-cluster: http://{name}.{namespace}.svc.cluster.local:{port}
+    - Off-cluster (local dev): http://{name}.{namespace}.{domain}:{port}
+
+    TODO: Port should be discovered from the K8s Service spec instead of
+    hardcoded. Agents deployed via the wizard use port 8000 (direct),
+    while agents with AuthBridge sidecar use port 8080 (envoy proxy).
+    The proper fix is to query the Service port for the agent name.
+    """
+    if settings.is_running_in_cluster:
+        return f"http://{name}.{namespace}.svc.cluster.local:{port}"
+    else:
+        domain = settings.domain_name
+        return f"http://{name}.{namespace}.{domain}:{port}"
 
 
 @router.get(
     "/{namespace}/{name}/agent-card",
     response_model=AgentCardResponse,
-    dependencies=[Depends(require_roles(ROLE_VIEWER))],
 )
 async def get_agent_card(
     namespace: str,
@@ -74,13 +92,22 @@ async def get_agent_card(
 
     The agent card describes the agent's capabilities, skills, and metadata.
     """
-    agent_url = get_agent_url(name, namespace)
+    # Try port 8080 first (AuthBridge agents), fallback to 8000 (direct agents)
+    # TODO: discover port from K8s Service spec
+    agent_url = _get_agent_url(name, namespace, port=8080)
     card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(card_url)
-            response.raise_for_status()
+            try:
+                response = await client.get(card_url)
+                response.raise_for_status()
+            except (httpx.ConnectError, httpx.HTTPStatusError):
+                # Fallback to port 8000 (sandbox agents without AuthBridge)
+                agent_url = _get_agent_url(name, namespace, port=8000)
+                card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
+                response = await client.get(card_url)
+                response.raise_for_status()
             card_data = response.json()
 
             # Parse capabilities
@@ -138,6 +165,7 @@ async def send_message(
     name: str,
     request: ChatRequest,
     http_request: Request,
+    user: TokenData = Depends(get_required_user),
 ) -> ChatResponse:
     """
     Send a message to an A2A agent and get the response.
@@ -148,7 +176,8 @@ async def send_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    agent_url = get_agent_url(name, namespace)
+    # TODO: discover port from K8s Service. Try 8080 (AuthBridge), fallback 8000 (direct)
+    agent_url = _get_agent_url(name, namespace, port=8080)
     session_id = request.session_id or uuid4().hex
 
     # Build A2A message payload
@@ -208,6 +237,7 @@ async def send_message(
                 content=content or "No response from agent",
                 session_id=session_id,
                 is_complete=True,
+                username=user.username,
             )
 
     except httpx.HTTPStatusError as e:
@@ -276,7 +306,11 @@ def _extract_text_from_parts(parts: list) -> str:
 
 
 async def _stream_a2a_response(
-    agent_url: str, message: str, session_id: str, authorization: Optional[str] = None
+    agent_url: str,
+    message: str,
+    session_id: str,
+    authorization: Optional[str] = None,
+    username: Optional[str] = None,
 ):
     """Generator for streaming A2A responses with event metadata."""
     import json
@@ -329,7 +363,10 @@ async def _stream_a2a_response(
                         data = line[6:]
                         if data == "[DONE]":
                             logger.info("Received [DONE] signal from agent")
-                            yield f"data: {json.dumps({'done': True, 'session_id': session_id})}\n\n"
+                            done_payload = {"done": True, "session_id": session_id}
+                            if username:
+                                done_payload["username"] = username
+                            yield f"data: {json.dumps(done_payload)}\n\n"
                             break
 
                         try:
@@ -338,12 +375,22 @@ async def _stream_a2a_response(
                             if "result" in chunk:
                                 logger.info(f"Result keys: {list(chunk['result'].keys())}")
 
+                            # Fan out event to sidecar manager
+                            try:
+                                from app.services.sidecar_manager import get_sidecar_manager
+
+                                get_sidecar_manager().fan_out_event(session_id, chunk)
+                            except Exception:
+                                pass  # Sidecar fan-out is best-effort
+
                             if "result" not in chunk:
                                 logger.info("Skipping chunk - no 'result' field")
                                 continue
 
                             result = chunk["result"]
                             payload = {"session_id": session_id}
+                            if username:
+                                payload["username"] = username
 
                             # TaskArtifactUpdateEvent
                             if "artifact" in result:
@@ -381,8 +428,16 @@ async def _stream_a2a_response(
                                     parts = status["message"].get("parts", [])
                                     status_message = _extract_text_from_parts(parts)
 
+                                # Detect HITL (Human-in-the-Loop) requests
+                                event_type = "status"
+                                if state == "INPUT_REQUIRED":
+                                    event_type = "hitl_request"
+                                    logger.info(
+                                        f"HITL request detected: taskId={result.get('taskId')}"
+                                    )
+
                                 payload["event"] = {
-                                    "type": "status",
+                                    "type": event_type,
                                     "taskId": result.get("taskId", ""),
                                     "state": state,
                                     "final": is_final,
@@ -477,6 +532,7 @@ async def stream_message(
     name: str,
     request: ChatRequest,
     http_request: Request,
+    user: TokenData = Depends(get_required_user),
 ):
     """
     Send a message to an A2A agent and stream the response.
@@ -487,14 +543,15 @@ async def stream_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    agent_url = get_agent_url(name, namespace)
+    # TODO: discover port from K8s Service. Try 8080 (AuthBridge), fallback 8000 (direct)
+    agent_url = _get_agent_url(name, namespace, port=8080)
     session_id = request.session_id or uuid4().hex
 
     # Extract Authorization header if present
     authorization = http_request.headers.get("Authorization")
 
     return StreamingResponse(
-        _stream_a2a_response(agent_url, request.message, session_id, authorization),
+        _stream_a2a_response(agent_url, request.message, session_id, authorization, user.username),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from app.core.auth import require_roles, get_required_user, ROLE_VIEWER, ROLE_OPERATOR, TokenData
 from app.core.config import settings
+from app.utils.routes import get_agent_url
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -60,17 +61,10 @@ class ChatResponse(BaseModel):
     username: Optional[str] = None
 
 
-def _get_agent_url(name: str, namespace: str, port: int = 8080) -> str:
-    """Get the URL for an A2A agent.
+def _get_agent_url_with_port(name: str, namespace: str, port: int = 8080) -> str:
+    """Get agent URL with custom port (for sandbox agents on port 8000).
 
-    Returns different URL formats based on deployment context:
-    - In-cluster: http://{name}.{namespace}.svc.cluster.local:{port}
-    - Off-cluster (local dev): http://{name}.{namespace}.{domain}:{port}
-
-    TODO: Port should be discovered from the K8s Service spec instead of
-    hardcoded. Agents deployed via the wizard use port 8000 (direct),
-    while agents with AuthBridge sidecar use port 8080 (envoy proxy).
-    The proper fix is to query the Service port for the agent name.
+    For standard agents, use get_agent_url() from app.utils.routes instead.
     """
     if settings.is_running_in_cluster:
         return f"http://{name}.{namespace}.svc.cluster.local:{port}"
@@ -94,7 +88,7 @@ async def get_agent_card(
     """
     # Try port 8080 first (AuthBridge agents), fallback to 8000 (direct agents)
     # TODO: discover port from K8s Service spec
-    agent_url = _get_agent_url(name, namespace, port=8080)
+    agent_url = get_agent_url(name, namespace)
     card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
 
     try:
@@ -104,7 +98,7 @@ async def get_agent_card(
                 response.raise_for_status()
             except (httpx.ConnectError, httpx.HTTPStatusError):
                 # Fallback to port 8000 (sandbox agents without AuthBridge)
-                agent_url = _get_agent_url(name, namespace, port=8000)
+                agent_url = _get_agent_url_with_port(name, namespace, port=8000)
                 card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
                 response = await client.get(card_url)
                 response.raise_for_status()
@@ -177,7 +171,7 @@ async def send_message(
     authenticated requests.
     """
     # TODO: discover port from K8s Service. Try 8080 (AuthBridge), fallback 8000 (direct)
-    agent_url = _get_agent_url(name, namespace, port=8080)
+    agent_url = get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 
     # Build A2A message payload
@@ -544,7 +538,7 @@ async def stream_message(
     authenticated requests.
     """
     # TODO: discover port from K8s Service. Try 8080 (AuthBridge), fallback 8000 (direct)
-    agent_url = _get_agent_url(name, namespace, port=8080)
+    agent_url = get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 
     # Extract Authorization header if present

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -64,6 +64,7 @@ class ChatResponse(BaseModel):
 @router.get(
     "/{namespace}/{name}/agent-card",
     response_model=AgentCardResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
 )
 async def get_agent_card(
     namespace: str,

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -74,7 +74,7 @@ async def get_agent_card(
     Fetch the A2A agent card for an agent.
 
     The agent card describes the agent's capabilities, skills, and metadata.
-    All agents (including sandbox) go through AuthBridge on port 8080.
+    All agents are reached via their cluster-internal URL through AuthBridge.
     """
     agent_url = get_agent_url(name, namespace)
     card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
@@ -324,19 +324,26 @@ async def _stream_a2a_response(
                 headers=headers,
             ) as response:
                 response.raise_for_status()
-                logger.info(f"Connected to agent, status={response.status_code}")
+                logger.debug("Connected to agent, status=%d", response.status_code)
+
+                # Resolve sidecar manager once before the loop (not per-chunk)
+                _sidecar_mgr = None
+                if getattr(settings, "kagenti_feature_flag_sidecars", False):
+                    try:
+                        from app.services.sidecar_manager import get_sidecar_manager
+
+                        _sidecar_mgr = get_sidecar_manager()
+                    except ImportError:
+                        pass
 
                 async for line in response.aiter_lines():
                     if not line:
                         continue
 
-                    logger.info(f"Received line from agent: {line[:300]}")
-
                     # Parse SSE format
                     if line.startswith("data: "):
                         data = line[6:]
                         if data == "[DONE]":
-                            logger.info("Received [DONE] signal from agent")
                             done_payload = {"done": True, "session_id": session_id}
                             if username:
                                 done_payload["username"] = username
@@ -346,17 +353,14 @@ async def _stream_a2a_response(
                         try:
                             chunk = json.loads(data)
 
-                            # Fan out event to sidecars (only when sandbox flag is on)
-                            if settings.kagenti_feature_flag_sidecars:
+                            # Fan out event to sidecars (resolved once above)
+                            if _sidecar_mgr is not None:
                                 try:
-                                    from app.services.sidecar_manager import get_sidecar_manager
-
-                                    get_sidecar_manager().fan_out_event(session_id, chunk)
+                                    _sidecar_mgr.fan_out_event(session_id, chunk)
                                 except Exception:
                                     logger.debug("Sidecar fan-out failed", exc_info=True)
 
                             if "result" not in chunk:
-                                logger.info("Skipping chunk - no 'result' field")
                                 continue
 
                             result = chunk["result"]
@@ -366,7 +370,7 @@ async def _stream_a2a_response(
 
                             # TaskArtifactUpdateEvent
                             if "artifact" in result:
-                                logger.info("Processing TaskArtifactUpdateEvent")
+                                logger.debug("Processing TaskArtifactUpdateEvent")
                                 artifact = result.get("artifact", {})
                                 parts = artifact.get("parts", [])
                                 content = _extract_text_from_parts(parts)
@@ -380,7 +384,7 @@ async def _stream_a2a_response(
                                 if content:
                                     payload["content"] = content
 
-                                logger.info(f"Yielding artifact event: {artifact.get('name')}")
+                                logger.debug("Yielding artifact event")
                                 yield f"data: {json.dumps(payload)}\n\n"
 
                             # TaskStatusUpdateEvent
@@ -389,9 +393,8 @@ async def _stream_a2a_response(
                                 is_final = result.get("final", False)
                                 state = status.get("state", "UNKNOWN")
 
-                                logger.info(
-                                    f"Processing TaskStatusUpdateEvent: taskId={result.get('taskId')}, "
-                                    f"state={state}, final={is_final}"
+                                logger.debug(
+                                    "TaskStatusUpdateEvent: state=%s final=%s", state, is_final
                                 )
 
                                 # Extract status message text if present
@@ -404,9 +407,7 @@ async def _stream_a2a_response(
                                 event_type = "status"
                                 if state == "INPUT_REQUIRED":
                                     event_type = "hitl_request"
-                                    logger.info(
-                                        f"HITL request detected: taskId={result.get('taskId')}"
-                                    )
+                                    logger.info("HITL request detected")
 
                                 payload["event"] = {
                                     "type": event_type,

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,11 +50,14 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "http://dockerhost:11434/v1"
+          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
         - name: LLM_API_KEY
-          value: "dummy"
+          valueFrom:
+            secretKeyRef:
+              name: openai-secret
+              key: apikey
         - name: LLM_MODEL
-          value: "qwen2.5:3b"
+          value: "llama-scout-17b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,14 +50,11 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
+          value: "http://dockerhost:11434/v1"
         - name: LLM_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: openai-secret
-              key: apikey
+          value: "dummy"
         - name: LLM_MODEL
-          value: "llama-scout-17b"
+          value: "qwen2.5:3b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:


### PR DESCRIPTION
## Summary
- sandbox.py: session management, SSE streaming, history loading
- sandbox_deploy.py: agent deployment lifecycle (create, delete, reconfigure)
- sandbox_files.py: workspace file browsing and content retrieval
- sandbox_trigger.py: event-driven sandbox triggers CRUD
- sidecar.py: sidecar agent management API
- token_usage.py: per-session LLM token analytics
- events.py: paginated event retrieval
- integrations.py: A2A/MCP integration management
- models.py: available LLM models endpoint
- llm_keys.py: virtual key management
- chat.py: extended with sandbox session support

11 files | Part of Sandbox Agent streaming PR series