### PR TITLE
feat: add sandbox pages — sessions, sandboxes, integrations, triggers

### DIFF
--- a/kagenti/ui-v2/src/App.tsx
+++ b/kagenti/ui-v2/src/App.tsx
@@ -23,6 +23,7 @@ import { AdminPage } from './pages/AdminPage';
 import { IntegrationsPage } from './pages/IntegrationsPage';
 import { IntegrationDetailPage } from './pages/IntegrationDetailPage';
 import { AddIntegrationPage } from './pages/AddIntegrationPage';
+// These components are added by PRs #988 (graph) and #989 (file browser)
 import { FileBrowser } from './components/FileBrowser';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { SandboxPage } from './pages/SandboxPage';

--- a/kagenti/ui-v2/src/App.tsx
+++ b/kagenti/ui-v2/src/App.tsx
@@ -20,7 +20,17 @@ import { ObservabilityPage } from './pages/ObservabilityPage';
 import { ImportAgentPage } from './pages/ImportAgentPage';
 import { ImportToolPage } from './pages/ImportToolPage';
 import { AdminPage } from './pages/AdminPage';
+import { IntegrationsPage } from './pages/IntegrationsPage';
+import { IntegrationDetailPage } from './pages/IntegrationDetailPage';
+import { AddIntegrationPage } from './pages/AddIntegrationPage';
+import { FileBrowser } from './components/FileBrowser';
 import { NotFoundPage } from './pages/NotFoundPage';
+import { SandboxPage } from './pages/SandboxPage';
+import { SandboxCreatePage } from './pages/SandboxCreatePage';
+import { SandboxesPage } from './pages/SandboxesPage';
+import { SessionsTablePage } from './pages/SessionsTablePage';
+import { SessionGraphPage } from './pages/SessionGraphPage';
+import { TriggerManagementPage } from './pages/TriggerManagementPage';
 
 function App() {
   const features = useFeatureFlags();
@@ -96,6 +106,21 @@ function App() {
             </ProtectedRoute>
           }
         />
+        {features.integrations && (
+          <>
+            <Route path="/integrations" element={<ProtectedRoute><IntegrationsPage /></ProtectedRoute>} />
+            <Route path="/integrations/add" element={<ProtectedRoute><AddIntegrationPage /></ProtectedRoute>} />
+            <Route path="/integrations/:namespace/:name" element={<ProtectedRoute><IntegrationDetailPage /></ProtectedRoute>} />
+          </>
+        )}
+        {features.sandbox && (
+          <>
+            <Route path="/sessions" element={<ProtectedRoute><SessionsTablePage /></ProtectedRoute>} />
+          </>
+        )}
+        {features.triggers && (
+          <Route path="/triggers" element={<ProtectedRoute><TriggerManagementPage /></ProtectedRoute>} />
+        )}
         <Route
           path="/mcp-gateway"
           element={
@@ -136,6 +161,17 @@ function App() {
             </ProtectedRoute>
           }
         />
+        {features.sandbox && (
+          <>
+            <Route path="/sandbox" element={<ProtectedRoute><SandboxPage /></ProtectedRoute>} />
+            <Route path="/sandbox/create" element={<ProtectedRoute><SandboxCreatePage /></ProtectedRoute>} />
+            <Route path="/sandbox/sessions" element={<ProtectedRoute><SessionsTablePage /></ProtectedRoute>} />
+            <Route path="/sandbox/graph" element={<ProtectedRoute><SessionGraphPage /></ProtectedRoute>} />
+            <Route path="/sandboxes" element={<ProtectedRoute><SandboxesPage /></ProtectedRoute>} />
+            <Route path="/sandbox/files/:namespace/:agentName/:contextId" element={<ProtectedRoute><FileBrowser /></ProtectedRoute>} />
+            <Route path="/sandbox/files/:namespace/:agentName" element={<ProtectedRoute><FileBrowser /></ProtectedRoute>} />
+          </>
+        )}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </AppLayout>

--- a/kagenti/ui-v2/src/components/SessionStatsPanel.tsx
+++ b/kagenti/ui-v2/src/components/SessionStatsPanel.tsx
@@ -1,0 +1,393 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+/**
+ * SessionStatsPanel — session overview, timing, and tool call statistics.
+ *
+ * Data sourced from both the messages array (always available) and
+ * AgentLoop objects (available when the reasoning loop SSE pipeline is active).
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Card, CardBody, CardTitle, Progress } from '@patternfly/react-core';
+import type { AgentLoop } from '../types/agentLoop';
+import { tokenUsageService } from '../services/api';
+
+interface Message {
+  role: string;
+  timestamp: Date;
+  content: string;
+  toolData?: { type: string; name?: string; tools?: Array<{ name: string }> };
+}
+
+interface SessionStatsPanelProps {
+  agentLoops: Map<string, AgentLoop>;
+  messages: Message[];
+  modelContextLimit?: number;
+  contextId?: string;
+  isVisible?: boolean;
+  isStreaming?: boolean;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = (seconds % 60).toFixed(0);
+  return `${m}m ${s}s`;
+}
+
+export const SessionStatsPanel: React.FC<SessionStatsPanelProps> = ({
+  agentLoops,
+  messages,
+  modelContextLimit = 131072,
+  contextId,
+  isVisible = true,
+  isStreaming = false,
+}) => {
+  const loops = Array.from(agentLoops.values());
+
+  // Fetch authoritative budget data from the LLM Budget Proxy via backend API.
+  // This persists across page reloads / stream disconnects (proxy records every call).
+  const [proxyTokens, setProxyTokens] = useState<number>(0);
+  useEffect(() => {
+    if (!contextId || !isVisible) return;
+
+    const fetchTokenUsage = async () => {
+      try {
+        const data = await tokenUsageService.getSessionTokenUsage(contextId);
+        setProxyTokens(data.total_tokens);
+      } catch (err) {
+        console.warn('Failed to fetch token usage:', err);
+      }
+    };
+
+    fetchTokenUsage(); // Initial fetch
+
+    // Poll while streaming
+    if (isStreaming) {
+      const interval = setInterval(fetchTokenUsage, 3000);
+      return () => clearInterval(interval);
+    }
+  }, [contextId, isVisible, isStreaming]);
+
+  // ── Message Stats (always available) ──
+  // Count user messages from both flat messages AND loop.userMessage
+  const flatUserCount = messages.filter((m) => m.role === 'user').length;
+  const loopUserCount = loops.filter((l) => l.userMessage?.trim()).length;
+  const userMsgCount = flatUserCount + loopUserCount;
+  // Count assistant responses from both flat messages AND agent loops
+  // (loop mode skips adding to messages array — content is in agentLoops)
+  const flatAssistantCount = messages.filter(
+    (m) => m.role === 'assistant' && m.content?.trim() && !m.toolData
+  ).length;
+  // Count loops with any activity as assistant responses.
+  // A loop that ran (has steps) counts even if it failed before the reporter.
+  const loopAnswerCount = loops.filter(
+    (l) => l.steps.length > 0 || l.finalAnswer?.trim()
+  ).length;
+  const assistantMsgCount = flatAssistantCount + loopAnswerCount;
+
+  // ── Tool calls from messages (fallback when no loop data) ──
+  const msgToolMap = new Map<string, { calls: number; results: number }>();
+  for (const msg of messages) {
+    if (!msg.toolData) continue;
+    if (msg.toolData.type === 'tool_call') {
+      const names = msg.toolData.tools?.map((t) => t.name) || [msg.toolData.name || 'unknown'];
+      for (const name of names) {
+        const entry = msgToolMap.get(name) || { calls: 0, results: 0 };
+        entry.calls++;
+        msgToolMap.set(name, entry);
+      }
+    } else if (msg.toolData.type === 'tool_result') {
+      const name = msg.toolData.name || 'unknown';
+      const entry = msgToolMap.get(name) || { calls: 0, results: 0 };
+      entry.results++;
+      msgToolMap.set(name, entry);
+    }
+  }
+
+  // ── Token Usage (from loops only) ──
+  const tokenRows = loops.flatMap((loop) =>
+    loop.steps
+      .filter((s) => s.tokens.prompt > 0 || s.tokens.completion > 0)
+      .map((step, i) => ({
+        turn: `${loop.id.slice(0, 6)}/${i + 1}`,
+        prompt: step.tokens.prompt,
+        completion: step.tokens.completion,
+        total: step.tokens.prompt + step.tokens.completion,
+      }))
+  );
+  const totalPrompt = tokenRows.reduce((s, r) => s + r.prompt, 0);
+  const totalCompletion = tokenRows.reduce((s, r) => s + r.completion, 0);
+  const totalTokens = totalPrompt + totalCompletion;
+
+  // ── Context Window ──
+  const contextPct = modelContextLimit > 0 ? (totalTokens / modelContextLimit) * 100 : 0;
+  const contextVariant =
+    contextPct > 80 ? ('danger' as const) : contextPct > 50 ? ('warning' as const) : undefined;
+
+  // ── Timing ──
+  const sessionStart = messages.length > 0 ? messages[0].timestamp : null;
+  const sessionEnd = messages.length > 0 ? messages[messages.length - 1].timestamp : null;
+  const sessionDurationS =
+    sessionStart && sessionEnd
+      ? (sessionEnd.getTime() - sessionStart.getTime()) / 1000
+      : 0;
+
+  // ── Tool Calls (prefer loop data, fall back to message data) ──
+  const loopToolMap = new Map<string, { calls: number; results: number }>();
+  for (const loop of loops) {
+    for (const step of loop.steps) {
+      for (const tc of step.toolCalls) {
+        const name = tc.name || tc.type || 'unknown';
+        const entry = loopToolMap.get(name) || { calls: 0, results: 0 };
+        entry.calls++;
+        loopToolMap.set(name, entry);
+      }
+      for (const tr of step.toolResults) {
+        const name = tr.name || tr.type || 'unknown';
+        const entry = loopToolMap.get(name) || { calls: 0, results: 0 };
+        entry.results++;
+        loopToolMap.set(name, entry);
+      }
+    }
+  }
+  const toolSource = loopToolMap.size > 0 ? loopToolMap : msgToolMap;
+  const toolRows = Array.from(toolSource.entries()).map(([name, stats]) => ({
+    name,
+    ...stats,
+  }));
+
+  const tableStyle: React.CSSProperties = {
+    width: '100%',
+    fontSize: '0.85em',
+    borderCollapse: 'collapse',
+  };
+  const thStyle: React.CSSProperties = {
+    textAlign: 'left',
+    padding: '6px 10px',
+    borderBottom: '2px solid var(--pf-v5-global--BorderColor--100)',
+    fontWeight: 600,
+  };
+  const tdStyle: React.CSSProperties = {
+    padding: '5px 10px',
+    borderBottom: '1px solid var(--pf-v5-global--BorderColor--100)',
+    fontVariantNumeric: 'tabular-nums',
+  };
+
+  return (
+    <div
+      data-testid="session-stats-panel"
+      style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 16, overflowY: 'auto' }}
+    >
+      {/* Session Overview — always shows something */}
+      <Card>
+        <CardTitle>Session Overview</CardTitle>
+        <CardBody>
+          <table style={tableStyle}>
+            <tbody>
+              <tr>
+                <td style={{ ...tdStyle, fontWeight: 600 }}>Messages</td>
+                <td style={{ ...tdStyle, textAlign: 'right' }} data-testid="stats-messages">
+                  <span data-testid="stats-user-msg-count">{userMsgCount}</span> user / <span data-testid="stats-assistant-msg-count">{assistantMsgCount}</span> assistant
+                </td>
+              </tr>
+              <tr>
+                <td style={{ ...tdStyle, fontWeight: 600 }}>Tool Calls</td>
+                <td style={{ ...tdStyle, textAlign: 'right' }} data-testid="stats-tool-calls">
+                  {toolRows.reduce((s, r) => s + r.calls, 0)}
+                </td>
+              </tr>
+              <tr>
+                <td style={{ ...tdStyle, fontWeight: 600 }}>Session Duration</td>
+                <td style={{ ...tdStyle, textAlign: 'right' }}>
+                  {sessionDurationS > 0 ? formatDuration(sessionDurationS) : '—'}
+                </td>
+              </tr>
+              {loops.length > 0 && (
+                <tr>
+                  <td style={{ ...tdStyle, fontWeight: 600 }}>Reasoning Loops</td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }} data-testid="stats-loop-count">{loops.length}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardBody>
+      </Card>
+
+      {/* Token Usage — only when loop data available */}
+      {tokenRows.length > 0 && (
+        <Card>
+          <CardTitle>Token Usage</CardTitle>
+          <CardBody>
+            <table style={tableStyle}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>Turn</th>
+                  <th style={{ ...thStyle, textAlign: 'right' }}>Prompt</th>
+                  <th style={{ ...thStyle, textAlign: 'right' }}>Completion</th>
+                  <th style={{ ...thStyle, textAlign: 'right' }}>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tokenRows.map((r, i) => (
+                  <tr key={i}>
+                    <td style={tdStyle}>{r.turn}</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>{r.prompt.toLocaleString()}</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>
+                      {r.completion.toLocaleString()}
+                    </td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>{r.total.toLocaleString()}</td>
+                  </tr>
+                ))}
+                <tr style={{ fontWeight: 600 }} data-testid="stats-token-totals">
+                  <td style={tdStyle}>Total</td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }} data-testid="stats-total-prompt">
+                    {totalPrompt.toLocaleString()}
+                  </td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }} data-testid="stats-total-completion">
+                    {totalCompletion.toLocaleString()}
+                  </td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }} data-testid="stats-total-tokens">
+                    {totalTokens.toLocaleString()}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </CardBody>
+        </Card>
+      )}
+
+      {/* Context Window — only when token data available */}
+      {totalTokens > 0 && (
+        <Card>
+          <CardTitle>Context Window</CardTitle>
+          <CardBody>
+            <Progress
+              value={Math.min(contextPct, 100)}
+              title={`${totalTokens.toLocaleString()} / ${modelContextLimit.toLocaleString()} tokens (${contextPct.toFixed(1)}%)`}
+              variant={contextVariant}
+              measureLocation="outside"
+            />
+          </CardBody>
+        </Card>
+      )}
+
+      {/* Tool Calls — from loops or messages */}
+      {toolRows.length > 0 && (
+        <Card>
+          <CardTitle>Tool Calls</CardTitle>
+          <CardBody>
+            <table style={tableStyle}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>Tool</th>
+                  <th style={{ ...thStyle, textAlign: 'right' }}>Calls</th>
+                  <th style={{ ...thStyle, textAlign: 'right' }}>Results</th>
+                </tr>
+              </thead>
+              <tbody>
+                {toolRows.map((r) => (
+                  <tr key={r.name}>
+                    <td style={tdStyle}>{r.name}</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>{r.calls}</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>{r.results}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardBody>
+        </Card>
+      )}
+
+      {/* Budget — from proxy API (authoritative) with loop data fallback */}
+      {(() => {
+        const loopTokensUsed = loops.reduce((s, l) => s + l.budget.tokensUsed, 0);
+        const loopTokensTotal = loops.reduce((s, l) => s + l.budget.tokensBudget, 0);
+        // Prefer proxy data (persists across reloads), fall back to loop events
+        const budgetTokensUsed = proxyTokens > 0 ? proxyTokens : loopTokensUsed;
+        const budgetTokensTotal = loopTokensTotal > 0 ? loopTokensTotal : (proxyTokens > 0 ? 1000000 : 0);
+        const budgetWallClock = loops.reduce((s, l) => s + l.budget.wallClockS, 0);
+        const budgetMaxWallClock = loops.reduce((s, l) => s + l.budget.maxWallClockS, 0);
+        const hasBudget = budgetTokensUsed > 0 || budgetTokensTotal > 0;
+        if (!hasBudget) return null;
+
+        const tokenPct = budgetTokensTotal > 0 ? (budgetTokensUsed / budgetTokensTotal) * 100 : 0;
+        const wallPct = budgetMaxWallClock > 0 ? (budgetWallClock / budgetMaxWallClock) * 100 : 0;
+        const colorVariant = (pct: number) =>
+          pct > 80 ? ('danger' as const) : pct > 50 ? ('warning' as const) : undefined;
+
+        return (
+          <Card>
+            <CardTitle>Budget</CardTitle>
+            <CardBody>
+              <div style={{ marginBottom: 12 }}>
+                <div style={{ fontSize: '0.85em', marginBottom: 4, fontWeight: 600 }}>
+                  Tokens: <span data-testid="stats-budget-tokens-used">{budgetTokensUsed.toLocaleString()}</span> / <span data-testid="stats-budget-tokens-total">{budgetTokensTotal.toLocaleString()}</span>
+                </div>
+                {budgetTokensTotal > 0 && (
+                  <Progress
+                    value={Math.min(tokenPct, 100)}
+                    title={`${tokenPct.toFixed(1)}%`}
+                    variant={colorVariant(tokenPct)}
+                    measureLocation="outside"
+                  />
+                )}
+              </div>
+              <div style={{ marginBottom: 12 }}>
+                <div style={{ fontSize: '0.85em', marginBottom: 4, fontWeight: 600 }}>
+                  Wall Clock: <span data-testid="stats-budget-wallclock">{formatDuration(budgetWallClock)}</span> / {formatDuration(budgetMaxWallClock)}
+                </div>
+                {budgetMaxWallClock > 0 && (
+                  <Progress
+                    value={Math.min(wallPct, 100)}
+                    title={`${wallPct.toFixed(1)}%`}
+                    variant={colorVariant(wallPct)}
+                    measureLocation="outside"
+                  />
+                )}
+              </div>
+              <table style={tableStyle}>
+                <tbody>
+                  <tr>
+                    <td style={{ ...tdStyle, fontWeight: 600 }}>Plan Steps</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>{loops.reduce((s, l) => s + (l.totalSteps || l.plan.length), 0)}</td>
+                  </tr>
+                  <tr>
+                    <td style={{ ...tdStyle, fontWeight: 600 }}>Graph Node Visits</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }} data-testid="stats-node-visits">{loops.reduce((s, l) => s + l.nodeVisits, 0)}</td>
+                  </tr>
+                  <tr>
+                    <td style={{ ...tdStyle, fontWeight: 600 }}>Tool Calls</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>{loops.reduce((s, l) => s + l.steps.reduce((ts, st) => ts + st.toolCalls.length, 0), 0)}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </CardBody>
+          </Card>
+        );
+      })()}
+
+      {/* Timing per loop — only when loop data available */}
+      {loops.length > 0 && (
+        <Card>
+          <CardTitle>Loop Timing</CardTitle>
+          <CardBody>
+            <table style={tableStyle}>
+              <tbody>
+                {loops.map((loop) => (
+                  <tr key={loop.id}>
+                    <td style={tdStyle}>Loop {loop.id.slice(0, 6)}</td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>
+                      {formatDuration(loop.budget.wallClockS)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardBody>
+        </Card>
+      )}
+    </div>
+  );
+};

--- a/kagenti/ui-v2/src/pages/AddIntegrationPage.tsx
+++ b/kagenti/ui-v2/src/pages/AddIntegrationPage.tsx
@@ -1,0 +1,616 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  PageSection,
+  Title,
+  Text,
+  TextContent,
+  Card,
+  CardTitle,
+  CardBody,
+  Form,
+  FormGroup,
+  TextInput,
+  FormSelect,
+  FormSelectOption,
+  Button,
+  Alert,
+  Split,
+  SplitItem,
+  ExpandableSection,
+  ActionGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Checkbox,
+} from '@patternfly/react-core';
+import { TrashIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { useMutation } from '@tanstack/react-query';
+
+import { integrationService } from '@/services/api';
+import { NamespaceSelector } from '@/components/NamespaceSelector';
+import type { IntegrationProvider, IntegrationAgentRef } from '@/types';
+
+// Webhook event options
+const WEBHOOK_EVENTS = ['pull_request', 'push', 'issue_comment', 'check_suite'];
+
+// Alert source options
+const ALERT_SOURCES: Array<{ value: 'prometheus' | 'pagerduty'; label: string }> = [
+  { value: 'prometheus', label: 'Prometheus' },
+  { value: 'pagerduty', label: 'PagerDuty' },
+];
+
+interface ScheduleEntry {
+  name: string;
+  cron: string;
+  skill: string;
+  agent: string;
+}
+
+interface AlertEntry {
+  name: string;
+  source: 'prometheus' | 'pagerduty';
+  agent: string;
+}
+
+export const AddIntegrationPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  // Card 1: Repository
+  const [namespace, setNamespace] = useState('team1');
+  const [name, setName] = useState('');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [provider, setProvider] = useState<IntegrationProvider>('github');
+  const [branch, setBranch] = useState('main');
+  const [credentialsSecret, setCredentialsSecret] = useState('');
+
+  // Card 2: Agents
+  const [agents, setAgents] = useState<IntegrationAgentRef[]>([
+    { name: '', namespace: 'team1' },
+  ]);
+
+  // Card 3: Webhooks
+  const [webhooksExpanded, setWebhooksExpanded] = useState(false);
+  const [webhookEvents, setWebhookEvents] = useState<string[]>([]);
+  const [branchFilter, setBranchFilter] = useState('');
+
+  // Card 4: Schedules
+  const [schedulesExpanded, setSchedulesExpanded] = useState(false);
+  const [schedules, setSchedules] = useState<ScheduleEntry[]>([]);
+
+  // Card 5: Alerts
+  const [alertsExpanded, setAlertsExpanded] = useState(false);
+  const [alerts, setAlerts] = useState<AlertEntry[]>([]);
+
+  const createMutation = useMutation({
+    mutationFn: (data: Parameters<typeof integrationService.create>[0]) =>
+      integrationService.create(data),
+    onSuccess: () => {
+      navigate('/integrations');
+    },
+  });
+
+  // --- Agent helpers ---
+  const addAgent = () => {
+    setAgents([...agents, { name: '', namespace }]);
+  };
+
+  const removeAgent = (index: number) => {
+    setAgents(agents.filter((_, i) => i !== index));
+  };
+
+  const updateAgent = (index: number, field: keyof IntegrationAgentRef, value: string) => {
+    const updated = [...agents];
+    updated[index] = { ...updated[index], [field]: value };
+    setAgents(updated);
+  };
+
+  // --- Schedule helpers ---
+  const addSchedule = () => {
+    setSchedules([...schedules, { name: '', cron: '', skill: '', agent: '' }]);
+  };
+
+  const removeSchedule = (index: number) => {
+    setSchedules(schedules.filter((_, i) => i !== index));
+  };
+
+  const updateSchedule = (index: number, field: keyof ScheduleEntry, value: string) => {
+    const updated = [...schedules];
+    updated[index] = { ...updated[index], [field]: value };
+    setSchedules(updated);
+  };
+
+  // --- Alert helpers ---
+  const addAlert = () => {
+    setAlerts([...alerts, { name: '', source: 'prometheus', agent: '' }]);
+  };
+
+  const removeAlert = (index: number) => {
+    setAlerts(alerts.filter((_, i) => i !== index));
+  };
+
+  const updateAlert = (index: number, field: keyof AlertEntry, value: string) => {
+    const updated = [...alerts];
+    updated[index] = { ...updated[index], [field]: value } as AlertEntry;
+    setAlerts(updated);
+  };
+
+  // --- Webhook event toggle ---
+  const toggleWebhookEvent = (event: string, checked: boolean) => {
+    if (checked) {
+      setWebhookEvents([...webhookEvents, event]);
+    } else {
+      setWebhookEvents(webhookEvents.filter((e) => e !== event));
+    }
+  };
+
+  // --- Validation ---
+  const validateForm = (): boolean => {
+    if (!name.trim()) return false;
+    if (!repoUrl.trim()) return false;
+    if (!namespace) return false;
+    // Need at least one agent with a name
+    const validAgents = agents.filter((a) => a.name.trim());
+    if (validAgents.length === 0) return false;
+    return true;
+  };
+
+  // --- Submit ---
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    const validAgents = agents.filter((a) => a.name.trim());
+
+    // Build webhooks array
+    const webhooks =
+      webhookEvents.length > 0
+        ? [
+            {
+              name: `${name}-webhook`,
+              events: webhookEvents,
+              ...(branchFilter.trim()
+                ? { filters: { branches: [branchFilter.trim()] } }
+                : {}),
+            },
+          ]
+        : undefined;
+
+    // Build schedules array (only entries with required fields filled)
+    const validSchedules = schedules.filter(
+      (s) => s.name.trim() && s.cron.trim() && s.skill.trim() && s.agent.trim()
+    );
+
+    // Build alerts array (only entries with required fields filled)
+    const validAlerts = alerts
+      .filter((a) => a.name.trim() && a.agent.trim())
+      .map((a) => ({
+        name: a.name,
+        source: a.source,
+        matchLabels: {},
+        agent: a.agent,
+      }));
+
+    createMutation.mutate({
+      name: name.trim(),
+      namespace,
+      repository: {
+        url: repoUrl.trim(),
+        provider,
+        branch: branch.trim() || 'main',
+        ...(credentialsSecret.trim()
+          ? { credentialsSecret: credentialsSecret.trim() }
+          : {}),
+      },
+      agents: validAgents,
+      ...(webhooks ? { webhooks } : {}),
+      ...(validSchedules.length > 0 ? { schedules: validSchedules } : {}),
+      ...(validAlerts.length > 0 ? { alerts: validAlerts } : {}),
+    });
+  };
+
+  return (
+    <>
+      <PageSection variant="light">
+        <TextContent>
+          <Title headingLevel="h1">Add Integration</Title>
+          <Text component="p">
+            Connect a repository and bind agents to respond to events, schedules, and alerts.
+          </Text>
+        </TextContent>
+      </PageSection>
+
+      <PageSection>
+        {createMutation.isError && (
+          <Alert
+            variant="danger"
+            title="Failed to create integration"
+            isInline
+            style={{ marginBottom: '16px' }}
+          >
+            {createMutation.error instanceof Error
+              ? createMutation.error.message
+              : 'An unexpected error occurred'}
+          </Alert>
+        )}
+
+        <Form onSubmit={handleSubmit}>
+          {/* Card 1: Repository */}
+          <Card style={{ marginBottom: '16px' }}>
+            <CardTitle>Repository</CardTitle>
+            <CardBody>
+              <FormGroup label="Namespace" isRequired fieldId="namespace">
+                <NamespaceSelector
+                  namespace={namespace}
+                  onNamespaceChange={setNamespace}
+                />
+              </FormGroup>
+
+              <FormGroup label="Name" isRequired fieldId="name">
+                <TextInput
+                  id="name"
+                  value={name}
+                  onChange={(_event, value) => setName(value)}
+                  placeholder="my-integration"
+                  isRequired
+                />
+              </FormGroup>
+
+              <FormGroup label="Repository URL" isRequired fieldId="repo-url">
+                <TextInput
+                  id="repo-url"
+                  value={repoUrl}
+                  onChange={(_event, value) => setRepoUrl(value)}
+                  placeholder="https://github.com/org/repo"
+                  isRequired
+                />
+              </FormGroup>
+
+              <FormGroup label="Provider" fieldId="provider">
+                <FormSelect
+                  id="provider"
+                  value={provider}
+                  onChange={(_event, value) => setProvider(value as IntegrationProvider)}
+                >
+                  <FormSelectOption value="github" label="GitHub" />
+                  <FormSelectOption value="gitlab" label="GitLab" />
+                  <FormSelectOption value="bitbucket" label="Bitbucket" />
+                </FormSelect>
+              </FormGroup>
+
+              <FormGroup label="Branch" fieldId="branch">
+                <TextInput
+                  id="branch"
+                  value={branch}
+                  onChange={(_event, value) => setBranch(value)}
+                  placeholder="main"
+                />
+              </FormGroup>
+
+              <FormGroup label="Credentials Secret" fieldId="credentials-secret">
+                <TextInput
+                  id="credentials-secret"
+                  value={credentialsSecret}
+                  onChange={(_event, value) => setCredentialsSecret(value)}
+                  placeholder="repo-credentials"
+                />
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem>
+                      Kubernetes Secret name containing repository access credentials
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              </FormGroup>
+            </CardBody>
+          </Card>
+
+          {/* Card 2: Agents */}
+          <Card style={{ marginBottom: '16px' }}>
+            <CardTitle>Agents</CardTitle>
+            <CardBody>
+              {agents.map((agent, index) => (
+                <Split
+                  key={index}
+                  hasGutter
+                  style={{ marginBottom: '8px', alignItems: 'flex-end' }}
+                >
+                  <SplitItem isFilled>
+                    <FormGroup
+                      label={index === 0 ? 'Agent Name' : undefined}
+                      isRequired
+                      fieldId={`agent-name-${index}`}
+                    >
+                      <TextInput
+                        id={`agent-name-${index}`}
+                        value={agent.name}
+                        onChange={(_event, value) => updateAgent(index, 'name', value)}
+                        placeholder="agent-name"
+                        isRequired
+                      />
+                    </FormGroup>
+                  </SplitItem>
+                  <SplitItem isFilled>
+                    <FormGroup
+                      label={index === 0 ? 'Agent Namespace' : undefined}
+                      fieldId={`agent-ns-${index}`}
+                    >
+                      <TextInput
+                        id={`agent-ns-${index}`}
+                        value={agent.namespace}
+                        onChange={(_event, value) => updateAgent(index, 'namespace', value)}
+                        placeholder={namespace}
+                      />
+                    </FormGroup>
+                  </SplitItem>
+                  <SplitItem>
+                    <Button
+                      variant="plain"
+                      aria-label="Remove agent"
+                      onClick={() => removeAgent(index)}
+                      isDisabled={agents.length === 1}
+                    >
+                      <TrashIcon />
+                    </Button>
+                  </SplitItem>
+                </Split>
+              ))}
+              <Button
+                variant="link"
+                icon={<PlusCircleIcon />}
+                onClick={addAgent}
+              >
+                Add Agent
+              </Button>
+            </CardBody>
+          </Card>
+
+          {/* Card 3: Webhooks */}
+          <Card style={{ marginBottom: '16px' }}>
+            <CardBody>
+              <ExpandableSection
+                toggleText="Webhooks"
+                isExpanded={webhooksExpanded}
+                onToggle={(_event, expanded) => setWebhooksExpanded(expanded)}
+              >
+                <FormGroup label="Webhook Events" fieldId="webhook-events">
+                  {WEBHOOK_EVENTS.map((event) => (
+                    <Checkbox
+                      key={event}
+                      id={`webhook-event-${event}`}
+                      label={event}
+                      isChecked={webhookEvents.includes(event)}
+                      onChange={(_event, checked) => toggleWebhookEvent(event, checked)}
+                      style={{ marginBottom: '4px' }}
+                    />
+                  ))}
+                </FormGroup>
+
+                <FormGroup label="Branch Filter" fieldId="branch-filter">
+                  <TextInput
+                    id="branch-filter"
+                    value={branchFilter}
+                    onChange={(_event, value) => setBranchFilter(value)}
+                    placeholder="main"
+                  />
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem>
+                        Only trigger for events on this branch (optional)
+                      </HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                </FormGroup>
+              </ExpandableSection>
+            </CardBody>
+          </Card>
+
+          {/* Card 4: Schedules */}
+          <Card style={{ marginBottom: '16px' }}>
+            <CardBody>
+              <ExpandableSection
+                toggleText="Schedules"
+                isExpanded={schedulesExpanded}
+                onToggle={(_event, expanded) => setSchedulesExpanded(expanded)}
+              >
+                {schedules.map((schedule, index) => (
+                  <Split
+                    key={index}
+                    hasGutter
+                    style={{ marginBottom: '8px', alignItems: 'flex-end' }}
+                  >
+                    <SplitItem isFilled>
+                      <FormGroup
+                        label={index === 0 ? 'Name' : undefined}
+                        fieldId={`schedule-name-${index}`}
+                      >
+                        <TextInput
+                          id={`schedule-name-${index}`}
+                          value={schedule.name}
+                          onChange={(_event, value) =>
+                            updateSchedule(index, 'name', value)
+                          }
+                          placeholder="nightly-scan"
+                        />
+                      </FormGroup>
+                    </SplitItem>
+                    <SplitItem isFilled>
+                      <FormGroup
+                        label={index === 0 ? 'Cron' : undefined}
+                        fieldId={`schedule-cron-${index}`}
+                      >
+                        <TextInput
+                          id={`schedule-cron-${index}`}
+                          value={schedule.cron}
+                          onChange={(_event, value) =>
+                            updateSchedule(index, 'cron', value)
+                          }
+                          placeholder="0 2 * * *"
+                        />
+                      </FormGroup>
+                    </SplitItem>
+                    <SplitItem isFilled>
+                      <FormGroup
+                        label={index === 0 ? 'Skill' : undefined}
+                        fieldId={`schedule-skill-${index}`}
+                      >
+                        <TextInput
+                          id={`schedule-skill-${index}`}
+                          value={schedule.skill}
+                          onChange={(_event, value) =>
+                            updateSchedule(index, 'skill', value)
+                          }
+                          placeholder="code-review"
+                        />
+                      </FormGroup>
+                    </SplitItem>
+                    <SplitItem isFilled>
+                      <FormGroup
+                        label={index === 0 ? 'Agent' : undefined}
+                        fieldId={`schedule-agent-${index}`}
+                      >
+                        <TextInput
+                          id={`schedule-agent-${index}`}
+                          value={schedule.agent}
+                          onChange={(_event, value) =>
+                            updateSchedule(index, 'agent', value)
+                          }
+                          placeholder="agent-name"
+                        />
+                      </FormGroup>
+                    </SplitItem>
+                    <SplitItem>
+                      <Button
+                        variant="plain"
+                        aria-label="Remove schedule"
+                        onClick={() => removeSchedule(index)}
+                      >
+                        <TrashIcon />
+                      </Button>
+                    </SplitItem>
+                  </Split>
+                ))}
+                <Button
+                  variant="link"
+                  icon={<PlusCircleIcon />}
+                  onClick={addSchedule}
+                >
+                  Add Schedule
+                </Button>
+              </ExpandableSection>
+            </CardBody>
+          </Card>
+
+          {/* Card 5: Alerts */}
+          <Card style={{ marginBottom: '16px' }}>
+            <CardBody>
+              <ExpandableSection
+                toggleText="Alerts"
+                isExpanded={alertsExpanded}
+                onToggle={(_event, expanded) => setAlertsExpanded(expanded)}
+              >
+                {alerts.map((alert, index) => (
+                  <Split
+                    key={index}
+                    hasGutter
+                    style={{ marginBottom: '8px', alignItems: 'flex-end' }}
+                  >
+                    <SplitItem isFilled>
+                      <FormGroup
+                        label={index === 0 ? 'Name' : undefined}
+                        fieldId={`alert-name-${index}`}
+                      >
+                        <TextInput
+                          id={`alert-name-${index}`}
+                          value={alert.name}
+                          onChange={(_event, value) =>
+                            updateAlert(index, 'name', value)
+                          }
+                          placeholder="high-cpu-alert"
+                        />
+                      </FormGroup>
+                    </SplitItem>
+                    <SplitItem isFilled>
+                      <FormGroup
+                        label={index === 0 ? 'Source' : undefined}
+                        fieldId={`alert-source-${index}`}
+                      >
+                        <FormSelect
+                          id={`alert-source-${index}`}
+                          value={alert.source}
+                          onChange={(_event, value) =>
+                            updateAlert(index, 'source', value)
+                          }
+                        >
+                          {ALERT_SOURCES.map((src) => (
+                            <FormSelectOption
+                              key={src.value}
+                              value={src.value}
+                              label={src.label}
+                            />
+                          ))}
+                        </FormSelect>
+                      </FormGroup>
+                    </SplitItem>
+                    <SplitItem isFilled>
+                      <FormGroup
+                        label={index === 0 ? 'Agent' : undefined}
+                        fieldId={`alert-agent-${index}`}
+                      >
+                        <TextInput
+                          id={`alert-agent-${index}`}
+                          value={alert.agent}
+                          onChange={(_event, value) =>
+                            updateAlert(index, 'agent', value)
+                          }
+                          placeholder="agent-name"
+                        />
+                      </FormGroup>
+                    </SplitItem>
+                    <SplitItem>
+                      <Button
+                        variant="plain"
+                        aria-label="Remove alert"
+                        onClick={() => removeAlert(index)}
+                      >
+                        <TrashIcon />
+                      </Button>
+                    </SplitItem>
+                  </Split>
+                ))}
+                <Button
+                  variant="link"
+                  icon={<PlusCircleIcon />}
+                  onClick={addAlert}
+                >
+                  Add Alert
+                </Button>
+              </ExpandableSection>
+            </CardBody>
+          </Card>
+
+          {/* Actions */}
+          <ActionGroup style={{ marginTop: '24px' }}>
+            <Button
+              variant="primary"
+              type="submit"
+              isLoading={createMutation.isPending}
+              isDisabled={createMutation.isPending || !validateForm()}
+            >
+              {createMutation.isPending ? 'Creating...' : 'Create Integration'}
+            </Button>
+            <Button variant="link" onClick={() => navigate('/integrations')}>
+              Cancel
+            </Button>
+          </ActionGroup>
+        </Form>
+      </PageSection>
+    </>
+  );
+};

--- a/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
@@ -50,6 +50,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Agent } from '@/types';
 import { agentService } from '@/services/api';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
+import { SandboxWizard } from '@/components/SandboxWizard';
 
 export const AgentCatalogPage: React.FC = () => {
   const navigate = useNavigate();
@@ -59,6 +60,8 @@ export const AgentCatalogPage: React.FC = () => {
   const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [reconfigureModalOpen, setReconfigureModalOpen] = useState(false);
+  const [agentToReconfigure, setAgentToReconfigure] = useState<Agent | null>(null);
 
   const {
     data: agents = [],
@@ -85,6 +88,12 @@ export const AgentCatalogPage: React.FC = () => {
       handleCloseDeleteModal();
     },
   });
+
+  const handleReconfigureClick = (agent: Agent) => {
+    setAgentToReconfigure(agent);
+    setReconfigureModalOpen(true);
+    setOpenMenuId(null);
+  };
 
   const handleDeleteClick = (agent: Agent) => {
     setAgentToDelete(agent);
@@ -284,6 +293,12 @@ export const AgentCatalogPage: React.FC = () => {
                             View details
                           </DropdownItem>
                           <DropdownItem
+                            key="reconfigure"
+                            onClick={() => handleReconfigureClick(agent)}
+                          >
+                            Reconfigure
+                          </DropdownItem>
+                          <DropdownItem
                             key="delete"
                             onClick={() => handleDeleteClick(agent)}
                             isDanger
@@ -350,6 +365,26 @@ export const AgentCatalogPage: React.FC = () => {
           onChange={(_e, value) => setDeleteConfirmText(value)}
           aria-label="Confirm agent name"
           style={{ marginTop: '8px' }}
+        />
+      </Modal>
+
+      {/* Reconfigure Modal */}
+      <Modal
+        variant={ModalVariant.large}
+        title={`Reconfigure ${agentToReconfigure?.name}`}
+        isOpen={reconfigureModalOpen}
+        onClose={() => setReconfigureModalOpen(false)}
+        showClose
+      >
+        <SandboxWizard
+          mode="reconfigure"
+          agentName={agentToReconfigure?.name}
+          namespace={agentToReconfigure?.namespace || namespace}
+          onClose={() => setReconfigureModalOpen(false)}
+          onSuccess={() => {
+            setReconfigureModalOpen(false);
+            queryClient.invalidateQueries({ queryKey: ['agents', namespace] });
+          }}
         />
       </Modal>
     </>

--- a/kagenti/ui-v2/src/pages/IntegrationDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/IntegrationDetailPage.tsx
@@ -1,0 +1,708 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  PageSection,
+  Title,
+  Breadcrumb,
+  BreadcrumbItem,
+  Spinner,
+  EmptyState,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Button,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Label,
+  LabelGroup,
+  Card,
+  CardTitle,
+  CardBody,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Split,
+  SplitItem,
+  Flex,
+  FlexItem,
+  Text,
+  TextContent,
+  Modal,
+  ModalVariant,
+  TextInput,
+  Icon,
+  Switch,
+} from '@patternfly/react-core';
+import {
+  Table,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+} from '@patternfly/react-table';
+import {
+  CodeBranchIcon,
+  ExternalLinkAltIcon,
+  ExclamationTriangleIcon,
+  PluggedIcon,
+  ClockIcon,
+  BellIcon,
+} from '@patternfly/react-icons';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { integrationService } from '@/services/api';
+
+export const IntegrationDetailPage: React.FC = () => {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = React.useState<number>(0);
+  const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = React.useState('');
+  const [testingConnection, setTestingConnection] = React.useState(false);
+  const [testResult, setTestResult] = React.useState<{ success: boolean; message: string } | null>(null);
+
+  // Fetch integration detail
+  const {
+    data: integration,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['integration', namespace, name],
+    queryFn: () => integrationService.get(namespace!, name!),
+    enabled: !!namespace && !!name,
+  });
+
+  // Delete mutation
+  const deleteMutation = useMutation({
+    mutationFn: () => integrationService.delete(namespace!, name!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['integrations'] });
+      navigate('/integrations');
+    },
+  });
+
+  // Test connection handler
+  const handleTestConnection = async () => {
+    if (!namespace || !name) return;
+    setTestingConnection(true);
+    setTestResult(null);
+    try {
+      const result = await integrationService.testConnection(namespace, name);
+      setTestResult(result);
+    } catch (err) {
+      setTestResult({
+        success: false,
+        message: err instanceof Error ? err.message : 'Connection test failed',
+      });
+    } finally {
+      setTestingConnection(false);
+    }
+  };
+
+  const handleDeleteConfirm = () => {
+    if (deleteConfirmText === name) {
+      deleteMutation.mutate();
+    }
+  };
+
+  const handleCloseDeleteModal = () => {
+    setDeleteModalOpen(false);
+    setDeleteConfirmText('');
+  };
+
+  // Helper: render status badge
+  const renderStatusBadge = (status: string) => {
+    let color: 'green' | 'blue' | 'red' = 'red';
+    if (status === 'Connected') {
+      color = 'green';
+    } else if (status === 'Pending') {
+      color = 'blue';
+    }
+    return <Label color={color}>{status}</Label>;
+  };
+
+  // Helper: render provider label
+  const renderProviderLabel = (provider: string) => {
+    let color: 'blue' | 'orange' | 'purple' = 'blue';
+    if (provider === 'gitlab') {
+      color = 'orange';
+    } else if (provider === 'bitbucket') {
+      color = 'purple';
+    }
+    return <Label color={color}>{provider}</Label>;
+  };
+
+  // Strip protocol from URL for display
+  const stripProtocol = (url: string) => url.replace(/^https?:\/\//, '');
+
+  // Format date
+  const formatDate = (dateStr?: string) => {
+    if (!dateStr) return 'N/A';
+    try {
+      return new Date(dateStr).toLocaleString();
+    } catch {
+      return dateStr;
+    }
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <PageSection>
+        <div className="kagenti-loading-center">
+          <Spinner size="lg" aria-label="Loading integration details" />
+        </div>
+      </PageSection>
+    );
+  }
+
+  // Error state
+  if (isError || !integration) {
+    return (
+      <PageSection>
+        <EmptyState>
+          <EmptyStateHeader
+            titleText="Integration not found"
+            icon={<EmptyStateIcon icon={CodeBranchIcon} />}
+            headingLevel="h4"
+          />
+          <EmptyStateBody>
+            {error instanceof Error
+              ? error.message
+              : `Unable to load integration "${name}" in namespace "${namespace}".`}
+          </EmptyStateBody>
+          <Button variant="primary" onClick={() => navigate('/integrations')}>
+            Back to Integrations
+          </Button>
+        </EmptyState>
+      </PageSection>
+    );
+  }
+
+  // Overview tab
+  const renderOverviewTab = () => (
+    <Card>
+      <CardTitle>Details</CardTitle>
+      <CardBody>
+        <DescriptionList isHorizontal>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Repository URL</DescriptionListTerm>
+            <DescriptionListDescription>
+              <a
+                href={integration.repository.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {stripProtocol(integration.repository.url)}{' '}
+                <ExternalLinkAltIcon />
+              </a>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+
+          <DescriptionListGroup>
+            <DescriptionListTerm>Provider</DescriptionListTerm>
+            <DescriptionListDescription>
+              {renderProviderLabel(integration.repository.provider)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+
+          <DescriptionListGroup>
+            <DescriptionListTerm>Branch</DescriptionListTerm>
+            <DescriptionListDescription>
+              <Label icon={<CodeBranchIcon />} isCompact>
+                {integration.repository.branch}
+              </Label>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+
+          <DescriptionListGroup>
+            <DescriptionListTerm>Credentials Secret</DescriptionListTerm>
+            <DescriptionListDescription>
+              {integration.repository.credentialsSecret || 'None'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+
+          <DescriptionListGroup>
+            <DescriptionListTerm>Namespace</DescriptionListTerm>
+            <DescriptionListDescription>
+              <Label isCompact>{integration.namespace}</Label>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+
+          <DescriptionListGroup>
+            <DescriptionListTerm>Created At</DescriptionListTerm>
+            <DescriptionListDescription>
+              {formatDate(integration.createdAt)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+
+          {integration.webhookUrl && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Webhook URL</DescriptionListTerm>
+              <DescriptionListDescription>
+                <code>{integration.webhookUrl}</code>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+
+          {integration.lastWebhookEvent && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Last Webhook Event</DescriptionListTerm>
+              <DescriptionListDescription>
+                {formatDate(integration.lastWebhookEvent)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+
+          {integration.lastScheduleRun && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Last Schedule Run</DescriptionListTerm>
+              <DescriptionListDescription>
+                {formatDate(integration.lastScheduleRun)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+        </DescriptionList>
+      </CardBody>
+
+      {/* Agents section */}
+      <CardTitle>Agents</CardTitle>
+      <CardBody>
+        {integration.agents.length === 0 ? (
+          <Text component="small">No agents assigned to this integration.</Text>
+        ) : (
+          <LabelGroup>
+            {integration.agents.map((agent) => (
+              <Label
+                key={`${agent.namespace}-${agent.name}`}
+                color="cyan"
+                onClick={() =>
+                  navigate(`/agents/${agent.namespace}/${agent.name}`)
+                }
+                style={{ cursor: 'pointer' }}
+              >
+                {agent.name}
+              </Label>
+            ))}
+          </LabelGroup>
+        )}
+      </CardBody>
+
+      {/* Conditions section */}
+      {integration.conditions && integration.conditions.length > 0 && (
+        <>
+          <CardTitle>Conditions</CardTitle>
+          <CardBody>
+            <Table aria-label="Integration conditions" variant="compact">
+              <Thead>
+                <Tr>
+                  <Th>Type</Th>
+                  <Th>Status</Th>
+                  <Th>Message</Th>
+                  <Th>Last Transition</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {integration.conditions.map((condition, idx) => (
+                  <Tr key={idx}>
+                    <Td dataLabel="Type">{condition.type}</Td>
+                    <Td dataLabel="Status">
+                      <Label
+                        color={condition.status === 'True' ? 'green' : 'red'}
+                        isCompact
+                      >
+                        {condition.status}
+                      </Label>
+                    </Td>
+                    <Td dataLabel="Message">{condition.message || '-'}</Td>
+                    <Td dataLabel="Last Transition">
+                      {formatDate(condition.lastTransitionTime)}
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </CardBody>
+        </>
+      )}
+
+      {/* Test connection result */}
+      {testResult && (
+        <CardBody>
+          <Label color={testResult.success ? 'green' : 'red'}>
+            {testResult.message}
+          </Label>
+        </CardBody>
+      )}
+    </Card>
+  );
+
+  // Webhooks tab
+  const renderWebhooksTab = () => {
+    if (integration.webhooks.length === 0) {
+      return (
+        <EmptyState>
+          <EmptyStateHeader
+            titleText="No webhooks configured"
+            icon={<EmptyStateIcon icon={PluggedIcon} />}
+            headingLevel="h4"
+          />
+          <EmptyStateBody>
+            No webhook configurations found for this integration. Configure
+            webhooks to trigger agent actions on repository events such as push,
+            pull request, or issue creation.
+          </EmptyStateBody>
+        </EmptyState>
+      );
+    }
+
+    return (
+      <Table aria-label="Webhooks table" variant="compact">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Events</Th>
+            <Th>Branch Filters</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {integration.webhooks.map((webhook) => (
+            <Tr key={webhook.name}>
+              <Td dataLabel="Name">{webhook.name}</Td>
+              <Td dataLabel="Events">
+                <LabelGroup>
+                  {webhook.events.map((event) => (
+                    <Label key={event} isCompact color="blue">
+                      {event}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              </Td>
+              <Td dataLabel="Branch Filters">
+                {webhook.filters?.branches && webhook.filters.branches.length > 0 ? (
+                  <LabelGroup>
+                    {webhook.filters.branches.map((branch) => (
+                      <Label key={branch} isCompact icon={<CodeBranchIcon />}>
+                        {branch}
+                      </Label>
+                    ))}
+                  </LabelGroup>
+                ) : (
+                  <Text component="small">All branches</Text>
+                )}
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    );
+  };
+
+  // Schedules tab
+  const renderSchedulesTab = () => {
+    if (integration.schedules.length === 0) {
+      return (
+        <EmptyState>
+          <EmptyStateHeader
+            titleText="No schedules configured"
+            icon={<EmptyStateIcon icon={ClockIcon} />}
+            headingLevel="h4"
+          />
+          <EmptyStateBody>
+            No schedule configurations found for this integration. Set up
+            cron-based schedules to run agent skills on a recurring basis.
+          </EmptyStateBody>
+        </EmptyState>
+      );
+    }
+
+    return (
+      <Table aria-label="Schedules table" variant="compact">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Cron</Th>
+            <Th>Skill</Th>
+            <Th>Agent</Th>
+            <Th>Enabled</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {integration.schedules.map((schedule) => (
+            <Tr key={schedule.name}>
+              <Td dataLabel="Name">{schedule.name}</Td>
+              <Td dataLabel="Cron">
+                <code>{schedule.cron}</code>
+              </Td>
+              <Td dataLabel="Skill">
+                <Label isCompact>{schedule.skill}</Label>
+              </Td>
+              <Td dataLabel="Agent">
+                <Label
+                  color="cyan"
+                  isCompact
+                  onClick={() =>
+                    navigate(`/agents/${namespace}/${schedule.agent}`)
+                  }
+                  style={{ cursor: 'pointer' }}
+                >
+                  {schedule.agent}
+                </Label>
+              </Td>
+              <Td dataLabel="Enabled">
+                <Switch
+                  id={`schedule-${schedule.name}-toggle`}
+                  isChecked={schedule.enabled !== false}
+                  isDisabled
+                  aria-label={`Schedule ${schedule.name} enabled status`}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    );
+  };
+
+  // Alerts tab
+  const renderAlertsTab = () => {
+    if (integration.alerts.length === 0) {
+      return (
+        <EmptyState>
+          <EmptyStateHeader
+            titleText="No alerts configured"
+            icon={<EmptyStateIcon icon={BellIcon} />}
+            headingLevel="h4"
+          />
+          <EmptyStateBody>
+            No alert routing configurations found for this integration. Connect
+            Prometheus or PagerDuty alerts to trigger agent-based remediation
+            workflows.
+          </EmptyStateBody>
+        </EmptyState>
+      );
+    }
+
+    return (
+      <Table aria-label="Alerts table" variant="compact">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Source</Th>
+            <Th>Match Labels</Th>
+            <Th>Agent</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {integration.alerts.map((alert) => (
+            <Tr key={alert.name}>
+              <Td dataLabel="Name">{alert.name}</Td>
+              <Td dataLabel="Source">
+                <Label
+                  isCompact
+                  color={alert.source === 'prometheus' ? 'orange' : 'purple'}
+                >
+                  {alert.source}
+                </Label>
+              </Td>
+              <Td dataLabel="Match Labels">
+                <LabelGroup>
+                  {Object.entries(alert.matchLabels).map(([key, value]) => (
+                    <Label key={key} isCompact>
+                      {key}={value}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              </Td>
+              <Td dataLabel="Agent">
+                <Label
+                  color="cyan"
+                  isCompact
+                  onClick={() =>
+                    navigate(`/agents/${namespace}/${alert.agent}`)
+                  }
+                  style={{ cursor: 'pointer' }}
+                >
+                  {alert.agent}
+                </Label>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    );
+  };
+
+  return (
+    <>
+      {/* Breadcrumb */}
+      <PageSection variant="light" type="breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbItem
+            to="/integrations"
+            onClick={(e) => {
+              e.preventDefault();
+              navigate('/integrations');
+            }}
+          >
+            Integrations
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>{name}</BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
+
+      {/* Header */}
+      <PageSection variant="light">
+        <Split hasGutter>
+          <SplitItem isFilled>
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsMd' }}
+            >
+              <FlexItem>
+                <Title headingLevel="h1">{integration.name}</Title>
+              </FlexItem>
+              <FlexItem>{renderStatusBadge(integration.status)}</FlexItem>
+              <FlexItem>
+                {renderProviderLabel(integration.repository.provider)}
+              </FlexItem>
+            </Flex>
+          </SplitItem>
+          <SplitItem>
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <Button
+                  variant="secondary"
+                  onClick={handleTestConnection}
+                  isLoading={testingConnection}
+                  isDisabled={testingConnection}
+                >
+                  Test Connection
+                </Button>
+              </FlexItem>
+              <FlexItem>
+                <Button
+                  variant="danger"
+                  onClick={() => setDeleteModalOpen(true)}
+                >
+                  Delete
+                </Button>
+              </FlexItem>
+            </Flex>
+          </SplitItem>
+        </Split>
+      </PageSection>
+
+      {/* Tabs */}
+      <PageSection>
+        <Tabs
+          activeKey={activeTab}
+          onSelect={(_event, tabIndex) => setActiveTab(tabIndex as number)}
+          aria-label="Integration detail tabs"
+        >
+          <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>}>
+            {renderOverviewTab()}
+          </Tab>
+          <Tab
+            eventKey={1}
+            title={
+              <TabTitleText>
+                Webhooks
+                {integration.webhooks.length > 0
+                  ? ` (${integration.webhooks.length})`
+                  : ''}
+              </TabTitleText>
+            }
+          >
+            {renderWebhooksTab()}
+          </Tab>
+          <Tab
+            eventKey={2}
+            title={
+              <TabTitleText>
+                Schedules
+                {integration.schedules.length > 0
+                  ? ` (${integration.schedules.length})`
+                  : ''}
+              </TabTitleText>
+            }
+          >
+            {renderSchedulesTab()}
+          </Tab>
+          <Tab
+            eventKey={3}
+            title={
+              <TabTitleText>
+                Alerts
+                {integration.alerts.length > 0
+                  ? ` (${integration.alerts.length})`
+                  : ''}
+              </TabTitleText>
+            }
+          >
+            {renderAlertsTab()}
+          </Tab>
+        </Tabs>
+      </PageSection>
+
+      {/* Delete Warning Modal */}
+      <Modal
+        variant={ModalVariant.small}
+        titleIconVariant="warning"
+        title="Delete integration?"
+        isOpen={deleteModalOpen}
+        onClose={handleCloseDeleteModal}
+        actions={[
+          <Button
+            key="delete"
+            variant="danger"
+            onClick={handleDeleteConfirm}
+            isLoading={deleteMutation.isPending}
+            isDisabled={
+              deleteMutation.isPending || deleteConfirmText !== name
+            }
+          >
+            Delete
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={handleCloseDeleteModal}
+            isDisabled={deleteMutation.isPending}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        <TextContent>
+          <Text>
+            <Icon status="warning" style={{ marginRight: '8px' }}>
+              <ExclamationTriangleIcon />
+            </Icon>
+            The integration <strong>{name}</strong> will be permanently deleted.
+            This will also remove all associated webhooks, schedules, and alert
+            configurations.
+          </Text>
+          <Text component="small" style={{ marginTop: '16px', display: 'block' }}>
+            Type <strong>{name}</strong> to confirm deletion:
+          </Text>
+        </TextContent>
+        <TextInput
+          id="delete-confirm-input"
+          value={deleteConfirmText}
+          onChange={(_e, value) => setDeleteConfirmText(value)}
+          aria-label="Confirm integration name"
+          style={{ marginTop: '8px' }}
+        />
+      </Modal>
+    </>
+  );
+};

--- a/kagenti/ui-v2/src/pages/IntegrationsPage.tsx
+++ b/kagenti/ui-v2/src/pages/IntegrationsPage.tsx
@@ -1,0 +1,462 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  PageSection,
+  Title,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  Button,
+  Spinner,
+  EmptyState,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
+  Label,
+  LabelGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+  Text,
+  TextContent,
+  Icon,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Dropdown,
+  DropdownList,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import {
+  Table,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+} from '@patternfly/react-table';
+import {
+  CodeBranchIcon,
+  PlusCircleIcon,
+  EllipsisVIcon,
+  ExclamationTriangleIcon,
+  BellIcon,
+  ClockIcon,
+  PluggedIcon,
+} from '@patternfly/react-icons';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { Integration } from '@/types';
+import { integrationService } from '@/services/api';
+import { NamespaceSelector } from '@/components/NamespaceSelector';
+
+export const IntegrationsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [namespace, setNamespace] = useState<string>('team1');
+  const [activeTabKey, setActiveTabKey] = useState<number>(0);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [integrationToDelete, setIntegrationToDelete] = useState<Integration | null>(null);
+  const [deleteConfirmText, setDeleteConfirmText] = useState('');
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+
+  const {
+    data: integrations = [],
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['integrations', namespace],
+    queryFn: () => integrationService.list(namespace),
+    enabled: !!namespace,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ namespace: ns, name }: { namespace: string; name: string }) =>
+      integrationService.delete(ns, name),
+    onSuccess: (_data, variables) => {
+      queryClient.setQueryData<Integration[]>(
+        ['integrations', variables.namespace],
+        (old) => old?.filter((i) => i.name !== variables.name) ?? []
+      );
+      queryClient.invalidateQueries({ queryKey: ['integrations', variables.namespace] });
+      handleCloseDeleteModal();
+    },
+  });
+
+  const handleDeleteClick = (integration: Integration) => {
+    setIntegrationToDelete(integration);
+    setDeleteModalOpen(true);
+    setOpenMenuId(null);
+  };
+
+  const handleCloseDeleteModal = () => {
+    setDeleteModalOpen(false);
+    setIntegrationToDelete(null);
+    setDeleteConfirmText('');
+  };
+
+  const handleDeleteConfirm = () => {
+    if (integrationToDelete && deleteConfirmText === integrationToDelete.name) {
+      deleteMutation.mutate({
+        namespace: integrationToDelete.namespace,
+        name: integrationToDelete.name,
+      });
+    }
+  };
+
+  // Compute tab counts
+  const totalWebhooks = integrations.reduce((sum, i) => sum + i.webhooks.length, 0);
+  const totalSchedules = integrations.reduce((sum, i) => sum + i.schedules.length, 0);
+  const totalAlerts = integrations.reduce((sum, i) => sum + i.alerts.length, 0);
+
+  const columns = ['Name', 'Repository', 'Provider', 'Agents', 'Webhooks', 'Schedules', 'Status', ''];
+
+  const stripProtocol = (url: string) => url.replace(/^https?:\/\//, '');
+
+  const renderStatusBadge = (status: string) => {
+    let color: 'green' | 'blue' | 'red' = 'red';
+    if (status === 'Connected') {
+      color = 'green';
+    } else if (status === 'Pending') {
+      color = 'blue';
+    }
+    return <Label color={color}>{status}</Label>;
+  };
+
+  const renderProviderLabel = (provider: string) => {
+    let color: 'blue' | 'orange' | 'purple' = 'blue';
+    if (provider === 'gitlab') {
+      color = 'orange';
+    } else if (provider === 'bitbucket') {
+      color = 'purple';
+    }
+    return <Label color={color} isCompact>{provider}</Label>;
+  };
+
+  const renderAgentChips = (agents: Integration['agents']) => {
+    if (agents.length === 0) return <Text component="small">None</Text>;
+    return (
+      <LabelGroup>
+        {agents.map((agent) => (
+          <Label key={`${agent.namespace}-${agent.name}`} color="cyan" isCompact>
+            {agent.name}
+          </Label>
+        ))}
+      </LabelGroup>
+    );
+  };
+
+  const getMenuId = (integration: Integration) => `${integration.namespace}-${integration.name}`;
+
+  const renderRepositoriesTab = () => {
+    if (isLoading) {
+      return (
+        <div className="kagenti-loading-center">
+          <Spinner size="lg" aria-label="Loading integrations" />
+        </div>
+      );
+    }
+
+    if (isError) {
+      return (
+        <EmptyState>
+          <EmptyStateHeader
+            titleText="Error loading integrations"
+            icon={<EmptyStateIcon icon={CodeBranchIcon} />}
+            headingLevel="h4"
+          />
+          <EmptyStateBody>
+            {error instanceof Error
+              ? error.message
+              : 'Unable to fetch integrations from the cluster.'}
+          </EmptyStateBody>
+        </EmptyState>
+      );
+    }
+
+    if (integrations.length === 0) {
+      return (
+        <EmptyState>
+          <EmptyStateHeader
+            titleText="No integrations found"
+            icon={<EmptyStateIcon icon={CodeBranchIcon} />}
+            headingLevel="h4"
+          />
+          <EmptyStateBody>
+            No integrations found in namespace &quot;{namespace}&quot;.
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button
+                variant="primary"
+                onClick={() => navigate('/integrations/add')}
+              >
+                Add Integration
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      );
+    }
+
+    return (
+      <Table aria-label="Integrations table" variant="compact">
+        <Thead>
+          <Tr>
+            {columns.map((col, idx) => (
+              <Th key={col || `col-${idx}`}>{col}</Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {integrations.map((integration) => {
+            const menuId = getMenuId(integration);
+            return (
+              <Tr key={menuId}>
+                <Td dataLabel="Name">
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() =>
+                      navigate(`/integrations/${integration.namespace}/${integration.name}`)
+                    }
+                  >
+                    {integration.name}
+                  </Button>
+                </Td>
+                <Td dataLabel="Repository">
+                  <a
+                    href={integration.repository.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {stripProtocol(integration.repository.url)}
+                  </a>
+                </Td>
+                <Td dataLabel="Provider">
+                  {renderProviderLabel(integration.repository.provider)}
+                </Td>
+                <Td dataLabel="Agents">
+                  {renderAgentChips(integration.agents)}
+                </Td>
+                <Td dataLabel="Webhooks">{integration.webhooks.length}</Td>
+                <Td dataLabel="Schedules">{integration.schedules.length}</Td>
+                <Td dataLabel="Status">
+                  {renderStatusBadge(integration.status)}
+                </Td>
+                <Td isActionCell>
+                  <Dropdown
+                    isOpen={openMenuId === menuId}
+                    onSelect={() => setOpenMenuId(null)}
+                    onOpenChange={(isOpen) => setOpenMenuId(isOpen ? menuId : null)}
+                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        aria-label="Actions menu"
+                        variant="plain"
+                        onClick={() =>
+                          setOpenMenuId(openMenuId === menuId ? null : menuId)
+                        }
+                        isExpanded={openMenuId === menuId}
+                      >
+                        <EllipsisVIcon />
+                      </MenuToggle>
+                    )}
+                    popperProps={{ position: 'right' }}
+                  >
+                    <DropdownList>
+                      <DropdownItem
+                        key="view"
+                        onClick={() =>
+                          navigate(`/integrations/${integration.namespace}/${integration.name}`)
+                        }
+                      >
+                        View details
+                      </DropdownItem>
+                      <DropdownItem
+                        key="delete"
+                        onClick={() => handleDeleteClick(integration)}
+                        isDanger
+                      >
+                        Delete integration
+                      </DropdownItem>
+                    </DropdownList>
+                  </Dropdown>
+                </Td>
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </Table>
+    );
+  };
+
+  return (
+    <>
+      <PageSection variant="light">
+        <Title headingLevel="h1">Integrations</Title>
+      </PageSection>
+
+      <PageSection variant="light" padding={{ default: 'noPadding' }}>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem>
+              <NamespaceSelector
+                namespace={namespace}
+                onNamespaceChange={setNamespace}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button
+                variant="primary"
+                icon={<PlusCircleIcon />}
+                onClick={() => navigate('/integrations/add')}
+              >
+                Add Integration
+              </Button>
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+      </PageSection>
+
+      <PageSection>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={(_event, tabIndex) => setActiveTabKey(tabIndex as number)}
+          aria-label="Integration tabs"
+        >
+          <Tab
+            eventKey={0}
+            title={
+              <TabTitleText>
+                Repositories{integrations.length > 0 ? ` (${integrations.length})` : ''}
+              </TabTitleText>
+            }
+          >
+            {renderRepositoriesTab()}
+          </Tab>
+          <Tab
+            eventKey={1}
+            title={
+              <TabTitleText>
+                Webhooks{totalWebhooks > 0 ? ` (${totalWebhooks})` : ''}
+              </TabTitleText>
+            }
+          >
+            <EmptyState>
+              <EmptyStateHeader
+                titleText="Webhooks"
+                icon={<EmptyStateIcon icon={PluggedIcon} />}
+                headingLevel="h4"
+              />
+              <EmptyStateBody>
+                Webhook configuration will be available here. Configure webhooks to trigger
+                agent actions on repository events such as push, pull request, or issue creation.
+              </EmptyStateBody>
+            </EmptyState>
+          </Tab>
+          <Tab
+            eventKey={2}
+            title={
+              <TabTitleText>
+                Schedules{totalSchedules > 0 ? ` (${totalSchedules})` : ''}
+              </TabTitleText>
+            }
+          >
+            <EmptyState>
+              <EmptyStateHeader
+                titleText="Schedules"
+                icon={<EmptyStateIcon icon={ClockIcon} />}
+                headingLevel="h4"
+              />
+              <EmptyStateBody>
+                Schedule configuration will be available here. Set up cron-based schedules
+                to run agent skills on a recurring basis.
+              </EmptyStateBody>
+            </EmptyState>
+          </Tab>
+          <Tab
+            eventKey={3}
+            title={
+              <TabTitleText>
+                Alerts{totalAlerts > 0 ? ` (${totalAlerts})` : ''}
+              </TabTitleText>
+            }
+          >
+            <EmptyState>
+              <EmptyStateHeader
+                titleText="Alerts"
+                icon={<EmptyStateIcon icon={BellIcon} />}
+                headingLevel="h4"
+              />
+              <EmptyStateBody>
+                Alert routing configuration will be available here. Connect Prometheus or
+                PagerDuty alerts to trigger agent-based remediation workflows.
+              </EmptyStateBody>
+            </EmptyState>
+          </Tab>
+        </Tabs>
+      </PageSection>
+
+      {/* Delete Warning Modal */}
+      <Modal
+        variant={ModalVariant.small}
+        titleIconVariant="warning"
+        title="Delete integration?"
+        isOpen={deleteModalOpen}
+        onClose={handleCloseDeleteModal}
+        actions={[
+          <Button
+            key="delete"
+            variant="danger"
+            onClick={handleDeleteConfirm}
+            isLoading={deleteMutation.isPending}
+            isDisabled={
+              deleteMutation.isPending ||
+              deleteConfirmText !== integrationToDelete?.name
+            }
+          >
+            Delete
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={handleCloseDeleteModal}
+            isDisabled={deleteMutation.isPending}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        <TextContent>
+          <Text>
+            <Icon status="warning" style={{ marginRight: '8px' }}>
+              <ExclamationTriangleIcon />
+            </Icon>
+            The integration <strong>{integrationToDelete?.name}</strong> will be permanently
+            deleted. This will also remove all associated webhooks, schedules, and alert
+            configurations.
+          </Text>
+          <Text component="small" style={{ marginTop: '16px', display: 'block' }}>
+            Type <strong>{integrationToDelete?.name}</strong> to confirm deletion:
+          </Text>
+        </TextContent>
+        <TextInput
+          id="delete-confirm-input"
+          value={deleteConfirmText}
+          onChange={(_e, value) => setDeleteConfirmText(value)}
+          aria-label="Confirm integration name"
+          style={{ marginTop: '8px' }}
+        />
+      </Modal>
+    </>
+  );
+};

--- a/kagenti/ui-v2/src/pages/SandboxCreatePage.tsx
+++ b/kagenti/ui-v2/src/pages/SandboxCreatePage.tsx
@@ -1,0 +1,27 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+/**
+ * SandboxCreatePage -- Thin wrapper around the reusable SandboxWizard component.
+ */
+
+import React from 'react';
+import { PageSection, Title } from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import { SandboxWizard } from '@/components/SandboxWizard';
+
+export const SandboxCreatePage: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <PageSection variant="light">
+      <Title headingLevel="h1" style={{ marginBottom: 16 }}>
+        Create Sandbox Agent
+      </Title>
+      <SandboxWizard
+        mode="create"
+        onClose={() => navigate('/sandbox')}
+        onSuccess={() => navigate('/sandbox')}
+      />
+    </PageSection>
+  );
+};

--- a/kagenti/ui-v2/src/pages/SandboxPage.tsx
+++ b/kagenti/ui-v2/src/pages/SandboxPage.tsx
@@ -825,20 +825,27 @@ export const SandboxPage: React.FC = () => {
   // Sidecar agents state
   const [sidecars, setSidecars] = useState<SidecarInfo[]>([]);
   const [reconfigureOpen, setReconfigureOpen] = useState(false);
-  // Poll sidecars list when we have a contextId
+  const sidecarErrorCount = useRef(0);
+  // Poll sidecars list when we have a contextId (with error backoff)
   useEffect(() => {
     if (!contextId || !namespace) return;
+    let timer: ReturnType<typeof setTimeout>;
+    let cancelled = false;
     const poll = async () => {
       try {
         const list = await sidecarService.list(namespace, contextId);
         setSidecars(list);
+        sidecarErrorCount.current = 0;
       } catch {
-        // Sidecar API not available — ignore
+        sidecarErrorCount.current++;
+      }
+      if (!cancelled) {
+        const delay = Math.min(5000 * (1 + sidecarErrorCount.current), 60000);
+        timer = setTimeout(poll, delay);
       }
     };
     poll();
-    const interval = setInterval(poll, 5000);
-    return () => clearInterval(interval);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [contextId, namespace]);
 
   const handleSidecarToggleEnable = async (sidecarType: string, enabled: boolean) => {

--- a/kagenti/ui-v2/src/pages/SandboxPage.tsx
+++ b/kagenti/ui-v2/src/pages/SandboxPage.tsx
@@ -1538,7 +1538,7 @@ export const SandboxPage: React.FC = () => {
             await pollSession(attempt + 1);
           }
         };
-        pollSession(0);
+        pollSession(0).catch(() => { /* prevent unhandled promise rejection */ });
       } else {
         setError(msg);
         sessionDispatch({

--- a/kagenti/ui-v2/src/pages/SandboxPage.tsx
+++ b/kagenti/ui-v2/src/pages/SandboxPage.tsx
@@ -27,10 +27,6 @@ import { sandboxService } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { SessionSidebar } from '../components/SessionSidebar';
 import { SkillWhisperer } from '../components/SkillWhisperer';
-// SandboxConfig disabled — model/repo/branch not yet wired to backend
-// import { SandboxConfig, SandboxConfigValues } from '../components/SandboxConfig';
-// NamespaceSelector removed from session view — namespace shown as read-only Label
-// import { NamespaceSelector } from '../components/NamespaceSelector';
 import { DelegationCard, type DelegationState } from '../components/DelegationCard';
 import { HitlApprovalCard } from '../components/HitlApprovalCard';
 import { AgentLoopCard } from '../components/AgentLoopCard';
@@ -735,10 +731,6 @@ export const SandboxPage: React.FC = () => {
     loadMoreTasks,
   } = useSessionLoader(namespace, contextId);
 
-  // Derived loading flags for backward compatibility
-  const loadingHistory = sessionIsLoading;
-  const loadingSession = sessionIsLoading;
-
   // Synchronous guard against double-send (React StrictMode double-invokes
   // effects/callbacks, and async setState batching means two rapid calls
   // can both see isStreaming===false before either sets it to true).
@@ -901,9 +893,6 @@ export const SandboxPage: React.FC = () => {
     }
   };
 
-  // SandboxConfig disabled — model/repo/branch not yet wired to backend
-  // const [config, setConfig] = useState({ model: 'gpt-4o-mini', repo: '', branch: 'main' });
-
   // Fetch agent card to get skills for / autocomplete
   const { data: agentCard } = useQuery({
     queryKey: ['sandbox-agent-card', namespace, selectedAgent],
@@ -984,7 +973,7 @@ export const SandboxPage: React.FC = () => {
 
   /** Load an older page of history (triggered by scrolling to top). */
   const loadOlderHistory = useCallback(async () => {
-    if (!hasMoreHistory || loadingHistory || oldestIndex === null) return;
+    if (!hasMoreHistory || sessionIsLoading || oldestIndex === null) return;
     const container = scrollContainerRef.current;
     const prevScrollHeight = container?.scrollHeight ?? 0;
 
@@ -1052,7 +1041,7 @@ export const SandboxPage: React.FC = () => {
     } catch {
       // ignore
     }
-  }, [hasMoreHistory, loadingHistory, oldestIndex, namespace, contextId, sessionDispatch]);
+  }, [hasMoreHistory, sessionIsLoading, oldestIndex, namespace, contextId, sessionDispatch]);
 
   // IntersectionObserver for infinite scroll — triggers when sentinel at top is visible
   useEffect(() => {
@@ -1061,7 +1050,7 @@ export const SandboxPage: React.FC = () => {
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0]?.isIntersecting && hasMoreHistory && !loadingHistory) {
+        if (entries[0]?.isIntersecting && hasMoreHistory && !sessionIsLoading) {
           loadOlderHistory();
         }
       },
@@ -1069,7 +1058,7 @@ export const SandboxPage: React.FC = () => {
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [hasMoreHistory, loadingHistory, loadOlderHistory]);
+  }, [hasMoreHistory, sessionIsLoading, loadOlderHistory]);
 
   // Auto-scroll to bottom on new messages
   const shouldAutoScroll = useRef(true);
@@ -1232,12 +1221,7 @@ export const SandboxPage: React.FC = () => {
     let accumulatedContent = '';
     let buffer = '';
     let seenLoopId = false; // Once any loop_id event seen, suppress flat messages
-    // msgCountBeforeStream removed — no longer wiping messages on loop start
     const collectedMessages: Message[] = [];
-
-    // Snapshot current message count so retroactive cleanup only
-    // removes flat messages from THIS turn, not previous turns
-    // msgCountBeforeStream = messages.length; // removed — see MESSAGES_SET removal
 
     try {
       while (true) {
@@ -1288,8 +1272,6 @@ export const SandboxPage: React.FC = () => {
               const loopId = data.loop_id;
               const le = data.loop_event || data;
               const eventType = le.type;
-              console.log(`[sse] LOOP_RECV loop=${loopId?.substring(0, 8)} type=${eventType} step=${le.step ?? ''} tools=${le.tools?.length ?? 0}`);
-
               // Apply event using shared builder
               updateLoop(loopId, (prev) => applyLoopEvent(prev, le));
 
@@ -1689,11 +1671,6 @@ export const SandboxPage: React.FC = () => {
             <SplitItem isFilled />
           </Split>
 
-          {/* SandboxConfig disabled — model/repo/branch not yet wired to backend.
-              TODO: wire config to agent via A2A message metadata or per-session config endpoint.
-          <SandboxConfig config={config} onChange={setConfig} />
-          */}
-
           {error && (
             <Alert
               variant="danger"
@@ -1770,12 +1747,12 @@ export const SandboxPage: React.FC = () => {
                 padding: '12px 16px',
               }}
             >
-            {loadingSession && (
+            {sessionIsLoading && (
               <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <Spinner size="lg" />
               </div>
             )}
-            {!loadingSession && (<>
+            {!sessionIsLoading && (<>
 
               {/* Sentinel for infinite scroll — loads older messages */}
               <div ref={sentinelRef} style={{ minHeight: 1 }} />

--- a/kagenti/ui-v2/src/pages/SandboxPage.tsx
+++ b/kagenti/ui-v2/src/pages/SandboxPage.tsx
@@ -1,0 +1,2231 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import {
+  PageSection,
+  Card,
+  CardBody,
+  TextArea,
+  Button,
+  Split,
+  SplitItem,
+  Spinner,
+  Alert,
+  Label,
+  Tooltip,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core';
+import { PaperPlaneIcon, UserIcon, RobotIcon, FileIcon, ShieldAltIcon, CogIcon, StopCircleIcon } from '@patternfly/react-icons';
+import { useSearchParams } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import { useQuery } from '@tanstack/react-query';
+import { sandboxService } from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
+import { SessionSidebar } from '../components/SessionSidebar';
+import { SkillWhisperer } from '../components/SkillWhisperer';
+// SandboxConfig disabled — model/repo/branch not yet wired to backend
+// import { SandboxConfig, SandboxConfigValues } from '../components/SandboxConfig';
+// NamespaceSelector removed from session view — namespace shown as read-only Label
+// import { NamespaceSelector } from '../components/NamespaceSelector';
+import { DelegationCard, type DelegationState } from '../components/DelegationCard';
+import { HitlApprovalCard } from '../components/HitlApprovalCard';
+import { AgentLoopCard } from '../components/AgentLoopCard';
+import { SimpleLoopCard } from '../components/SimpleLoopCard';
+import { GraphLoopView } from '../components/GraphLoopView';
+import { FloatingViewBar, type ViewMode, isValidViewMode } from '../components/FloatingViewBar';
+import { FilePreviewModal } from '../components/FilePreviewModal';
+import { SessionStatsPanel } from '../components/SessionStatsPanel';
+import { LlmUsagePanel } from '../components/LlmUsagePanel';
+import { FileBrowser } from '../components/FileBrowser';
+import { PodStatusPanel } from '../components/PodStatusPanel';
+import { SidecarPanel } from '../components/SidecarTab';
+import { ModelSwitcher } from '../components/ModelSwitcher';
+import { SandboxWizard } from '../components/SandboxWizard';
+import { SubSessionsPanel, useChildSessionCount } from '../components/SubSessionsPanel';
+import { sidecarService, type SidecarInfo } from '../services/api';
+import type { AgentLoop } from '../types/agentLoop';
+import { applyLoopEvent, createDefaultAgentLoop } from '../utils/loopBuilder';
+import { useSessionLoader } from '../hooks/useSessionLoader';
+
+const DELEGATION_EVENT_TYPES = ['delegation_start', 'delegation_progress', 'delegation_complete'] as const;
+type DelegationEventType = typeof DELEGATION_EVENT_TYPES[number];
+
+interface ToolCallData {
+  type: 'tool_call' | 'tool_result' | 'thinking' | 'llm_response' | 'error' | 'hitl_request' | DelegationEventType;
+  name?: string;
+  args?: string | Record<string, unknown>;
+  output?: string;
+  content?: string;
+  message?: string;
+  command?: string;
+  reason?: string;
+  tools?: Array<{ name: string; args: string | Record<string, unknown> }>;
+  // Delegation fields
+  child_context_id?: string;
+  delegation_mode?: string;
+  task?: string;
+  variant?: string;
+  state?: string;
+}
+
+interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: Date;
+  toolData?: ToolCallData;
+  username?: string;
+  /** Stable sort key from the backend (_index) or insertion order. */
+  order: number;
+}
+
+/** Format timestamp for display — HH:mm:ss.mmm for precise ordering. */
+function formatMsgTime(d: Date): string {
+  const h = String(d.getHours()).padStart(2, '0');
+  const m = String(d.getMinutes()).padStart(2, '0');
+  const s = String(d.getSeconds()).padStart(2, '0');
+  const ms = String(d.getMilliseconds()).padStart(3, '0');
+  return `${h}:${m}:${s}.${ms}`;
+}
+
+/** Regex matching absolute file paths in agent output. */
+const FILE_PATH_RE = /(?<!\w)(\/(?:workspace|data|repos|app|home|tmp|opt|var|srv)\/[\w./_-]+(?:\.\w+)?)/g;
+
+/**
+ * Convert file paths in text to markdown links pointing to the file browser.
+ * Skips paths that are already inside backticks (those are handled by the
+ * custom `code` component in buildMarkdownComponents).
+ */
+function linkifyFilePaths(text: string, namespace: string, agentName: string): string {
+  // Split text by backtick-delimited sections to avoid double-processing
+  const parts = text.split(/(`[^`]+`)/g);
+  return parts
+    .map((part, i) => {
+      // Odd indices are backtick-wrapped — leave them alone
+      if (i % 2 === 1) return part;
+      // Even indices are plain text — linkify paths
+      return part.replace(FILE_PATH_RE, (match) =>
+        `[${match}](/sandbox/files/${namespace}/${agentName}?path=${encodeURIComponent(match)})`
+      );
+    })
+    .join('');
+}
+
+/** Inline file path card that renders as a clickable Label with file preview modal. */
+const FilePathCard: React.FC<{ path: string; namespace: string; agentName: string }> = ({ path, namespace, agentName }) => {
+  const [showModal, setShowModal] = useState(false);
+  const fileName = path.split('/').pop() || path;
+
+  return (
+    <>
+      <Tooltip content="Click for details">
+        <Label isCompact icon={<FileIcon />} onClick={() => setShowModal(true)} style={{ cursor: 'pointer', margin: '0 2px' }}>
+          {fileName}
+        </Label>
+      </Tooltip>
+      <FilePreviewModal
+        filePath={path}
+        namespace={namespace}
+        agentName={agentName}
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+      />
+    </>
+  );
+};
+
+/** Build custom ReactMarkdown components that render file browser links as FilePathCard. */
+function buildMarkdownComponents(namespace: string, agentName: string) {
+  return {
+    a: ({ href, children }: any) => {
+      // If it's a file browser link, render FilePathCard
+      if (href?.startsWith('/sandbox/files/')) {
+        const pathMatch = href.match(/path=([^&]+)/);
+        const filePath = pathMatch ? decodeURIComponent(pathMatch[1]) : '';
+        return <FilePathCard path={filePath} namespace={namespace} agentName={agentName} />;
+      }
+      // Regular link
+      return <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>;
+    },
+    // Inline code that contains a file path → render as FilePathCard
+    code: ({ children, className }: any) => {
+      // Only handle inline code (no className means no language = not a code block)
+      if (className) {
+        return <code className={className}>{children}</code>;
+      }
+      const text = String(children).trim();
+      if (FILE_PATH_RE.test(text)) {
+        // Reset lastIndex since FILE_PATH_RE is global
+        FILE_PATH_RE.lastIndex = 0;
+        return <FilePathCard path={text} namespace={namespace} agentName={agentName} />;
+      }
+      FILE_PATH_RE.lastIndex = 0;
+      return <code>{children}</code>;
+    },
+  };
+}
+
+/**
+ * Parse a graph event line — JSON first, regex fallback for old Python repr.
+ * Mirrors the backend's _parse_graph_event() logic so tool calls render
+ * during streaming even when the LangGraphSerializer isn't deployed.
+ */
+function parseGraphEvent(text: string): ToolCallData | null {
+  const stripped = text.trim();
+  if (!stripped) return null;
+
+  // New format: structured JSON
+  try {
+    const data = JSON.parse(stripped);
+    if (data && typeof data === 'object' && data.type) {
+      return data as ToolCallData;
+    }
+  } catch {
+    // Not JSON — try regex fallback
+  }
+
+  // Old format: Python repr — "assistant: {'messages': [AIMessage(...)]}"
+  if (stripped.startsWith('assistant:')) {
+    if (stripped.includes('tool_calls=') || (stripped.includes("'name':") && stripped.includes("'args':"))) {
+      const calls = [...stripped.matchAll(/'name':\s*'([^']+)'.*?'args':\s*(\{[^}]*\}?)/g)];
+      if (calls.length > 0) {
+        return {
+          type: 'tool_call',
+          tools: calls.map(c => ({ name: c[1], args: c[2] })),
+        };
+      }
+    }
+    // Extract content
+    const contentMatch = stripped.match(/content='((?:[^'\\]|\\.){1,2000})'/) ||
+                         stripped.match(/content="((?:[^"\\]|\\.){1,2000})"/) ||
+                         stripped.match(/content='([^']{1,500})/);
+    if (contentMatch && contentMatch[1].trim()) {
+      return { type: 'llm_response', content: contentMatch[1].slice(0, 2000) };
+    }
+  } else if (stripped.startsWith('tools:')) {
+    // Extract tool result
+    const patterns = [
+      /content='((?:[^'\\]|\\.)*?)'\s*,\s*name='([^']*)'/,
+      /content="((?:[^"\\]|\\.)*?)"\s*,\s*name='([^']*)'/,
+      /content='((?:[^'\\]|\\.)*?)'\s*,\s*name="([^"]*)"/,
+      /content="((?:[^"\\]|\\.)*?)"\s*,\s*name="([^"]*)"/,
+    ];
+    for (const pattern of patterns) {
+      const match = stripped.match(pattern);
+      if (match) {
+        return {
+          type: 'tool_result',
+          name: match[2],
+          output: match[1].slice(0, 2000).replace(/\\n/g, '\n'),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Message bubble component
+// ---------------------------------------------------------------------------
+
+/** Expandable tool call step in the conversation. */
+const ToolCallStep: React.FC<{
+  data: ToolCallData;
+  onApprove?: () => void;
+  onDeny?: () => void;
+}> = ({ data, onApprove, onDeny }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (data.type === 'tool_call') {
+    return (
+      <div
+        data-testid="tool-call-step"
+        style={{
+          margin: '4px 0',
+          padding: '6px 10px',
+          borderLeft: '3px solid var(--pf-v5-global--info-color--100)',
+          backgroundColor: 'var(--pf-v5-global--BackgroundColor--200)',
+          borderRadius: '0 4px 4px 0',
+          fontSize: '0.85em',
+          cursor: 'pointer',
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div style={{ fontWeight: 600 }}>
+          {expanded ? '▼' : '▶'} Tool Call:{' '}
+          {(() => {
+            if (!data.tools || data.tools.length === 0) return 'unknown';
+            const counts = data.tools.reduce((acc, t) => {
+              const name = t.name || 'unknown';
+              acc[name] = (acc[name] || 0) + 1;
+              return acc;
+            }, {} as Record<string, number>);
+            return Object.entries(counts)
+              .map(([name, count]) => count > 1 ? `${name} (${count})` : name)
+              .join(', ');
+          })()}
+        </div>
+        {expanded &&
+          data.tools?.map((t, i) => (
+            <pre
+              key={i}
+              style={{
+                margin: '4px 0',
+                padding: 8,
+                backgroundColor: 'var(--pf-v5-global--BackgroundColor--dark-300)',
+                color: 'var(--pf-v5-global--Color--light-100)',
+                borderRadius: 4,
+                fontSize: '0.9em',
+                overflow: 'auto',
+              }}
+            >
+              {t.name}({typeof t.args === 'string' ? t.args : JSON.stringify(t.args, null, 2)})
+            </pre>
+          ))}
+      </div>
+    );
+  }
+
+  if (data.type === 'tool_result') {
+    return (
+      <div
+        data-testid="tool-result-step"
+        style={{
+          margin: '4px 0',
+          padding: '6px 10px',
+          borderLeft: '3px solid var(--pf-v5-global--success-color--100)',
+          backgroundColor: 'var(--pf-v5-global--BackgroundColor--200)',
+          borderRadius: '0 4px 4px 0',
+          fontSize: '0.85em',
+          cursor: 'pointer',
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div style={{ fontWeight: 600 }}>
+          {expanded ? '▼' : '▶'} Result: {data.name || 'tool'}
+        </div>
+        {expanded && (
+          <pre
+            style={{
+              margin: '4px 0',
+              padding: 8,
+              backgroundColor: 'var(--pf-v5-global--BackgroundColor--dark-300)',
+              color: 'var(--pf-v5-global--Color--light-100)',
+              borderRadius: 4,
+              fontSize: '0.9em',
+              overflow: 'auto',
+              maxHeight: 200,
+            }}
+          >
+            {data.output || '(no output)'}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  if (data.type === 'thinking' || data.type === 'llm_response') {
+    return (
+      <div
+        style={{
+          margin: '4px 0',
+          padding: '4px 10px',
+          fontSize: '0.82em',
+          fontStyle: 'italic',
+          color: 'var(--pf-v5-global--Color--200)',
+        }}
+      >
+        {data.content}
+      </div>
+    );
+  }
+
+  if (data.type === 'error') {
+    return (
+      <div
+        style={{
+          margin: '4px 0',
+          padding: '6px 10px',
+          borderLeft: '3px solid var(--pf-v5-global--danger-color--100)',
+          backgroundColor: 'var(--pf-v5-global--BackgroundColor--200)',
+          borderRadius: '0 4px 4px 0',
+          fontSize: '0.85em',
+        }}
+      >
+        <div style={{ fontWeight: 600, color: 'var(--pf-v5-global--danger-color--100)' }}>
+          Error
+        </div>
+        <pre style={{ margin: '4px 0', padding: 8, fontSize: '0.9em', overflow: 'auto', maxHeight: 150 }}>
+          {data.message || '(unknown error)'}
+        </pre>
+      </div>
+    );
+  }
+
+  if (data.type === 'hitl_request') {
+    return (
+      <HitlApprovalCard
+        command={data.command || ''}
+        reason={data.reason || 'Agent requests approval'}
+        onApprove={onApprove}
+        onReject={onDeny}
+      />
+    );
+  }
+
+  // Delegation events — render DelegationCard inline
+  if (DELEGATION_EVENT_TYPES.includes(data.type as DelegationEventType)) {
+    const delegationState: DelegationState = {
+      childId: data.child_context_id || '',
+      mode: data.delegation_mode || 'in-process',
+      task: data.task || data.message || '',
+      variant: data.variant || 'sandbox-legion',
+      status: data.type === 'delegation_complete'
+        ? (data.state === 'COMPLETED' ? 'completed' : 'failed')
+        : data.type === 'delegation_progress' ? 'working' : 'spawning',
+    };
+    return <DelegationCard delegation={delegationState} result={data.content} />;
+  }
+
+  return null;
+};
+
+const ChatBubble: React.FC<{
+  msg: Message;
+  currentUsername?: string;
+  namespace: string;
+  agentName: string;
+  onApprove?: () => void;
+  onDeny?: () => void;
+}> = ({ msg, currentUsername, namespace, agentName, onApprove, onDeny }) => {
+  const isUser = msg.role === 'user';
+
+  // Tool call/result steps render as compact expandable items
+  if (!isUser && msg.toolData) {
+    return <ToolCallStep data={msg.toolData} onApprove={onApprove} onDeny={onDeny} />;
+  }
+
+  // Display name: show actual username with (you) suffix for own messages
+  const displayName = isUser
+    ? (msg.username
+        ? (msg.username === currentUsername ? `${msg.username} (you)` : msg.username)
+        : 'You')
+    : 'Agent';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 10,
+        padding: '10px 14px',
+        marginBottom: 4,
+        borderRadius: 8,
+        backgroundColor: isUser
+          ? 'var(--pf-v5-global--BackgroundColor--200)'
+          : 'var(--pf-v5-global--BackgroundColor--100)',
+        border: isUser
+          ? 'none'
+          : '1px solid var(--pf-v5-global--BorderColor--100)',
+      }}
+    >
+      {/* Avatar */}
+      <div
+        style={{
+          flexShrink: 0,
+          width: 32,
+          height: 32,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: isUser
+            ? 'var(--pf-v5-global--primary-color--100)'
+            : 'var(--pf-v5-global--success-color--100)',
+          color: '#fff',
+          fontSize: 14,
+        }}
+      >
+        {isUser ? <UserIcon /> : <RobotIcon />}
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {/* Header row */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 4,
+          }}
+        >
+          <span style={{ fontWeight: 600, fontSize: '0.9em' }} data-testid={`chat-sender-${msg.id}`}>
+            {displayName}
+          </span>
+          <span
+            style={{
+              fontSize: '0.75em',
+              color: 'var(--pf-v5-global--Color--200)',
+              cursor: 'default',
+            }}
+            title={msg.timestamp.toISOString()}
+          >
+            {formatMsgTime(msg.timestamp)}
+          </span>
+        </div>
+
+        {/* Body */}
+        {isUser ? (
+          <p style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{msg.content}</p>
+        ) : (
+          <div className="sandbox-markdown" style={{ fontSize: '0.92em' }}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={buildMarkdownComponents(namespace, agentName)}>
+              {linkifyFilePaths(msg.content, namespace, agentName)}
+            </ReactMarkdown>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Group messages into "turns" for collapsed rendering.
+ * A turn is: one user message + all consecutive assistant messages after it.
+ * The last text-content assistant message in a turn is the "final answer".
+ * Everything else (tool calls, intermediate messages) goes behind a toggle.
+ */
+interface Turn {
+  user?: Message;
+  assistantMessages: Message[];
+  finalAnswer: string;
+}
+
+function groupMessagesIntoTurns(messages: Message[]): Turn[] {
+  // Sort by the stable `order` field (backend _index or insertion position).
+  // This is necessary because messages from polling, SSE, and history loads
+  // may be merged in non-chronological order.
+  const sorted = [...messages].sort((a, b) => a.order - b.order);
+  const turns: Turn[] = [];
+  let current: Turn = { assistantMessages: [], finalAnswer: '' };
+
+  for (const msg of sorted) {
+    if (msg.role === 'user') {
+      // Start new turn
+      if (current.user || current.assistantMessages.length > 0) {
+        turns.push(current);
+      }
+      current = { user: msg, assistantMessages: [], finalAnswer: '' };
+    } else {
+      current.assistantMessages.push(msg);
+      // Track last non-empty text content as the final answer
+      if (msg.content && msg.content.trim() && !msg.toolData) {
+        current.finalAnswer = msg.content;
+      }
+    }
+  }
+  if (current.user || current.assistantMessages.length > 0) {
+    turns.push(current);
+  }
+  return turns;
+}
+
+/** Interactive event types that must ALWAYS be visible (not collapsed). */
+const INTERACTIVE_TYPES = new Set(['hitl_request', 'delegation_start', 'delegation_progress', 'delegation_complete']);
+
+/** Collapsed agent turn: final answer visible, intermediate steps behind toggle. */
+const CollapsedTurn: React.FC<{
+  turn: Turn;
+  namespace: string;
+  agentName: string;
+  onApprove?: () => void;
+  onDeny?: () => void;
+}> = ({ turn, namespace, agentName, onApprove, onDeny }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  // Split messages: interactive (always visible) vs collapsible (behind toggle)
+  const interactive = turn.assistantMessages.filter(
+    (m) => m.toolData && INTERACTIVE_TYPES.has(m.toolData.type)
+  );
+  const collapsible = turn.assistantMessages.filter(
+    (m) =>
+      // Must have content or tool data to be worth showing
+      (m.content?.trim() || m.toolData) &&
+      // Not the final answer (already shown above)
+      (m.content !== turn.finalAnswer || m.toolData) &&
+      // Not interactive events (shown outside toggle)
+      !(m.toolData && INTERACTIVE_TYPES.has(m.toolData.type))
+  );
+
+  return (
+    <div
+      data-testid="collapsed-turn"
+      style={{
+        display: 'flex',
+        gap: 10,
+        padding: '10px 14px',
+        marginBottom: 4,
+        borderRadius: 8,
+        border: '1px solid var(--pf-v5-global--success-color--100)',
+        backgroundColor: 'var(--pf-v5-global--BackgroundColor--100)',
+      }}
+    >
+      {/* Avatar */}
+      <div
+        style={{
+          flexShrink: 0,
+          width: 32,
+          height: 32,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'var(--pf-v5-global--success-color--100)',
+          color: '#fff',
+          fontSize: 14,
+        }}
+      >
+        <RobotIcon />
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {/* Timestamp header */}
+        {turn.assistantMessages.length > 0 && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+            <span style={{ fontWeight: 600, fontSize: '0.9em' }}>{agentName || 'Agent'}</span>
+            <span
+              style={{ fontSize: '0.75em', color: 'var(--pf-v5-global--Color--200)', cursor: 'default' }}
+              title={turn.assistantMessages[0].timestamp.toISOString()}
+            >
+              {formatMsgTime(turn.assistantMessages[0].timestamp)}
+            </span>
+          </div>
+        )}
+        {/* Final answer — always visible */}
+        {turn.finalAnswer && (
+          <div className="sandbox-markdown" style={{ fontSize: '0.92em', marginBottom: 6 }}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={buildMarkdownComponents(namespace, agentName)}>
+              {linkifyFilePaths(turn.finalAnswer, namespace, agentName)}
+            </ReactMarkdown>
+          </div>
+        )}
+
+        {/* Interactive events — ALWAYS visible (HITL approve/deny, delegation) */}
+        {interactive.map((m) => (
+          <div key={m.id} style={{ marginBottom: 4 }}>
+            <ToolCallStep data={m.toolData!} onApprove={onApprove} onDeny={onDeny} />
+          </div>
+        ))}
+
+        {/* Collapsible steps toggle */}
+        {collapsible.length > 0 && (
+          <>
+            <div
+              onClick={() => setExpanded((prev) => !prev)}
+              data-testid="turn-details-toggle"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '2px 8px',
+                borderRadius: 4,
+                border: '1px solid var(--pf-v5-global--BorderColor--100)',
+                fontSize: '0.8em',
+                fontWeight: 500,
+                color: 'var(--pf-v5-global--Color--200)',
+                cursor: 'pointer',
+                userSelect: 'none',
+              }}
+            >
+              {expanded ? '[-]' : '[+]'} {collapsible.length} step{collapsible.length !== 1 ? 's' : ''}
+            </div>
+
+            {expanded && (
+              <div style={{ marginTop: 8, paddingLeft: 8, borderLeft: '2px solid var(--pf-v5-global--BorderColor--100)', maxHeight: 400, overflowY: 'auto' }}>
+                {collapsible.map((m) => (
+                  <div key={m.id} style={{ marginBottom: 4, fontSize: '0.85em' }}>
+                    {m.toolData ? (
+                      <ToolCallStep data={m.toolData} onApprove={onApprove} onDeny={onDeny} />
+                    ) : m.content ? (
+                      <div className="sandbox-markdown" style={{ color: 'var(--pf-v5-global--Color--200)' }}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]} components={buildMarkdownComponents(namespace, agentName)}>
+                          {linkifyFilePaths(m.content, namespace, agentName)}
+                        </ReactMarkdown>
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// SandboxPage
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY_SESSION = 'kagenti-sandbox-last-session';
+const STORAGE_KEY_NAMESPACE = 'kagenti-sandbox-last-namespace';
+const STORAGE_KEY_AGENT_PREFIX = 'kagenti-sandbox-agent:'; // keyed by session id
+
+/**
+ * Determine initial session ID.
+ *
+ * Priority: URL ?session= param > localStorage (only if URL has no param
+ * and the page was just reloaded, not a fresh navigation).
+ */
+function getInitialSession(params: URLSearchParams): string {
+  const fromUrl = params.get('session');
+  if (fromUrl) return fromUrl;
+
+  // Only restore from localStorage if this looks like a reload (referrer is same origin)
+  // or if the navigation entry type is "reload".
+  try {
+    const navEntries = performance.getEntriesByType('navigation');
+    const isReload =
+      navEntries.length > 0 &&
+      (navEntries[0] as PerformanceNavigationTiming).type === 'reload';
+    if (isReload) {
+      return localStorage.getItem(STORAGE_KEY_SESSION) || '';
+    }
+  } catch {
+    // fallback — don't restore
+  }
+  return '';
+}
+
+export const SandboxPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  // setNamespace removed — namespace is read-only during active session
+  const [namespace] = useState(
+    () =>
+      localStorage.getItem(STORAGE_KEY_NAMESPACE) || 'team1'
+  );
+  const [contextId, setContextId] = useState(() =>
+    getInitialSession(searchParams)
+  );
+  /** Auto-incrementing counter for message ordering. */
+  const orderCounterRef = useRef(1_000_000);
+  const [input, setInput] = useState('');
+  const [streamingContent, setStreamingContent] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // --- Session loader hook: state-machine for session lifecycle ---
+  const {
+    messages,
+    agentLoops,
+    hasMoreHistory,
+    oldestIndex,
+    isLoading: sessionIsLoading,
+    isStreaming,
+    dispatch: sessionDispatch,
+    subscribeAbortRef,
+    sendInProgressRef,
+    hasMoreTasks,
+    loadMoreTasks,
+  } = useSessionLoader(namespace, contextId);
+
+  // Derived loading flags for backward compatibility
+  const loadingHistory = sessionIsLoading;
+  const loadingSession = sessionIsLoading;
+
+  // Synchronous guard against double-send (React StrictMode double-invokes
+  // effects/callbacks, and async setState batching means two rapid calls
+  // can both see isStreaming===false before either sets it to true).
+  const sendingRef = useRef(false);
+  /** Last user message text — attached to the next AgentLoop created during streaming. */
+  const lastUserMessageRef = useRef<string>('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const { getToken, user } = useAuth();
+  const currentUsername = user?.username || 'you';
+  const [selectedAgent, setSelectedAgent] = useState(() => {
+    // Restore agent from URL param first, then localStorage keyed by session
+    const urlAgent = searchParams.get('agent');
+    if (urlAgent) return urlAgent;
+    const sid = getInitialSession(searchParams);
+    if (sid) {
+      const stored = localStorage.getItem(STORAGE_KEY_AGENT_PREFIX + sid);
+      if (stored) return stored;
+    }
+    return 'sandbox-legion';
+  });
+  // Refs mirror state for use in async closures (avoids stale state)
+  const selectedAgentRef = useRef(selectedAgent);
+  useEffect(() => { selectedAgentRef.current = selectedAgent; }, [selectedAgent]);
+  const contextIdRef = useRef(contextId);
+  useEffect(() => { contextIdRef.current = contextId; }, [contextId]);
+
+  // Sync selectedAgent when URL ?agent= param changes (e.g. SPA navigation)
+  useEffect(() => {
+    const urlAgent = searchParams.get('agent');
+    if (urlAgent && urlAgent !== selectedAgent) {
+      selectedAgentRef.current = urlAgent; // Update ref immediately (no race)
+      setSelectedAgent(urlAgent);
+    }
+  }, [searchParams]);
+  const [skillWhispererDismissed, setSkillWhispererDismissed] = useState(false);
+  const [sessionModelOverride, setSessionModelOverride] = useState<string>('');
+  const [activeTab, setActiveTab] = useState<string>(() => searchParams.get('tab') || 'chat');
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    const param = searchParams.get('view');
+    return isValidViewMode(param) ? param : 'advanced';
+  });
+  const handleViewModeChange = useCallback((mode: ViewMode) => {
+    setViewMode(mode);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (mode === 'advanced') {
+        next.delete('view');
+      } else {
+        next.set('view', mode);
+      }
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
+  // Memoize full loop array for graph view multi-message mode
+  const allLoopsArray = useMemo(() => Array.from(agentLoops.values()), [agentLoops]);
+
+  const renderLoopCard = useCallback((loop: AgentLoop, streaming: boolean) => {
+    if (viewMode === 'simple') return <SimpleLoopCard key={loop.id} loop={loop} />;
+    if (viewMode === 'graph') return <GraphLoopView key={loop.id} loop={loop} allLoops={allLoopsArray} />;
+    return <AgentLoopCard key={loop.id} loop={loop} isStreaming={streaming} namespace={namespace} agentName={selectedAgent} />;
+  }, [viewMode, namespace, selectedAgent, allLoopsArray]);
+
+  // Keyboard shortcuts: Alt+1/2/3 for view modes
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.altKey && !e.ctrlKey && !e.metaKey) {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+        if (e.key === '1') handleViewModeChange('simple');
+        else if (e.key === '2') handleViewModeChange('advanced');
+        else if (e.key === '3') handleViewModeChange('graph');
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [handleViewModeChange]);
+
+  // Child session count for sub-sessions tab badge
+  const childSessionCount = useChildSessionCount(namespace, contextId);
+
+  // Sidecar agents state
+  const [sidecars, setSidecars] = useState<SidecarInfo[]>([]);
+  const [reconfigureOpen, setReconfigureOpen] = useState(false);
+  // Poll sidecars list when we have a contextId
+  useEffect(() => {
+    if (!contextId || !namespace) return;
+    const poll = async () => {
+      try {
+        const list = await sidecarService.list(namespace, contextId);
+        setSidecars(list);
+      } catch {
+        // Sidecar API not available — ignore
+      }
+    };
+    poll();
+    const interval = setInterval(poll, 5000);
+    return () => clearInterval(interval);
+  }, [contextId, namespace]);
+
+  const handleSidecarToggleEnable = async (sidecarType: string, enabled: boolean) => {
+    if (!contextId || !namespace) return;
+    try {
+      if (enabled) {
+        await sidecarService.enable(namespace, contextId, sidecarType);
+      } else {
+        await sidecarService.disable(namespace, contextId, sidecarType);
+        // Switch to chat if we disabled the active tab
+        if (activeTab === `sidecar-${sidecarType}`) {
+          setActiveTab('chat');
+        }
+      }
+      // Refresh list
+      const list = await sidecarService.list(namespace, contextId);
+      setSidecars(list);
+    } catch (e) {
+      console.error('Sidecar toggle error:', e);
+    }
+  };
+
+  const handleSidecarToggleAutoApprove = async (sidecarType: string, auto: boolean) => {
+    if (!contextId || !namespace) return;
+    try {
+      await sidecarService.updateConfig(namespace, contextId, sidecarType, { auto_approve: auto });
+      const list = await sidecarService.list(namespace, contextId);
+      setSidecars(list);
+    } catch (e) {
+      console.error('Sidecar auto-approve toggle error:', e);
+    }
+  };
+
+  const handleSidecarConfigChange = async (sidecarType: string, key: string, value: unknown) => {
+    if (!contextId || !namespace) return;
+    try {
+      await sidecarService.updateConfig(namespace, contextId, sidecarType, { [key]: value });
+      const list = await sidecarService.list(namespace, contextId);
+      setSidecars(list);
+    } catch (e) {
+      console.error('Sidecar config change error:', e);
+    }
+  };
+
+  const handleSidecarReset = async (sidecarType: string) => {
+    if (!contextId || !namespace) return;
+    try {
+      await sidecarService.reset(namespace, contextId, sidecarType);
+      const list = await sidecarService.list(namespace, contextId);
+      setSidecars(list);
+    } catch (e) {
+      console.error('Sidecar reset error:', e);
+    }
+  };
+
+  // SandboxConfig disabled — model/repo/branch not yet wired to backend
+  // const [config, setConfig] = useState({ model: 'gpt-4o-mini', repo: '', branch: 'main' });
+
+  // Fetch agent card to get skills for / autocomplete
+  const { data: agentCard } = useQuery({
+    queryKey: ['sandbox-agent-card', namespace, selectedAgent],
+    queryFn: () => sandboxService.getAgentCard(namespace, selectedAgent),
+    enabled: !!namespace && !!selectedAgent,
+    staleTime: 60000,
+    retry: 1,
+  });
+
+  // Built-in sandbox tools — always available for / autocomplete
+  const BUILTIN_TOOLS = [
+    { id: 'shell', name: 'Shell', description: 'Execute a shell command in the sandbox' },
+    { id: 'file_read', name: 'File Read', description: 'Read a file from the workspace' },
+    { id: 'file_write', name: 'File Write', description: 'Write content to a file' },
+    { id: 'web_fetch', name: 'Web Fetch', description: 'Fetch content from a URL' },
+    { id: 'explore', name: 'Explore', description: 'Spawn a read-only sub-agent for research' },
+    { id: 'delegate', name: 'Delegate', description: 'Spawn a child agent session for a task' },
+  ];
+  // Merge agent card skills (e.g., loaded from .claude/skills/) with built-in tools.
+  // Agent card skills come first, then built-in tools that aren't already listed.
+  const cardSkills = agentCard?.skills || [];
+  const cardIds = new Set(cardSkills.map((s: { id: string }) => s.id));
+  const agentSkills = [
+    ...cardSkills.filter((s: { id: string }) => !BUILTIN_TOOLS.some((t) => t.id === s.id)),
+    ...BUILTIN_TOOLS.filter((t) => !cardIds.has(t.id)),
+  ];
+
+  // Reset whisperer dismiss state when input changes
+  useEffect(() => {
+    setSkillWhispererDismissed(false);
+  }, [input]);
+
+  // Handle skill selection from whisperer
+  const handleSkillSelect = useCallback((skillId: string) => {
+    // Replace the /query part with the selected skill
+    setInput((prev) => prev.replace(/(?:^|\s)\/([\w:.-]*)$/, (match) => {
+      const prefix = match.startsWith(' ') ? ' ' : '';
+      return `${prefix}/${skillId} `;
+    }));
+    setSkillWhispererDismissed(false);
+  }, []);
+
+  /** Handle HITL approve action. */
+  const handleHitlApprove = useCallback(async () => {
+    if (!namespace || !contextId) return;
+    try {
+      await sandboxService.approveSession(namespace, contextId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to approve';
+      setError(msg);
+    }
+  }, [namespace, contextId]);
+
+  /** Handle HITL deny action. */
+  const handleHitlDeny = useCallback(async () => {
+    if (!namespace || !contextId) return;
+    try {
+      await sandboxService.denySession(namespace, contextId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to deny';
+      setError(msg);
+    }
+  }, [namespace, contextId]);
+
+  // toMessage is now handled by useSessionLoader hook
+
+  // _subscribeToSession is now handled by useSessionLoader hook (Effect 2)
+
+  // loadInitialHistory, justFinishedStreamingRef, history trigger, and polling
+  // are now handled by useSessionLoader hook (Effects 1-4)
+
+  // Sync URL when contextId is set from localStorage restoration
+  useEffect(() => {
+    if (contextId && !searchParams.get('session')) {
+      setSearchParams({ session: contextId }, { replace: true });
+    }
+  }, [contextId, searchParams, setSearchParams]);
+
+  /** Load an older page of history (triggered by scrolling to top). */
+  const loadOlderHistory = useCallback(async () => {
+    if (!hasMoreHistory || loadingHistory || oldestIndex === null) return;
+    const container = scrollContainerRef.current;
+    const prevScrollHeight = container?.scrollHeight ?? 0;
+
+    try {
+      const page = await sandboxService.getHistory(namespace, contextId, {
+        limit: 30,
+        before: oldestIndex,
+      });
+      if (page.messages.length > 0) {
+        // Convert history messages to Message format for prepending
+        const newMsgs: Message[] = page.messages.map((h: { role: string; parts?: Array<Record<string, unknown>>; _index?: number; username?: string; metadata?: Record<string, unknown> }, i: number) => {
+          const firstPart = h.parts?.[0] as Record<string, unknown> | undefined;
+          const order = h._index ?? i;
+          const toolTypes = ['tool_call', 'tool_result', 'thinking', 'hitl_request', 'hitl_response', 'graph_event'];
+          if (firstPart?.kind === 'data' && toolTypes.includes(firstPart?.type as string)) {
+            return {
+              id: `history-${order}`,
+              role: h.role as 'user' | 'assistant',
+              content: '',
+              timestamp: new Date(),
+              toolData: firstPart as unknown as ToolCallData,
+              order,
+            };
+          }
+          const content = h.parts
+            ?.map((p: Record<string, unknown>) => {
+              if (typeof p.text === 'string') return p.text;
+              if (p.kind === 'data' && typeof p.content === 'string') return p.content;
+              return '';
+            })
+            .filter(Boolean)
+            .join('') || '';
+          return {
+            id: `history-${order}`,
+            role: h.role as 'user' | 'assistant',
+            content,
+            timestamp: new Date(),
+            username: h.username || (h.metadata?.username as string | undefined),
+            order,
+          };
+        });
+
+        sessionDispatch({
+          type: 'MESSAGES_PREPENDED',
+          messages: newMsgs,
+          oldestIndex: page.messages[0]._index ?? 0,
+          hasMoreHistory: page.has_more,
+        });
+
+        // Preserve scroll position after prepending
+        requestAnimationFrame(() => {
+          if (container) {
+            const newScrollHeight = container.scrollHeight;
+            container.scrollTop += newScrollHeight - prevScrollHeight;
+          }
+        });
+      } else {
+        sessionDispatch({
+          type: 'MESSAGES_PREPENDED',
+          messages: [],
+          oldestIndex: oldestIndex,
+          hasMoreHistory: false,
+        });
+      }
+    } catch {
+      // ignore
+    }
+  }, [hasMoreHistory, loadingHistory, oldestIndex, namespace, contextId, sessionDispatch]);
+
+  // IntersectionObserver for infinite scroll — triggers when sentinel at top is visible
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasMoreHistory && !loadingHistory) {
+          loadOlderHistory();
+        }
+      },
+      { threshold: 0.1 }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMoreHistory, loadingHistory, loadOlderHistory]);
+
+  // Auto-scroll to bottom on new messages
+  const shouldAutoScroll = useRef(true);
+  useEffect(() => {
+    if (shouldAutoScroll.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, streamingContent]);
+
+  const handleSelectSession = useCallback(
+    (id: string, sessionAgentName?: string) => {
+      setContextId(id);
+      // Only update selectedAgent when sessionAgentName is a non-empty string.
+      // When metadata is missing (race condition), preserve the current agent
+      // so subsequent messages don't get routed to the wrong agent.
+      if (sessionAgentName) {
+        setSelectedAgent(sessionAgentName);
+        if (id) localStorage.setItem(STORAGE_KEY_AGENT_PREFIX + id, sessionAgentName);
+      }
+      // Reset local UI state — hook handles session data via contextId change
+      setInput('');
+      setStreamingContent('');
+      setError(null);
+      shouldAutoScroll.current = true;
+      if (id) {
+        // Resolve the agent for the URL: prefer session agent, then localStorage, then current
+        const agentForUrl = sessionAgentName
+          || localStorage.getItem(STORAGE_KEY_AGENT_PREFIX + id)
+          || selectedAgent;
+        setSearchParams((prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('session', id);
+          next.set('agent', agentForUrl);
+          return next;
+        });
+        localStorage.setItem(STORAGE_KEY_SESSION, id);
+      } else {
+        sessionDispatch({ type: 'SESSION_CLEARED' });
+        setSearchParams({});
+        localStorage.removeItem(STORAGE_KEY_SESSION);
+      }
+    },
+    [setSearchParams, selectedAgent, sessionDispatch]
+  );
+
+  /** Start a new session with the chosen agent (from the New Session modal). */
+  const handleNewSession = useCallback(
+    (agentName: string) => {
+      selectedAgentRef.current = agentName; // sync ref immediately
+      setSelectedAgent(agentName);
+      // Clear contextId to start fresh (no existing session)
+      setContextId('');
+      sessionDispatch({ type: 'SESSION_CLEARED' });
+      setInput('');
+      setStreamingContent('');
+      setError(null);
+      shouldAutoScroll.current = true;
+      setSearchParams({});
+      localStorage.removeItem(STORAGE_KEY_SESSION);
+    },
+    [setSearchParams, sessionDispatch]
+  );
+
+  // Persist namespace to localStorage
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY_NAMESPACE, namespace);
+  }, [namespace]);
+
+  /** Send via non-streaming /chat endpoint (fallback). */
+  const sendNonStreaming = async (
+    messageToSend: string,
+    headers: Record<string, string>,
+    skill?: string,
+  ) => {
+    const body: Record<string, unknown> = {
+      message: messageToSend,
+      session_id: contextIdRef.current || undefined,
+      agent_name: selectedAgentRef.current || 'sandbox-legion',
+    };
+    if (skill) body.skill = skill;
+    const response = await fetch(
+      `/api/v1/sandbox/${encodeURIComponent(namespace)}/chat`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      }
+    );
+
+    if (!response.ok) {
+      const errData = await response.json().catch(() => ({}));
+      throw new Error(errData.detail || `HTTP error: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    if (data.context_id && !contextId) {
+      setContextId(data.context_id);
+      setSearchParams({ session: data.context_id });
+      localStorage.setItem(STORAGE_KEY_SESSION, data.context_id);
+    }
+
+    if (data.content) {
+      sessionDispatch({
+        type: 'MESSAGES_APPENDED',
+        messages: [{
+          id: `assistant-${Date.now()}`,
+          role: 'assistant',
+          content: data.content,
+          timestamp: new Date(),
+          order: orderCounterRef.current++,
+        }],
+      });
+    }
+  };
+
+  /** Update or create an AgentLoop in the loops map via dispatch. */
+  const updateLoop = useCallback((loopId: string, updater: (prev: AgentLoop) => AgentLoop) => {
+    sessionDispatch({
+      type: 'LOOPS_UPDATE',
+      updater: (prev) => {
+        const next = new Map(prev);
+        const existing = next.get(loopId) || createDefaultAgentLoop(loopId);
+        next.set(loopId, updater(existing));
+        return next;
+      },
+    });
+  }, [sessionDispatch]);
+
+  /** Attempt SSE streaming via /chat/stream, return true on success. */
+  const sendStreaming = async (
+    messageToSend: string,
+    headers: Record<string, string>,
+    skill?: string,
+  ): Promise<boolean> => {
+    const streamUrl = sandboxService.getStreamUrl(namespace);
+    const agentForRequest = selectedAgentRef.current || 'sandbox-legion';
+    const body: Record<string, unknown> = {
+      message: messageToSend,
+      session_id: contextIdRef.current || undefined,
+      agent_name: agentForRequest,
+    };
+    if (skill) body.skill = skill;
+    if (sessionModelOverride) body.model = sessionModelOverride;
+    const response = await fetch(streamUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      // If streaming not supported (404) or server error, signal fallback
+      return false;
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) return false;
+
+    const decoder = new TextDecoder();
+    let accumulatedContent = '';
+    let buffer = '';
+    let seenLoopId = false; // Once any loop_id event seen, suppress flat messages
+    // msgCountBeforeStream removed — no longer wiping messages on loop start
+    const collectedMessages: Message[] = [];
+
+    // Snapshot current message count so retroactive cleanup only
+    // removes flat messages from THIS turn, not previous turns
+    // msgCountBeforeStream = messages.length; // removed — see MESSAGES_SET removal
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        buffer += chunk;
+
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+
+          try {
+            const data = JSON.parse(line.slice(6));
+
+            // Track session ID from SSE — DON'T call setContextId here!
+            // Setting contextId mid-stream triggers the hook's Effect 1 which
+            // wipes messages. Instead, save to ref + URL and set state in finally.
+            if (data.session_id && !contextIdRef.current) {
+              contextIdRef.current = data.session_id;
+              // Update URL immediately (visual feedback, no state change)
+              setSearchParams((prev) => {
+                const next = new URLSearchParams(prev);
+                next.set('session', data.session_id);
+                return next;
+              });
+              localStorage.setItem(STORAGE_KEY_SESSION, data.session_id);
+              const currentAgent = new URLSearchParams(window.location.search).get('agent') || agentForRequest;
+              localStorage.setItem(STORAGE_KEY_AGENT_PREFIX + data.session_id, currentAgent);
+            }
+
+            // Handle agent loop events (grouped by loop_id)
+            // The backend forwards loop events with loop_id at top level
+            // and the full event in data.loop_event
+            if (data.loop_id) {
+              if (!seenLoopId) {
+                // First loop event: switch to loop mode.
+                // DON'T remove messages — the user message must stay visible.
+                // Loop card renders independently; flat content is suppressed
+                // by the seenLoopId flag (no more flat messages added).
+                seenLoopId = true;
+                accumulatedContent = '';
+                setStreamingContent('');
+              }
+              const loopId = data.loop_id;
+              const le = data.loop_event || data;
+              const eventType = le.type;
+              console.log(`[sse] LOOP_RECV loop=${loopId?.substring(0, 8)} type=${eventType} step=${le.step ?? ''} tools=${le.tools?.length ?? 0}`);
+
+              // Apply event using shared builder
+              updateLoop(loopId, (prev) => applyLoopEvent(prev, le));
+
+              // Don't process loop events through the old flat pipeline
+              continue;
+            }
+
+            // Handle HITL (Human-in-the-Loop) events
+            if (data.event?.type === 'hitl_request') {
+              collectedMessages.push({
+                id: `hitl-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                role: 'assistant',
+                content: '',
+                timestamp: new Date(),
+                order: orderCounterRef.current++,
+                toolData: {
+                  type: 'hitl_request',
+                  command: data.event.taskId || '',
+                  reason: data.event.message || 'Agent requests approval',
+                },
+              });
+              // Show the HITL message immediately (snapshot for StrictMode safety)
+              const hitlSnapshot = collectedMessages.splice(0);
+              sessionDispatch({ type: 'MESSAGES_APPENDED', messages: hitlSnapshot });
+              setStreamingContent('');
+            }
+
+            // Handle delegation events (Session E: sub-agent spawning)
+            if (data.event && DELEGATION_EVENT_TYPES.includes(data.event.type)) {
+              collectedMessages.push({
+                id: `deleg-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                role: 'assistant',
+                content: '',
+                timestamp: new Date(),
+                order: orderCounterRef.current++,
+                toolData: {
+                  type: data.event.type,
+                  child_context_id: data.event.child_context_id,
+                  delegation_mode: data.event.delegation_mode,
+                  task: data.event.task,
+                  variant: data.event.variant,
+                  state: data.event.state,
+                  content: data.content,
+                  message: data.event.message,
+                },
+              });
+              // Flush delegation events immediately (snapshot for StrictMode safety)
+              const delegSnapshot = collectedMessages.splice(0);
+              sessionDispatch({ type: 'MESSAGES_APPENDED', messages: delegSnapshot });
+            }
+
+            // Parse and immediately flush tool call/result events
+            // Skip if in loop mode — AgentLoopCard handles all rendering
+            if (!seenLoopId && data.event && data.event.message) {
+              const eventText = data.event.message;
+              let hadToolEvents = false;
+              for (const eventLine of eventText.split('\n')) {
+                const parsed = parseGraphEvent(eventLine);
+                if (parsed && (parsed.type === 'tool_call' || parsed.type === 'tool_result' || parsed.type === 'llm_response')) {
+                  collectedMessages.push({
+                    id: `stream-event-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                    role: 'assistant',
+                    content: '',
+                    timestamp: new Date(),
+                    order: orderCounterRef.current++,
+                    toolData: parsed,
+                  });
+                  hadToolEvents = true;
+                }
+              }
+              if (hadToolEvents) {
+                const snapshot = collectedMessages.splice(0);
+                sessionDispatch({ type: 'MESSAGES_APPENDED', messages: snapshot });
+              }
+            }
+
+            // Accumulate content for real-time display (final answer)
+            if (data.content) {
+              if (!seenLoopId) {
+                // No loop active — normal flat content display
+                accumulatedContent += data.content;
+                setStreamingContent(accumulatedContent);
+              } else {
+                // Loop mode: flat content is the final answer.
+                // Use it to fill the loop's finalAnswer (prevents "stuck in reasoning").
+                accumulatedContent += data.content;
+                const capturedContent = accumulatedContent;
+                sessionDispatch({
+                  type: 'LOOPS_UPDATE',
+                  updater: (prev) => {
+                    const next = new Map(prev);
+                    let found = false;
+                    for (const [lid, loop] of [...next].reverse()) {
+                      if (!loop.finalAnswer) {
+                        next.set(lid, { ...loop, status: 'done', finalAnswer: capturedContent });
+                        found = true;
+                        break;
+                      }
+                    }
+                    return found ? next : prev;
+                  },
+                });
+              }
+            }
+
+            // Handle errors from the backend
+            if (data.error) {
+              accumulatedContent = `Error: ${data.error}`;
+              setStreamingContent(accumulatedContent);
+            }
+
+            if (data.done) {
+              break;
+            }
+          } catch {
+            // Incomplete JSON chunk -- skip
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Finalize: add any remaining tool call messages, then the final response.
+    // In loop mode, skip flat finalization — AgentLoopCard has the content.
+    if (!seenLoopId) {
+      const finalSnapshot = collectedMessages.splice(0);
+      if (finalSnapshot.length > 0 || accumulatedContent) {
+        sessionDispatch({
+          type: 'MESSAGES_APPENDED',
+          messages: [
+            ...finalSnapshot,
+            {
+              id: `assistant-${Date.now()}`,
+              role: 'assistant',
+              content: accumulatedContent,
+              timestamp: new Date(),
+              order: orderCounterRef.current++,
+            },
+          ],
+        });
+      }
+    }
+
+    return true;
+  };
+
+  /** Cancel the in-progress agent loop: kill backend task, abort SSE stream, reset UI state. */
+  const cancelCurrentLoop = async () => {
+    // 1. Kill the backend task so the agent stops processing
+    if (contextId) {
+      try {
+        await sandboxService.killSession(namespace, contextId);
+      } catch (err) {
+        console.warn('[cancel] Failed to kill session:', err);
+      }
+    }
+
+    // 2. Abort the active subscribe/streaming SSE connection
+    if (subscribeAbortRef.current) {
+      subscribeAbortRef.current.abort();
+      subscribeAbortRef.current = null;
+    }
+
+    // 3. Mark active agent loops as 'canceled' and transition to LOADED
+    sessionDispatch({ type: 'LOOP_CANCEL' });
+
+    // 4. Reset streaming UI state
+    setStreamingContent('');
+    sendingRef.current = false;
+  };
+
+  const handleSendMessage = async () => {
+    if (!input.trim() || sendingRef.current) return;
+
+    // If agent is still processing, cancel the previous loop first
+    if (isStreaming) {
+      await cancelCurrentLoop();
+    }
+
+    sendingRef.current = true;
+    // Capture and clear input immediately to prevent double-send
+    const trimmed = input.trim();
+    setInput('');
+
+    shouldAutoScroll.current = true;
+
+    // Parse /skill:name prefix from message (e.g. "/rca:ci #758" → skill="rca:ci", text="#758")
+    const skillMatch = trimmed.match(/^\/([\w:.-]+)\s*(.*)/s);
+    const skill = skillMatch ? skillMatch[1] : undefined;
+
+    lastUserMessageRef.current = trimmed;
+    const userMessage: Message = {
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content: trimmed,
+      timestamp: new Date(),
+      order: orderCounterRef.current++,
+      username: currentUsername,
+    };
+    sessionDispatch({ type: 'MESSAGES_APPENDED', messages: [userMessage] });
+    // Send full text to backend (preserve skill prefix in history)
+    const messageToSend = trimmed;
+    sendInProgressRef.current = true;
+    sessionDispatch({ type: 'SEND_STARTED' });
+    setStreamingContent('');
+    setError(null);
+
+    try {
+      const token = await getToken();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+
+      // Try streaming first; fall back to non-streaming ONLY if the
+      // initial connection failed (HTTP error). Once the stream connects
+      // and starts receiving data, the message has already been sent to
+      // the agent — do NOT resend via non-streaming fallback.
+      let streamed = false;
+      try {
+        streamed = await sendStreaming(messageToSend, headers, skill);
+      } catch (streamErr) {
+        // Streaming threw — but if we got a 200 response, the message
+        // was already sent. Only fall back on connection/pre-send errors.
+        const streamMsg = streamErr instanceof Error ? streamErr.message : '';
+        if (streamMsg.includes('connection') || streamMsg.includes('chunked') || streamMsg.includes('network')) {
+          throw streamErr; // Let the outer catch handle with backoff
+        }
+        // Stream reader error after 200 — message was sent, don't resend
+        console.warn('[chat] Stream reader error (message already sent):', streamMsg);
+        streamed = true;
+      }
+
+      if (!streamed) {
+        await sendNonStreaming(messageToSend, headers, skill);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to send';
+      const isConnectionError = msg.includes('connection') || msg.includes('chunked') || msg.includes('network');
+      if (isConnectionError && contextId) {
+        // Connection dropped — agent may still be processing.
+        // Backoff loop: poll session status until completed or timeout.
+        setError('Connection interrupted — waiting for agent to finish...');
+        const pollSession = async (attempt: number) => {
+          if (attempt > 5) {
+            setError('Agent did not complete — try refreshing the page.');
+            return;
+          }
+          const delay = Math.min(2000 * Math.pow(1.5, attempt), 10000);
+          await new Promise((r) => setTimeout(r, delay));
+          try {
+            const detail = await sandboxService.getSession(namespace, contextId);
+            const state = detail?.status?.state;
+            if (state === 'completed' || state === 'failed') {
+              // Trigger a reload by re-selecting the session
+              sessionDispatch({ type: 'SESSION_SELECTED' });
+              setError(null);
+            } else {
+              setError(`Agent still working (attempt ${attempt + 1}/5)...`);
+              await pollSession(attempt + 1);
+            }
+          } catch {
+            await pollSession(attempt + 1);
+          }
+        };
+        pollSession(0);
+      } else {
+        setError(msg);
+        sessionDispatch({
+          type: 'MESSAGES_APPENDED',
+          messages: [{
+            id: `error-${Date.now()}`,
+            role: 'assistant',
+            content: `Error: ${msg}`,
+            timestamp: new Date(),
+            order: orderCounterRef.current++,
+          }],
+        });
+      }
+    } finally {
+      sendingRef.current = false;
+      sessionDispatch({ type: 'SEND_DONE' });
+      setStreamingContent('');
+      // Set contextId state AFTER SEND_DONE — deferred from streaming to avoid
+      // triggering Effect 1 mid-stream (which wipes messages).
+      // Keep sendInProgressRef=true until AFTER setContextId so Effect 1
+      // doesn't reload history when contextId changes.
+      if (contextIdRef.current && contextIdRef.current !== contextId) {
+        setContextId(contextIdRef.current);
+        // Clear sendInProgressRef on next tick — after React processes contextId
+        setTimeout(() => { sendInProgressRef.current = false; }, 0);
+      } else {
+        sendInProgressRef.current = false;
+      }
+      // SEND_DONE marks loops with finalAnswer as 'done', others as 'executing'.
+    }
+  };
+
+  return (
+    <PageSection variant="light" padding={{ default: 'noPadding' }}>
+      <div style={{ display: 'flex', height: 'calc(100vh - 80px)' }}>
+        {/* Left column: sessions + sandbox agents — sticky, doesn't scroll with main */}
+        <div
+          style={{
+            width: 280,
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            position: 'sticky',
+            top: 0,
+            borderRight: '1px solid var(--pf-v5-global--BorderColor--100)',
+            overflowY: 'auto',
+          }}
+        >
+          <div style={{ flex: 1, overflow: 'hidden' }}>
+            <SessionSidebar
+              namespace={namespace}
+              activeContextId={contextId}
+              onSelectSession={handleSelectSession}
+              onNewSession={handleNewSession}
+              selectedAgentName={selectedAgent}
+            />
+          </div>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            padding: 16,
+            overflow: 'hidden',
+            minWidth: 0,
+          }}
+        >
+          {/* Header info bar */}
+          <Split hasGutter style={{ marginBottom: 8, alignItems: 'center' }}>
+            <SplitItem>
+              <span style={{ fontSize: '0.9em', color: 'var(--pf-v5-global--Color--200)', marginRight: 4 }}>Agent:</span>
+              <Tooltip content="Active sandbox agent handling this session">
+                <Label isCompact color="purple">{selectedAgent}</Label>
+              </Tooltip>
+              <Tooltip content="Reconfigure agent">
+                <Button
+                  variant="plain"
+                  size="sm"
+                  style={{ padding: '0 4px', marginLeft: 4 }}
+                  onClick={() => setReconfigureOpen(true)}
+                >
+                  <CogIcon />
+                </Button>
+              </Tooltip>
+            </SplitItem>
+            <SplitItem>
+              <span style={{ fontSize: '0.9em', color: 'var(--pf-v5-global--Color--200)', marginRight: 4 }}>Namespace:</span>
+              <Tooltip content="Kubernetes namespace where the agent runs">
+                <Label isCompact color="blue">{namespace}</Label>
+              </Tooltip>
+            </SplitItem>
+            <SplitItem>
+              <span style={{ fontSize: '0.9em', color: 'var(--pf-v5-global--Color--200)', marginRight: 4 }}>Model:</span>
+              <ModelSwitcher
+                currentModel={sessionModelOverride || (agentCard as Record<string, unknown>)?.model as string || 'llama4-scout'}
+                onModelChange={setSessionModelOverride}
+                namespace={namespace}
+                agentName={selectedAgent}
+              />
+            </SplitItem>
+            <SplitItem>
+              <span style={{ fontSize: '0.9em', color: 'var(--pf-v5-global--Color--200)', marginRight: 4 }}>Security:</span>
+              <Tooltip content={
+                <div>
+                  <div><strong>Active Security Features:</strong></div>
+                  <div>&#10003; SPIFFE workload identity</div>
+                  <div>&#10003; Istio mTLS (ambient mode)</div>
+                  <div>&#10003; Permission-checked shell execution</div>
+                  <div>&#10003; Path-traversal prevention</div>
+                  <div>&#10003; TOFU config integrity verification</div>
+                  <div>&#10003; Per-session workspace isolation</div>
+                </div>
+              }>
+                <Label isCompact color="green" icon={<ShieldAltIcon />}>
+                  Secured
+                </Label>
+              </Tooltip>
+            </SplitItem>
+            {contextId && (
+              <SplitItem>
+                <span style={{ fontSize: '0.9em', color: 'var(--pf-v5-global--Color--200)', marginRight: 4 }}>Session:</span>
+                <Tooltip content={contextId}>
+                  <Label isCompact color="grey">{contextId.slice(0, 8)}...</Label>
+                </Tooltip>
+              </SplitItem>
+            )}
+            <SplitItem isFilled />
+          </Split>
+
+          {/* SandboxConfig disabled — model/repo/branch not yet wired to backend.
+              TODO: wire config to agent via A2A message metadata or per-session config endpoint.
+          <SandboxConfig config={config} onChange={setConfig} />
+          */}
+
+          {error && (
+            <Alert
+              variant="danger"
+              title={error}
+              isInline
+              style={{ marginBottom: 8 }}
+            />
+          )}
+
+          {/* Tab bar — stays pinned */}
+          <div style={{ display: 'flex', gap: 0, borderBottom: '2px solid var(--pf-v5-global--BorderColor--100)', flexShrink: 0, marginBottom: 8 }}>
+            {['chat', 'stats', 'llm-usage', 'sub-sessions', 'files', 'pod'].map((tab) => (
+              <button
+                key={tab}
+                role="tab"
+                onClick={() => {
+                  setActiveTab(tab);
+                  setSearchParams(prev => {
+                    const next = new URLSearchParams(prev);
+                    next.set('tab', tab);
+                    return next;
+                  }, { replace: true });
+                }}
+                style={{
+                  padding: '8px 16px',
+                  border: 'none',
+                  borderBottom: activeTab === tab ? '3px solid var(--pf-v5-global--primary-color--100)' : '3px solid transparent',
+                  backgroundColor: 'transparent',
+                  fontWeight: activeTab === tab ? 600 : 400,
+                  color: activeTab === tab ? 'var(--pf-v5-global--primary-color--100)' : 'inherit',
+                  cursor: 'pointer',
+                  fontSize: '0.95em',
+                  textTransform: 'capitalize',
+                }}
+              >
+                {tab === 'chat' ? 'Chat' : tab === 'stats' ? 'Stats' : tab === 'llm-usage' ? 'LLM Usage' : tab === 'sub-sessions' ? `Sub-sessions${childSessionCount > 0 ? ` (${childSessionCount})` : ''}` : tab === 'files' ? 'Files' : 'Pod'}
+              </button>
+            ))}
+            {/* Sidecar tabs removed — sidecars now in right panel */}
+          </div>
+
+          {/* Tab content — fills remaining space */}
+          <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+
+          {activeTab === 'chat' && (
+          <>
+          {/* View mode toggle */}
+          <FloatingViewBar
+            viewMode={viewMode}
+            onChange={handleViewModeChange}
+            budget={(() => {
+              // Extract budget from the latest loop's budget data
+              const loopArr = Array.from(agentLoops.values());
+              const latest = loopArr[loopArr.length - 1];
+              if (!latest?.budget) return null;
+              return {
+                tokensUsed: latest.budget.tokensUsed || 0,
+                tokensBudget: latest.budget.tokensBudget || 0,
+                wallClockS: latest.budget.wallClockS || 0,
+                maxWallClockS: latest.budget.maxWallClockS || 0,
+              };
+            })()}
+          />
+          {/* Chat messages */}
+          <Card style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+            <CardBody
+              ref={scrollContainerRef}
+              data-testid="chat-messages"
+              style={{
+                height: '100%',
+                overflowY: 'auto',
+                display: 'flex',
+                flexDirection: 'column',
+                padding: '12px 16px',
+              }}
+            >
+            {loadingSession && (
+              <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Spinner size="lg" />
+              </div>
+            )}
+            {!loadingSession && (<>
+
+              {/* Sentinel for infinite scroll — loads older messages */}
+              <div ref={sentinelRef} style={{ minHeight: 1 }} />
+              {/* Loading skeleton removed — causes empty frame flash.
+                  History loads fast enough that skeleton is not needed. */}
+
+              {/* Welcome card — only when no messages and no loops */}
+              {messages.length === 0 && agentLoops.size === 0 && !isStreaming && (
+              <div
+                data-testid="welcome-card"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 32,
+                  flex: 1,
+                }}
+              >
+                <div style={{ maxWidth: 480, textAlign: 'center' }}>
+                  {/* Agent name */}
+                  <h3 style={{ margin: '0 0 4px', fontSize: '1.1em' }}>{selectedAgent}</h3>
+                  <p style={{ margin: '0 0 8px', fontSize: '0.8em', color: 'var(--pf-v5-global--Color--200)' }}>
+                    {(agentCard as Record<string, unknown>)?.model as string || 'llama4-scout'} &middot; {namespace}
+                  </p>
+
+                    {/* Available tools + example prompts */}
+                    {(
+                      <>
+                        {agentSkills.length > 0 && (
+                          <div style={{ marginBottom: 16 }}>
+                            <div style={{ fontSize: '0.8em', color: 'var(--pf-v5-global--Color--200)', marginBottom: 6 }}>
+                              Available tools
+                            </div>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, justifyContent: 'center' }}>
+                              {agentSkills.slice(0, 8).map((skill: { id?: string; name?: string }) => (
+                                <Label key={skill.id || skill.name} isCompact color="blue">
+                                  {skill.name || skill.id}
+                                </Label>
+                              ))}
+                              {agentSkills.length > 8 && (
+                                <Label isCompact>+{agentSkills.length - 8} more</Label>
+                              )}
+                            </div>
+                          </div>
+                        )}
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                          {[
+                            'List the contents of the workspace directory',
+                            'Write a Python script that prints hello world',
+                            'What tools do you have available?',
+                          ].map((prompt) => (
+                            <button
+                              key={prompt}
+                              data-testid="example-prompt"
+                              onClick={() => setInput(prompt)}
+                              style={{
+                                padding: '8px 12px',
+                                borderRadius: 6,
+                                border: '1px solid var(--pf-v5-global--BorderColor--100)',
+                                backgroundColor: 'var(--pf-v5-global--BackgroundColor--200)',
+                                cursor: 'pointer',
+                                fontSize: '0.85em',
+                                textAlign: 'left',
+                                color: 'inherit',
+                              }}
+                            >
+                              {prompt}
+                            </button>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                </div>
+              </div>
+              )}
+
+              {/* "Load more" button for older turns */}
+              {(hasMoreHistory || hasMoreTasks) && (
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    padding: '8px 0',
+                    marginBottom: 8,
+                  }}
+                >
+                  <button
+                    onClick={() => {
+                      if (hasMoreTasks) loadMoreTasks();
+                    }}
+                    style={{
+                      padding: '6px 16px',
+                      borderRadius: 6,
+                      border: '1px solid var(--pf-v5-global--BorderColor--100)',
+                      backgroundColor: 'var(--pf-v5-global--BackgroundColor--200)',
+                      cursor: 'pointer',
+                      fontSize: '0.85em',
+                      color: 'var(--pf-v5-global--Color--200)',
+                    }}
+                  >
+                    Load earlier messages
+                  </button>
+                </div>
+              )}
+
+              {/* Render messages grouped into turns, with loop cards interleaved */}
+              {(() => {
+                const turns = groupMessagesIntoTurns(messages);
+                const loopArray = Array.from(agentLoops.values());
+                const hasLoopCards = loopArray.length > 0;
+                const elements: React.ReactNode[] = [];
+
+                // In graph mode, render a single GraphLoopView with all loops
+                // instead of one per turn. The graph view has its own message sidebar.
+                if (viewMode === 'graph' && hasLoopCards) {
+                  const lastLoop = loopArray[loopArray.length - 1];
+                  elements.push(
+                    <GraphLoopView
+                      key="graph-topology-view"
+                      loop={lastLoop}
+                      allLoops={loopArray}
+                    />
+                  );
+                  return elements;
+                }
+
+                // Pair user messages with loops by CONTENT MATCH first,
+                // then by task_id from taskSummaries, then by position.
+                // This ensures user message ALWAYS renders BEFORE its agent loop.
+                const pairedLoopIds = new Set<string>();
+
+                turns.forEach((turn, idx) => {
+                  // Find matching loop by userMessage content
+                  let matchedLoop: AgentLoop | undefined;
+                  if (turn.user && hasLoopCards) {
+                    const userText = turn.user.content.trim();
+                    matchedLoop = loopArray.find(
+                      (l) => !pairedLoopIds.has(l.id) && l.userMessage && l.userMessage.trim() === userText
+                    );
+                    // Fallback: pair by position for history-loaded sessions
+                    if (!matchedLoop && idx < loopArray.length && !pairedLoopIds.has(loopArray[idx].id)) {
+                      matchedLoop = loopArray[idx];
+                    }
+                    if (matchedLoop) pairedLoopIds.add(matchedLoop.id);
+                  }
+
+                  elements.push(
+                    <React.Fragment key={turn.user?.id || `turn-${idx}`}>
+                      {/* User message */}
+                      {turn.user && (
+                        <ChatBubble
+                          msg={turn.user}
+                          currentUsername={currentUsername}
+                          namespace={namespace}
+                          agentName={selectedAgent}
+                        />
+                      )}
+                      {/* Agent turn — collapsed (only when no loop cards handle the content) */}
+                      {turn.assistantMessages.length > 0 && !hasLoopCards && (
+                        <CollapsedTurn
+                          turn={turn}
+                          namespace={namespace}
+                          agentName={selectedAgent}
+                          onApprove={
+                            turn.assistantMessages.some((m) => m.toolData?.type === 'hitl_request')
+                              ? handleHitlApprove
+                              : undefined
+                          }
+                          onDeny={
+                            turn.assistantMessages.some((m) => m.toolData?.type === 'hitl_request')
+                              ? handleHitlDeny
+                              : undefined
+                          }
+                        />
+                      )}
+                      {/* Loop card paired with this user message */}
+                      {matchedLoop && renderLoopCard(matchedLoop, isStreaming && matchedLoop === loopArray[loopArray.length - 1])}
+                    </React.Fragment>,
+                  );
+                });
+
+                // Render any unpaired loops (e.g. during streaming before user message is in messages array)
+                loopArray.filter((l) => !pairedLoopIds.has(l.id)).forEach((loop) => {
+                  elements.push(
+                    <React.Fragment key={`loop-unpaired-${loop.id}`}>
+                      {loop.userMessage && (
+                        <ChatBubble
+                          msg={{
+                            id: `loop-user-${loop.id}`,
+                            role: 'user' as const,
+                            content: loop.userMessage,
+                            timestamp: new Date(),
+                            order: 0,
+                          }}
+                          currentUsername={currentUsername}
+                          namespace={namespace}
+                          agentName={selectedAgent}
+                        />
+                      )}
+                      {renderLoopCard(loop, isStreaming && loop === loopArray[loopArray.length - 1])}
+                    </React.Fragment>,
+                  );
+                });
+
+                return elements;
+              })()}
+
+              {/* Streaming indicator — only when no loop cards handle progress */}
+              {isStreaming && agentLoops.size === 0 && (
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: 10,
+                    padding: '10px 14px',
+                    borderRadius: 8,
+                    border:
+                      '1px solid var(--pf-v5-global--BorderColor--100)',
+                  }}
+                >
+                  <div
+                    style={{
+                      flexShrink: 0,
+                      width: 32,
+                      height: 32,
+                      borderRadius: '50%',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor:
+                        'var(--pf-v5-global--success-color--100)',
+                      color: '#fff',
+                      fontSize: 14,
+                    }}
+                  >
+                    <RobotIcon />
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontWeight: 600, fontSize: '0.9em', marginBottom: 4 }}>
+                      {selectedAgent || 'Agent'}{' '}
+                      <Label color="blue" isCompact style={{ marginLeft: 4 }}>
+                        thinking
+                      </Label>
+                    </div>
+                    {streamingContent ? (
+                      <div className="sandbox-markdown" style={{ fontSize: '0.92em' }}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {streamingContent}
+                        </ReactMarkdown>
+                      </div>
+                    ) : (
+                      <Spinner size="sm" />
+                    )}
+                  </div>
+                </div>
+              )}
+
+              <div ref={messagesEndRef} />
+            </>)}
+            </CardBody>
+          </Card>
+
+          {/* Input area */}
+          <Split hasGutter style={{ marginTop: 8 }}>
+            <SplitItem isFilled style={{ position: 'relative' }}>
+              {!skillWhispererDismissed && agentSkills.length > 0 && (
+                <SkillWhisperer
+                  skills={agentSkills}
+                  input={input}
+                  onSelect={handleSkillSelect}
+                  onDismiss={() => setSkillWhispererDismissed(true)}
+                />
+              )}
+              <TextArea
+                value={input}
+                onChange={(_e, value) => setInput(value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSendMessage();
+                  }
+                }}
+                placeholder="Type your message... (Enter to send, Shift+Enter for newline)"
+                aria-label="Message input"
+                rows={2}
+              />
+            </SplitItem>
+            <SplitItem>
+              {isStreaming ? (
+                <Button
+                  variant="danger"
+                  onClick={cancelCurrentLoop}
+                  icon={<StopCircleIcon />}
+                  data-testid="cancel-button"
+                >
+                  Cancel
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  onClick={handleSendMessage}
+                  isDisabled={!input.trim()}
+                  icon={<PaperPlaneIcon />}
+                  data-testid="send-button"
+                >
+                  Send
+                </Button>
+              )}
+            </SplitItem>
+          </Split>
+
+          </>
+          )}
+
+          {activeTab === 'stats' && (
+              <SessionStatsPanel
+                agentLoops={agentLoops}
+                messages={messages}
+                contextId={contextId}
+                isVisible={activeTab === 'stats'}
+                isStreaming={isStreaming}
+              />
+          )}
+
+          {activeTab === 'llm-usage' && contextId && (
+              <LlmUsagePanel
+                contextId={contextId}
+                isVisible={activeTab === 'llm-usage'}
+              />
+          )}
+
+          {activeTab === 'sub-sessions' && contextId && (
+              <SubSessionsPanel
+                contextId={contextId}
+                namespace={namespace}
+                onNavigateToSession={(cid, agent) => {
+                  handleSelectSession(cid, agent);
+                  setActiveTab('chat');
+                }}
+              />
+          )}
+
+          {activeTab === 'files' && (
+              <div style={{ flex: 1, overflow: 'hidden' }}>
+                <FileBrowser
+                  namespace={namespace}
+                  agentName={selectedAgent}
+                  contextId={contextId || undefined}
+                  embedded
+                  isStreaming={isStreaming}
+                />
+              </div>
+          )}
+
+          {activeTab === 'pod' && (
+              <div style={{ flex: 1, overflow: 'auto' }}>
+                <PodStatusPanel
+                  namespace={namespace}
+                  agentName={selectedAgent}
+                />
+              </div>
+          )}
+
+          </div> {/* end tab content */}
+
+        </div>
+
+        {/* Right panel: Sidecar Agents */}
+        {contextId && (
+          <div
+            style={{
+              width: 280,
+              flexShrink: 0,
+              borderLeft: '1px solid var(--pf-v5-global--BorderColor--100)',
+              height: '100%',
+              overflowY: 'auto',
+            }}
+          >
+            <SidecarPanel
+              namespace={namespace}
+              contextId={contextId}
+              sidecars={sidecars}
+              onToggleEnable={handleSidecarToggleEnable}
+              onToggleAutoApprove={handleSidecarToggleAutoApprove}
+              onConfigChange={handleSidecarConfigChange}
+              onReset={handleSidecarReset}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Markdown styling */}
+      <style>{`
+        .sandbox-markdown pre {
+          background: var(--pf-v5-global--BackgroundColor--dark-300);
+          color: var(--pf-v5-global--Color--light-100);
+          padding: 12px;
+          border-radius: 6px;
+          overflow-x: auto;
+          font-size: 0.88em;
+          margin: 8px 0;
+        }
+        .sandbox-markdown code {
+          font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', monospace;
+          font-size: 0.9em;
+        }
+        .sandbox-markdown :not(pre) > code {
+          background: var(--pf-v5-global--BackgroundColor--200);
+          padding: 2px 5px;
+          border-radius: 3px;
+        }
+        .sandbox-markdown table {
+          border-collapse: collapse;
+          margin: 8px 0;
+          width: 100%;
+        }
+        .sandbox-markdown th,
+        .sandbox-markdown td {
+          border: 1px solid var(--pf-v5-global--BorderColor--100);
+          padding: 6px 10px;
+          text-align: left;
+        }
+        .sandbox-markdown th {
+          background: var(--pf-v5-global--BackgroundColor--200);
+          font-weight: 600;
+        }
+        .sandbox-markdown p {
+          margin: 4px 0;
+        }
+        .sandbox-markdown ul,
+        .sandbox-markdown ol {
+          margin: 4px 0;
+          padding-left: 20px;
+        }
+        .sandbox-markdown blockquote {
+          border-left: 3px solid var(--pf-v5-global--BorderColor--100);
+          padding-left: 12px;
+          margin: 8px 0;
+          color: var(--pf-v5-global--Color--200);
+        }
+      `}</style>
+
+      {/* Reconfigure Modal */}
+      <Modal
+        variant={ModalVariant.large}
+        title={`Reconfigure ${selectedAgent}`}
+        isOpen={reconfigureOpen}
+        onClose={() => setReconfigureOpen(false)}
+        showClose
+      >
+        <SandboxWizard
+          mode="reconfigure"
+          agentName={selectedAgent}
+          namespace={namespace}
+          onClose={() => setReconfigureOpen(false)}
+          onSuccess={() => setReconfigureOpen(false)}
+        />
+      </Modal>
+    </PageSection>
+  );
+};

--- a/kagenti/ui-v2/src/pages/SandboxesPage.tsx
+++ b/kagenti/ui-v2/src/pages/SandboxesPage.tsx
@@ -1,0 +1,338 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+/**
+ * Sandboxes Page — Lists deployed sandbox agent pods/deployments
+ * with their associated sessions and resource status.
+ */
+
+import React, { useState } from 'react';
+import {
+  PageSection,
+  Title,
+  Card,
+  CardBody,
+  CardTitle,
+  Label,
+  Spinner,
+  Alert,
+  Split,
+  SplitItem,
+  Button,
+  ExpandableSection,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core';
+import { CogIcon } from '@patternfly/react-icons';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { sandboxService, sandboxFileService } from '../services/api';
+import { NamespaceSelector } from '../components/NamespaceSelector';
+import type { SandboxAgentInfo, TaskSummary } from '../types/sandbox';
+import { SandboxWizard } from '../components/SandboxWizard';
+
+function statusColor(
+  status: string
+): 'green' | 'gold' | 'red' | 'grey' {
+  switch (status) {
+    case 'ready':
+      return 'green';
+    case 'pending':
+      return 'gold';
+    case 'error':
+      return 'red';
+    default:
+      return 'grey';
+  }
+}
+
+function sessionStateColor(state: string): 'blue' | 'green' | 'red' | 'orange' | 'grey' {
+  switch (state) {
+    case 'working':
+    case 'submitted':
+      return 'blue';
+    case 'completed':
+      return 'green';
+    case 'failed':
+      return 'red';
+    case 'canceled':
+      return 'orange';
+    default:
+      return 'grey';
+  }
+}
+
+/** Single sandbox agent card with expandable session list. */
+const SandboxAgentCard: React.FC<{
+  agent: SandboxAgentInfo;
+  sessions: TaskSummary[];
+  namespace: string;
+}> = ({ agent, sessions, namespace }) => {
+  const navigate = useNavigate();
+  const [expanded, setExpanded] = useState(agent.active_sessions > 0);
+  const [reconfigureOpen, setReconfigureOpen] = useState(false);
+
+  const { data: storageStats } = useQuery({
+    queryKey: ['sandbox-stats', namespace, agent.name],
+    queryFn: () => sandboxFileService.getStorageStats(namespace, agent.name),
+    enabled: !!namespace && agent.status === 'ready',
+    staleTime: 60000,
+    retry: 1,
+  });
+
+  const agentSessions = sessions.filter((s) => {
+    const meta = s.metadata as Record<string, unknown> | null;
+    const agentName = (meta?.agent_name as string) || 'sandbox-legion';
+    return agentName === agent.name;
+  });
+
+  return (
+    <Card isCompact style={{ marginBottom: 12 }}>
+      <CardTitle>
+        <Split hasGutter>
+          <SplitItem>
+            <Label color={statusColor(agent.status)} isCompact>
+              {agent.status}
+            </Label>
+          </SplitItem>
+          <SplitItem isFilled>
+            <strong>{agent.name}</strong>
+          </SplitItem>
+          <SplitItem>
+            <Label isCompact>
+              {agent.replicas} replicas
+            </Label>
+          </SplitItem>
+          <SplitItem>
+            <Label color="blue" isCompact>
+              {agent.session_count} sessions
+            </Label>
+          </SplitItem>
+          {agent.active_sessions > 0 && (
+            <SplitItem>
+              <Label color="gold" isCompact>
+                {agent.active_sessions} active
+              </Label>
+            </SplitItem>
+          )}
+          {storageStats && (
+            <>
+              <SplitItem>
+                <Label color="purple" isCompact>
+                  {storageStats.total_mounts} mounts
+                </Label>
+              </SplitItem>
+              <SplitItem>
+                <Label color="grey" isCompact>
+                  {storageStats.mounts.find(m => m.mount_point === '/workspace')?.use_percent ||
+                   storageStats.mounts[0]?.use_percent || '\u2014'} disk
+                </Label>
+              </SplitItem>
+            </>
+          )}
+        </Split>
+      </CardTitle>
+      <CardBody>
+        <DescriptionList isCompact isHorizontal>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Image</DescriptionListTerm>
+            <DescriptionListDescription>
+              <code style={{ fontSize: '0.85em' }}>
+                {agent.image.length > 60
+                  ? '...' + agent.image.slice(-57)
+                  : agent.image}
+              </code>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Created</DescriptionListTerm>
+            <DescriptionListDescription>
+              {agent.created
+                ? new Date(agent.created).toLocaleString()
+                : 'Unknown'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Namespace</DescriptionListTerm>
+            <DescriptionListDescription>
+              {agent.namespace}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+
+        {agentSessions.length > 0 && (
+          <ExpandableSection
+            toggleText={`${expanded ? 'Hide' : 'Show'} ${agentSessions.length} session${agentSessions.length !== 1 ? 's' : ''}`}
+            isExpanded={expanded}
+            onToggle={(_e, isExp) => setExpanded(isExp)}
+            style={{ marginTop: 8 }}
+          >
+            <div style={{ maxHeight: 200, overflowY: 'auto' }}>
+              {agentSessions.map((session) => {
+                const state = session.status?.state ?? 'unknown';
+                const meta = session.metadata as Record<string, unknown> | null;
+                const title = (meta?.title as string) || session.context_id.substring(0, 12);
+                return (
+                  <div
+                    key={session.id}
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      padding: '4px 8px',
+                      borderBottom: '1px solid var(--pf-v5-global--BorderColor--100)',
+                      cursor: 'pointer',
+                    }}
+                    onClick={() =>
+                      navigate(
+                        `/sandbox?session=${encodeURIComponent(session.context_id)}`
+                      )
+                    }
+                  >
+                    <span style={{ fontSize: '0.9em' }}>
+                      {title.length > 40
+                        ? title.substring(0, 40) + '...'
+                        : title}
+                    </span>
+                    <Label
+                      color={sessionStateColor(state)}
+                      isCompact
+                    >
+                      {state}
+                    </Label>
+                  </div>
+                );
+              })}
+            </div>
+          </ExpandableSection>
+        )}
+
+        <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
+          <Button
+            variant="link"
+            size="sm"
+            onClick={() => navigate(`/sandbox?agent=${agent.name}`)}
+          >
+            Chat with {agent.name}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<CogIcon />}
+            onClick={() => setReconfigureOpen(true)}
+          >
+            Reconfigure
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => navigate(`/sandbox/files/${namespace}/${agent.name}`)}
+          >
+            Browse Files
+          </Button>
+        </div>
+
+        {/* Reconfigure Modal */}
+        <Modal
+          variant={ModalVariant.large}
+          title={`Reconfigure ${agent.name}`}
+          isOpen={reconfigureOpen}
+          onClose={() => setReconfigureOpen(false)}
+          showClose
+        >
+          <SandboxWizard
+            mode="reconfigure"
+            agentName={agent.name}
+            namespace={namespace}
+            onClose={() => setReconfigureOpen(false)}
+            onSuccess={() => setReconfigureOpen(false)}
+          />
+        </Modal>
+      </CardBody>
+    </Card>
+  );
+};
+
+export const SandboxesPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [namespace, setNamespace] = useState('team1');
+
+  const { data: agents, isLoading: agentsLoading, isError: agentsError } = useQuery({
+    queryKey: ['sandbox-agents', namespace],
+    queryFn: () => sandboxService.listAgents(namespace),
+    enabled: !!namespace,
+    refetchInterval: 15000,
+  });
+
+  const { data: sessionsData } = useQuery({
+    queryKey: ['sandbox-sessions', namespace, '', 1, 100],
+    queryFn: () =>
+      sandboxService.listSessions(namespace, { limit: 100 }),
+    enabled: !!namespace,
+  });
+
+  const sessions = sessionsData?.items ?? [];
+
+  return (
+    <PageSection variant="light">
+      <Split hasGutter style={{ marginBottom: 16 }}>
+        <SplitItem>
+          <Title headingLevel="h1">Sandboxes</Title>
+        </SplitItem>
+        <SplitItem isFilled />
+        <SplitItem>
+          <NamespaceSelector
+            namespace={namespace}
+            onNamespaceChange={setNamespace}
+          />
+        </SplitItem>
+        <SplitItem>
+          <Button
+            variant="primary"
+            onClick={() => navigate('/sandbox/create')}
+          >
+            + Import Agent
+          </Button>
+        </SplitItem>
+      </Split>
+
+      {agentsLoading && <Spinner size="lg" />}
+
+      {agentsError && (
+        <Alert variant="danger" title="Failed to load sandboxes" isInline>
+          Could not reach the sandbox agents API.
+        </Alert>
+      )}
+
+      {!agentsLoading && agents && agents.length === 0 && (
+        <Alert variant="info" title="No sandboxes deployed" isInline>
+          No sandbox agents found in namespace {namespace}.{' '}
+          <Button
+            variant="link"
+            isInline
+            onClick={() => navigate('/sandbox/create')}
+          >
+            Import an agent
+          </Button>{' '}
+          to get started.
+        </Alert>
+      )}
+
+      {!agentsLoading &&
+        agents &&
+        agents.map((agent) => (
+          <SandboxAgentCard
+            key={agent.name}
+            agent={agent}
+            sessions={sessions}
+            namespace={namespace}
+          />
+        ))}
+    </PageSection>
+  );
+};

--- a/kagenti/ui-v2/src/pages/SessionsTablePage.tsx
+++ b/kagenti/ui-v2/src/pages/SessionsTablePage.tsx
@@ -1,0 +1,385 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  PageSection,
+  Title,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  Button,
+  Spinner,
+  EmptyState,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Label,
+  Modal,
+  ModalVariant,
+  TextInput,
+  Text,
+  TextContent,
+  Icon,
+  Dropdown,
+  DropdownList,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@patternfly/react-core';
+import {
+  Table,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+} from '@patternfly/react-table';
+import {
+  ListIcon,
+  EllipsisVIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { sandboxService } from '@/services/api';
+import { NamespaceSelector } from '@/components/NamespaceSelector';
+
+// NOTE: We use the sandboxService.listSessions() which returns TaskListResponse
+// The session metadata contains: parent_context_id, session_type, passover_from, passover_to
+
+type SessionType = 'all' | 'root' | 'child' | 'passover';
+
+export const SessionsTablePage: React.FC = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [namespace, setNamespace] = useState<string>('team1');
+  const [typeFilter, setTypeFilter] = useState<SessionType>('all');
+  const [searchText, setSearchText] = useState('');
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [sessionToDelete, setSessionToDelete] = useState<any>(null);
+  const [deleteConfirmText, setDeleteConfirmText] = useState('');
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+
+  const {
+    data: sessionsResponse,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['sessions', namespace],
+    queryFn: () => sandboxService.listSessions(namespace),
+    enabled: !!namespace,
+  });
+
+  const sessions = sessionsResponse?.items ?? [];
+
+  // Filter by session type and search text
+  const filteredSessions = sessions.filter((s: any) => {
+    // Type filter
+    if (typeFilter !== 'all') {
+      const sessionType = s.metadata?.session_type || 'root';
+      if (sessionType !== typeFilter) return false;
+    }
+    // Search by context ID
+    if (searchText.trim()) {
+      const contextId = (s.context_id || s.id || '').toLowerCase();
+      if (!contextId.includes(searchText.trim().toLowerCase())) return false;
+    }
+    return true;
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ contextId }: { contextId: string }) =>
+      sandboxService.deleteSession(namespace, contextId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', namespace] });
+      handleCloseDeleteModal();
+    },
+  });
+
+  const handleDeleteClick = (session: any) => {
+    setSessionToDelete(session);
+    setDeleteModalOpen(true);
+    setOpenMenuId(null);
+  };
+
+  const handleCloseDeleteModal = () => {
+    setDeleteModalOpen(false);
+    setSessionToDelete(null);
+    setDeleteConfirmText('');
+  };
+
+  const handleDeleteConfirm = () => {
+    if (sessionToDelete) {
+      const contextId = sessionToDelete.context_id || sessionToDelete.id;
+      if (deleteConfirmText === contextId.slice(0, 8)) {
+        deleteMutation.mutate({ contextId });
+      }
+    }
+  };
+
+  const truncateId = (id: string) => id ? id.slice(0, 8) + '...' : '';
+
+  const getSessionType = (session: any): string => {
+    return session.metadata?.session_type || 'root';
+  };
+
+  const renderTypeBadge = (session: any) => {
+    const type = getSessionType(session);
+    const colors: Record<string, 'blue' | 'cyan' | 'purple' | 'grey'> = {
+      root: 'blue',
+      child: 'cyan',
+      passover: 'purple',
+    };
+    return <Label color={colors[type] || 'grey'} isCompact>{type}</Label>;
+  };
+
+  const renderStatusBadge = (session: any) => {
+    const state = session.status?.state || 'unknown';
+    let color: 'green' | 'blue' | 'red' | 'grey' = 'grey';
+    let label = state;
+    if (state === 'working' || state === 'running') {
+      color = 'green';
+      label = 'Running';
+    } else if (state === 'completed') {
+      color = 'blue';
+      label = 'Completed';
+    } else if (state === 'failed' || state === 'error') {
+      color = 'red';
+      label = 'Failed';
+    } else if (state === 'input-required') {
+      color = 'green';
+      label = 'Awaiting Input';
+    }
+    return <Label color={color}>{label}</Label>;
+  };
+
+  const columns = ['Session ID', 'Title', 'Type', 'Parent', 'Status', 'Created', ''];
+
+  return (
+    <>
+      <PageSection variant="light">
+        <Title headingLevel="h1">Sessions</Title>
+      </PageSection>
+
+      <PageSection variant="light" padding={{ default: 'noPadding' }}>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem>
+              <NamespaceSelector
+                namespace={namespace}
+                onNamespaceChange={setNamespace}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <TextInput
+                type="search"
+                aria-label="Search by context ID"
+                placeholder="Search by context ID"
+                value={searchText}
+                onChange={(_e, value) => setSearchText(value)}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <ToggleGroup aria-label="Session type filter">
+                {(['all', 'root', 'child', 'passover'] as SessionType[]).map((t) => (
+                  <ToggleGroupItem
+                    key={t}
+                    text={t.charAt(0).toUpperCase() + t.slice(1)}
+                    buttonId={`filter-${t}`}
+                    isSelected={typeFilter === t}
+                    onChange={() => setTypeFilter(t)}
+                  />
+                ))}
+              </ToggleGroup>
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+      </PageSection>
+
+      <PageSection>
+        {isLoading ? (
+          <div className="kagenti-loading-center">
+            <Spinner size="lg" aria-label="Loading sessions" />
+          </div>
+        ) : isError ? (
+          <EmptyState>
+            <EmptyStateHeader
+              titleText="Error loading sessions"
+              icon={<EmptyStateIcon icon={ListIcon} />}
+              headingLevel="h4"
+            />
+            <EmptyStateBody>
+              {error instanceof Error
+                ? error.message
+                : 'Unable to fetch sessions.'}
+            </EmptyStateBody>
+          </EmptyState>
+        ) : filteredSessions.length === 0 ? (
+          <EmptyState>
+            <EmptyStateHeader
+              titleText="No sessions found"
+              icon={<EmptyStateIcon icon={ListIcon} />}
+              headingLevel="h4"
+            />
+            <EmptyStateBody>
+              {typeFilter !== 'all'
+                ? `No ${typeFilter} sessions found in namespace "${namespace}".`
+                : `No sessions found in namespace "${namespace}".`}
+            </EmptyStateBody>
+          </EmptyState>
+        ) : (
+          <Table aria-label="Sessions table" variant="compact">
+            <Thead>
+              <Tr>
+                {columns.map((col, idx) => (
+                  <Th key={col || `col-${idx}`}>{col}</Th>
+                ))}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {filteredSessions.map((session: any) => {
+                const contextId = session.context_id || session.id;
+                const parentId = session.metadata?.parent_context_id;
+                const title = session.metadata?.title || session.metadata?.agent_variant || 'Untitled';
+                const createdAt = session.metadata?.created_at || session.status?.timestamp;
+
+                return (
+                  <Tr key={contextId}>
+                    <Td dataLabel="Session ID">
+                      <Button
+                        variant="link"
+                        isInline
+                        onClick={() => navigate(`/sandbox?session=${contextId}`)}
+                      >
+                        {truncateId(contextId)}
+                      </Button>
+                    </Td>
+                    <Td dataLabel="Title">{title}</Td>
+                    <Td dataLabel="Type">{renderTypeBadge(session)}</Td>
+                    <Td dataLabel="Parent">
+                      {parentId ? (
+                        <Button
+                          variant="link"
+                          isInline
+                          onClick={() => navigate(`/sandbox?session=${parentId}`)}
+                        >
+                          {truncateId(parentId)}
+                        </Button>
+                      ) : (
+                        '\u2014'
+                      )}
+                    </Td>
+                    <Td dataLabel="Status">{renderStatusBadge(session)}</Td>
+                    <Td dataLabel="Created">
+                      {createdAt
+                        ? new Date(createdAt).toLocaleString()
+                        : '\u2014'}
+                    </Td>
+                    <Td isActionCell>
+                      <Dropdown
+                        isOpen={openMenuId === contextId}
+                        onSelect={() => setOpenMenuId(null)}
+                        onOpenChange={(isOpen) =>
+                          setOpenMenuId(isOpen ? contextId : null)
+                        }
+                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                          <MenuToggle
+                            ref={toggleRef}
+                            aria-label="Actions menu"
+                            variant="plain"
+                            onClick={() =>
+                              setOpenMenuId(
+                                openMenuId === contextId ? null : contextId
+                              )
+                            }
+                            isExpanded={openMenuId === contextId}
+                          >
+                            <EllipsisVIcon />
+                          </MenuToggle>
+                        )}
+                        popperProps={{ position: 'right' }}
+                      >
+                        <DropdownList>
+                          <DropdownItem
+                            key="view"
+                            onClick={() =>
+                              navigate(`/sandbox?session=${contextId}`)
+                            }
+                          >
+                            View session
+                          </DropdownItem>
+                          <DropdownItem
+                            key="delete"
+                            onClick={() => handleDeleteClick(session)}
+                            isDanger
+                          >
+                            Delete session
+                          </DropdownItem>
+                        </DropdownList>
+                      </Dropdown>
+                    </Td>
+                  </Tr>
+                );
+              })}
+            </Tbody>
+          </Table>
+        )}
+      </PageSection>
+
+      <Modal
+        variant={ModalVariant.small}
+        titleIconVariant="warning"
+        title="Delete session?"
+        isOpen={deleteModalOpen}
+        onClose={handleCloseDeleteModal}
+        actions={[
+          <Button
+            key="delete"
+            variant="danger"
+            onClick={handleDeleteConfirm}
+            isLoading={deleteMutation.isPending}
+            isDisabled={
+              deleteMutation.isPending ||
+              !sessionToDelete ||
+              deleteConfirmText !== (sessionToDelete?.context_id || sessionToDelete?.id || '').slice(0, 8)
+            }
+          >
+            Delete
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={handleCloseDeleteModal}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        <TextContent>
+          <Text>
+            <Icon status="warning" style={{ marginRight: '8px' }}>
+              <ExclamationTriangleIcon />
+            </Icon>
+            Session <strong>{truncateId(sessionToDelete?.context_id || sessionToDelete?.id || '')}</strong>{' '}
+            will be permanently deleted.
+          </Text>
+          <Text component="small" style={{ marginTop: '16px', display: 'block' }}>
+            Type the first 8 characters of the session ID to confirm:
+          </Text>
+        </TextContent>
+        <TextInput
+          id="delete-confirm-input"
+          value={deleteConfirmText}
+          onChange={(_e, value) => setDeleteConfirmText(value)}
+          aria-label="Confirm session ID"
+          style={{ marginTop: '8px' }}
+        />
+      </Modal>
+    </>
+  );
+};

--- a/kagenti/ui-v2/src/pages/SessionsTablePage.tsx
+++ b/kagenti/ui-v2/src/pages/SessionsTablePage.tsx
@@ -51,6 +51,25 @@ import { NamespaceSelector } from '@/components/NamespaceSelector';
 // NOTE: We use the sandboxService.listSessions() which returns TaskListResponse
 // The session metadata contains: parent_context_id, session_type, passover_from, passover_to
 
+/** Shape of a session item returned by sandboxService.listSessions(). */
+interface SessionItem {
+  context_id?: string;
+  id?: string;
+  metadata?: {
+    session_type?: string;
+    parent_context_id?: string;
+    title?: string;
+    agent_variant?: string;
+    created_at?: string;
+    passover_from?: string;
+    passover_to?: string;
+  };
+  status?: {
+    state?: string;
+    timestamp?: string;
+  };
+}
+
 type SessionType = 'all' | 'root' | 'child' | 'passover';
 
 export const SessionsTablePage: React.FC = () => {
@@ -60,7 +79,7 @@ export const SessionsTablePage: React.FC = () => {
   const [typeFilter, setTypeFilter] = useState<SessionType>('all');
   const [searchText, setSearchText] = useState('');
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [sessionToDelete, setSessionToDelete] = useState<any>(null);
+  const [sessionToDelete, setSessionToDelete] = useState<SessionItem | null>(null);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
@@ -78,7 +97,7 @@ export const SessionsTablePage: React.FC = () => {
   const sessions = sessionsResponse?.items ?? [];
 
   // Filter by session type and search text
-  const filteredSessions = sessions.filter((s: any) => {
+  const filteredSessions = sessions.filter((s: SessionItem) => {
     // Type filter
     if (typeFilter !== 'all') {
       const sessionType = s.metadata?.session_type || 'root';
@@ -101,7 +120,7 @@ export const SessionsTablePage: React.FC = () => {
     },
   });
 
-  const handleDeleteClick = (session: any) => {
+  const handleDeleteClick = (session: SessionItem) => {
     setSessionToDelete(session);
     setDeleteModalOpen(true);
     setOpenMenuId(null);
@@ -124,11 +143,11 @@ export const SessionsTablePage: React.FC = () => {
 
   const truncateId = (id: string) => id ? id.slice(0, 8) + '...' : '';
 
-  const getSessionType = (session: any): string => {
+  const getSessionType = (session: SessionItem): string => {
     return session.metadata?.session_type || 'root';
   };
 
-  const renderTypeBadge = (session: any) => {
+  const renderTypeBadge = (session: SessionItem) => {
     const type = getSessionType(session);
     const colors: Record<string, 'blue' | 'cyan' | 'purple' | 'grey'> = {
       root: 'blue',
@@ -138,7 +157,7 @@ export const SessionsTablePage: React.FC = () => {
     return <Label color={colors[type] || 'grey'} isCompact>{type}</Label>;
   };
 
-  const renderStatusBadge = (session: any) => {
+  const renderStatusBadge = (session: SessionItem) => {
     const state = session.status?.state || 'unknown';
     let color: 'green' | 'blue' | 'red' | 'grey' = 'grey';
     let label = state;
@@ -242,7 +261,7 @@ export const SessionsTablePage: React.FC = () => {
               </Tr>
             </Thead>
             <Tbody>
-              {filteredSessions.map((session: any) => {
+              {filteredSessions.map((session: SessionItem) => {
                 const contextId = session.context_id || session.id;
                 const parentId = session.metadata?.parent_context_id;
                 const title = session.metadata?.title || session.metadata?.agent_variant || 'Untitled';

--- a/kagenti/ui-v2/src/pages/TriggerManagementPage.tsx
+++ b/kagenti/ui-v2/src/pages/TriggerManagementPage.tsx
@@ -1,0 +1,389 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React, { useState } from 'react';
+import {
+  PageSection,
+  Title,
+  TextContent,
+  Text,
+  Card,
+  CardBody,
+  Form,
+  FormGroup,
+  TextInput,
+  FormSelect,
+  FormSelectOption,
+  NumberInput,
+  Button,
+  Alert,
+  ActionGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { useMutation } from '@tanstack/react-query';
+
+import { triggerService } from '@/services/api';
+import { NamespaceSelector } from '@/components/NamespaceSelector';
+
+// Webhook event options
+const WEBHOOK_EVENTS = ['pull_request', 'push', 'issue_comment', 'check_suite'];
+
+// Alert severity options
+const ALERT_SEVERITIES = ['info', 'warning', 'critical'];
+
+export const TriggerManagementPage: React.FC = () => {
+  const [namespace, setNamespace] = useState('team1');
+  const [activeTabKey, setActiveTabKey] = useState<number>(0);
+
+  // Cron form state
+  const [cronSkill, setCronSkill] = useState('');
+  const [cronSchedule, setCronSchedule] = useState('');
+  const [cronTtl, setCronTtl] = useState(2);
+
+  // Webhook form state
+  const [webhookEvent, setWebhookEvent] = useState('pull_request');
+  const [webhookRepo, setWebhookRepo] = useState('');
+  const [webhookBranch, setWebhookBranch] = useState('main');
+  const [webhookPrNumber, setWebhookPrNumber] = useState<number | undefined>(undefined);
+  const [webhookTtl, setWebhookTtl] = useState(2);
+
+  // Alert form state
+  const [alertName, setAlertName] = useState('');
+  const [alertCluster, setAlertCluster] = useState('');
+  const [alertSeverity, setAlertSeverity] = useState('warning');
+  const [alertTtl, setAlertTtl] = useState(2);
+
+  // Success/error state
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const createMutation = useMutation({
+    mutationFn: (data: Parameters<typeof triggerService.create>[0]) =>
+      triggerService.create(data),
+    onSuccess: (result) => {
+      setSuccessMessage(
+        `Trigger created successfully. SandboxClaim: ${result.sandbox_claim}`
+      );
+    },
+  });
+
+  const handleCronSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSuccessMessage(null);
+    createMutation.mutate({
+      type: 'cron',
+      skill: cronSkill,
+      schedule: cronSchedule || undefined,
+      namespace,
+      ttl_hours: cronTtl,
+    });
+  };
+
+  const handleWebhookSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSuccessMessage(null);
+    createMutation.mutate({
+      type: 'webhook',
+      event: webhookEvent,
+      repo: webhookRepo,
+      branch: webhookBranch,
+      pr_number: webhookPrNumber,
+      namespace,
+      ttl_hours: webhookTtl,
+    });
+  };
+
+  const handleAlertSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSuccessMessage(null);
+    createMutation.mutate({
+      type: 'alert',
+      alert: alertName,
+      cluster: alertCluster || undefined,
+      severity: alertSeverity,
+      namespace,
+      ttl_hours: alertTtl,
+    });
+  };
+
+  const renderCronTab = () => (
+    <Card>
+      <CardBody>
+        <Form onSubmit={handleCronSubmit}>
+          <FormGroup label="Skill name" isRequired fieldId="cron-skill">
+            <TextInput
+              id="cron-skill"
+              value={cronSkill}
+              onChange={(_event, value) => setCronSkill(value)}
+              placeholder="tdd:ci"
+              isRequired
+            />
+          </FormGroup>
+
+          <FormGroup label="Schedule" fieldId="cron-schedule">
+            <TextInput
+              id="cron-schedule"
+              value={cronSchedule}
+              onChange={(_event, value) => setCronSchedule(value)}
+              placeholder="0 2 * * *"
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>Cron expression</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+
+          <FormGroup label="TTL Hours" fieldId="cron-ttl">
+            <NumberInput
+              id="cron-ttl"
+              value={cronTtl}
+              min={1}
+              max={168}
+              onMinus={() => setCronTtl(Math.max(1, cronTtl - 1))}
+              onPlus={() => setCronTtl(Math.min(168, cronTtl + 1))}
+              onChange={(event) => {
+                const val = Number((event.target as HTMLInputElement).value);
+                if (!isNaN(val)) setCronTtl(Math.max(1, Math.min(168, val)));
+              }}
+              widthChars={5}
+            />
+          </FormGroup>
+
+          <ActionGroup>
+            <Button
+              variant="primary"
+              type="submit"
+              isLoading={createMutation.isPending}
+              isDisabled={createMutation.isPending || !cronSkill.trim()}
+            >
+              Create Trigger
+            </Button>
+          </ActionGroup>
+        </Form>
+      </CardBody>
+    </Card>
+  );
+
+  const renderWebhookTab = () => (
+    <Card>
+      <CardBody>
+        <Form onSubmit={handleWebhookSubmit}>
+          <FormGroup label="Event type" isRequired fieldId="webhook-event">
+            <FormSelect
+              id="webhook-event"
+              value={webhookEvent}
+              onChange={(_event, value) => setWebhookEvent(value)}
+            >
+              {WEBHOOK_EVENTS.map((evt) => (
+                <FormSelectOption key={evt} value={evt} label={evt} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+
+          <FormGroup label="Repository URL" isRequired fieldId="webhook-repo">
+            <TextInput
+              id="webhook-repo"
+              value={webhookRepo}
+              onChange={(_event, value) => setWebhookRepo(value)}
+              placeholder="https://github.com/org/repo"
+              isRequired
+            />
+          </FormGroup>
+
+          <FormGroup label="Branch" fieldId="webhook-branch">
+            <TextInput
+              id="webhook-branch"
+              value={webhookBranch}
+              onChange={(_event, value) => setWebhookBranch(value)}
+              placeholder="main"
+            />
+          </FormGroup>
+
+          <FormGroup label="PR Number" fieldId="webhook-pr-number">
+            <NumberInput
+              id="webhook-pr-number"
+              value={webhookPrNumber ?? 0}
+              min={0}
+              onMinus={() => setWebhookPrNumber(Math.max(0, (webhookPrNumber ?? 0) - 1))}
+              onPlus={() => setWebhookPrNumber((webhookPrNumber ?? 0) + 1)}
+              onChange={(event) => {
+                const val = Number((event.target as HTMLInputElement).value);
+                if (!isNaN(val)) setWebhookPrNumber(val > 0 ? val : undefined);
+              }}
+              widthChars={5}
+            />
+          </FormGroup>
+
+          <FormGroup label="TTL Hours" fieldId="webhook-ttl">
+            <NumberInput
+              id="webhook-ttl"
+              value={webhookTtl}
+              min={1}
+              max={168}
+              onMinus={() => setWebhookTtl(Math.max(1, webhookTtl - 1))}
+              onPlus={() => setWebhookTtl(Math.min(168, webhookTtl + 1))}
+              onChange={(event) => {
+                const val = Number((event.target as HTMLInputElement).value);
+                if (!isNaN(val)) setWebhookTtl(Math.max(1, Math.min(168, val)));
+              }}
+              widthChars={5}
+            />
+          </FormGroup>
+
+          <ActionGroup>
+            <Button
+              variant="primary"
+              type="submit"
+              isLoading={createMutation.isPending}
+              isDisabled={createMutation.isPending || !webhookRepo.trim()}
+            >
+              Create Trigger
+            </Button>
+          </ActionGroup>
+        </Form>
+      </CardBody>
+    </Card>
+  );
+
+  const renderAlertTab = () => (
+    <Card>
+      <CardBody>
+        <Form onSubmit={handleAlertSubmit}>
+          <FormGroup label="Alert name" isRequired fieldId="alert-name">
+            <TextInput
+              id="alert-name"
+              value={alertName}
+              onChange={(_event, value) => setAlertName(value)}
+              placeholder="HighCPUUsage"
+              isRequired
+            />
+          </FormGroup>
+
+          <FormGroup label="Cluster" fieldId="alert-cluster">
+            <TextInput
+              id="alert-cluster"
+              value={alertCluster}
+              onChange={(_event, value) => setAlertCluster(value)}
+              placeholder="production-cluster"
+            />
+          </FormGroup>
+
+          <FormGroup label="Severity" fieldId="alert-severity">
+            <FormSelect
+              id="alert-severity"
+              value={alertSeverity}
+              onChange={(_event, value) => setAlertSeverity(value)}
+            >
+              {ALERT_SEVERITIES.map((sev) => (
+                <FormSelectOption key={sev} value={sev} label={sev} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+
+          <FormGroup label="TTL Hours" fieldId="alert-ttl">
+            <NumberInput
+              id="alert-ttl"
+              value={alertTtl}
+              min={1}
+              max={168}
+              onMinus={() => setAlertTtl(Math.max(1, alertTtl - 1))}
+              onPlus={() => setAlertTtl(Math.min(168, alertTtl + 1))}
+              onChange={(event) => {
+                const val = Number((event.target as HTMLInputElement).value);
+                if (!isNaN(val)) setAlertTtl(Math.max(1, Math.min(168, val)));
+              }}
+              widthChars={5}
+            />
+          </FormGroup>
+
+          <ActionGroup>
+            <Button
+              variant="primary"
+              type="submit"
+              isLoading={createMutation.isPending}
+              isDisabled={createMutation.isPending || !alertName.trim()}
+            >
+              Create Trigger
+            </Button>
+          </ActionGroup>
+        </Form>
+      </CardBody>
+    </Card>
+  );
+
+  return (
+    <>
+      <PageSection variant="light">
+        <TextContent>
+          <Title headingLevel="h1">Triggers</Title>
+          <Text component="p">
+            Create sandbox triggers from cron schedules, webhook events, or alerts.
+          </Text>
+        </TextContent>
+      </PageSection>
+
+      <PageSection variant="light" padding={{ default: 'noPadding' }}>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem>
+              <NamespaceSelector
+                namespace={namespace}
+                onNamespaceChange={setNamespace}
+              />
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+      </PageSection>
+
+      <PageSection>
+        {successMessage && (
+          <Alert
+            variant="success"
+            title="Trigger created"
+            isInline
+            style={{ marginBottom: '16px' }}
+          >
+            {successMessage}
+          </Alert>
+        )}
+
+        {createMutation.isError && (
+          <Alert
+            variant="danger"
+            title="Failed to create trigger"
+            isInline
+            style={{ marginBottom: '16px' }}
+          >
+            {createMutation.error instanceof Error
+              ? createMutation.error.message
+              : 'An unexpected error occurred'}
+          </Alert>
+        )}
+
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={(_event, tabIndex) => setActiveTabKey(tabIndex as number)}
+          aria-label="Trigger type tabs"
+        >
+          <Tab eventKey={0} title={<TabTitleText>Cron</TabTitleText>}>
+            {renderCronTab()}
+          </Tab>
+          <Tab eventKey={1} title={<TabTitleText>Webhook</TabTitleText>}>
+            {renderWebhookTab()}
+          </Tab>
+          <Tab eventKey={2} title={<TabTitleText>Alert</TabTitleText>}>
+            {renderAlertTab()}
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+};

--- a/kagenti/ui-v2/src/pages/index.ts
+++ b/kagenti/ui-v2/src/pages/index.ts
@@ -13,3 +13,4 @@ export { ImportAgentPage } from './ImportAgentPage';
 export { ImportToolPage } from './ImportToolPage';
 export { AdminPage } from './AdminPage';
 export { NotFoundPage } from './NotFoundPage';
+export { SandboxCreatePage } from './SandboxCreatePage';


### PR DESCRIPTION
## Summary
- SandboxPage: main session view with chat, tabs, and panels
- SandboxCreatePage, SandboxesPage: create and list sandbox agents
- SessionsTablePage: sortable/filterable sessions table
- SessionStatsPanel: session overview with timing stats
- TriggerManagementPage: CRUD for event triggers
- IntegrationsPage, IntegrationDetailPage, AddIntegrationPage
- AgentCatalogPage: browsable agent catalog
- Pages index barrel export

11 files | Part of Sandbox Agent streaming PR series