### PR TITLE
test: add sandbox backend unit and E2E tests

### DIFF
--- a/kagenti/backend/tests/test_llm_keys.py
+++ b/kagenti/backend/tests/test_llm_keys.py
@@ -247,8 +247,8 @@ class TestSecretDefaults:
         sandbox_deploy = pytest.importorskip(
             "app.routers.sandbox_deploy", reason="sandbox_deploy module not available"
         )
-        DEFAULT_LLM_SECRET = sandbox_deploy.DEFAULT_LLM_SECRET
-        DEFAULT_LLM_SECRET_KEY = sandbox_deploy.DEFAULT_LLM_SECRET_KEY
+        default_secret = sandbox_deploy.DEFAULT_LLM_SECRET
+        default_key = sandbox_deploy.DEFAULT_LLM_SECRET_KEY
 
-        assert DEFAULT_LLM_SECRET == "litellm-virtual-keys"
-        assert DEFAULT_LLM_SECRET_KEY == "api-key"
+        assert default_secret == "litellm-virtual-keys"
+        assert default_key == "api-key"

--- a/kagenti/backend/tests/test_llm_keys.py
+++ b/kagenti/backend/tests/test_llm_keys.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+pytest.importorskip("app.routers.llm_keys", reason="llm_keys module not available")
+
 from app.routers.llm_keys import (
     _get_team_id,
     _ensure_team,
@@ -242,7 +244,11 @@ class TestSecretDefaults:
     def test_sandbox_deploy_default_matches(self):
         """sandbox_deploy.py DEFAULT_LLM_SECRET should match the key
         created by 38-deploy-litellm.sh (litellm-virtual-keys/api-key)."""
-        from app.routers.sandbox_deploy import DEFAULT_LLM_SECRET, DEFAULT_LLM_SECRET_KEY
+        sandbox_deploy = pytest.importorskip(
+            "app.routers.sandbox_deploy", reason="sandbox_deploy module not available"
+        )
+        DEFAULT_LLM_SECRET = sandbox_deploy.DEFAULT_LLM_SECRET
+        DEFAULT_LLM_SECRET_KEY = sandbox_deploy.DEFAULT_LLM_SECRET_KEY
 
         assert DEFAULT_LLM_SECRET == "litellm-virtual-keys"
         assert DEFAULT_LLM_SECRET_KEY == "api-key"

--- a/kagenti/backend/tests/test_llm_keys.py
+++ b/kagenti/backend/tests/test_llm_keys.py
@@ -1,0 +1,248 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for LLM virtual key management API.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.routers.llm_keys import (
+    _get_team_id,
+    _ensure_team,
+    _create_virtual_key,
+    _master_headers,
+    KeyCreateRequest,
+    TeamCreateRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def set_master_key(monkeypatch):
+    """Set LITELLM_MASTER_KEY for all tests."""
+    monkeypatch.setattr("app.routers.llm_keys.LITELLM_MASTER_KEY", "sk-test-master")
+    monkeypatch.setattr("app.routers.llm_keys.LITELLM_BASE_URL", "http://litellm-test:4000")
+
+
+# ---------------------------------------------------------------------------
+# _master_headers
+# ---------------------------------------------------------------------------
+
+
+class TestMasterHeaders:
+    def test_returns_auth_header(self):
+        headers = _master_headers()
+        assert headers["Authorization"] == "Bearer sk-test-master"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_raises_503_when_no_key(self, monkeypatch):
+        monkeypatch.setattr("app.routers.llm_keys.LITELLM_MASTER_KEY", "")
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _master_headers()
+        assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# _get_team_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetTeamId:
+    @pytest.mark.asyncio
+    async def test_finds_team_by_alias(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            {"team_alias": "team1", "team_id": "tid-123"},
+            {"team_alias": "team2", "team_id": "tid-456"},
+        ]
+
+        with patch("app.routers.llm_keys.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.request = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            result = await _get_team_id("team1")
+            assert result == "tid-123"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            {"team_alias": "team2", "team_id": "tid-456"},
+        ]
+
+        with patch("app.routers.llm_keys.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.request = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            result = await _get_team_id("team1")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handles_nested_response(self):
+        """LiteLLM may return {"data": [...]} or a flat list."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"team_alias": "team1", "team_id": "tid-789"}]}
+
+        with patch("app.routers.llm_keys.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.request = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            result = await _get_team_id("team1")
+            assert result == "tid-789"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_team
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureTeam:
+    @pytest.mark.asyncio
+    async def test_returns_existing_team(self):
+        with patch("app.routers.llm_keys._get_team_id", return_value="tid-existing"):
+            result = await _ensure_team("team1")
+            assert result == "tid-existing"
+
+    @pytest.mark.asyncio
+    async def test_creates_new_team(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"team_id": "tid-new"}
+
+        with patch("app.routers.llm_keys._get_team_id", return_value=None):
+            with patch("app.routers.llm_keys.httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client.request = AsyncMock(return_value=mock_resp)
+                mock_client_cls.return_value = mock_client
+
+                result = await _ensure_team("team1", max_budget=200)
+                assert result == "tid-new"
+
+                # Verify the request was made correctly
+                call_args = mock_client.request.call_args
+                assert call_args[0][0] == "POST"
+                assert "/team/new" in call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# _create_virtual_key
+# ---------------------------------------------------------------------------
+
+
+class TestCreateVirtualKey:
+    @pytest.mark.asyncio
+    async def test_creates_key_with_team(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"token": "sk-virtual-abc123"}
+
+        with patch("app.routers.llm_keys.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.request = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            key = await _create_virtual_key(
+                team_id="tid-123",
+                key_alias="my-agent",
+                namespace="team1",
+                max_budget=50.0,
+                models=["llama-4-scout"],
+            )
+            assert key == "sk-virtual-abc123"
+
+            # Verify models passed in request
+            call_args = mock_client.request.call_args
+            body = call_args[1].get("json", {})
+            assert body.get("team_id") == "tid-123"
+            assert body.get("models") == ["llama-4-scout"]
+
+    @pytest.mark.asyncio
+    async def test_creates_key_without_models(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"key": "sk-virtual-def456"}
+
+        with patch("app.routers.llm_keys.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.request = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            key = await _create_virtual_key(
+                team_id="tid-123",
+                key_alias="my-agent",
+                namespace="team1",
+            )
+            assert key == "sk-virtual-def456"
+
+            body = mock_client.request.call_args[1].get("json", {})
+            assert "models" not in body
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class TestPydanticModels:
+    def test_team_create_defaults(self):
+        req = TeamCreateRequest(namespace="team1")
+        assert req.max_budget == 500.0
+        assert req.budget_duration == "30d"
+        assert req.models is None
+
+    def test_key_create_defaults(self):
+        req = KeyCreateRequest(namespace="team1", agent_name="sandbox-agent")
+        assert req.max_budget == 100.0
+        assert req.budget_duration == "30d"
+        assert req.models is None
+
+    def test_key_create_with_models(self):
+        req = KeyCreateRequest(
+            namespace="team1",
+            agent_name="sandbox-agent",
+            models=["llama-4-scout", "mistral-small"],
+        )
+        assert req.models == ["llama-4-scout", "mistral-small"]
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_LLM_SECRET consistency
+# ---------------------------------------------------------------------------
+
+
+class TestSecretDefaults:
+    def test_sandbox_deploy_default_matches(self):
+        """sandbox_deploy.py DEFAULT_LLM_SECRET should match the key
+        created by 38-deploy-litellm.sh (litellm-virtual-keys/api-key)."""
+        from app.routers.sandbox_deploy import DEFAULT_LLM_SECRET, DEFAULT_LLM_SECRET_KEY
+
+        assert DEFAULT_LLM_SECRET == "litellm-virtual-keys"
+        assert DEFAULT_LLM_SECRET_KEY == "api-key"

--- a/kagenti/backend/tests/test_loop_event_pipeline.py
+++ b/kagenti/backend/tests/test_loop_event_pipeline.py
@@ -373,7 +373,7 @@ class TestLoopEventPipelineAPI:
             sl = s_loops[lid]
             hl = h_loops[lid]
             assert sl["status"] == hl["status"], f"Status: {sl['status']} vs {hl['status']}"
-            assert len(sl["steps"]) == len(hl["steps"]), f"Step count differs"
+            assert len(sl["steps"]) == len(hl["steps"]), "Step count differs"
 
             for si in sl["steps"]:
                 ss = sl["steps"][si]

--- a/kagenti/backend/tests/test_loop_event_pipeline.py
+++ b/kagenti/backend/tests/test_loop_event_pipeline.py
@@ -40,6 +40,7 @@ import pytest
 UI_URL = os.environ.get("KAGENTI_UI_URL", "")
 KC_USER = os.environ.get("KEYCLOAK_USER", "admin")
 KC_PASSWORD = os.environ.get("KEYCLOAK_PASSWORD", "")
+VERIFY_SSL = os.environ.get("VERIFY_SSL", "false").lower() == "true"
 NAMESPACE = "team1"
 AGENT_NAME = "sandbox-legion"
 
@@ -86,7 +87,7 @@ def get_keycloak_token() -> str:
                     "username": KC_USER,
                     "password": KC_PASSWORD,
                 },
-                verify=False,
+                verify=VERIFY_SSL,
                 timeout=10,
             )
             if resp.status_code == 200:
@@ -113,7 +114,7 @@ def send_streaming_message(token: str, context_id: str, message: str) -> list[di
     """Send a message via streaming API, collect all loop events."""
     loop_events: list[dict] = []
 
-    with httpx.Client(timeout=180, verify=False) as client:
+    with httpx.Client(timeout=180, verify=VERIFY_SSL) as client:
         with client.stream(
             "POST",
             api_url(f"/sandbox/{NAMESPACE}/chat/stream"),
@@ -151,7 +152,7 @@ def get_history(token: str, context_id: str) -> dict:
     resp = httpx.get(
         api_url(f"/sandbox/{NAMESPACE}/sessions/{context_id}/history?limit=50"),
         headers={"Authorization": f"Bearer {token}"},
-        verify=False,
+        verify=VERIFY_SSL,
         timeout=15,
     )
     resp.raise_for_status()

--- a/kagenti/backend/tests/test_loop_event_pipeline.py
+++ b/kagenti/backend/tests/test_loop_event_pipeline.py
@@ -1,0 +1,386 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Loop Event Pipeline Consistency Test (via real API)
+
+Sends a message through the backend streaming API, waits for completion,
+then verifies that the history endpoint returns the same data needed for
+the frontend to render AgentLoopCards.
+
+Checks:
+1. Streaming SSE events contain all expected types
+2. History endpoint returns loop_events matching what was streamed
+3. Reconstructed AgentLoop has tool_calls, tool_results, tokens, finalAnswer
+4. tool_call count matches tool_result count
+
+Environment:
+  KAGENTI_UI_URL: Base URL (e.g. https://kagenti-ui-kagenti-system.apps....)
+  KEYCLOAK_USER / KEYCLOAK_PASSWORD: Auth credentials
+  KUBECONFIG: For kubectl access (fallback)
+
+Run:
+  KAGENTI_UI_URL=https://... KEYCLOAK_USER=admin KEYCLOAK_PASSWORD=... \
+    python -m pytest tests/test_loop_event_pipeline.py -v
+"""
+
+import json
+import os
+import time
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+UI_URL = os.environ.get("KAGENTI_UI_URL", "")
+KC_USER = os.environ.get("KEYCLOAK_USER", "admin")
+KC_PASSWORD = os.environ.get("KEYCLOAK_PASSWORD", "")
+NAMESPACE = "team1"
+AGENT_NAME = "sandbox-legion"
+
+
+def _skip_if_no_url():
+    if not UI_URL:
+        pytest.skip("Requires KAGENTI_UI_URL")
+    if not KC_PASSWORD:
+        pytest.skip("Requires KEYCLOAK_PASSWORD")
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def get_keycloak_token() -> str:
+    """Get an access token from Keycloak using password grant."""
+    parsed = urlparse(UI_URL)
+    # Keycloak route is typically keycloak-keycloak.<domain>
+    domain = parsed.hostname
+    if not domain:
+        raise ValueError(f"Cannot parse domain from {UI_URL}")
+    # Replace kagenti-ui-kagenti-system with keycloak-keycloak
+    parts = domain.split(".")
+    kc_host = "keycloak-keycloak." + ".".join(parts[1:])
+    kc_url = f"https://{kc_host}"
+
+    # Try realm + client combinations
+    combos = [
+        ("master", "admin-cli"),
+        ("master", "kagenti-ui"),
+        ("kagenti", "kagenti-ui"),
+        ("kagenti", "admin-cli"),
+    ]
+    for realm, client_id in combos:
+        token_url = f"{kc_url}/realms/{realm}/protocol/openid-connect/token"
+        try:
+            resp = httpx.post(
+                token_url,
+                data={
+                    "grant_type": "password",
+                    "client_id": client_id,
+                    "username": KC_USER,
+                    "password": KC_PASSWORD,
+                },
+                verify=False,
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if "access_token" in data:
+                    return data["access_token"]
+        except Exception:
+            continue
+
+    raise RuntimeError(f"Failed to get Keycloak token from {kc_url}")
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+
+
+def api_url(path: str) -> str:
+    """Build full API URL."""
+    return f"{UI_URL}/api/v1{path}"
+
+
+def send_streaming_message(token: str, context_id: str, message: str) -> list[dict]:
+    """Send a message via streaming API, collect all loop events."""
+    loop_events: list[dict] = []
+
+    with httpx.Client(timeout=180, verify=False) as client:
+        with client.stream(
+            "POST",
+            api_url(f"/sandbox/{NAMESPACE}/chat/stream"),
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "message": message,
+                "context_id": context_id,
+                "agent_name": AGENT_NAME,
+            },
+        ) as resp:
+            resp.raise_for_status()
+            buffer = ""
+            for chunk in resp.iter_text():
+                buffer += chunk
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line.startswith("data:"):
+                        continue
+                    try:
+                        data = json.loads(line[5:].strip())
+                        if "loop_event" in data:
+                            loop_events.append(data["loop_event"])
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+
+    return loop_events
+
+
+def get_history(token: str, context_id: str) -> dict:
+    """Fetch session history from the API."""
+    resp = httpx.get(
+        api_url(f"/sandbox/{NAMESPACE}/sessions/{context_id}/history?limit=50"),
+        headers={"Authorization": f"Bearer {token}"},
+        verify=False,
+        timeout=15,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Reconstruction (mirrors frontend loadInitialHistory logic)
+# ---------------------------------------------------------------------------
+
+
+def reconstruct_loops(events: list[dict]) -> dict[str, dict]:
+    """Simulate frontend AgentLoop reconstruction from loop_events."""
+    loops: dict[str, dict] = {}
+
+    for le in events:
+        lid = le.get("loop_id", "unknown")
+        if lid not in loops:
+            loops[lid] = {
+                "id": lid,
+                "steps": {},
+                "status": "planning",
+                "plan": [],
+                "finalAnswer": "",
+            }
+        loop = loops[lid]
+        et = le.get("type", "")
+
+        if et == "planner_output":
+            loop["plan"] = le.get("steps", [])
+            loop["status"] = "planning"
+        elif et == "executor_step":
+            si = le.get("step", 0)
+            existing = loop["steps"].get(
+                si, {"toolCalls": [], "toolResults": [], "status": "running"}
+            )
+            loop["steps"][si] = {
+                "index": si,
+                "description": le.get("description", "") or existing.get("description", ""),
+                "reasoning": le.get("reasoning", "") or existing.get("reasoning", ""),
+                "tokens": {
+                    "prompt": le.get("prompt_tokens", 0)
+                    or existing.get("tokens", {}).get("prompt", 0),
+                    "completion": le.get("completion_tokens", 0)
+                    or existing.get("tokens", {}).get("completion", 0),
+                },
+                "toolCalls": existing.get("toolCalls", []),
+                "toolResults": existing.get("toolResults", []),
+                "status": existing.get("status", "running"),
+            }
+            loop["status"] = "executing"
+        elif et == "tool_call":
+            si = le.get("step", 0)
+            if si in loop["steps"]:
+                loop["steps"][si]["toolCalls"].extend(le.get("tools", []))
+        elif et == "tool_result":
+            si = le.get("step", 0)
+            if si in loop["steps"]:
+                loop["steps"][si]["toolResults"].append(
+                    {
+                        "name": le.get("name", ""),
+                        "output": le.get("output", ""),
+                    }
+                )
+                loop["steps"][si]["status"] = "done"
+        elif et == "micro_reasoning":
+            si = le.get("step", 0)
+            if si in loop["steps"]:
+                if "microReasonings" not in loop["steps"][si]:
+                    loop["steps"][si]["microReasonings"] = []
+                loop["steps"][si]["microReasonings"].append(
+                    {
+                        "type": "micro_reasoning",
+                        "micro_step": le.get("micro_step", 0),
+                        "reasoning": le.get("reasoning", ""),
+                        "next_action": le.get("next_action", ""),
+                        "model": le.get("model", ""),
+                        "prompt_tokens": le.get("prompt_tokens", 0),
+                        "completion_tokens": le.get("completion_tokens", 0),
+                        "system_prompt": le.get("system_prompt", ""),
+                        "prompt_messages": le.get("prompt_messages", []),
+                    }
+                )
+        elif et == "reflector_decision":
+            loop["status"] = "reflecting"
+        elif et == "reporter_output":
+            loop["status"] = "done"
+            loop["finalAnswer"] = le.get("content", "")
+
+    # Mark all as done (historical)
+    for loop in loops.values():
+        if loop["status"] != "done":
+            loop["status"] = "done"
+        for s in loop["steps"].values():
+            if s["status"] == "running":
+                s["status"] = "done"
+
+    return loops
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def auth_token():
+    _skip_if_no_url()
+    return get_keycloak_token()
+
+
+@pytest.fixture(scope="module")
+def session_data(auth_token):
+    """Send a message and capture both streaming events and history."""
+    context_id = f"pipeline-test-{int(time.time())}-{os.urandom(4).hex()}"
+
+    # Step 1: Send message via streaming API, capture SSE loop events
+    streaming_events = send_streaming_message(
+        auth_token,
+        context_id,
+        "Create a file called /workspace/pipeline-test.txt with 'hello pipeline' and then read it back",
+    )
+
+    # Step 2: Wait for persistence
+    time.sleep(3)
+
+    # Step 3: Fetch history
+    history = get_history(auth_token, context_id)
+
+    return {
+        "context_id": context_id,
+        "streaming_events": streaming_events,
+        "history": history,
+        "history_loop_events": history.get("loop_events", []),
+    }
+
+
+class TestLoopEventPipelineAPI:
+    """End-to-end pipeline test via real API."""
+
+    def test_streaming_has_events(self, session_data):
+        """Streaming SSE should produce loop events."""
+        events = session_data["streaming_events"]
+        assert len(events) > 0, "No loop events received from streaming"
+        types = {e.get("type") for e in events}
+        print(f"Streaming event types: {types}")
+        assert "planner_output" in types
+        assert "executor_step" in types
+
+    def test_streaming_has_tool_calls(self, session_data):
+        """Streaming should include tool_call events."""
+        events = session_data["streaming_events"]
+        tool_calls = [e for e in events if e.get("type") == "tool_call"]
+        assert len(tool_calls) > 0, f"No tool_call events. Types: {[e.get('type') for e in events]}"
+        for tc in tool_calls:
+            tools = tc.get("tools", [])
+            assert len(tools) > 0, "tool_call has empty tools array"
+            assert tools[0].get("name"), "tool missing name"
+
+    def test_streaming_has_reporter(self, session_data):
+        """Streaming should end with reporter_output."""
+        events = session_data["streaming_events"]
+        reporters = [e for e in events if e.get("type") == "reporter_output"]
+        assert len(reporters) > 0, "No reporter_output event"
+        assert reporters[-1].get("content"), "reporter_output has no content"
+
+    def test_history_has_loop_events(self, session_data):
+        """History endpoint should return loop_events."""
+        le = session_data["history_loop_events"]
+        assert len(le) > 0, "History has no loop_events"
+
+    def test_history_matches_streaming(self, session_data):
+        """History loop_events should match streaming events."""
+        streaming = session_data["streaming_events"]
+        history = session_data["history_loop_events"]
+
+        s_types = [e.get("type") for e in streaming]
+        h_types = [e.get("type") for e in history]
+
+        print(f"Streaming types: {s_types}")
+        print(f"History types:   {h_types}")
+
+        # History should have the same event types
+        assert set(h_types) == set(s_types), (
+            f"Type mismatch: streaming={set(s_types)}, history={set(h_types)}"
+        )
+        # Same count (no lost events)
+        assert len(history) == len(streaming), (
+            f"Event count mismatch: streaming={len(streaming)}, history={len(history)}"
+        )
+
+    def test_reconstruction_from_history(self, session_data):
+        """Reconstructed loops from history should have tool data."""
+        le = session_data["history_loop_events"]
+        loops = reconstruct_loops(le)
+
+        assert len(loops) > 0, "No loops reconstructed"
+
+        for lid, loop in loops.items():
+            assert loop["status"] == "done", f"Loop {lid} not done"
+            assert loop["finalAnswer"], f"Loop {lid} no finalAnswer"
+
+            total_tc = sum(len(s["toolCalls"]) for s in loop["steps"].values())
+            total_tr = sum(len(s["toolResults"]) for s in loop["steps"].values())
+            assert total_tc > 0, f"Loop {lid}: 0 tool_calls after reconstruction"
+            assert total_tr > 0, f"Loop {lid}: 0 tool_results after reconstruction"
+            assert total_tc == total_tr, (
+                f"Loop {lid}: tool_calls={total_tc} != tool_results={total_tr}"
+            )
+
+    def test_reconstruction_from_streaming(self, session_data):
+        """Reconstructed loops from streaming should match history reconstruction."""
+        s_loops = reconstruct_loops(session_data["streaming_events"])
+        h_loops = reconstruct_loops(session_data["history_loop_events"])
+
+        assert set(s_loops.keys()) == set(h_loops.keys()), "Loop IDs differ"
+
+        for lid in s_loops:
+            sl = s_loops[lid]
+            hl = h_loops[lid]
+            assert sl["status"] == hl["status"], f"Status: {sl['status']} vs {hl['status']}"
+            assert len(sl["steps"]) == len(hl["steps"]), f"Step count differs"
+
+            for si in sl["steps"]:
+                ss = sl["steps"][si]
+                hs = hl["steps"][si]
+                assert len(ss["toolCalls"]) == len(hs["toolCalls"]), (
+                    f"Step {si} toolCalls: streaming={len(ss['toolCalls'])}, history={len(hs['toolCalls'])}"
+                )
+                assert len(ss["toolResults"]) == len(hs["toolResults"]), (
+                    f"Step {si} toolResults: streaming={len(ss['toolResults'])}, history={len(hs['toolResults'])}"
+                )

--- a/kagenti/backend/tests/test_sandbox_metadata.py
+++ b/kagenti/backend/tests/test_sandbox_metadata.py
@@ -1,0 +1,296 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for sandbox session metadata merge logic.
+
+Verifies that list_sessions() properly merges title/owner/visibility
+from earlier task rows into the response when the latest task row
+(picked by DISTINCT ON context_id ... ORDER BY id DESC) lacks metadata.
+
+The A2A SDK creates immutable task rows per message exchange. The backend's
+_set_owner_metadata() sets title/owner on the first row, but the agent
+creates later rows that don't carry this metadata forward. The merge
+logic in list_sessions() compensates by looking up metadata from sibling
+rows.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_task_row(
+    *,
+    id: int,
+    context_id: str,
+    kind: str = "task",
+    status: dict | None = None,
+    metadata: dict | None = None,
+):
+    """Create a mock DB row matching the tasks table schema."""
+    row = {
+        "id": str(id),  # TaskSummary.id is a string
+        "context_id": context_id,
+        "kind": kind,
+        "status": json.dumps(status or {"state": "completed"}),
+        "metadata": json.dumps(metadata) if metadata else None,
+    }
+    return row
+
+
+class TestParseJsonField:
+    """Tests for _parse_json_field helper."""
+
+    def test_parses_json_string(self):
+        from app.routers.sandbox import _parse_json_field
+
+        result = _parse_json_field('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_returns_dict_as_is(self):
+        from app.routers.sandbox import _parse_json_field
+
+        d = {"key": "value"}
+        result = _parse_json_field(d)
+        assert result is d
+
+    def test_returns_none_for_none(self):
+        from app.routers.sandbox import _parse_json_field
+
+        assert _parse_json_field(None) is None
+
+    def test_raises_on_empty_string(self):
+        """Empty string is technically invalid JSON — json.loads raises."""
+        import json
+
+        from app.routers.sandbox import _parse_json_field
+
+        with pytest.raises(json.JSONDecodeError):
+            _parse_json_field("")
+
+    def test_raises_on_invalid_json(self):
+        """Non-JSON string should raise JSONDecodeError."""
+        import json
+
+        from app.routers.sandbox import _parse_json_field
+
+        with pytest.raises(json.JSONDecodeError):
+            _parse_json_field("not json")
+
+
+class TestRowToSummary:
+    """Tests for _row_to_summary conversion."""
+
+    def test_summary_with_metadata(self):
+        from app.routers.sandbox import _row_to_summary
+
+        row = _make_task_row(
+            id=1,
+            context_id="ctx-123",
+            metadata={"title": "My Session", "owner": "admin"},
+        )
+        summary = _row_to_summary(row)
+        assert summary.context_id == "ctx-123"
+        assert summary.metadata["title"] == "My Session"
+        assert summary.metadata["owner"] == "admin"
+
+    def test_summary_without_metadata(self):
+        from app.routers.sandbox import _row_to_summary
+
+        row = _make_task_row(id=1, context_id="ctx-456", metadata=None)
+        summary = _row_to_summary(row)
+        assert summary.context_id == "ctx-456"
+        # metadata should be None or empty — no title
+        assert not (summary.metadata or {}).get("title")
+
+    def test_summary_with_empty_metadata(self):
+        from app.routers.sandbox import _row_to_summary
+
+        row = _make_task_row(id=1, context_id="ctx-789", metadata={})
+        summary = _row_to_summary(row)
+        assert summary.context_id == "ctx-789"
+
+
+class TestMetadataMergeLogic:
+    """Tests for the metadata merge in list_sessions().
+
+    These test the Python-side merge logic that fills in title/owner
+    from sibling rows when the latest row lacks them.
+    """
+
+    def test_merge_fills_missing_title(self):
+        """When latest row has no title, it should come from a sibling row."""
+        from app.routers.sandbox import TaskSummary, _parse_json_field
+
+        # Simulate: latest row has no metadata, earlier row has title+owner
+        items = [
+            TaskSummary(
+                id="2",
+                context_id="ctx-aaa",
+                kind="task",
+                status={"state": "completed"},
+                metadata=None,  # latest row — no metadata
+            ),
+        ]
+
+        # Simulate the donor row from the merge query
+        donor_metadata = {"title": "Hello world", "owner": "admin", "visibility": "private"}
+
+        # Apply merge logic (extracted from list_sessions)
+        missing_meta = [s for s in items if not (s.metadata or {}).get("title")]
+        assert len(missing_meta) == 1
+
+        for s in missing_meta:
+            if s.metadata is None:
+                s.metadata = {}
+            for key in ("title", "owner", "visibility"):
+                if key not in s.metadata and key in donor_metadata:
+                    s.metadata[key] = donor_metadata[key]
+
+        assert items[0].metadata["title"] == "Hello world"
+        assert items[0].metadata["owner"] == "admin"
+        assert items[0].metadata["visibility"] == "private"
+
+    def test_merge_preserves_existing_metadata(self):
+        """When latest row already has title, the merge should NOT overwrite it."""
+        from app.routers.sandbox import TaskSummary
+
+        items = [
+            TaskSummary(
+                id="3",
+                context_id="ctx-bbb",
+                kind="task",
+                status={"state": "completed"},
+                metadata={"title": "Original Title", "owner": "admin"},
+            ),
+        ]
+
+        donor_metadata = {"title": "Should NOT Replace", "owner": "other-user"}
+
+        missing_meta = [s for s in items if not (s.metadata or {}).get("title")]
+        # The item already has a title, so it should NOT be in missing_meta
+        assert len(missing_meta) == 0
+
+        # Title should remain unchanged
+        assert items[0].metadata["title"] == "Original Title"
+
+    def test_merge_handles_partial_donor(self):
+        """Donor row with only title (no owner) should still fill title."""
+        from app.routers.sandbox import TaskSummary
+
+        items = [
+            TaskSummary(
+                id="4",
+                context_id="ctx-ccc",
+                kind="task",
+                status={"state": "completed"},
+                metadata=None,
+            ),
+        ]
+
+        donor_metadata = {"title": "Partial Donor"}
+
+        missing_meta = [s for s in items if not (s.metadata or {}).get("title")]
+        for s in missing_meta:
+            if s.metadata is None:
+                s.metadata = {}
+            for key in ("title", "owner", "visibility"):
+                if key not in s.metadata and key in donor_metadata:
+                    s.metadata[key] = donor_metadata[key]
+
+        assert items[0].metadata["title"] == "Partial Donor"
+        assert "owner" not in items[0].metadata
+
+    def test_merge_skips_items_with_title(self):
+        """Items that already have a title should be skipped entirely."""
+        from app.routers.sandbox import TaskSummary
+
+        items = [
+            TaskSummary(
+                id="5",
+                context_id="ctx-ddd",
+                kind="task",
+                status={"state": "completed"},
+                metadata={"title": "Has Title"},
+            ),
+            TaskSummary(
+                id="6",
+                context_id="ctx-eee",
+                kind="task",
+                status={"state": "working"},
+                metadata=None,
+            ),
+        ]
+
+        missing_meta = [s for s in items if not (s.metadata or {}).get("title")]
+        # Only the second item should need merging
+        assert len(missing_meta) == 1
+        assert missing_meta[0].context_id == "ctx-eee"
+
+
+class TestSessionChainModels:
+    """Tests for SessionChainEntry and SessionChainResponse models."""
+
+    def test_chain_entry_root(self):
+        from app.routers.sandbox import SessionChainEntry
+
+        entry = SessionChainEntry(
+            context_id="ctx-root",
+            type="root",
+            status="completed",
+            title="Root session",
+        )
+        assert entry.context_id == "ctx-root"
+        assert entry.type == "root"
+        assert entry.parent is None
+
+    def test_chain_entry_child(self):
+        from app.routers.sandbox import SessionChainEntry
+
+        entry = SessionChainEntry(
+            context_id="ctx-child",
+            type="child",
+            status="working",
+            parent="ctx-root",
+        )
+        assert entry.parent == "ctx-root"
+        assert entry.passover_from is None
+
+    def test_chain_entry_passover(self):
+        from app.routers.sandbox import SessionChainEntry
+
+        entry = SessionChainEntry(
+            context_id="ctx-pass",
+            type="passover",
+            passover_from="ctx-root",
+        )
+        assert entry.passover_from == "ctx-root"
+
+    def test_chain_response_structure(self):
+        from app.routers.sandbox import SessionChainEntry, SessionChainResponse
+
+        response = SessionChainResponse(
+            root="ctx-root",
+            chain=[
+                SessionChainEntry(context_id="ctx-root", type="root", status="completed"),
+                SessionChainEntry(
+                    context_id="ctx-child1",
+                    type="child",
+                    parent="ctx-root",
+                    status="working",
+                ),
+                SessionChainEntry(
+                    context_id="ctx-pass1",
+                    type="passover",
+                    passover_from="ctx-root",
+                    status="active",
+                ),
+            ],
+        )
+        assert response.root == "ctx-root"
+        assert len(response.chain) == 3
+        assert response.chain[0].type == "root"
+        assert response.chain[1].type == "child"
+        assert response.chain[2].type == "passover"

--- a/kagenti/backend/tests/test_sandbox_metadata.py
+++ b/kagenti/backend/tests/test_sandbox_metadata.py
@@ -167,7 +167,7 @@ class TestMetadataMergeLogic:
             ),
         ]
 
-        donor_metadata = {"title": "Should NOT Replace", "owner": "other-user"}
+        _donor_metadata = {"title": "Should NOT Replace", "owner": "other-user"}
 
         missing_meta = [s for s in items if not (s.metadata or {}).get("title")]
         # The item already has a title, so it should NOT be in missing_meta

--- a/kagenti/backend/tests/test_sandbox_metadata.py
+++ b/kagenti/backend/tests/test_sandbox_metadata.py
@@ -20,6 +20,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytest.importorskip("app.routers.sandbox", reason="Sandbox modules not available")
+
 
 def _make_task_row(
     *,

--- a/kagenti/backend/tests/test_sandbox_trigger.py
+++ b/kagenti/backend/tests/test_sandbox_trigger.py
@@ -9,6 +9,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+pytest.importorskip("app.routers.sandbox_trigger", reason="sandbox_trigger module not available")
+
 from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.routers.sandbox_trigger import router
 

--- a/kagenti/backend/tests/test_sandbox_trigger.py
+++ b/kagenti/backend/tests/test_sandbox_trigger.py
@@ -1,0 +1,134 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for sandbox trigger API endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
+from app.routers.sandbox_trigger import router
+
+
+@pytest.fixture
+def client():
+    """FastAPI test client with sandbox trigger router (auth bypassed)."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    # Override auth dependency to allow all requests in tests
+    app.dependency_overrides[require_roles(ROLE_OPERATOR)] = lambda: None
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_kubectl():
+    """Mock kubectl so no real clusters are needed."""
+    mock_result = MagicMock(returncode=0, stdout="", stderr="")
+    with patch("triggers.subprocess.run", return_value=mock_result):
+        yield mock_result
+
+
+class TestCronTrigger:
+    """POST /api/v1/sandbox/trigger with type=cron."""
+
+    def test_cron_trigger_success(self, client):
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={"type": "cron", "skill": "rca:ci", "schedule": "0 2 * * *"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "sandbox_claim" in data
+        assert data["sandbox_claim"].startswith("cron-rca-ci-")
+        assert data["namespace"] == "team1"
+
+    def test_cron_trigger_missing_skill(self, client):
+        resp = client.post("/api/v1/sandbox/trigger", json={"type": "cron"})
+        assert resp.status_code == 422
+
+
+class TestWebhookTrigger:
+    """POST /api/v1/sandbox/trigger with type=webhook."""
+
+    def test_webhook_trigger_success(self, client):
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={
+                "type": "webhook",
+                "event": "pull_request",
+                "repo": "kagenti/kagenti",
+                "branch": "feat/x",
+                "pr_number": 42,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sandbox_claim"].startswith("gh-kagenti-kagenti-")
+
+    def test_webhook_trigger_missing_repo(self, client):
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={"type": "webhook", "event": "pull_request"},
+        )
+        assert resp.status_code == 422
+
+    def test_webhook_trigger_custom_namespace(self, client):
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={
+                "type": "webhook",
+                "event": "issue_comment",
+                "repo": "kagenti/kagenti",
+                "namespace": "team2",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["namespace"] == "team2"
+
+
+class TestAlertTrigger:
+    """POST /api/v1/sandbox/trigger with type=alert."""
+
+    def test_alert_trigger_success(self, client):
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={
+                "type": "alert",
+                "alert": "PodCrashLoop",
+                "cluster": "prod",
+                "severity": "critical",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sandbox_claim"].startswith("alert-podcrashloop-")
+
+    def test_alert_trigger_missing_alert(self, client):
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={"type": "alert"},
+        )
+        assert resp.status_code == 422
+
+
+class TestErrorHandling:
+    """Test error cases."""
+
+    def test_unknown_trigger_type(self, client):
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={"type": "unknown"},
+        )
+        assert resp.status_code == 400
+
+    def test_kubectl_failure(self, client, mock_kubectl):
+        mock_kubectl.returncode = 1
+        mock_kubectl.stderr = "connection refused"
+        resp = client.post(
+            "/api/v1/sandbox/trigger",
+            json={"type": "cron", "skill": "test"},
+        )
+        assert resp.status_code == 500

--- a/kagenti/backend/tests/test_session_db.py
+++ b/kagenti/backend/tests/test_session_db.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytest.importorskip("app.services.session_db", reason="session_db module not available")
+
 
 class TestCreatePool:
     """Tests for _create_pool() with retry and SSL handling."""

--- a/kagenti/backend/tests/test_session_db.py
+++ b/kagenti/backend/tests/test_session_db.py
@@ -1,0 +1,232 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for session_db pool management.
+
+Verifies:
+- Pool creation with ssl=False for Istio compatibility
+- Retry on transient connection failures
+- No retry on auth/catalog errors (non-transient)
+- Stale pool eviction
+- Closed pool detection and recreation
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestCreatePool:
+    """Tests for _create_pool() with retry and SSL handling."""
+
+    @pytest.fixture(autouse=True)
+    def reset_pool_cache(self):
+        """Clear pool cache before each test."""
+        from app.services.session_db import _pool_cache
+
+        _pool_cache.clear()
+        yield
+        _pool_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_pool_created_with_ssl_false(self):
+        """Pool creation should pass ssl=False for Istio ambient compatibility."""
+        mock_pool = MagicMock()
+        with patch("app.services.session_db.asyncpg") as mock_asyncpg:
+            mock_asyncpg.create_pool = AsyncMock(return_value=mock_pool)
+
+            from app.services.session_db import _create_pool
+
+            pool = await _create_pool("postgresql://user:pass@host:5432/db")
+            assert pool is mock_pool
+
+            call_kwargs = mock_asyncpg.create_pool.call_args
+            assert call_kwargs.kwargs["ssl"] is False
+
+    @pytest.mark.asyncio
+    async def test_pool_created_with_command_timeout(self):
+        """Pool creation should set command_timeout to prevent hanging queries."""
+        mock_pool = MagicMock()
+        with patch("app.services.session_db.asyncpg") as mock_asyncpg:
+            mock_asyncpg.create_pool = AsyncMock(return_value=mock_pool)
+
+            from app.services.session_db import _create_pool
+
+            await _create_pool("postgresql://user:pass@host:5432/db")
+
+            call_kwargs = mock_asyncpg.create_pool.call_args
+            assert call_kwargs.kwargs["command_timeout"] == 30
+
+    @pytest.mark.asyncio
+    async def test_retry_on_transient_failure(self):
+        """Pool creation should retry on transient connection errors."""
+        mock_pool = MagicMock()
+        with patch("app.services.session_db.asyncpg") as mock_asyncpg:
+            # Fail twice, succeed on third attempt
+            mock_asyncpg.create_pool = AsyncMock(
+                side_effect=[
+                    ConnectionError("Connection refused"),
+                    OSError("Network unreachable"),
+                    mock_pool,
+                ]
+            )
+            mock_asyncpg.InvalidPasswordError = type("InvalidPasswordError", (Exception,), {})
+            mock_asyncpg.InvalidCatalogNameError = type("InvalidCatalogNameError", (Exception,), {})
+
+            from app.services.session_db import _create_pool
+
+            with patch("app.services.session_db._POOL_RETRY_DELAY", 0.01):
+                pool = await _create_pool("postgresql://user:pass@host:5432/db")
+
+            assert pool is mock_pool
+            assert mock_asyncpg.create_pool.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_auth_error(self):
+        """Pool creation should NOT retry on InvalidPasswordError."""
+        with patch("app.services.session_db.asyncpg") as mock_asyncpg:
+            InvalidPasswordError = type("InvalidPasswordError", (Exception,), {})
+            mock_asyncpg.InvalidPasswordError = InvalidPasswordError
+            mock_asyncpg.InvalidCatalogNameError = type("InvalidCatalogNameError", (Exception,), {})
+            mock_asyncpg.create_pool = AsyncMock(side_effect=InvalidPasswordError("wrong password"))
+
+            from app.services.session_db import _create_pool
+
+            with pytest.raises(InvalidPasswordError):
+                await _create_pool("postgresql://user:wrong@host:5432/db")
+
+            # Should fail immediately — no retries
+            assert mock_asyncpg.create_pool.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_catalog_error(self):
+        """Pool creation should NOT retry on InvalidCatalogNameError."""
+        with patch("app.services.session_db.asyncpg") as mock_asyncpg:
+            InvalidCatalogNameError = type("InvalidCatalogNameError", (Exception,), {})
+            mock_asyncpg.InvalidPasswordError = type("InvalidPasswordError", (Exception,), {})
+            mock_asyncpg.InvalidCatalogNameError = InvalidCatalogNameError
+            mock_asyncpg.create_pool = AsyncMock(
+                side_effect=InvalidCatalogNameError("DB not found")
+            )
+
+            from app.services.session_db import _create_pool
+
+            with pytest.raises(InvalidCatalogNameError):
+                await _create_pool("postgresql://user:pass@host:5432/nope")
+
+            assert mock_asyncpg.create_pool.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries(self):
+        """Pool creation should raise after exhausting retries."""
+        with patch("app.services.session_db.asyncpg") as mock_asyncpg:
+            mock_asyncpg.InvalidPasswordError = type("InvalidPasswordError", (Exception,), {})
+            mock_asyncpg.InvalidCatalogNameError = type("InvalidCatalogNameError", (Exception,), {})
+            mock_asyncpg.create_pool = AsyncMock(side_effect=ConnectionError("Connection refused"))
+
+            from app.services.session_db import _create_pool
+
+            with patch("app.services.session_db._POOL_RETRY_DELAY", 0.01):
+                with pytest.raises(ConnectionError):
+                    await _create_pool("postgresql://user:pass@host:5432/db")
+
+            assert mock_asyncpg.create_pool.call_count == 3
+
+
+class TestGetSessionPool:
+    """Tests for get_session_pool() caching and stale pool detection."""
+
+    @pytest.fixture(autouse=True)
+    def reset_pool_cache(self):
+        """Clear pool cache before each test."""
+        from app.services.session_db import _pool_cache
+
+        _pool_cache.clear()
+        yield
+        _pool_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_pool(self):
+        """get_session_pool() should return cached pool on subsequent calls."""
+        mock_pool = MagicMock()
+        mock_pool._closed = False
+
+        from app.services.session_db import _pool_cache, get_session_pool
+
+        _pool_cache["team1"] = mock_pool
+
+        pool = await get_session_pool("team1")
+        assert pool is mock_pool
+
+    @pytest.mark.asyncio
+    async def test_recreates_closed_pool(self):
+        """get_session_pool() should recreate a pool that was externally closed."""
+        old_pool = MagicMock()
+        old_pool._closed = True
+
+        new_pool = MagicMock()
+        new_pool._closed = False
+
+        from app.services.session_db import _pool_cache, get_session_pool
+
+        _pool_cache["team1"] = old_pool
+
+        with patch("app.services.session_db._create_pool", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = new_pool
+            with patch("app.services.session_db._dsn_for_namespace", return_value="postgresql://x"):
+                pool = await get_session_pool("team1")
+
+            assert pool is new_pool
+            assert _pool_cache["team1"] is new_pool
+            mock_create.assert_called_once()
+
+
+class TestEvictPool:
+    """Tests for evict_pool() cache invalidation."""
+
+    @pytest.fixture(autouse=True)
+    def reset_pool_cache(self):
+        from app.services.session_db import _pool_cache
+
+        _pool_cache.clear()
+        yield
+        _pool_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_evict_removes_from_cache(self):
+        """evict_pool() should remove the pool from cache and close it."""
+        mock_pool = MagicMock()
+        mock_pool.close = AsyncMock()
+
+        from app.services.session_db import _pool_cache, evict_pool
+
+        _pool_cache["team1"] = mock_pool
+
+        await evict_pool("team1")
+
+        assert "team1" not in _pool_cache
+        mock_pool.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_evict_nonexistent_is_noop(self):
+        """evict_pool() on a namespace without a pool should be a no-op."""
+        from app.services.session_db import evict_pool
+
+        # Should not raise
+        await evict_pool("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_evict_survives_close_error(self):
+        """evict_pool() should still remove from cache even if close() fails."""
+        mock_pool = MagicMock()
+        mock_pool.close = AsyncMock(side_effect=RuntimeError("close failed"))
+
+        from app.services.session_db import _pool_cache, evict_pool
+
+        _pool_cache["team1"] = mock_pool
+
+        await evict_pool("team1")
+
+        assert "team1" not in _pool_cache

--- a/kagenti/backend/tests/test_session_db.py
+++ b/kagenti/backend/tests/test_session_db.py
@@ -87,7 +87,7 @@ class TestCreatePool:
     async def test_no_retry_on_auth_error(self):
         """Pool creation should NOT retry on InvalidPasswordError."""
         with patch("app.services.session_db.asyncpg") as mock_asyncpg:
-            InvalidPasswordError = type("InvalidPasswordError", (Exception,), {})
+            InvalidPasswordError = type("InvalidPasswordError", (Exception,), {})  # noqa: N806
             mock_asyncpg.InvalidPasswordError = InvalidPasswordError
             mock_asyncpg.InvalidCatalogNameError = type("InvalidCatalogNameError", (Exception,), {})
             mock_asyncpg.create_pool = AsyncMock(side_effect=InvalidPasswordError("wrong password"))
@@ -104,7 +104,7 @@ class TestCreatePool:
     async def test_no_retry_on_catalog_error(self):
         """Pool creation should NOT retry on InvalidCatalogNameError."""
         with patch("app.services.session_db.asyncpg") as mock_asyncpg:
-            InvalidCatalogNameError = type("InvalidCatalogNameError", (Exception,), {})
+            InvalidCatalogNameError = type("InvalidCatalogNameError", (Exception,), {})  # noqa: N806
             mock_asyncpg.InvalidPasswordError = type("InvalidPasswordError", (Exception,), {})
             mock_asyncpg.InvalidCatalogNameError = InvalidCatalogNameError
             mock_asyncpg.create_pool = AsyncMock(

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,11 +50,14 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "http://dockerhost:11434/v1"
+          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
         - name: LLM_API_KEY
-          value: "dummy"
+          valueFrom:
+            secretKeyRef:
+              name: openai-secret
+              key: apikey
         - name: LLM_MODEL
-          value: "qwen2.5:3b"
+          value: "llama-scout-17b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,14 +50,11 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
+          value: "http://dockerhost:11434/v1"
         - name: LLM_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: openai-secret
-              key: apikey
+          value: "dummy"
         - name: LLM_MODEL
-          value: "llama-scout-17b"
+          value: "qwen2.5:3b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:

--- a/kagenti/tests/e2e/common/test_sandbox_legion.py
+++ b/kagenti/tests/e2e/common/test_sandbox_legion.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""
+Sandbox Legion E2E Tests for Kagenti Platform
+
+Tests sandbox legion functionality via A2A protocol:
+- Agent deployment and agent card
+- Shell command execution (ls, grep)
+- File write and read operations
+- Multi-turn context persistence (same contextId sees prior files)
+
+Usage:
+    SANDBOX_LEGION_URL=http://... pytest tests/e2e/common/test_sandbox_agent.py -v
+"""
+
+import os
+import pathlib
+
+import pytest
+import httpx
+import yaml
+from uuid import uuid4
+from a2a.client import ClientConfig, ClientFactory
+from a2a.types import (
+    Message as A2AMessage,
+    TextPart,
+    TaskArtifactUpdateEvent,
+)
+
+from kagenti.tests.e2e.conftest import (
+    _fetch_openshift_ingress_ca,
+)
+
+# Skip entire module if sandbox agents are not deployed
+pytestmark = pytest.mark.skipif(
+    not os.getenv("SANDBOX_LEGION_URL") and not os.getenv("ENABLE_SANDBOX_TESTS"),
+    reason="Sandbox agents not deployed (set SANDBOX_LEGION_URL or ENABLE_SANDBOX_TESTS)",
+)
+
+
+def _get_sandbox_legion_url() -> str:
+    """Get the sandbox legion URL from env or default to in-cluster DNS."""
+    return os.getenv(
+        "SANDBOX_LEGION_URL",
+        "http://sandbox-legion.team1.svc.cluster.local:8000",
+    )
+
+
+def _is_openshift_from_config():
+    """Detect if running on OpenShift from KAGENTI_CONFIG_FILE."""
+    config_file = os.getenv("KAGENTI_CONFIG_FILE")
+    if not config_file:
+        return False
+
+    config_path = pathlib.Path(config_file)
+    if not config_path.is_absolute():
+        repo_root = pathlib.Path(__file__).parent.parent.parent.parent.parent
+        config_path = repo_root / config_file
+
+    if not config_path.exists():
+        return False
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except Exception:
+        return False
+
+    if config.get("openshift", False):
+        return True
+
+    charts = config.get("charts", {})
+    if charts.get("kagenti-deps", {}).get("values", {}).get("openshift", False):
+        return True
+    if charts.get("kagenti", {}).get("values", {}).get("openshift", False):
+        return True
+
+    return False
+
+
+def _fetch_ingress_ca():
+    """Fetch OpenShift ingress CA from default-ingress-cert configmap."""
+    import subprocess
+    import tempfile
+
+    # Try the ingress-specific CA first (signs route certificates)
+    for ns, cm, key in [
+        ("kagenti-system", "kube-root-ca.crt", "ca.crt"),
+        ("openshift-config", "kube-root-ca.crt", "ca.crt"),
+        ("openshift-config-managed", "default-ingress-cert", "ca-bundle.crt"),
+    ]:
+        jsonpath = "{.data." + key.replace(".", "\\.") + "}"
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "get",
+                    "configmap",
+                    cm,
+                    "-n",
+                    ns,
+                    "-o",
+                    f"jsonpath={jsonpath}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode == 0 and result.stdout.startswith("-----BEGIN"):
+                f = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".crt", delete=False, prefix="ingress-ca-"
+                )
+                f.write(result.stdout)
+                f.close()
+                return f.name
+        except Exception:
+            continue
+    return None
+
+
+def _get_ssl_context():
+    """Get SSL context for httpx client."""
+    import ssl
+
+    if not _is_openshift_from_config():
+        return True
+
+    ca_path = os.getenv("OPENSHIFT_INGRESS_CA")
+    if not ca_path or not pathlib.Path(ca_path).exists():
+        ca_path = _fetch_ingress_ca()
+    if not ca_path:
+        ca_path = _fetch_openshift_ingress_ca()
+
+    if not ca_path:
+        raise RuntimeError(
+            "Could not fetch OpenShift ingress CA certificate. "
+            "Set OPENSHIFT_INGRESS_CA env var to the CA bundle path."
+        )
+
+    return ssl.create_default_context(cafile=ca_path)
+
+
+async def _extract_response(client, message):
+    """Send an A2A message (non-streaming) and extract the text response.
+
+    Uses the non-streaming send_message API which returns a direct JSON
+    response. This avoids SSE connection drops from OpenShift routes.
+    """
+    from a2a.types import SendMessageRequest, MessageSendParams
+
+    params = MessageSendParams(message=message)
+    request = SendMessageRequest(id=uuid4().hex, params=params)
+    response = await client.send_message(request)
+
+    # Extract from response
+    root = getattr(response, "root", response)
+    if hasattr(root, "error") and root.error:
+        raise RuntimeError(f"A2A error: {root.error}")
+
+    result = getattr(root, "result", None)
+    if result is None:
+        return "", ["NoResult"]
+
+    full_response = ""
+    events_received = ["NonStreaming"]
+
+    # Result can be a Task or a Message
+    if hasattr(result, "artifacts") and result.artifacts:
+        for artifact in result.artifacts:
+            for part in artifact.parts or []:
+                p = getattr(part, "root", part)
+                if hasattr(p, "text"):
+                    full_response += p.text
+    elif hasattr(result, "parts"):
+        for part in result.parts or []:
+            p = getattr(part, "root", part)
+            if hasattr(p, "text"):
+                full_response += p.text
+
+    return full_response, events_received
+
+
+async def _connect_to_agent(agent_url):
+    """Connect to the sandbox legion via A2A protocol."""
+    ssl_verify = _get_ssl_context()
+    httpx_client = httpx.AsyncClient(timeout=180.0, verify=ssl_verify)
+
+    from a2a.client import A2AClient
+    from a2a.client.card_resolver import A2ACardResolver
+
+    resolver = A2ACardResolver(httpx_client, agent_url)
+    card = await resolver.get_agent_card()
+    card.url = agent_url
+    client = A2AClient(httpx_client=httpx_client, url=agent_url)
+    return client, card
+
+
+async def _connect_to_agent_streaming(agent_url):
+    """Connect to the sandbox legion via A2A streaming protocol.
+
+    Uses ClientFactory which returns a streaming-capable client.
+    SSE streaming keeps the connection alive with heartbeat events,
+    avoiding gateway timeouts on multi-turn requests.
+    """
+    ssl_verify = _get_ssl_context()
+    httpx_client = httpx.AsyncClient(timeout=180.0, verify=ssl_verify)
+    config = ClientConfig(httpx_client=httpx_client)
+
+    from a2a.client.card_resolver import A2ACardResolver
+
+    resolver = A2ACardResolver(httpx_client, agent_url)
+    card = await resolver.get_agent_card()
+    card.url = agent_url
+    client = await ClientFactory.connect(card, client_config=config)
+    return client, card
+
+
+async def _extract_response_streaming(client, message):
+    """Send an A2A message via streaming and extract the text response.
+
+    Uses SSE streaming which keeps the connection alive with heartbeat
+    events, preventing gateway timeouts on long-running multi-turn
+    requests (LLM call + checkpointer lookup).
+    """
+    full_response = ""
+    events_received = []
+
+    async for result in client.send_message(message):
+        if isinstance(result, tuple):
+            task, event = result
+            events_received.append(type(event).__name__ if event else "Task(final)")
+
+            if isinstance(event, TaskArtifactUpdateEvent):
+                if hasattr(event, "artifact") and event.artifact:
+                    for part in event.artifact.parts or []:
+                        p = getattr(part, "root", part)
+                        if hasattr(p, "text"):
+                            full_response += p.text
+
+            if event is None and task and task.artifacts:
+                for artifact in task.artifacts:
+                    for part in artifact.parts or []:
+                        p = getattr(part, "root", part)
+                        if hasattr(p, "text"):
+                            full_response += p.text
+
+        elif isinstance(result, A2AMessage):
+            events_received.append("Message")
+            for part in result.parts or []:
+                p = getattr(part, "root", part)
+                if hasattr(p, "text"):
+                    full_response += p.text
+
+    return full_response, events_received
+
+
+class TestSandboxLegionDeployment:
+    """Verify sandbox-legion deployment and agent card."""
+
+    def test_deployment_ready(self, k8s_apps_client):
+        """Verify sandbox-legion deployment exists and is ready."""
+        deployment = k8s_apps_client.read_namespaced_deployment(
+            name="sandbox-legion", namespace="team1"
+        )
+        assert deployment is not None
+        desired = deployment.spec.replicas or 1
+        ready = deployment.status.ready_replicas or 0
+        assert ready >= desired, f"sandbox-legion not ready: {ready}/{desired} replicas"
+
+    def test_service_exists(self, k8s_client):
+        """Verify sandbox-legion service exists."""
+        service = k8s_client.read_namespaced_service(
+            name="sandbox-legion", namespace="team1"
+        )
+        assert service is not None
+
+    @pytest.mark.asyncio
+    async def test_agent_card(self):
+        """Verify agent card returns correct metadata."""
+        agent_url = _get_sandbox_legion_url()
+        try:
+            _, card = await _connect_to_agent(agent_url)
+        except Exception as e:
+            pytest.fail(f"Sandbox agent not reachable at {agent_url}: {e}")
+
+        assert card.name in ("Sandbox Assistant", "Sandbox Legion"), (
+            f"Unexpected agent name: {card.name}"
+        )
+        assert card.capabilities.streaming is True
+        assert len(card.skills) > 0
+
+        skill_tags = []
+        for skill in card.skills:
+            skill_tags.extend(skill.tags or [])
+        assert "shell" in skill_tags, f"Missing 'shell' tag in skills: {skill_tags}"
+
+        print(f"\n  Agent card: {card.name}")
+        print(f"  Skills: {[s.name for s in card.skills]}")
+        print(f"  Tags: {skill_tags}")
+
+
+class TestSandboxLegionShellExecution:
+    """Test shell command execution via A2A protocol."""
+
+    @pytest.mark.asyncio
+    async def test_shell_ls(self):
+        """
+        Test agent can list workspace directory contents.
+
+        Sends a natural language request to list files.
+        Expects the response to mention workspace subdirectories.
+        """
+        agent_url = _get_sandbox_legion_url()
+        try:
+            client, _ = await _connect_to_agent(agent_url)
+        except Exception as e:
+            pytest.fail(f"Sandbox agent not reachable at {agent_url}: {e}")
+
+        message = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(text="List the contents of the current directory using ls")
+            ],
+            messageId=uuid4().hex,
+        )
+
+        try:
+            response, events = await _extract_response(client, message)
+        except Exception as e:
+            pytest.fail(f"Error during A2A conversation: {e}")
+
+        assert response, f"Agent did not return any response\n  Events: {events}"
+
+        # The workspace should have subdirectories from ensure_workspace
+        response_lower = response.lower()
+        workspace_indicators = ["data", "scripts", "repos", "output"]
+        has_workspace_content = any(
+            indicator in response_lower for indicator in workspace_indicators
+        )
+
+        print(f"\n  Response: {response[:300]}")
+        print(f"  Events: {events}")
+
+        assert has_workspace_content, (
+            f"Response doesn't mention workspace directories.\n"
+            f"Expected one of: {workspace_indicators}\n"
+            f"Response: {response}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_write_and_read(self):
+        """
+        Test agent can write a file and read it back.
+
+        Sends a request to write content to a file, then read it.
+        Expects the response to contain the written content.
+        """
+        agent_url = _get_sandbox_legion_url()
+        try:
+            client, _ = await _connect_to_agent(agent_url)
+        except Exception as e:
+            pytest.fail(f"Sandbox agent not reachable at {agent_url}: {e}")
+
+        message = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text=(
+                        "Write the text 'sandbox-e2e-test-payload' to a file "
+                        "called data/e2e_test.txt, then read it back and tell "
+                        "me exactly what the file contains."
+                    )
+                )
+            ],
+            messageId=uuid4().hex,
+        )
+
+        try:
+            response, events = await _extract_response(client, message)
+        except Exception as e:
+            pytest.fail(f"Error during A2A conversation: {e}")
+
+        assert response, f"Agent did not return any response\n  Events: {events}"
+
+        print(f"\n  Response: {response[:300]}")
+        print(f"  Events: {events}")
+
+        assert "sandbox-e2e-test-payload" in response, (
+            f"Response doesn't contain the written content.\n"
+            f"Expected: 'sandbox-e2e-test-payload'\n"
+            f"Response: {response}"
+        )
+
+
+class TestSandboxLegionContextPersistence:
+    """Test multi-turn context persistence via shared contextId.
+
+    Each turn uses a fresh non-streaming HTTP request to avoid
+    connection drops from the OpenShift route / Istio ztunnel.
+    """
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_file_persistence(self, test_session_id):
+        """
+        Test that files written in turn 1 are readable in turn 2
+        when using the same contextId.
+
+        Turn 1: Write a file with unique content
+        Turn 2: Read the file back and verify content matches
+        """
+        agent_url = _get_sandbox_legion_url()
+
+        # contextId must be <= 36 chars (VARCHAR(36) in A2A SDK tasks table)
+        context_id = uuid4().hex[:36]
+        unique_marker = f"persistence-check-{uuid4().hex[:8]}"
+
+        print(f"\n=== Multi-turn Context Persistence Test ===")
+        print(f"  Context ID: {context_id}")
+        print(f"  Unique marker: {unique_marker}")
+
+        # Turn 1: Write a file (fresh connection)
+        client1, _ = await _connect_to_agent(agent_url)
+        msg1 = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text=f"Write the text '{unique_marker}' to a file called data/persist_test.txt"
+                )
+            ],
+            messageId=uuid4().hex,
+            contextId=context_id,
+        )
+
+        response1, events1 = await _extract_response(client1, msg1)
+        assert response1, f"Turn 1: No response\n  Events: {events1}"
+        print(f"  Turn 1 response: {response1[:200]}")
+
+        # Turn 2: Read the file back (fresh connection)
+        client2, _ = await _connect_to_agent(agent_url)
+        msg2 = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text="Read the file data/persist_test.txt and tell me exactly what it contains."
+                )
+            ],
+            messageId=uuid4().hex,
+            contextId=context_id,
+        )
+
+        response2, events2 = await _extract_response(client2, msg2)
+        assert response2, f"Turn 2: No response\n  Events: {events2}"
+        print(f"  Turn 2 response: {response2[:200]}")
+
+        assert unique_marker in response2, (
+            f"Turn 2 response doesn't contain the marker from turn 1.\n"
+            f"Expected: '{unique_marker}'\n"
+            f"Turn 2 response: {response2}"
+        )
+
+        print(f"\n  Multi-turn persistence verified")
+        print(f"  Marker '{unique_marker}' survived across turns")
+
+
+class TestSandboxLegionMemory:
+    """Test multi-turn conversational memory via shared contextId.
+
+    Each turn uses a fresh non-streaming HTTP request to avoid
+    connection drops from the OpenShift route / Istio ztunnel.
+    """
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_memory(self, test_session_id):
+        """
+        Verify agent remembers context across turns.
+
+        Turn 1: Tell the agent a name ("My name is Bob Beep")
+        Turn 2: Ask for the name back ("What is my name?")
+        Expects the agent to recall "Bob Beep" from turn 1.
+        """
+        agent_url = _get_sandbox_legion_url()
+
+        # contextId must be <= 36 chars (VARCHAR(36) in A2A SDK tasks table)
+        context_id = uuid4().hex[:36]
+
+        print(f"\n=== Multi-turn Memory Test ===")
+        print(f"  Context ID: {context_id}")
+
+        # Turn 1: Tell the agent a name (fresh connection)
+        client1, _ = await _connect_to_agent(agent_url)
+        msg1 = A2AMessage(
+            role="user",
+            parts=[TextPart(text="My name is Bob Beep")],
+            messageId=uuid4().hex,
+            contextId=context_id,
+        )
+
+        response1, events1 = await _extract_response(client1, msg1)
+        assert response1, f"Turn 1: No response\n  Events: {events1}"
+        print(f"  Turn 1 response: {response1[:200]}")
+
+        # Turn 2: Ask for the name back (fresh connection)
+        client2, _ = await _connect_to_agent(agent_url)
+        msg2 = A2AMessage(
+            role="user",
+            parts=[TextPart(text="What is my name?")],
+            messageId=uuid4().hex,
+            contextId=context_id,
+        )
+
+        response2, events2 = await _extract_response(client2, msg2)
+        assert response2, f"Turn 2: No response\n  Events: {events2}"
+        print(f"  Turn 2 response: {response2[:200]}")
+
+        assert "Bob Beep" in response2, (
+            f"Agent didn't remember the name.\n"
+            f"Expected 'Bob Beep' in response.\n"
+            f"Response: {response2}"
+        )
+
+        print(f"\n  Multi-turn memory verified: agent remembered 'Bob Beep'")
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/kagenti/tests/e2e/common/test_sandbox_legion.py
+++ b/kagenti/tests/e2e/common/test_sandbox_legion.py
@@ -16,6 +16,9 @@ import os
 import pathlib
 
 import pytest
+
+pytest.importorskip("a2a.client", reason="a2a package not available")
+
 import httpx
 import yaml
 from uuid import uuid4

--- a/kagenti/tests/e2e/common/test_sandbox_legion_tasks.py
+++ b/kagenti/tests/e2e/common/test_sandbox_legion_tasks.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""
+Sandbox Legion Real Task E2E Tests
+
+Tests the sandbox legion performing useful real-world tasks:
+- Reading and analyzing public GitHub issues/PRs
+- Performing root cause analysis on CI failure logs
+- Answering questions about repository structure
+
+These tests verify the agent can use its tools (shell, file_read,
+file_write, web_fetch, explore) to accomplish meaningful work, not
+just that the tools function in isolation.
+
+The agent communicates via A2A protocol with a shared contextId for
+multi-turn conversations.
+
+Usage:
+    pytest tests/e2e/common/test_sandbox_agent_tasks.py -v
+"""
+
+import os
+import pathlib
+import textwrap
+
+import pytest
+import httpx
+import yaml
+from uuid import uuid4
+from a2a.types import (
+    Message as A2AMessage,
+    TextPart,
+)
+
+from kagenti.tests.e2e.conftest import _fetch_openshift_ingress_ca
+
+# Skip entire module if sandbox agents are not deployed
+pytestmark = pytest.mark.skipif(
+    not os.getenv("SANDBOX_LEGION_URL") and not os.getenv("ENABLE_SANDBOX_TESTS"),
+    reason="Sandbox agents not deployed (set SANDBOX_LEGION_URL or ENABLE_SANDBOX_TESTS)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level skip if sandbox-legion is not deployed
+# ---------------------------------------------------------------------------
+
+
+def _get_sandbox_legion_url() -> str:
+    """Get the sandbox legion URL from env or default to in-cluster DNS."""
+    return os.getenv(
+        "SANDBOX_LEGION_URL",
+        "http://sandbox-legion.team1.svc.cluster.local:8000",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (shared with test_sandbox_legion.py)
+# ---------------------------------------------------------------------------
+
+
+def _is_openshift_from_config():
+    config_file = os.getenv("KAGENTI_CONFIG_FILE")
+    if not config_file:
+        return False
+    config_path = pathlib.Path(config_file)
+    if not config_path.is_absolute():
+        repo_root = pathlib.Path(__file__).parent.parent.parent.parent.parent
+        config_path = repo_root / config_file
+    if not config_path.exists():
+        return False
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except Exception:
+        return False
+    if config.get("openshift", False):
+        return True
+    charts = config.get("charts", {})
+    return charts.get("kagenti-deps", {}).get("values", {}).get(
+        "openshift", False
+    ) or charts.get("kagenti", {}).get("values", {}).get("openshift", False)
+
+
+def _fetch_ingress_ca():
+    """Fetch OpenShift ingress CA from default-ingress-cert configmap."""
+    import subprocess
+    import tempfile
+
+    for ns, cm, key in [
+        ("kagenti-system", "kube-root-ca.crt", "ca.crt"),
+        ("openshift-config-managed", "default-ingress-cert", "ca-bundle.crt"),
+    ]:
+        jsonpath = "{.data." + key.replace(".", "\\.") + "}"
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "get",
+                    "configmap",
+                    cm,
+                    "-n",
+                    ns,
+                    "-o",
+                    f"jsonpath={jsonpath}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode == 0 and result.stdout.startswith("-----BEGIN"):
+                f = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".crt", delete=False, prefix="ingress-ca-"
+                )
+                f.write(result.stdout)
+                f.close()
+                return f.name
+        except Exception:
+            continue
+    return None
+
+
+def _get_ssl_context():
+    import ssl
+
+    if not _is_openshift_from_config():
+        return True
+    ca_path = os.getenv("OPENSHIFT_INGRESS_CA")
+    if not ca_path or not pathlib.Path(ca_path).exists():
+        ca_path = _fetch_ingress_ca()
+    if not ca_path:
+        ca_path = _fetch_openshift_ingress_ca()
+    if not ca_path:
+        raise RuntimeError("Could not fetch OpenShift ingress CA certificate.")
+    return ssl.create_default_context(cafile=ca_path)
+
+
+async def _extract_response(client, message):
+    """Send an A2A message (non-streaming) and extract the text response."""
+    from a2a.types import SendMessageRequest, MessageSendParams
+
+    params = MessageSendParams(message=message)
+    request = SendMessageRequest(id=uuid4().hex, params=params)
+    response = await client.send_message(request)
+
+    root = getattr(response, "root", response)
+    if hasattr(root, "error") and root.error:
+        raise RuntimeError(f"A2A error: {root.error}")
+
+    result = getattr(root, "result", None)
+    if result is None:
+        return ""
+
+    full_response = ""
+    if hasattr(result, "artifacts") and result.artifacts:
+        for artifact in result.artifacts:
+            for part in artifact.parts or []:
+                p = getattr(part, "root", part)
+                if hasattr(p, "text"):
+                    full_response += p.text
+    elif hasattr(result, "parts"):
+        for part in result.parts or []:
+            p = getattr(part, "root", part)
+            if hasattr(p, "text"):
+                full_response += p.text
+
+    return full_response
+
+
+async def _connect_to_agent(agent_url):
+    ssl_verify = _get_ssl_context()
+    httpx_client = httpx.AsyncClient(timeout=180.0, verify=ssl_verify)
+
+    from a2a.client import A2AClient
+    from a2a.client.card_resolver import A2ACardResolver
+
+    resolver = A2ACardResolver(httpx_client, agent_url)
+    card = await resolver.get_agent_card()
+    card.url = agent_url
+    client = A2AClient(httpx_client=httpx_client, url=agent_url)
+    return client, card
+
+
+# ---------------------------------------------------------------------------
+# Mock CI failure log for RCA testing
+# ---------------------------------------------------------------------------
+
+MOCK_CI_FAILURE_LOG = textwrap.dedent("""\
+    === CI Run: E2E K8s 1.32.2 (Kind) ===
+    Run ID: 22196748318
+    Branch: main
+    Trigger: push
+    Started: 2026-02-19T19:27:34Z
+
+    === Phase 1: Cluster Creation ===
+    [OK] Kind cluster created (v1.32.2)
+    [OK] Istio ambient installed
+    [OK] Keycloak deployed
+
+    === Phase 2: Platform Install ===
+    [OK] Helm install kagenti-deps
+    [OK] Helm install kagenti
+    [OK] CRDs verified
+    [WARN] MLflow pod restart: OOMKilled (256Mi limit, 290Mi used)
+    [OK] MLflow pod recovered after restart
+
+    === Phase 3: Agent Deployment ===
+    [OK] Weather-tool built via Shipwright
+    [OK] Weather-service deployed
+    [ERROR] Weather-service pod CrashLoopBackOff after 3 restarts
+    Container logs:
+      Traceback (most recent call last):
+        File "/app/src/weather_service/server.py", line 45, in main
+          llm = ChatOpenAI(model=config.llm_model, base_url=config.llm_api_base)
+        File "/app/.venv/lib/python3.12/site-packages/langchain_openai/chat_models/base.py", line 182, in __init__
+          super().__init__(**kwargs)
+      pydantic.ValidationError: 1 validation error for ChatOpenAI
+        api_key
+          Field required [type=missing, input_value={...}, input_type=dict]
+
+    Root cause: LLM_API_KEY environment variable not set in weather-service deployment.
+    The deployment manifest references a Secret 'llm-credentials' that does not exist.
+
+    === Phase 4: E2E Tests ===
+    [SKIP] All agent tests skipped (weather-service not ready)
+
+    Total: 0 passed, 0 failed, 47 skipped
+    Exit code: 1
+""")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxLegionGitHubAnalysis:
+    """Test the agent performing real GitHub repository analysis."""
+
+    @pytest.mark.asyncio
+    async def test_analyze_closed_issue(self):
+        """
+        Ask the agent to analyze a real closed issue from kagenti/kagenti.
+
+        The agent should use web_fetch to read the issue and provide a
+        summary that includes relevant keywords.
+        """
+        agent_url = _get_sandbox_legion_url()
+        try:
+            client, _ = await _connect_to_agent(agent_url)
+        except Exception as e:
+            pytest.fail(f"Sandbox agent not reachable at {agent_url}: {e}")
+
+        # Issue #751 is about Agent Catalog bugs — a real closed issue
+        message = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text=(
+                        "Fetch and analyze GitHub issue #751 from the "
+                        "kagenti/kagenti repository. Use the URL: "
+                        "https://api.github.com/repos/kagenti/kagenti/issues/751 "
+                        "Tell me: (1) what the issue title is, "
+                        "(2) whether it's open or closed, "
+                        "(3) a one-sentence summary of the problem."
+                    )
+                )
+            ],
+            messageId=uuid4().hex,
+        )
+
+        response = await _extract_response(client, message)
+        assert response, "Agent returned no response"
+
+        response_lower = response.lower()
+        print(f"\n  Response: {response[:500]}")
+
+        # The issue is about Agent Catalog — check for relevant terms
+        assert any(
+            term in response_lower for term in ["catalog", "agent", "import", "751"]
+        ), (
+            f"Response doesn't mention expected keywords about issue #751.\n"
+            f"Response: {response[:300]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_analyze_closed_pr(self):
+        """
+        Ask the agent to analyze a recent closed PR from kagenti/kagenti.
+
+        The agent should fetch the PR data and summarize what changed.
+        """
+        agent_url = _get_sandbox_legion_url()
+        try:
+            client, _ = await _connect_to_agent(agent_url)
+        except Exception as e:
+            pytest.fail(f"Sandbox agent not reachable at {agent_url}: {e}")
+
+        # PR #753 is a small chore PR — bump kagenti-webhook
+        message = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text=(
+                        "Fetch GitHub pull request #753 from kagenti/kagenti. "
+                        "Use the URL: "
+                        "https://api.github.com/repos/kagenti/kagenti/pulls/753 "
+                        "Tell me: (1) the PR title, (2) who authored it, "
+                        "(3) whether it was merged."
+                    )
+                )
+            ],
+            messageId=uuid4().hex,
+        )
+
+        response = await _extract_response(client, message)
+        assert response, "Agent returned no response"
+
+        response_lower = response.lower()
+        print(f"\n  Response: {response[:500]}")
+
+        # PR #753 is about bumping kagenti-webhook
+        assert any(
+            term in response_lower for term in ["webhook", "bump", "753", "chore"]
+        ), (
+            f"Response doesn't mention expected keywords about PR #753.\n"
+            f"Response: {response[:300]}"
+        )
+
+
+class TestSandboxLegionRCA:
+    """Test the agent performing root cause analysis on CI failures."""
+
+    @pytest.mark.asyncio
+    async def test_rca_on_mock_ci_log(self):
+        """
+        Write a mock CI failure log to the workspace, then ask the
+        agent to perform root cause analysis.
+
+        The agent should:
+        1. Read the log file
+        2. Identify the error (CrashLoopBackOff, missing LLM_API_KEY)
+        3. Suggest a fix (create the llm-credentials Secret)
+        """
+        agent_url = _get_sandbox_legion_url()
+        try:
+            client, _ = await _connect_to_agent(agent_url)
+        except Exception as e:
+            pytest.fail(f"Sandbox agent not reachable at {agent_url}: {e}")
+
+        context_id = f"rca-{uuid4().hex[:8]}"
+
+        # Turn 1: Write the mock CI log
+        msg1 = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text=(
+                        f"Write the following CI failure log to "
+                        f"data/ci-failure.log:\n\n{MOCK_CI_FAILURE_LOG}"
+                    )
+                )
+            ],
+            messageId=uuid4().hex,
+            contextId=context_id,
+        )
+
+        response1 = await _extract_response(client, msg1)
+        assert response1, "Turn 1: No response"
+        print(f"\n  Turn 1 (write log): {response1[:200]}")
+
+        # Turn 2: Ask for RCA
+        msg2 = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text=(
+                        "Read the file data/ci-failure.log and perform a "
+                        "root cause analysis. Your response MUST include: "
+                        "(1) the exact error that caused the failure, "
+                        "(2) the root cause, "
+                        "(3) a specific fix recommendation. "
+                        "Be precise — quote the actual error message."
+                    )
+                )
+            ],
+            messageId=uuid4().hex,
+            contextId=context_id,
+        )
+
+        response2 = await _extract_response(client, msg2)
+        assert response2, "Turn 2: No response"
+
+        response2_lower = response2.lower()
+        print(f"\n  Turn 2 (RCA): {response2[:800]}")
+
+        # The agent should identify the key failure indicators
+        assert any(
+            term in response2_lower
+            for term in ["crashloopbackoff", "crash", "api_key", "api key"]
+        ), (
+            f"RCA response doesn't identify the crash/API key issue.\n"
+            f"Response: {response2[:500]}"
+        )
+
+        assert any(
+            term in response2_lower
+            for term in ["llm-credentials", "secret", "missing", "not set"]
+        ), (
+            f"RCA response doesn't mention the missing secret.\n"
+            f"Response: {response2[:500]}"
+        )
+
+        print(f"\n  RCA test passed — agent correctly identified root cause")
+
+
+class TestSandboxLegionRepoExploration:
+    """Test the agent exploring its own workspace."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_structure_analysis(self):
+        """
+        Ask the agent to analyze its workspace structure and report
+        what it finds. This tests the explore tool indirectly through
+        the shell tool.
+        """
+        agent_url = _get_sandbox_legion_url()
+        try:
+            client, _ = await _connect_to_agent(agent_url)
+        except Exception as e:
+            pytest.fail(f"Sandbox agent not reachable at {agent_url}: {e}")
+
+        message = A2AMessage(
+            role="user",
+            parts=[
+                TextPart(
+                    text=(
+                        "List all files and directories in the current "
+                        "workspace using 'find . -maxdepth 2 -type d'. "
+                        "Then tell me how many subdirectories exist "
+                        "and name them."
+                    )
+                )
+            ],
+            messageId=uuid4().hex,
+        )
+
+        response = await _extract_response(client, message)
+        assert response, "Agent returned no response"
+
+        response_lower = response.lower()
+        print(f"\n  Response: {response[:500]}")
+
+        # Workspace should have standard subdirectories
+        assert any(
+            term in response_lower for term in ["data", "scripts", "repos", "output"]
+        ), (
+            f"Response doesn't mention expected workspace directories.\n"
+            f"Response: {response[:300]}"
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/kagenti/tests/e2e/common/test_sandbox_sessions_api.py
+++ b/kagenti/tests/e2e/common/test_sandbox_sessions_api.py
@@ -31,6 +31,8 @@ from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
+VERIFY_SSL = os.environ.get("VERIFY_SSL", "false").lower() == "true"
+
 
 def _get_backend_url() -> str:
     """Get the Kagenti backend URL.
@@ -136,7 +138,7 @@ def _get_auth_headers() -> dict:
 
     verify_ssl: bool | str = True
     if os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower() == "false":
-        verify_ssl = False
+        verify_ssl = VERIFY_SSL
     elif os.environ.get("KEYCLOAK_CA_BUNDLE"):
         verify_ssl = os.environ["KEYCLOAK_CA_BUNDLE"]
 
@@ -186,7 +188,7 @@ def _check_sandbox_api_available() -> bool:
     headers = _get_auth_headers()
     # Use verify=False at module-import time (SSL helpers defined later in file)
     ssl_env = os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower()
-    ssl_verify = False if ssl_env in ("false", "0", "no") else True
+    ssl_verify = VERIFY_SSL if ssl_env in ("false", "0", "no") else True
     try:
         resp = httpx.get(
             f"{url}/api/v1/sandbox/team1/sessions",
@@ -252,7 +254,7 @@ def _get_ssl_context():
     # Honour KEYCLOAK_VERIFY_SSL=false — disable SSL verification entirely
     # (needed on HyperShift clusters with self-signed ingress certs).
     if os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower() in ("false", "0", "no"):
-        return False
+        return VERIFY_SSL
 
     if not _is_openshift_from_config():
         return True
@@ -265,9 +267,10 @@ def _get_ssl_context():
         # Fallback: disable verification when the CA cannot be obtained
         # (e.g. HyperShift clusters where the ingress CA configmap is absent).
         logger.warning(
-            "Could not fetch OpenShift ingress CA — falling back to verify=False"
+            "Could not fetch OpenShift ingress CA — falling back to VERIFY_SSL=%s",
+            VERIFY_SSL,
         )
-        return False
+        return VERIFY_SSL
     return ssl.create_default_context(cafile=ca_path)
 
 

--- a/kagenti/tests/e2e/common/test_sandbox_sessions_api.py
+++ b/kagenti/tests/e2e/common/test_sandbox_sessions_api.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""
+Sandbox Sessions API E2E Tests
+
+Tests the backend sandbox sessions API that reads from the A2A SDK's
+DatabaseTaskStore. Verifies:
+- Session list pagination and search
+- Session detail retrieval (history, artifacts)
+- Session delete and kill operations
+- Data persistence across agent pod restarts
+
+Prerequisites:
+    - sandbox-legion deployed in team1 namespace with TASK_STORE_DB_URL set
+    - postgres-sessions StatefulSet running in team1
+    - At least one A2A message sent to create a task in the DB
+
+Usage:
+    SANDBOX_LEGION_URL=http://... pytest tests/e2e/common/test_sandbox_sessions_api.py -v
+"""
+
+import base64
+import logging
+import os
+import pathlib
+import subprocess
+
+import httpx
+import pytest
+import yaml
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+
+def _get_backend_url() -> str:
+    """Get the Kagenti backend URL.
+
+    Tries in order:
+    1. KAGENTI_BACKEND_URL env var (explicit)
+    2. Auto-discover from OpenShift route (kagenti-backend in kagenti-system)
+    3. Fallback to in-cluster DNS
+    """
+    explicit = os.getenv("KAGENTI_BACKEND_URL")
+    if explicit:
+        return explicit
+
+    # Auto-discover from route
+    try:
+        result = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                "route",
+                "kagenti-api",
+                "-n",
+                "kagenti-system",
+                "-o",
+                "jsonpath={.spec.host}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout:
+            return f"https://{result.stdout}"
+    except Exception:
+        pass
+
+    return "http://kagenti-backend.kagenti-system.svc.cluster.local:8000"
+
+
+# ---------------------------------------------------------------------------
+# Auth helper — acquire Keycloak token for backend API calls
+# ---------------------------------------------------------------------------
+
+_cached_auth_headers: dict | None = None
+
+
+def _get_auth_headers() -> dict:
+    """Get Authorization headers for backend API calls.
+
+    When Keycloak auth is enabled, acquires a token using admin credentials
+    from the keycloak-initial-admin secret. When auth is disabled (Kind
+    without Keycloak), returns empty headers.
+
+    The token is cached for the module lifetime to avoid repeated token
+    requests.
+    """
+    global _cached_auth_headers
+    if _cached_auth_headers is not None:
+        return _cached_auth_headers
+
+    # Try to get Keycloak credentials from K8s secret
+    try:
+        import kubernetes.client
+        import kubernetes.config
+        from kubernetes.config import ConfigException
+
+        try:
+            if os.getenv("KUBERNETES_SERVICE_HOST"):
+                kubernetes.config.load_incluster_config()
+            else:
+                kubernetes.config.load_kube_config()
+        except ConfigException:
+            logger.info("No K8s config — assuming auth disabled, using empty headers")
+            _cached_auth_headers = {}
+            return _cached_auth_headers
+
+        api = kubernetes.client.CoreV1Api()
+        try:
+            secret = api.read_namespaced_secret(
+                name="keycloak-initial-admin", namespace="keycloak"
+            )
+        except Exception:
+            logger.info(
+                "keycloak-initial-admin secret not found — auth likely disabled"
+            )
+            _cached_auth_headers = {}
+            return _cached_auth_headers
+
+        if not secret.data:
+            _cached_auth_headers = {}
+            return _cached_auth_headers
+
+        username = base64.b64decode(secret.data["username"]).decode("utf-8")
+        password = base64.b64decode(secret.data["password"]).decode("utf-8")
+
+    except ImportError:
+        logger.info("kubernetes package not available — assuming auth disabled")
+        _cached_auth_headers = {}
+        return _cached_auth_headers
+
+    # Acquire token from Keycloak
+    keycloak_base_url = os.environ.get("KEYCLOAK_URL", "http://localhost:8081")
+    token_url = f"{keycloak_base_url}/realms/master/protocol/openid-connect/token"
+
+    verify_ssl: bool | str = True
+    if os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower() == "false":
+        verify_ssl = False
+    elif os.environ.get("KEYCLOAK_CA_BUNDLE"):
+        verify_ssl = os.environ["KEYCLOAK_CA_BUNDLE"]
+
+    try:
+        resp = httpx.post(
+            token_url,
+            data={
+                "grant_type": "password",
+                "client_id": "admin-cli",
+                "username": username,
+                "password": password,
+            },
+            timeout=10,
+            verify=verify_ssl,
+        )
+        if resp.status_code == 200:
+            token_data = resp.json()
+            access_token = token_data["access_token"]
+            _cached_auth_headers = {"Authorization": f"Bearer {access_token}"}
+            logger.info("Acquired Keycloak token for backend API calls")
+            return _cached_auth_headers
+        else:
+            logger.warning(
+                "Keycloak token request failed (%d) — using empty headers: %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+    except Exception as exc:
+        logger.warning(
+            "Could not reach Keycloak at %s — assuming auth disabled: %s",
+            keycloak_base_url,
+            exc,
+        )
+
+    _cached_auth_headers = {}
+    return _cached_auth_headers
+
+
+def _check_sandbox_api_available() -> bool:
+    """Check if the backend has the sandbox sessions API endpoint.
+
+    Sends a request with auth headers (if available). Accepts 200 or 401
+    as proof the endpoint exists (401 means auth is required but endpoint
+    is registered). Only 404 means the endpoint is not deployed.
+    """
+    url = _get_backend_url()
+    headers = _get_auth_headers()
+    # Use verify=False at module-import time (SSL helpers defined later in file)
+    ssl_env = os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower()
+    ssl_verify = False if ssl_env in ("false", "0", "no") else True
+    try:
+        resp = httpx.get(
+            f"{url}/api/v1/sandbox/team1/sessions",
+            timeout=10,
+            verify=ssl_verify,
+            headers=headers,
+        )
+        # 404 = endpoint not registered; anything else = endpoint exists
+        return resp.status_code != 404
+    except Exception:
+        return False
+
+
+# Skip entire module if sandbox agents are not deployed
+pytestmark = [
+    pytest.mark.skipif(
+        not os.getenv("SANDBOX_LEGION_URL") and not os.getenv("ENABLE_SANDBOX_TESTS"),
+        reason="Sandbox agents not deployed (set SANDBOX_LEGION_URL or ENABLE_SANDBOX_TESTS)",
+    ),
+    pytest.mark.skipif(
+        not _check_sandbox_api_available(),
+        reason="Backend sandbox sessions API not available (needs backend rebuild from source)",
+    ),
+]
+
+
+def _get_sandbox_legion_url() -> str:
+    """Get the sandbox legion URL."""
+    return os.getenv(
+        "SANDBOX_LEGION_URL",
+        "http://sandbox-legion.team1.svc.cluster.local:8000",
+    )
+
+
+def _is_openshift_from_config():
+    config_file = os.getenv("KAGENTI_CONFIG_FILE")
+    if not config_file:
+        return False
+    config_path = pathlib.Path(config_file)
+    if not config_path.is_absolute():
+        repo_root = pathlib.Path(__file__).parent.parent.parent.parent.parent
+        config_path = repo_root / config_file
+    if not config_path.exists():
+        return False
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except Exception:
+        return False
+    if config.get("openshift", False):
+        return True
+    charts = config.get("charts", {})
+    return charts.get("kagenti-deps", {}).get("values", {}).get(
+        "openshift", False
+    ) or charts.get("kagenti", {}).get("values", {}).get("openshift", False)
+
+
+def _get_ssl_context():
+    import ssl
+
+    from kagenti.tests.e2e.conftest import _fetch_openshift_ingress_ca
+
+    # Honour KEYCLOAK_VERIFY_SSL=false — disable SSL verification entirely
+    # (needed on HyperShift clusters with self-signed ingress certs).
+    if os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower() in ("false", "0", "no"):
+        return False
+
+    if not _is_openshift_from_config():
+        return True
+    ca_path = os.getenv("OPENSHIFT_INGRESS_CA")
+    if not ca_path or not pathlib.Path(ca_path).exists():
+        ca_path = _fetch_ingress_ca()
+    if not ca_path:
+        ca_path = _fetch_openshift_ingress_ca()
+    if not ca_path:
+        # Fallback: disable verification when the CA cannot be obtained
+        # (e.g. HyperShift clusters where the ingress CA configmap is absent).
+        logger.warning(
+            "Could not fetch OpenShift ingress CA — falling back to verify=False"
+        )
+        return False
+    return ssl.create_default_context(cafile=ca_path)
+
+
+def _fetch_ingress_ca():
+    """Fetch OpenShift ingress CA from default-ingress-cert configmap."""
+    import subprocess
+    import tempfile
+
+    for ns, cm, key in [
+        ("kagenti-system", "kube-root-ca.crt", "ca.crt"),
+        ("openshift-config-managed", "default-ingress-cert", "ca-bundle.crt"),
+    ]:
+        jsonpath = "{.data." + key.replace(".", "\\.") + "}"
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "get",
+                    "configmap",
+                    cm,
+                    "-n",
+                    ns,
+                    "-o",
+                    f"jsonpath={jsonpath}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode == 0 and result.stdout.startswith("-----BEGIN"):
+                f = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".crt", delete=False, prefix="ingress-ca-"
+                )
+                f.write(result.stdout)
+                f.close()
+                return f.name
+        except Exception:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _send_a2a_message(agent_url: str, text: str, context_id: str | None = None):
+    """Send an A2A message to sandbox-legion and return the task result."""
+    ssl_verify = _get_ssl_context()
+    async with httpx.AsyncClient(timeout=120.0, verify=ssl_verify) as client:
+        msg = {
+            "jsonrpc": "2.0",
+            "method": "message/send",
+            "id": f"test-{uuid4().hex[:8]}",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": text}],
+                    "messageId": uuid4().hex,
+                }
+            },
+        }
+        if context_id:
+            msg["params"]["message"]["contextId"] = context_id
+
+        resp = await client.post(f"{agent_url}/", json=msg)
+        data = resp.json()
+        if "error" in data:
+            pytest.fail(f"A2A error: {data['error']}")
+        return data.get("result", {})
+
+
+# ---------------------------------------------------------------------------
+# Polling helper — TaskStore commits asynchronously so tests must wait
+# ---------------------------------------------------------------------------
+
+_MAX_POLL_ATTEMPTS = 10
+_POLL_INTERVAL_S = 2
+
+
+async def _wait_for_session(
+    backend_url: str,
+    context_id: str,
+    *,
+    max_attempts: int = _MAX_POLL_ATTEMPTS,
+    interval: float = _POLL_INTERVAL_S,
+) -> dict | None:
+    """Poll the sessions API until *context_id* appears, returning the detail.
+
+    Uses exponential backoff and includes auth headers. Logs non-200
+    status codes to aid debugging when the session never appears.
+    """
+    import asyncio
+
+    ssl_verify = _get_ssl_context()
+    headers = _get_auth_headers()
+    last_status = None
+    last_body = ""
+    for attempt in range(max_attempts):
+        # Exponential backoff capped at 15s
+        delay = min(interval * (1.5**attempt), 15)
+        await asyncio.sleep(delay)
+        try:
+            async with httpx.AsyncClient(timeout=30.0, verify=ssl_verify) as client:
+                resp = await client.get(
+                    f"{backend_url}/api/v1/sandbox/team1/sessions/{context_id}",
+                    headers=headers,
+                )
+                last_status = resp.status_code
+                if resp.status_code == 200:
+                    return resp.json()
+                if resp.status_code == 404:
+                    # Session not yet in DB — keep polling
+                    continue
+                # Auth or server errors — log and keep trying (DB pool may
+                # need time to initialise)
+                last_body = resp.text[:300]
+                logger.warning(
+                    "Poll attempt %d/%d for session %s: HTTP %d — %s",
+                    attempt + 1,
+                    max_attempts,
+                    context_id,
+                    resp.status_code,
+                    last_body,
+                )
+        except httpx.HTTPError as exc:
+            last_status = None
+            last_body = str(exc)
+            logger.warning(
+                "Poll attempt %d/%d for session %s: connection error — %s",
+                attempt + 1,
+                max_attempts,
+                context_id,
+                exc,
+            )
+    # Return None with a clear log message for the assertion
+    logger.error(
+        "Session %s not found after %d poll attempts (last status=%s, body=%s)",
+        context_id,
+        max_attempts,
+        last_status,
+        last_body[:200],
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxSessionsAPI:
+    """Test the backend /api/v1/sandbox/{namespace}/sessions endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_session_persists_in_db(self):
+        """Send A2A message, verify task appears in sessions API."""
+        agent_url = _get_sandbox_legion_url()
+        backend_url = _get_backend_url()
+
+        result = await _send_a2a_message(agent_url, "Say: session-api-test")
+        context_id = result.get("contextId", result.get("context_id"))
+        assert context_id, f"No context_id in result: {result}"
+
+        detail = await _wait_for_session(backend_url, context_id)
+        assert detail is not None, (
+            f"Session {context_id} not found after {_MAX_POLL_ATTEMPTS} attempts"
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_detail_has_history(self):
+        """Verify session detail includes task history."""
+        agent_url = _get_sandbox_legion_url()
+        backend_url = _get_backend_url()
+
+        result = await _send_a2a_message(agent_url, "Say: detail-test")
+        context_id = result.get("contextId", result.get("context_id"))
+        assert context_id
+
+        detail = await _wait_for_session(backend_url, context_id)
+        assert detail is not None, f"Session {context_id} not found"
+        assert detail["context_id"] == context_id
+        assert detail["kind"] == "task"
+        assert "status" in detail
+        # Verify the session actually has history content (not just an empty shell)
+        history = detail.get("history", [])
+        assert len(history) > 0, (
+            f"Session {context_id} has no history entries — expected at least the user message"
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_list_search(self):
+        """Verify search parameter filters by context_id."""
+        backend_url = _get_backend_url()
+        headers = _get_auth_headers()
+
+        ssl_verify = _get_ssl_context()
+        async with httpx.AsyncClient(timeout=30.0, verify=ssl_verify) as client:
+            # Search for a non-existent context ID
+            resp = await client.get(
+                f"{backend_url}/api/v1/sandbox/team1/sessions",
+                params={"search": "nonexistent-context-id-xyz"},
+                headers=headers,
+            )
+            assert resp.status_code == 200, (
+                f"List sessions failed: HTTP {resp.status_code} — {resp.text[:300]}"
+            )
+            data = resp.json()
+            assert data["total"] == 0, "Search returned unexpected results"
+
+    @pytest.mark.asyncio
+    async def test_session_list_pagination(self):
+        """Verify pagination parameters work correctly."""
+        backend_url = _get_backend_url()
+        headers = _get_auth_headers()
+
+        ssl_verify = _get_ssl_context()
+        async with httpx.AsyncClient(timeout=30.0, verify=ssl_verify) as client:
+            resp = await client.get(
+                f"{backend_url}/api/v1/sandbox/team1/sessions",
+                params={"limit": 2, "offset": 0},
+                headers=headers,
+            )
+            assert resp.status_code == 200, (
+                f"List sessions failed: HTTP {resp.status_code} — {resp.text[:300]}"
+            )
+            data = resp.json()
+            assert data["limit"] == 2
+            assert data["offset"] == 0
+            assert len(data["items"]) <= 2
+
+    @pytest.mark.asyncio
+    async def test_session_kill(self):
+        """Send A2A message, then kill the session via API."""
+        agent_url = _get_sandbox_legion_url()
+        backend_url = _get_backend_url()
+        headers = _get_auth_headers()
+
+        result = await _send_a2a_message(agent_url, "Say: kill-test")
+        context_id = result.get("contextId", result.get("context_id"))
+        assert context_id
+
+        # Wait for DB commit before operating
+        detail = await _wait_for_session(backend_url, context_id)
+        assert detail is not None, f"Session {context_id} not found before kill"
+
+        ssl_verify = _get_ssl_context()
+        async with httpx.AsyncClient(timeout=30.0, verify=ssl_verify) as client:
+            resp = await client.post(
+                f"{backend_url}/api/v1/sandbox/team1/sessions/{context_id}/kill",
+                headers=headers,
+            )
+            assert resp.status_code == 200, (
+                f"Kill failed: {resp.status_code} {resp.text}"
+            )
+            killed = resp.json()
+            status = killed.get("status", {})
+            state = status.get("state", "").lower()
+            assert state in ("canceled", "cancelled", "failed"), (
+                f"Kill should set state to canceled, got: {state!r} (full status: {status})"
+            )
+
+    @pytest.mark.asyncio
+    async def test_session_delete(self):
+        """Send A2A message, then delete the session via API."""
+        agent_url = _get_sandbox_legion_url()
+        backend_url = _get_backend_url()
+        headers = _get_auth_headers()
+
+        result = await _send_a2a_message(agent_url, "Say: delete-test")
+        context_id = result.get("contextId", result.get("context_id"))
+        assert context_id
+
+        # Wait for DB commit before operating
+        detail = await _wait_for_session(backend_url, context_id)
+        assert detail is not None, f"Session {context_id} not found before delete"
+
+        ssl_verify = _get_ssl_context()
+        async with httpx.AsyncClient(timeout=30.0, verify=ssl_verify) as client:
+            # Delete
+            resp = await client.delete(
+                f"{backend_url}/api/v1/sandbox/team1/sessions/{context_id}",
+                headers=headers,
+            )
+            assert resp.status_code == 204, (
+                f"Delete failed: HTTP {resp.status_code} — {resp.text[:300]}"
+            )
+
+            # Verify gone
+            resp2 = await client.get(
+                f"{backend_url}/api/v1/sandbox/team1/sessions/{context_id}",
+                headers=headers,
+            )
+            assert resp2.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_session_not_found(self):
+        """Verify 404 for non-existent session."""
+        backend_url = _get_backend_url()
+        headers = _get_auth_headers()
+
+        ssl_verify = _get_ssl_context()
+        async with httpx.AsyncClient(timeout=30.0, verify=ssl_verify) as client:
+            resp = await client.get(
+                f"{backend_url}/api/v1/sandbox/team1/sessions/nonexistent-id",
+                headers=headers,
+            )
+            assert resp.status_code == 404, (
+                f"Expected 404 but got HTTP {resp.status_code} — {resp.text[:300]}"
+            )

--- a/kagenti/tests/e2e/common/test_sandbox_variants.py
+++ b/kagenti/tests/e2e/common/test_sandbox_variants.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+Sandbox Agent Variants E2E Tests
+
+Parameterized tests that verify multi-turn conversation, tool calls, and
+session isolation across ALL deployed sandbox agent variants:
+
+- sandbox-legion     (persistent, OpenAI, shared pod)
+- sandbox-hardened   (persistent, OpenAI, hardened security)
+- sandbox-basic      (stateless, OpenAI, shared pod)
+- sandbox-restricted (persistent, OpenAI, restricted proxy, hardened)
+
+Each variant must:
+1. Respond to agent card requests
+2. Execute shell commands (tool call)
+3. Write and read files (tool call persistence within session)
+4. Maintain multi-turn context (memory across turns)
+5. Isolate sessions (different context_ids don't share workspace)
+
+Usage:
+    pytest tests/e2e/common/test_sandbox_variants.py -v
+    pytest tests/e2e/common/test_sandbox_variants.py -v -k "legion"
+    pytest tests/e2e/common/test_sandbox_variants.py -v -k "hardened"
+"""
+
+import os
+import pathlib
+
+import pytest
+import httpx
+from uuid import uuid4
+
+from kagenti.tests.e2e.conftest import _fetch_openshift_ingress_ca
+
+# Skip entire module if sandbox agents are not deployed
+pytestmark = pytest.mark.skipif(
+    not os.getenv("SANDBOX_LEGION_URL") and not os.getenv("ENABLE_SANDBOX_TESTS"),
+    reason="Sandbox agents not deployed (set SANDBOX_LEGION_URL or ENABLE_SANDBOX_TESTS)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Agent variant configurations
+# ---------------------------------------------------------------------------
+
+AGENT_VARIANTS = [
+    pytest.param("sandbox-legion", id="legion"),
+    pytest.param("sandbox-hardened", id="hardened"),
+    pytest.param("sandbox-basic", id="basic"),
+    pytest.param("sandbox-restricted", id="restricted"),
+]
+
+NAMESPACE = os.getenv("SANDBOX_NAMESPACE", "team1")
+
+
+def _get_agent_url(agent_name: str) -> str | None:
+    """Get the agent URL — from env var, or fall back to in-cluster DNS.
+
+    Environment variables checked (example for sandbox-legion):
+        SANDBOX_LEGION_URL — explicit URL (e.g. OpenShift route)
+
+    Falls back to in-cluster DNS:
+        http://sandbox-legion.<NAMESPACE>.svc.cluster.local:8000
+
+    Returns None when the env var is not set AND in-cluster DNS is
+    unlikely to work (i.e. no ENABLE_SANDBOX_TESTS flag).
+    """
+    env_key = f"SANDBOX_{agent_name.split('-', 1)[-1].upper()}_URL"
+    url = os.getenv(env_key)
+    if url:
+        return url
+    # Fall back to in-cluster DNS (works when tests run inside the cluster)
+    return f"http://{agent_name}.{NAMESPACE}.svc.cluster.local:8000"
+
+
+def _is_openshift_from_config() -> bool:
+    config_file = os.getenv("KAGENTI_CONFIG_FILE")
+    if not config_file:
+        return False
+    import yaml
+
+    config_path = pathlib.Path(config_file)
+    if not config_path.is_absolute():
+        repo_root = pathlib.Path(__file__).parent.parent.parent.parent.parent
+        config_path = repo_root / config_path
+    if not config_path.exists():
+        return False
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+    return cfg.get("cluster", {}).get("type") == "openshift"
+
+
+def _make_client(agent_name: str) -> httpx.Client:
+    """Create an HTTP client with optional OpenShift CA."""
+    kwargs: dict = {"timeout": 180.0, "follow_redirects": True}
+    if _is_openshift_from_config():
+        ca_data = _fetch_openshift_ingress_ca()
+        if ca_data:
+            import ssl
+            import tempfile
+
+            ca_file = tempfile.NamedTemporaryFile(suffix=".pem", delete=False)
+            ca_file.write(ca_data.encode())
+            ca_file.close()
+            ctx = ssl.create_default_context(cafile=ca_file.name)
+            kwargs["verify"] = ctx
+    return httpx.Client(**kwargs)
+
+
+def _skip_if_unreachable(agent_name: str, agent_url: str) -> None:
+    """Skip the test if the agent URL is not reachable.
+
+    Performs a quick connectivity check (GET agent card) with a short
+    timeout.  This turns DNS/connection failures into clean skips
+    instead of ugly tracebacks.
+    """
+    client = _make_client(agent_name)
+    try:
+        resp = client.get(
+            f"{agent_url}/.well-known/agent-card.json",
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+    except Exception as exc:
+        env_key = f"SANDBOX_{agent_name.split('-', 1)[-1].upper()}_URL"
+        pytest.skip(
+            f"Agent {agent_name} not reachable at {agent_url} "
+            f"(set {env_key} to the route URL): {exc}"
+        )
+    finally:
+        client.close()
+
+
+def _send_message(
+    client: httpx.Client,
+    agent_url: str,
+    message: str,
+    context_id: str,
+) -> dict:
+    """Send an A2A message/send and return the result."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": uuid4().hex,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": message}],
+                "messageId": uuid4().hex,
+                "contextId": context_id,
+            }
+        },
+    }
+
+    resp = client.post(f"{agent_url}/", json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+
+    if "error" in data:
+        raise RuntimeError(f"A2A error: {data['error']}")
+
+    return data.get("result", {})
+
+
+def _extract_text(result: dict) -> str:
+    """Extract text from A2A result artifacts or status message."""
+    texts = []
+    for artifact in result.get("artifacts", []):
+        for part in artifact.get("parts", []):
+            if "text" in part:
+                texts.append(part["text"])
+    if not texts:
+        status = result.get("status", {})
+        msg = status.get("message", {})
+        for part in msg.get("parts", []):
+            if "text" in part:
+                texts.append(part["text"])
+    return "\n".join(texts)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("agent_name", AGENT_VARIANTS)
+class TestAgentCard:
+    """Verify each agent variant serves a valid agent card."""
+
+    def test_agent_card_accessible(self, agent_name: str):
+        agent_url = _get_agent_url(agent_name)
+        _skip_if_unreachable(agent_name, agent_url)
+        client = _make_client(agent_name)
+
+        resp = client.get(f"{agent_url}/.well-known/agent-card.json")
+        assert resp.status_code == 200, f"Agent card not accessible: {resp.status_code}"
+
+        card = resp.json()
+        assert "capabilities" in card, "Agent card missing capabilities"
+        assert "defaultInputModes" in card, "Agent card missing defaultInputModes"
+        client.close()
+
+    def test_agent_card_has_streaming(self, agent_name: str):
+        agent_url = _get_agent_url(agent_name)
+        _skip_if_unreachable(agent_name, agent_url)
+        client = _make_client(agent_name)
+
+        resp = client.get(f"{agent_url}/.well-known/agent-card.json")
+        card = resp.json()
+        assert card.get("capabilities", {}).get("streaming") is True, (
+            f"Agent {agent_name} should support streaming"
+        )
+        client.close()
+
+
+@pytest.mark.parametrize("agent_name", AGENT_VARIANTS)
+class TestMultiTurnConversation:
+    """Verify multi-turn conversation with tool calls for each variant."""
+
+    def test_shell_command(self, agent_name: str):
+        """Agent can execute a shell command and return output."""
+        agent_url = _get_agent_url(agent_name)
+        _skip_if_unreachable(agent_name, agent_url)
+        client = _make_client(agent_name)
+        context_id = uuid4().hex[:36]
+
+        result = _send_message(
+            client,
+            agent_url,
+            "Run the command: echo hello-from-test",
+            context_id,
+        )
+
+        text = _extract_text(result)
+        assert text, f"Agent {agent_name} returned empty response"
+        # The response must contain the actual echo output
+        assert "hello-from-test" in text.lower(), (
+            f"Agent {agent_name} response doesn't contain expected echo output: {text[:200]}"
+        )
+        client.close()
+
+    def test_file_write_and_read(self, agent_name: str):
+        """Agent can write a file and read it back in the same session."""
+        agent_url = _get_agent_url(agent_name)
+        _skip_if_unreachable(agent_name, agent_url)
+        client = _make_client(agent_name)
+        context_id = uuid4().hex[:36]
+        marker = f"variant-test-{agent_name}-{uuid4().hex[:8]}"
+
+        # Turn 1: Write file
+        result1 = _send_message(
+            client,
+            agent_url,
+            f'Write the text "{marker}" to a file called variant-marker.txt',
+            context_id,
+        )
+        text1 = _extract_text(result1)
+        assert text1, f"Write response empty for {agent_name}"
+
+        # Turn 2: Read file back
+        result2 = _send_message(
+            client,
+            agent_url,
+            "Read the file variant-marker.txt and tell me its exact contents.",
+            context_id,
+        )
+        text2 = _extract_text(result2)
+        assert marker in text2, (
+            f"Agent {agent_name} did not return marker '{marker}' from file read. "
+            f"Got: {text2[:300]}"
+        )
+        client.close()
+
+    def test_multi_turn_context_memory(self, agent_name: str):
+        """Agent remembers information across turns within the same session."""
+        agent_url = _get_agent_url(agent_name)
+        _skip_if_unreachable(agent_name, agent_url)
+        client = _make_client(agent_name)
+        context_id = uuid4().hex[:36]
+        secret_word = f"zebra-{uuid4().hex[:6]}"
+
+        # Turn 1: Tell agent a secret word
+        _send_message(
+            client,
+            agent_url,
+            f"Remember this secret word: {secret_word}. Just acknowledge.",
+            context_id,
+        )
+
+        # Turn 2: Ask for the secret word
+        result2 = _send_message(
+            client,
+            agent_url,
+            "What was the secret word I told you earlier?",
+            context_id,
+        )
+        text2 = _extract_text(result2)
+        assert secret_word in text2, (
+            f"Agent {agent_name} forgot the secret word '{secret_word}'. "
+            f"Got: {text2[:300]}"
+        )
+        client.close()
+
+
+@pytest.mark.parametrize("agent_name", AGENT_VARIANTS)
+class TestSessionIsolation:
+    """Verify that different sessions are isolated from each other."""
+
+    def test_workspace_isolation(self, agent_name: str):
+        """Files in session A are NOT visible in session B."""
+        agent_url = _get_agent_url(agent_name)
+        _skip_if_unreachable(agent_name, agent_url)
+        client = _make_client(agent_name)
+
+        session_a = uuid4().hex[:36]
+        session_b = uuid4().hex[:36]
+        marker = f"isolation-{agent_name}-{uuid4().hex[:8]}"
+
+        # Session A: Write a file
+        _send_message(
+            client,
+            agent_url,
+            f'Write "{marker}" to isolation-test.txt',
+            session_a,
+        )
+
+        # Session B: Try to read the file (should not exist)
+        result_b = _send_message(
+            client,
+            agent_url,
+            "Read the file isolation-test.txt. If it does not exist, say FILE_NOT_FOUND.",
+            session_b,
+        )
+        text_b = _extract_text(result_b)
+        # Session B should NOT contain the marker from Session A
+        assert marker not in text_b, (
+            f"Session isolation FAILED for {agent_name}: "
+            f"Session B contains Session A's marker '{marker}'. Got: {text_b[:300]}"
+        )
+        client.close()

--- a/kagenti/tests/e2e/kagenti_operator/test_litellm_proxy.py
+++ b/kagenti/tests/e2e/kagenti_operator/test_litellm_proxy.py
@@ -20,6 +20,11 @@ LITELLM_PROXY_URL = os.getenv("LITELLM_PROXY_URL", "http://localhost:14000")
 LITELLM_MASTER_KEY = os.getenv("LITELLM_MASTER_KEY", "")
 LITELLM_VIRTUAL_KEY = os.getenv("LITELLM_VIRTUAL_KEY", "")
 
+pytestmark = pytest.mark.skipif(
+    not LITELLM_MASTER_KEY,
+    reason="LITELLM_MASTER_KEY not set — LiteLLM proxy not deployed",
+)
+
 
 @pytest.fixture(scope="module")
 def master_client():

--- a/kagenti/tests/e2e/kagenti_operator/test_litellm_proxy.py
+++ b/kagenti/tests/e2e/kagenti_operator/test_litellm_proxy.py
@@ -1,0 +1,301 @@
+"""
+LiteLLM Proxy E2E tests.
+
+Tests the LiteLLM proxy gateway deployed in kagenti-system.
+Requires port-forward to litellm-proxy service (91-test-litellm.sh sets this up).
+
+Environment variables:
+    LITELLM_PROXY_URL: LiteLLM proxy URL (default: http://localhost:14000)
+    LITELLM_MASTER_KEY: Master API key for admin operations
+    LITELLM_VIRTUAL_KEY: Virtual key for agent operations (optional)
+"""
+
+import os
+
+import httpx
+import pytest
+
+
+LITELLM_PROXY_URL = os.getenv("LITELLM_PROXY_URL", "http://localhost:14000")
+LITELLM_MASTER_KEY = os.getenv("LITELLM_MASTER_KEY", "")
+LITELLM_VIRTUAL_KEY = os.getenv("LITELLM_VIRTUAL_KEY", "")
+
+
+@pytest.fixture(scope="module")
+def master_client():
+    """HTTP client authenticated with master key."""
+    return httpx.Client(
+        base_url=LITELLM_PROXY_URL,
+        headers={"Authorization": f"Bearer {LITELLM_MASTER_KEY}"},
+        timeout=30.0,
+    )
+
+
+@pytest.fixture(scope="module")
+def virtual_client():
+    """HTTP client authenticated with virtual (agent) key."""
+    if not LITELLM_VIRTUAL_KEY:
+        pytest.skip("LITELLM_VIRTUAL_KEY not set")
+    return httpx.Client(
+        base_url=LITELLM_PROXY_URL,
+        headers={"Authorization": f"Bearer {LITELLM_VIRTUAL_KEY}"},
+        timeout=30.0,
+    )
+
+
+class TestLiteLLMHealth:
+    """Health and readiness checks."""
+
+    def test_readiness(self):
+        resp = httpx.get(f"{LITELLM_PROXY_URL}/health/readiness", timeout=10)
+        assert resp.status_code == 200, f"Readiness check failed: {resp.text}"
+
+    def test_liveliness(self):
+        resp = httpx.get(f"{LITELLM_PROXY_URL}/health/liveliness", timeout=10)
+        assert resp.status_code == 200, f"Liveliness check failed: {resp.text}"
+
+
+class TestLiteLLMModels:
+    """Model listing and configuration."""
+
+    def test_list_models(self, master_client):
+        resp = master_client.get("/v1/models")
+        assert resp.status_code == 200, f"Model listing failed: {resp.text}"
+        data = resp.json()
+        assert "data" in data, "Response missing 'data' field"
+        model_ids = [m["id"] for m in data["data"]]
+        assert len(model_ids) > 0, "No models returned"
+
+    def test_maas_models_present(self, master_client):
+        """MAAS models (llama, mistral, deepseek) are always expected."""
+        resp = master_client.get("/v1/models")
+        model_ids = [m["id"] for m in resp.json()["data"]]
+        for expected in ["llama-4-scout", "mistral-small", "deepseek-r1"]:
+            assert expected in model_ids, (
+                f"Expected model '{expected}' not in {model_ids}"
+            )
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY not configured",
+    )
+    def test_openai_models_present(self, master_client):
+        """OpenAI models present when OPENAI_API_KEY is configured."""
+        resp = master_client.get("/v1/models")
+        model_ids = [m["id"] for m in resp.json()["data"]]
+        assert "gpt-4o-mini" in model_ids
+        assert "gpt-4o" in model_ids
+
+    def test_model_info(self, master_client):
+        resp = master_client.get("/model/info")
+        assert resp.status_code == 200, f"Model info failed: {resp.text}"
+        data = resp.json()["data"]
+        assert len(data) >= 3, f"Expected >= 3 models, got {len(data)}"
+
+
+class TestLiteLLMChatCompletions:
+    """Chat completion through the proxy."""
+
+    def test_chat_completion_llama4(self, master_client):
+        """Test chat completion with Llama 4 Scout (default model)."""
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "llama-4-scout",
+                "messages": [{"role": "user", "content": "Say hello in one word."}],
+                "max_tokens": 10,
+            },
+            timeout=60.0,
+        )
+        assert resp.status_code == 200, f"Chat failed: {resp.text}"
+        data = resp.json()
+        assert "choices" in data, "Response missing 'choices'"
+        assert len(data["choices"]) > 0, "No choices returned"
+        content = data["choices"][0]["message"]["content"]
+        assert len(content) > 0, "Empty response content"
+
+    def test_chat_completion_has_usage(self, master_client):
+        """Verify token usage is returned in response."""
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "llama-4-scout",
+                "messages": [{"role": "user", "content": "Say hi."}],
+                "max_tokens": 5,
+            },
+            timeout=60.0,
+        )
+        data = resp.json()
+        assert "usage" in data, "Response missing 'usage'"
+        usage = data["usage"]
+        assert usage.get("prompt_tokens", 0) > 0, "No prompt tokens"
+        assert usage.get("completion_tokens", 0) > 0, "No completion tokens"
+        assert usage.get("total_tokens", 0) > 0, "No total tokens"
+
+    def test_chat_with_metadata(self, master_client):
+        """Verify metadata tagging works for spend attribution."""
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "llama-4-scout",
+                "messages": [{"role": "user", "content": "Say test."}],
+                "max_tokens": 5,
+                "metadata": {
+                    "session_id": "e2e-test-session",
+                    "agent_name": "e2e-test-agent",
+                    "namespace": "team1",
+                },
+            },
+            timeout=60.0,
+        )
+        assert resp.status_code == 200, f"Chat with metadata failed: {resp.text}"
+
+    def test_chat_mistral(self, master_client):
+        """Test chat completion with Mistral Small."""
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "mistral-small",
+                "messages": [{"role": "user", "content": "Say hello in one word."}],
+                "max_tokens": 10,
+            },
+            timeout=60.0,
+        )
+        assert resp.status_code == 200, f"Mistral chat failed: {resp.text}"
+        content = resp.json()["choices"][0]["message"]["content"]
+        assert len(content) > 0, "Empty response"
+
+    def test_chat_deepseek(self, master_client):
+        """Test chat completion with DeepSeek R1.
+
+        DeepSeek R1 is a reasoning model that may return content in the
+        'reasoning_content' field or wrap output in <think> tags. The content
+        field itself can be None when all output is reasoning.
+        """
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-r1",
+                "messages": [{"role": "user", "content": "Say hello in one word."}],
+                "max_tokens": 50,
+            },
+            timeout=60.0,
+        )
+        assert resp.status_code == 200, f"DeepSeek chat failed: {resp.text}"
+        message = resp.json()["choices"][0]["message"]
+        # DeepSeek R1 may put output in content or reasoning_content
+        content = message.get("content") or ""
+        reasoning = message.get("reasoning_content") or ""
+        assert len(content) + len(reasoning) > 0, (
+            "Both content and reasoning_content are empty"
+        )
+
+
+_openai_configured = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not configured",
+)
+
+
+class TestLiteLLMOpenAI:
+    """OpenAI model tests (skipped if OPENAI_API_KEY not configured)."""
+
+    @_openai_configured
+    def test_chat_gpt4o_mini(self, master_client):
+        """Test chat completion with GPT-4o mini."""
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "Say hello in one word."}],
+                "max_tokens": 10,
+            },
+            timeout=30.0,
+        )
+        assert resp.status_code == 200, f"GPT-4o-mini chat failed: {resp.text}"
+        content = resp.json()["choices"][0]["message"]["content"]
+        assert len(content) > 0, "Empty response"
+
+    @_openai_configured
+    def test_chat_gpt4o(self, master_client):
+        """Test chat completion with GPT-4o."""
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Say hello in one word."}],
+                "max_tokens": 10,
+            },
+            timeout=30.0,
+        )
+        assert resp.status_code == 200, f"GPT-4o chat failed: {resp.text}"
+        content = resp.json()["choices"][0]["message"]["content"]
+        assert len(content) > 0, "Empty response"
+
+    @_openai_configured
+    def test_gpt4o_mini_has_usage(self, master_client):
+        """Verify token usage tracking works for OpenAI models."""
+        resp = master_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "Say hi."}],
+                "max_tokens": 5,
+            },
+            timeout=30.0,
+        )
+        usage = resp.json()["usage"]
+        assert usage["total_tokens"] > 0, "No tokens tracked for OpenAI model"
+
+
+class TestLiteLLMVirtualKeys:
+    """Virtual key authentication for agent namespaces."""
+
+    def test_virtual_key_can_list_models(self, virtual_client):
+        """Virtual key should be able to list available models."""
+        resp = virtual_client.get("/v1/models")
+        assert resp.status_code == 200, f"Virtual key model list failed: {resp.text}"
+
+    def test_virtual_key_can_chat(self, virtual_client):
+        """Virtual key should be able to make chat completions."""
+        resp = virtual_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "llama-4-scout",
+                "messages": [{"role": "user", "content": "Say ok."}],
+                "max_tokens": 5,
+            },
+            timeout=60.0,
+        )
+        assert resp.status_code == 200, f"Virtual key chat failed: {resp.text}"
+
+    def test_invalid_key_rejected(self):
+        """Invalid API key should be rejected."""
+        resp = httpx.post(
+            f"{LITELLM_PROXY_URL}/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-invalid-key-12345"},
+            json={
+                "model": "llama-4-scout",
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 5,
+            },
+            timeout=10.0,
+        )
+        assert resp.status_code == 401, (
+            f"Expected 401 for invalid key, got {resp.status_code}"
+        )
+
+
+class TestLiteLLMSpendTracking:
+    """Spend and usage tracking via database."""
+
+    def test_spend_logs_endpoint(self, master_client):
+        """Verify spend logs endpoint returns data."""
+        resp = master_client.get("/spend/logs")
+        assert resp.status_code == 200, f"Spend logs failed: {resp.text}"
+
+    def test_global_spend(self, master_client):
+        """Verify global spend endpoint returns aggregated data."""
+        resp = master_client.get("/global/spend")
+        # 200 with data or empty list both acceptable
+        assert resp.status_code == 200, f"Global spend failed: {resp.text}"


### PR DESCRIPTION
## Summary
- Backend unit tests: sandbox metadata, triggers, session DB, event pipeline, LLM keys
- E2E integration tests: sandbox legion tasks, sessions API, variants, LiteLLM proxy

10 files | Part of Sandbox Agent streaming PR series
Requires: K3 PRs merged, feature flags enabled for testing