### PR TITLE
fix: Add serviceaccounts RBAC to kagenti-backend ClusterRole

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -359,6 +359,11 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "patch", "delete"]
+  # ServiceAccounts — ensure_service_account() creates a dedicated SA so the
+  # webhook's SPIFFE identity uses the workload name (see kagenti#959)
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "create"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary

- Add `serviceaccounts` `get` and `create` verbs to the `kagenti-backend` ClusterRole in the Helm chart

## Problem

PR #959 added `ensure_service_account()` to the backend, which creates a dedicated ServiceAccount before each workload deployment so the webhook derives the correct SPIFFE ID. However, the backend's ClusterRole was missing `serviceaccounts` permissions, causing a `403 Forbidden` error when the backend tries to finalize Shipwright builds into deployments:

```
serviceaccounts "weather-tool" is forbidden: User "system:serviceaccount:kagenti-system:kagenti-backend"
cannot get resource "serviceaccounts" in API group "" in the namespace "team1"
```

This causes builds to complete successfully but deployments to never be created.

## Test plan

- [ ] Reinstall Kagenti (or apply the RBAC manually)
- [ ] Import an agent/tool via UI (Build from Source)
- [ ] Verify the build completes AND the deployment is created
- [ ] Verify the ServiceAccount is created in the workload namespace

Fixes regression introduced by #959.