### PR TITLE
docs: add dual-mode consistency check to pr-review skill

### DIFF
--- a/.claude/skills/github:pr-review/SKILL.md
+++ b/.claude/skills/github:pr-review/SKILL.md
@@ -30,7 +30,6 @@ comments, and posts a GitHub review after user approval.
 - [Phase 1: Gather PR Data](#phase-1-gather-pr-data)
 - [Phase 2: Analyze Changes](#phase-2-analyze-changes)
 - [Phase 3: Review Checklist](#phase-3-review-checklist)
-  - [3.10 Feature Gate / Dual-Mode Code](#310-feature-gate--dual-mode-code)
 - [Phase 4: Draft Review](#phase-4-draft-review)
 - [Phase 5: Submit Review](#phase-5-submit-review)
 - [Troubleshooting](#troubleshooting)
@@ -240,8 +239,8 @@ Dual-mode bugs often appear as a value read from CM-A in the new path but CM-B i
 legacy path — the inconsistency is only visible by comparing both files side-by-side.
 
 ```bash
-# Example: find all ConfigMap name references in the diff
-grep -E '"[a-z-]+-config"|"environments"|"authbridge"' $LOG_DIR/pr-<number>.diff
+# Example: find all ConfigMap name references in the diff (substring match)
+grep -E 'authbridge-config|environments|spiffe-helper' $LOG_DIR/pr-<number>.diff
 ```
 
 This check catches a class of bugs where a new code path was written against a planned


### PR DESCRIPTION
## Summary

- Adds **§3.10 Feature Gate / Dual-Mode Code** checklist to the `github:pr-review` skill: when a PR introduces two parallel code paths (legacy vs resolved, ValueFrom vs literal env vars), verify both paths read from the same ConfigMaps and inject the same env var names. Includes a grep command to cross-reference ConfigMap name constants across all diff files.
- Adds **Subagent model access denied (401)** troubleshooting note: when the Explore subagent fails due to model access restrictions, instruct the reviewer to explicitly cross-reference new constants across ALL files in the diff rather than reading sequentially.

## Root Cause

During review of kagenti-extensions PR #217, the review missed that `namespace_config.go` reads `KEYCLOAK_URL`/`KEYCLOAK_REALM` from the `environments` ConfigMap while the legacy `container_builder.go` path reads them from `authbridge-config`. This cross-file mismatch is exactly the class of bug §3.10 is designed to catch.

The bug was only surfaced after the PR author posted a follow-up comment showing the actual pod spec.

## Test plan
- [ ] Verify skill renders correctly in `gh pr view` / local markdown preview
- [ ] Apply §3.10 checklist on next dual-mode PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)