### PR TITLE
feat: add sandbox UI build config, services, and cleanup

### DIFF
--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -70,6 +70,10 @@ charts:
     enabled: true
     values:
       openshift: true
+      featureFlags:
+        sandbox: true
+        integrations: true
+        triggers: true
       components:
         agentNamespaces:
           enabled: true

--- a/kagenti/auth/create-test-users.sh
+++ b/kagenti/auth/create-test-users.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Create Test Users in Keycloak
+#
+# Creates dev-user and ns-admin test users in the master realm (or the realm
+# where the kagenti OAuth client is registered). Idempotent — safe to run
+# multiple times.
+#
+# Prerequisites:
+#   - kubectl/oc access to the cluster
+#   - Keycloak pod running in the keycloak namespace
+#   - keycloak-initial-admin secret exists
+#
+# Usage:
+#   # From the repository root:
+#   ./kagenti/auth/create-test-users.sh
+#
+#   # With custom realm (default: master):
+#   KEYCLOAK_REALM=demo ./kagenti/auth/create-test-users.sh
+#
+#   # With custom namespace:
+#   KEYCLOAK_NAMESPACE=my-keycloak ./kagenti/auth/create-test-users.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../.github/scripts/lib/logging.sh" 2>/dev/null || {
+    log_step() { echo "==> [$1] $2"; }
+    log_info() { echo "  INFO: $*"; }
+    log_success() { echo "  OK: $*"; }
+    log_warn() { echo "  WARN: $*"; }
+    log_error() { echo "  ERROR: $*"; }
+}
+
+log_step "D" "Create test users in Keycloak"
+
+KC_NS="${KEYCLOAK_NAMESPACE:-keycloak}"
+KC_POD="keycloak-0"
+KCADM="/opt/keycloak/bin/kcadm.sh"
+# TODO: Upstream is moving kagenti OAuth client from master realm to demo realm.
+# Once that lands (after rebase), change default to "demo" and update the
+# kagenti-ui-oauth-secret job to use demo realm endpoints.
+REALM="${KEYCLOAK_REALM:-master}"
+
+# ── Step 1: Wait for Keycloak pod ─────────────────────────────────────────
+log_info "Waiting for Keycloak pod to be ready..."
+kubectl wait --for=condition=Ready pod/$KC_POD -n "$KC_NS" --timeout=120s
+
+# ── Step 2: Login to Keycloak ─────────────────────────────────────────────
+log_info "Reading credentials from keycloak-initial-admin secret..."
+KC_USER=$(kubectl get secret keycloak-initial-admin -n "$KC_NS" \
+    -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+KC_PASS=$(kubectl get secret keycloak-initial-admin -n "$KC_NS" \
+    -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+
+if [ -z "$KC_USER" ] || [ -z "$KC_PASS" ]; then
+    log_error "Could not read keycloak-initial-admin secret"
+    exit 1
+fi
+
+log_info "Logging in as $KC_USER..."
+kubectl exec -n "$KC_NS" "$KC_POD" -- bash -c \
+    "$KCADM config credentials --server http://localhost:8080 --realm master \
+     --user '$KC_USER' --password '$KC_PASS' --config /tmp/kc/kcadm.config" \
+    >/dev/null 2>&1
+
+# ── Step 3: Create test users ─────────────────────────────────────────────
+create_user() {
+    local username=$1
+    local password=$2
+    local email=$3
+    local first=$4
+    local last=$5
+
+    log_info "Creating user: $username (realm: $REALM)"
+    kubectl exec -n "$KC_NS" "$KC_POD" -- bash -c "
+$KCADM create users --config /tmp/kc/kcadm.config -r $REALM \
+    -s username=$username -s enabled=true -s emailVerified=true \
+    -s email=$email -s firstName='$first' -s lastName='$last' \
+    2>/dev/null && echo 'Created' || echo 'Exists'
+
+$KCADM set-password --config /tmp/kc/kcadm.config -r $REALM \
+    --username $username --new-password $password \
+    2>/dev/null && echo 'Password set' || echo 'Password unchanged'
+"
+}
+
+# For the admin user, preserve the existing password from keycloak-initial-admin
+# (changing it via kcadm can fail silently, causing test/secret mismatch).
+# For dev-user and ns-admin, reuse existing passwords or generate random ones.
+_existing_dev=$(kubectl get secret kagenti-test-users -n "$KC_NS" \
+    -o jsonpath='{.data.dev-user-password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+_existing_ns=$(kubectl get secret kagenti-test-users -n "$KC_NS" \
+    -o jsonpath='{.data.ns-admin-password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+
+_rand() { LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 15; }
+
+# Admin password: use the actual Keycloak password (do not try to change it)
+ADMIN_PASS="$KC_PASS"
+DEV_PASS="${DEV_USER_PASSWORD:-${_existing_dev:-$(_rand)}}"
+NS_PASS="${NS_ADMIN_PASSWORD:-${_existing_ns:-$(_rand)}}"
+
+# Admin user already exists (created by 36-fix-keycloak-admin.sh) — skip creation
+log_info "Admin user already exists with keycloak-initial-admin password — skipping"
+create_user "dev-user"  "$DEV_PASS"   "dev-user@kagenti.local" "Dev"       "User"
+create_user "ns-admin"  "$NS_PASS"    "ns-admin@kagenti.local" "Namespace" "Admin"
+
+# ── Step 4: Create and assign Kagenti roles ───────────────────────────────
+log_info "Creating Kagenti roles (idempotent)..."
+for role in kagenti-viewer kagenti-operator kagenti-admin; do
+    kubectl exec -n "$KC_NS" "$KC_POD" -- bash -c \
+        "$KCADM create roles --config /tmp/kc/kcadm.config -r $REALM -s name=$role 2>/dev/null || true"
+done
+
+assign_role() {
+    local username=$1
+    local rolename=$2
+    kubectl exec -n "$KC_NS" "$KC_POD" -- bash -c \
+        "$KCADM add-roles --config /tmp/kc/kcadm.config -r $REALM --uusername $username --rolename $rolename 2>/dev/null || true"
+}
+
+# admin: all roles
+assign_role admin kagenti-viewer
+assign_role admin kagenti-operator
+assign_role admin kagenti-admin
+
+# dev-user: viewer + operator (can chat, browse files)
+assign_role dev-user kagenti-viewer
+assign_role dev-user kagenti-operator
+
+# ns-admin: all roles (namespace admin)
+assign_role ns-admin kagenti-viewer
+assign_role ns-admin kagenti-operator
+assign_role ns-admin kagenti-admin
+
+log_success "Kagenti roles assigned"
+
+# ── Step 5: Store passwords in a secret for show-services.sh ─────────────
+log_info "Storing test user passwords in kagenti-test-users secret..."
+kubectl create secret generic kagenti-test-users -n "$KC_NS" \
+    --from-literal=admin-password="$ADMIN_PASS" \
+    --from-literal=dev-user-password="$DEV_PASS" \
+    --from-literal=ns-admin-password="$NS_PASS" \
+    --dry-run=client -o yaml | kubectl apply -f -
+log_success "kagenti-test-users secret updated"
+
+# ── Step 6: Summary ──────────────────────────────────────────────────────
+log_success "Test users created in realm: $REALM"
+echo ""
+echo "  Users:"
+echo "    admin     / $ADMIN_PASS   (admin)"
+echo "    dev-user  / $DEV_PASS   (developer)"
+echo "    ns-admin  / $NS_PASS   (namespace admin)"
+echo ""
+echo "  These users can log in to the Kagenti UI."
+echo "  Run show-services.sh --reveal to see all credentials."

--- a/kagenti/backend/app/models/event.py
+++ b/kagenti/backend/app/models/event.py
@@ -1,0 +1,31 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+SQLAlchemy-style event table schema for per-event persistence.
+
+Events are stored individually (one row per SSE event) instead of as a
+blob in task metadata. This enables paginated retrieval, turn-level
+loading, and efficient history reconstruction.
+
+Uses raw asyncpg (matching session_db.py pattern) rather than SQLAlchemy
+ORM, because the sessions database is managed via asyncpg pools.
+"""
+
+# Schema DDL — executed via _ensure_events_schema() on pool creation.
+EVENTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS events (
+    id BIGSERIAL PRIMARY KEY,
+    context_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    event_index INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    event_category TEXT,
+    langgraph_node TEXT,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (context_id, task_id, event_index)
+);
+CREATE INDEX IF NOT EXISTS idx_events_ctx_idx ON events(context_id, event_index);
+CREATE INDEX IF NOT EXISTS idx_events_task ON events(task_id, event_index);
+"""

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,11 +50,14 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "http://dockerhost:11434/v1"
+          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
         - name: LLM_API_KEY
-          value: "dummy"
+          valueFrom:
+            secretKeyRef:
+              name: openai-secret
+              key: apikey
         - name: LLM_MODEL
-          value: "qwen2.5:3b"
+          value: "llama-scout-17b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,14 +50,11 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
+          value: "http://dockerhost:11434/v1"
         - name: LLM_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: openai-secret
-              key: apikey
+          value: "dummy"
         - name: LLM_MODEL
-          value: "llama-scout-17b"
+          value: "qwen2.5:3b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -8,11 +8,9 @@ WORKDIR /app
 
 # Copy package files
 COPY ui-v2/package.json ./
-# Note: If using npm, use package-lock.json instead
-# COPY package-lock.json ./
 
 # Install dependencies
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY ui-v2/ .

--- a/kagenti/ui-v2/nginx.conf
+++ b/kagenti/ui-v2/nginx.conf
@@ -19,6 +19,24 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # SSE streaming for sandbox chat — must come before the generic /api/ block
+    # so that streaming requests get the correct proxy settings
+    location /api/v1/sandbox/ {
+        proxy_pass http://kagenti-backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
+
     # API proxy to backend
     location /api/ {
         proxy_pass http://kagenti-backend:8000;
@@ -28,8 +46,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
     }
 
     # Health check endpoint

--- a/kagenti/ui-v2/package.json
+++ b/kagenti/ui-v2/package.json
@@ -24,10 +24,8 @@
     "@xyflow/react": "^12.10.1",
     "dagre": "^0.8.5",
     "js-yaml": "^4.1.0",
-    "mermaid": "^11.12.3",
     "keycloak-js": "~25.0.6",
     "mermaid": "^11.12.3",
-    "playwright": "^1.50.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
@@ -36,6 +34,7 @@
   },
   "devDependencies": {
     "@playwright/test": "~1.59.1",
+    "playwright": "^1.50.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.2",
     "@types/react": "^18.3.3",

--- a/kagenti/ui-v2/package.json
+++ b/kagenti/ui-v2/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test:unit": "vitest run src/utils/validation.test.ts src/contexts/keycloakRedirectUri.test.ts",
+    "test:unit": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug"
@@ -26,6 +26,8 @@
     "js-yaml": "^4.1.0",
     "mermaid": "^11.12.3",
     "keycloak-js": "~25.0.6",
+    "mermaid": "^11.12.3",
+    "playwright": "^1.50.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary
- UI build: Dockerfile (npm ci), nginx proxy config for SSE streaming
- UI deps: package.json with graph/diagram dependencies, vitest config
- useSessionLoader hook, eventService, AgentGraphCard types
- Graph streaming animation CSS
- skill-packs.yaml for pinned sandbox agent skills
- Keycloak test user creation script
- Remove empty bracket-name artifact files

20 files | Part of Sandbox Agent streaming PR series