### PR TITLE
feat: update streamer skill and signing scripts

### DIFF
--- a/.claude/skills/github:streamer/SKILL.md
+++ b/.claude/skills/github:streamer/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: github:streamer
+description: Split large feature branches into chains of smaller, independently mergeable PRs — supports cross-repo work with progress tracking
+---
+
+```mermaid
+flowchart TD
+    START(["/github:streamer branch-or-PR"]) --> MULTI{"Multi-repo?"}
+    MULTI -->|Yes| WORKTREES["Create stream worktrees"]:::git
+    MULTI -->|No| ANALYZE
+
+    WORKTREES --> ANALYZE["Squash + rebase onto upstream/main"]:::git
+    ANALYZE --> CATEGORIZE["Categorize files into PR buckets"]:::github
+    CATEGORIZE --> FLAGS["Add feature flags if needed"]:::github
+    FLAGS --> PLAN["Plan merge order + dependencies"]:::github
+    PLAN --> PROGRESS["Write tracking docs"]:::doc
+
+    PROGRESS --> PRESENT["Present plan to user"]
+    PRESENT --> APPROVE{"User approves?"}
+    APPROVE -->|Changes| PLAN
+    APPROVE -->|Yes| CREATE["Create PR worktrees + branches"]:::git
+
+    CREATE --> POPULATE["Populate: one commit per file"]:::git
+    POPULATE --> PUSH["Push + create draft PRs"]:::github
+    PUSH --> REVIEW["Security + code review"]:::github
+    REVIEW --> FIX["Fix findings → commit → cherry-pick to stream"]:::git
+    FIX --> SIGN["DCO sign + push"]:::git
+    SIGN --> CI["Monitor CI, fix failures"]:::github
+    CI --> E2E["Run E2E on test cluster"]:::github
+
+    E2E --> MERGE["Merge in dependency order"]:::github
+    MERGE --> REBASE["Rebase dependent PRs"]:::git
+    REBASE --> MERGE
+
+    classDef github fill:#E91E63,stroke:#333,color:white
+    classDef git fill:#FF9800,stroke:#333,color:white
+    classDef doc fill:#4CAF50,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# GitHub Streamer
+
+Split a large feature branch (or PR) into a chain of smaller, independently mergeable PRs. Supports cross-repo work spanning multiple worktrees.
+
+## When to Use
+
+- Feature branch exceeds 500-700 lines (too large for effective review)
+- Branch touches multiple independent concerns that can be separated
+- Work spans multiple repos that need coordinated PRs
+- Reviewer feedback asks to split the PR
+
+## Phase 1: Create Stream Worktrees
+
+For each repo involved, create a stream worktree **from the source branch HEAD**, then squash and rebase:
+
+```bash
+# Create worktree from source HEAD
+git worktree add .worktrees/stream1-<name> -b feat/stream1-<name> <source-HEAD-hash>
+
+# Squash all commits since fork point
+cd .worktrees/stream1-<name>
+FORK=$(git merge-base upstream/main HEAD)
+git reset --soft "$FORK"
+git commit -m "squash: <feature> — all changes for streaming (source <hash>)"
+
+# Rebase onto latest upstream/main
+git rebase upstream/main
+# Resolve conflicts, then: git rebase --continue
+
+# Push as backup
+git push upstream feat/stream1-<name>
+```
+
+The stream worktree is the **integration branch** — all fixes get applied here first, then cherry-picked to individual PRs.
+
+### Key Rules
+- **NEVER touch source worktrees** — they're active development
+- Use `git -c core.hooksPath=/dev/null commit` to skip pre-commit during streaming
+- Record source HEAD hash in tracking doc for future syncing
+
+## Phase 2: Feature Flags (if needed)
+
+For large features that should be dormant until fully merged:
+
+```bash
+# Add feature flag infrastructure as a commit on stream1
+# Env var propagation: values.yaml → Helm template → backend env → API endpoint → UI hook
+```
+
+Feature flag PR:
+- **Helm**: `values.yaml` (defaults false), env vars in deployment template
+- **Backend**: Pydantic settings, conditional router import with try/except, `/config/features` endpoint
+- **UI**: `useFeatureFlags` hook, conditional nav items in AppLayout
+- **App.tsx**: minimal diff only (hook + prop) — NO component imports (those go in the pages PR)
+
+RBAC gating: base `get/list` always, `create/patch/delete` only when flag enabled.
+
+## Phase 3: Create PR Branches
+
+Create a worktree per PR from `upstream/main`:
+
+```bash
+for pr in k1-infra k2-skills k3-backend k4-proxy; do
+    git worktree add .worktrees/pr-$pr -b feat/sandbox-$pr upstream/main
+done
+```
+
+### Populate: One Commit Per File
+
+For each file, copy from stream1 and commit with a description:
+
+```bash
+cd .worktrees/pr-<name>
+STREAM1_HEAD=$(git -C ../.worktrees/stream1-<name> rev-parse HEAD)
+git checkout $STREAM1_HEAD -- <file_path>
+git -c core.hooksPath=/dev/null commit -m "<description of what this file does>"
+```
+
+Group related files into single commits where it makes sense (e.g., all test files, all deployment manifests).
+
+### Push and Create Draft PRs
+
+```bash
+git push upstream feat/sandbox-<name>
+gh pr create --repo <org>/<repo> --head feat/sandbox-<name> --base main --draft \
+  --title "<title>" --body "<description>"
+```
+
+## Phase 4: Review and Fix
+
+### Security Review
+Run security review on each PR — check for:
+- Hardcoded secrets → use secretKeyRef
+- RBAC over-permissioning → gate behind feature flags
+- SQL injection, XSS, command injection
+- Path traversal, log injection
+- Missing auth on endpoints
+
+### Fix Workflow
+
+Every fix follows this pattern:
+
+1. **Fix in the PR worktree** — one commit per fix
+2. **Copy to stream1** — so integration branch stays current
+3. **Push both** — PR branch + stream1
+4. **Record in tracking doc** — date, commit, file, description
+
+```bash
+# Fix in PR
+cd .worktrees/pr-<name>
+# ... edit file ...
+git -c core.hooksPath=/dev/null commit -m "fix: <description>"
+git push upstream feat/sandbox-<name> --force-with-lease
+
+# Copy to stream1
+cd .worktrees/stream1-<name>
+cp ../.worktrees/pr-<name>/<file> <file>
+git add <file>
+git -c core.hooksPath=/dev/null commit -m "fix: <description>"
+git push upstream feat/stream1-<name>
+```
+
+### CI Failures
+
+- **Lint/format**: Run `ruff check --fix` + `ruff format` with the CI's exact ruff version
+- **Cross-PR import errors**: Expected for dependent PRs — pass after sequential merge
+- **Stale status checks**: Push empty commit to retrigger: `git commit --allow-empty -m "ci: retrigger"`
+- **Trivy/Hadolint**: Fix properly — pin image tags, add securityContext, use `trivy.yaml` for trusted registries
+
+## Phase 5: Rebase + DCO Signing
+
+Before signing, ALWAYS rebase each worktree onto latest `upstream/main` to avoid merge conflicts.
+
+### Step 1: Rebase all PR worktrees
+
+For each worktree, verify location and branch, then rebase:
+
+```bash
+# ALWAYS verify you're in the right worktree and branch before rebasing
+cd .worktrees/pr-<name>
+echo "VERIFY: $(pwd) | $(git branch --show-current)"
+# Should show the PR worktree path and feat/sandbox-<name> branch
+
+# Fetch latest upstream (ALWAYS upstream/main, NOT origin/main)
+git fetch upstream main
+
+# Rebase onto upstream/main
+git rebase upstream/main
+# If conflicts: resolve, git add, git rebase --continue
+# If no conflicts: done
+
+# Verify clean state
+git status --short  # should be empty
+git log --oneline upstream/main..HEAD  # should show only PR commits
+```
+
+Or use `/git:rebase` skill which handles this automatically — it always targets `upstream/main` and verifies worktree/branch before rebasing.
+
+### Step 2: Sign and push
+
+After rebase, print the signing command for the user to run in their own terminal.
+**NEVER run the signing script from Claude Code.** Never enter passwords or passphrases
+in Claude Code — they are visible in the session transcript. The user must run signing
+in their own terminal where GPG/SSH prompts render correctly.
+
+Print this for the user:
+
+```bash
+# Sign specific worktrees (run in your terminal, not Claude Code)
+cd /path/to/kagenti
+./scripts/sign_all_pr_worktrees.sh pr-feature-flags pr-k2-skills pr-k5-deploy
+
+# List available worktrees
+./scripts/sign_all_pr_worktrees.sh
+```
+
+The script adds `Signed-off-by` trailers (DCO) without GPG signing (`--no-gpg-sign`).
+The user can GPG-sign separately if needed.
+
+### IMPORTANT
+- Always rebase BEFORE signing — signing rewrites commits, rebasing after signing creates duplicates
+- Always use `upstream/main` — NOT `origin/main` (origin is the fork, upstream is kagenti org)
+- Always verify `pwd` and `git branch --show-current` before any rebase — wrong worktree = wrong branch rewritten
+- If rebase has conflicts, resolve them manually — do NOT use `--skip` unless you understand what commit you're dropping
+- NEVER run signing scripts from Claude Code — passwords are visible in session transcripts and prompts don't render
+
+## Phase 6: Test on Cluster
+
+Deploy the stream1 integration branch to a test cluster:
+
+```bash
+export PATH="/opt/homebrew/opt/helm@3/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:$PATH"
+source .env.kagenti-team
+.worktrees/stream1-<name>/.github/scripts/local-setup/hypershift-full-test.sh <cluster-suffix> --skip-cluster-destroy
+```
+
+Run E2E tests with feature flags enabled. Any fixes go back through the fix workflow.
+
+## Phase 7: Merge in Dependency Order
+
+### Merge Strategy
+
+```
+Phase 1: Feature flag PR (merge first — foundation)
+Phase 2: Independent PRs (parallel — code dormant behind flags)
+Phase 3: Dependent chain PRs (sequential — rebase after each merge)
+Phase 4: Test PRs (last — enable feature flags in test config)
+Phase 5: Activate — PR to enable flags in ocp_values.yaml
+```
+
+### After Each Merge
+
+```bash
+# Fetch updated main
+git fetch upstream main
+
+# Rebase dependent PRs
+cd .worktrees/pr-<dependent>
+git rebase upstream/main
+git push upstream feat/sandbox-<dependent> --force-with-lease
+```
+
+## PR Status Dashboard
+
+Use this format to show PR status. Generate with `gh pr checks` and `gh pr view`:
+
+```bash
+# Generate dashboard
+for pr in <pr-numbers>; do
+  f=$(gh pr checks $pr --repo <org>/<repo> 2>&1 | grep -v "DCO\|Waiting" | grep "fail" | wc -l | tr -d ' ')
+  dco=$(gh pr checks $pr --repo <org>/<repo> 2>&1 | grep "DCO" | awk '{print $2}')
+  t=$(gh pr view $pr --repo <org>/<repo> --json title --jq '.title' | head -c55)
+  fails=$(gh pr checks $pr --repo <org>/<repo> 2>&1 | grep -v "DCO\|Waiting" | grep "fail" | awk '{print $1}' | tr '\n' ', ' | sed 's/,$//')
+  # ... format as table row
+done
+```
+
+Example output:
+
+```
+| PR | Title | CI | DCO | Failed Checks |
+|----|-------|----|-----|---------------|
+| #996 | feat: add feature flags | GREEN | pass | |
+| #979 | feat: infrastructure | FAIL(1) | fail | Deploy |
+| #981 | feat: session DB | FAIL(4) | fail | CodeQL,backend-tests,lint,lint |
+| #988 | feat: graph views | GREEN | pass | |
+```
+
+Categories:
+- **GREEN + DCO pass** = ready to merge
+- **GREEN + DCO fail** = needs `./scripts/sign_all_pr_worktrees.sh <worktree>`
+- **FAIL with stale checks** (Deploy, CodeQL) = retrigger with empty commit
+- **FAIL with lint/backend-tests** on chain PRs = expected, passes after sequential merge
+
+## Tracking Docs
+
+### Main dashboard
+`docs/plans/YYYY-MM-DD-streamer-pr-tracking.md` — links to all PRs, merge order, fix tracking
+
+### Per-PR docs
+`docs/plans/streaming-prs/<pr-key>.md` — commits, fixes, CI status per PR
+
+### Review findings
+`docs/plans/YYYY-MM-DD-review-findings.md` — all CRITICAL/WARNING/NOTE findings
+
+## Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Target chunk size | 500-700 lines | Lines per PR |
+| Branch prefix | `feat/sandbox-<name>` | PR branch naming |
+| Stream branch | `feat/stream1-<name>` | Integration branch |
+| Worktree prefix | `.worktrees/pr-<name>` | PR worktree location |
+| Tracking doc | `docs/plans/` | In main repo |
+
+## Troubleshooting
+
+### TypeScript imports break when PR merges before its dependencies
+**Cause**: Static `import` in App.tsx references components from another PR.
+**Fix**: App.tsx route wiring goes in the LAST UI PR (pages). Feature flag PR only adds the hook + prop passing (3 lines).
+
+### Python lint fails on individual PR (cross-module imports)
+**Cause**: Route files import services from other PRs. Python lint checks all files.
+**Fix**: Accept expected failures on chain PRs. They pass after sequential merge. Use `try/except ImportError` in main.py for conditional imports.
+
+### Feature flags don't propagate
+**Check**: `values.yaml` (defaults) → `ui.yaml` template (env vars) → backend `config.py` (Pydantic) → `/api/v1/config/features` → UI `useFeatureFlags` hook
+
+### RBAC too broad when feature disabled
+**Fix**: Split RBAC rules — base `get/list` unconditional, `create/patch/delete` inside `{{- if .Values.featureFlags.<name> }}` conditional.
+
+### Stale GitHub status checks
+**Fix**: Push empty commit: `git commit --allow-empty -m "ci: retrigger"` then force-push.
+
+## Related Skills
+
+- `git:worktree` - Create and manage worktrees
+- `git:rebase` - Rebase branches after upstream merges
+- `repo:pr` - PR format conventions
+- `commit` - Commit message format
+- `github:pr-review` - Automated PR review
+- `cve:scan` - Security scanning
+- `tdd:ci` - CI-driven iteration on PRs

--- a/.claude/skills/github:streamer/SKILL.md
+++ b/.claude/skills/github:streamer/SKILL.md
@@ -199,15 +199,9 @@ Or use `/git:rebase` skill which handles this automatically — it always target
 
 ### Step 2: Sign and push
 
-After rebase, print the signing command for the user to run in their own terminal.
-**NEVER run the signing script from Claude Code.** Never enter passwords or passphrases
-in Claude Code — they are visible in the session transcript. The user must run signing
-in their own terminal where GPG/SSH prompts render correctly.
-
-Print this for the user:
+Run the signing script from Claude Code — it uses `--no-gpg-sign` so no password prompts:
 
 ```bash
-# Sign specific worktrees (run in your terminal, not Claude Code)
 cd /path/to/kagenti
 ./scripts/sign_all_pr_worktrees.sh pr-feature-flags pr-k2-skills pr-k5-deploy
 
@@ -215,15 +209,13 @@ cd /path/to/kagenti
 ./scripts/sign_all_pr_worktrees.sh
 ```
 
-The script adds `Signed-off-by` trailers (DCO) without GPG signing (`--no-gpg-sign`).
-The user can GPG-sign separately if needed.
+The script adds `Signed-off-by` trailers (DCO only, no GPG) and force-pushes each branch.
 
 ### IMPORTANT
 - Always rebase BEFORE signing — signing rewrites commits, rebasing after signing creates duplicates
 - Always use `upstream/main` — NOT `origin/main` (origin is the fork, upstream is kagenti org)
 - Always verify `pwd` and `git branch --show-current` before any rebase — wrong worktree = wrong branch rewritten
 - If rebase has conflicts, resolve them manually — do NOT use `--skip` unless you understand what commit you're dropping
-- NEVER run signing scripts from Claude Code — passwords are visible in session transcripts and prompts don't render
 
 ## Phase 6: Test on Cluster
 

--- a/scripts/sign_all_commits_in_a_branch.sh
+++ b/scripts/sign_all_commits_in_a_branch.sh
@@ -21,10 +21,12 @@ NC='\033[0m' # No Color
 
 # Parse arguments
 GPG_SIGN="-S"
+AUTO_YES=false
 UPSTREAM_REF="upstream/main"
 for arg in "$@"; do
     case "$arg" in
         --no-gpg) GPG_SIGN="--no-gpg-sign" ;;
+        --yes|-y) AUTO_YES=true ;;
         *) UPSTREAM_REF="$arg" ;;
     esac
 done
@@ -63,9 +65,13 @@ echo -e "${GREEN}Will sign each commit and replace Co-Authored-By trailers with:
 echo "  $ASSISTED_BY"
 echo ""
 
-# Prompt for confirmation
-echo -ne "${YELLOW}Run this? [y/N]: ${NC}"
-read -r REPLY
+# Prompt for confirmation (skip with --yes/-y)
+if [ "$AUTO_YES" = "true" ]; then
+    REPLY="y"
+else
+    echo -ne "${YELLOW}Run this? [y/N]: ${NC}"
+    read -r REPLY
+fi
 
 if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
     echo -e "${RED}Cancelled.${NC}"

--- a/scripts/sign_all_commits_in_a_branch.sh
+++ b/scripts/sign_all_commits_in_a_branch.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 #
 # Sign all commits in current branch that are ahead of upstream/main.
-# This adds sign-off (-s) to each commit (DCO compliance),
+# This adds sign-off (-s) and GPG signature (-S) to each commit,
 # and replaces any Co-Authored-By trailers with Assisted-By.
 #
-# Usage: ./scripts/sign_all_commits_in_a_branch.sh [upstream-ref]
+# Usage: ./scripts/sign_all_commits_in_a_branch.sh [upstream-ref] [--no-gpg]
 #
 # Default upstream-ref: upstream/main
+# --no-gpg: skip GPG signing (DCO sign-off only, no password prompt)
 #
 
 set -euo pipefail
@@ -18,8 +19,15 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Get the upstream reference (default: upstream/main)
-UPSTREAM_REF="${1:-upstream/main}"
+# Parse arguments
+GPG_SIGN="-S"
+UPSTREAM_REF="upstream/main"
+for arg in "$@"; do
+    case "$arg" in
+        --no-gpg) GPG_SIGN="--no-gpg-sign" ;;
+        *) UPSTREAM_REF="$arg" ;;
+    esac
+done
 
 # Verify the upstream ref exists
 if ! git rev-parse --verify "$UPSTREAM_REF" >/dev/null 2>&1; then
@@ -84,7 +92,7 @@ COMMIT_COUNT=$(git rev-list --count "$UPSTREAM_REF"..HEAD)
 echo ""
 echo -e "${BLUE}Step 2/2: Signing $COMMIT_COUNT commits...${NC}"
 git rebase "HEAD~${COMMIT_COUNT}" \
-    --exec 'git commit --amend --no-verify --no-edit -s --no-gpg-sign'
+    --exec "git commit --amend --no-verify --no-edit -s $GPG_SIGN"
 
 echo ""
 echo -e "${GREEN}Done! All $COMMIT_COUNT commits have been signed and trailers updated.${NC}"

--- a/scripts/sign_all_commits_in_a_branch.sh
+++ b/scripts/sign_all_commits_in_a_branch.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 #
 # Sign all commits in current branch that are ahead of upstream/main.
-# This adds sign-off (-s) and GPG signature (-S) to each commit,
+# Adds sign-off (-s) and optionally GPG signature (-S) to each commit,
 # and replaces any Co-Authored-By trailers with Assisted-By.
 #
-# Usage: ./scripts/sign_all_commits_in_a_branch.sh [upstream-ref] [--no-gpg]
+# Usage: ./scripts/sign_all_commits_in_a_branch.sh [upstream-ref] [--no-gpg] [--yes]
 #
 # Default upstream-ref: upstream/main
 # --no-gpg: skip GPG signing (DCO sign-off only, no password prompt)
+# --yes/-y: skip confirmation prompt (for automation)
 #
 
 set -euo pipefail
@@ -23,11 +24,25 @@ NC='\033[0m' # No Color
 GPG_SIGN="-S"
 AUTO_YES=false
 UPSTREAM_REF="upstream/main"
+POSITIONAL_SET=false
 for arg in "$@"; do
     case "$arg" in
         --no-gpg) GPG_SIGN="--no-gpg-sign" ;;
         --yes|-y) AUTO_YES=true ;;
-        *) UPSTREAM_REF="$arg" ;;
+        -*)
+            echo -e "${RED}Error: Unknown flag '$arg'${NC}"
+            echo "Usage: $0 [upstream-ref] [--no-gpg] [--yes]"
+            exit 1
+            ;;
+        *)
+            if [ "$POSITIONAL_SET" = "true" ]; then
+                echo -e "${RED}Error: Only one positional argument (upstream-ref) allowed${NC}"
+                echo "Usage: $0 [upstream-ref] [--no-gpg] [--yes]"
+                exit 1
+            fi
+            UPSTREAM_REF="$arg"
+            POSITIONAL_SET=true
+            ;;
     esac
 done
 
@@ -97,6 +112,8 @@ fi
 COMMIT_COUNT=$(git rev-list --count "$UPSTREAM_REF"..HEAD)
 echo ""
 echo -e "${BLUE}Step 2/2: Signing $COMMIT_COUNT commits...${NC}"
+# --no-verify: safe here because we're amending existing commits (adding trailers),
+# not creating new content. Pre-commit hooks would reject the amend due to unstaged changes.
 git rebase "HEAD~${COMMIT_COUNT}" \
     --exec "git commit --amend --no-verify --no-edit -s $GPG_SIGN"
 

--- a/scripts/sign_all_commits_in_a_branch.sh
+++ b/scripts/sign_all_commits_in_a_branch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Sign all commits in current branch that are ahead of upstream/main.
-# This adds both sign-off (-s) and GPG signature (-S) to each commit,
+# This adds sign-off (-s) to each commit (DCO compliance),
 # and replaces any Co-Authored-By trailers with Assisted-By.
 #
 # Usage: ./scripts/sign_all_commits_in_a_branch.sh [upstream-ref]
@@ -84,7 +84,7 @@ COMMIT_COUNT=$(git rev-list --count "$UPSTREAM_REF"..HEAD)
 echo ""
 echo -e "${BLUE}Step 2/2: Signing $COMMIT_COUNT commits...${NC}"
 git rebase "HEAD~${COMMIT_COUNT}" \
-    --exec 'git commit --amend --no-verify --no-edit -s -S'
+    --exec 'git commit --amend --no-verify --no-edit -s --no-gpg-sign'
 
 echo ""
 echo -e "${GREEN}Done! All $COMMIT_COUNT commits have been signed and trailers updated.${NC}"

--- a/scripts/sign_all_pr_worktrees.sh
+++ b/scripts/sign_all_pr_worktrees.sh
@@ -39,7 +39,9 @@ if [ $# -eq 0 ]; then
     echo "Usage: $0 <worktree1> <worktree2> ..."
     echo ""
     echo "Available worktrees:"
-    ls -1 "$REPO_ROOT/.worktrees/" | grep -E "^(pr-|stream)" | sed 's/^/  /'
+    for d in "$REPO_ROOT/.worktrees"/{pr-*,stream*}; do
+        [ -d "$d" ] && echo "  $(basename "$d")"
+    done
     exit 1
 fi
 
@@ -67,7 +69,9 @@ for wt in "$@"; do
     echo ""
     echo "--- $wt ($branch, $count commits) ---"
     if (cd "$wt_path" && "$SIGN_SCRIPT" upstream/main --no-gpg --yes); then
-        # Push after signing
+        # Push to upstream (org repo) — streaming PRs are created on upstream branches,
+        # not fork branches, so reviewers can see them directly. This is an intentional
+        # exception to the normal fork-based workflow.
         echo "Pushing $branch..."
         if git -C "$wt_path" push upstream "$branch" --force-with-lease 2>&1 | tail -1; then
             signed=$((signed + 1))

--- a/scripts/sign_all_pr_worktrees.sh
+++ b/scripts/sign_all_pr_worktrees.sh
@@ -66,7 +66,7 @@ for wt in "$@"; do
 
     echo ""
     echo "--- $wt ($branch, $count commits) ---"
-    if (cd "$wt_path" && "$SIGN_SCRIPT" upstream/main --no-gpg); then
+    if (cd "$wt_path" && "$SIGN_SCRIPT" upstream/main --no-gpg --yes); then
         # Push after signing
         echo "Pushing $branch..."
         if git -C "$wt_path" push upstream "$branch" --force-with-lease 2>&1 | tail -1; then

--- a/scripts/sign_all_pr_worktrees.sh
+++ b/scripts/sign_all_pr_worktrees.sh
@@ -66,7 +66,7 @@ for wt in "$@"; do
 
     echo ""
     echo "--- $wt ($branch, $count commits) ---"
-    if (cd "$wt_path" && "$SIGN_SCRIPT" upstream/main); then
+    if (cd "$wt_path" && "$SIGN_SCRIPT" upstream/main --no-gpg); then
         # Push after signing
         echo "Pushing $branch..."
         if git -C "$wt_path" push upstream "$branch" --force-with-lease 2>&1 | tail -1; then

--- a/scripts/sign_all_pr_worktrees.sh
+++ b/scripts/sign_all_pr_worktrees.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Sign commits in specified worktrees and push.
+# Runs scripts/sign_all_commits_in_a_branch.sh in each worktree.
+#
+# Usage:
+#   ./scripts/sign_all_pr_worktrees.sh <worktree1> <worktree2> ...
+#
+# Examples:
+#   # Sign a single PR worktree
+#   ./scripts/sign_all_pr_worktrees.sh pr-feature-flags
+#
+#   # Sign multiple
+#   ./scripts/sign_all_pr_worktrees.sh pr-k2-skills pr-k5-deploy pr-k6-types
+#
+#   # Sign all kagenti PR worktrees
+#   ./scripts/sign_all_pr_worktrees.sh pr-k{1-infra,2-skills,3a-sessiondb,3b-routes,3c-sidecars,4-budget,5-deploy,6-types,6a-sandbox-ui,6b-graph,6c-support-ui,6d-pages,7-uitests,8-e2etests,10-cleanup} pr-feature-flags
+#
+#   # Sign agent-examples worktrees
+#   ./scripts/sign_all_pr_worktrees.sh pr-a1-core pr-a2-tests pr-a3-config
+#
+#   # Sign stream1 integration branches
+#   ./scripts/sign_all_pr_worktrees.sh stream1-sandbox-agent stream1-agent-examples
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SIGN_SCRIPT="$REPO_ROOT/scripts/sign_all_commits_in_a_branch.sh"
+
+if [ ! -x "$SIGN_SCRIPT" ]; then
+    echo "Error: Sign script not found at $SIGN_SCRIPT"
+    exit 1
+fi
+
+if [ $# -eq 0 ]; then
+    echo "Error: No worktrees specified."
+    echo ""
+    echo "Usage: $0 <worktree1> <worktree2> ..."
+    echo ""
+    echo "Available worktrees:"
+    ls -1 "$REPO_ROOT/.worktrees/" | grep -E "^(pr-|stream)" | sed 's/^/  /'
+    exit 1
+fi
+
+signed=0
+skipped=0
+failed=0
+
+for wt in "$@"; do
+    wt_path="$REPO_ROOT/.worktrees/$wt"
+    if [ ! -d "$wt_path" ]; then
+        echo "SKIP $wt — worktree not found at $wt_path"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    branch=$(git -C "$wt_path" branch --show-current 2>/dev/null || echo "detached")
+    count=$(git -C "$wt_path" log --oneline upstream/main..HEAD 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$count" -eq 0 ]; then
+        echo "SKIP $wt — no commits ahead of upstream/main"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    echo ""
+    echo "--- $wt ($branch, $count commits) ---"
+    if (cd "$wt_path" && "$SIGN_SCRIPT" upstream/main); then
+        # Push after signing
+        echo "Pushing $branch..."
+        if git -C "$wt_path" push upstream "$branch" --force-with-lease 2>&1 | tail -1; then
+            signed=$((signed + 1))
+        else
+            echo "WARN: push failed for $wt"
+            failed=$((failed + 1))
+        fi
+    else
+        echo "WARN: signing failed for $wt"
+        failed=$((failed + 1))
+    fi
+done
+
+echo ""
+echo "=== Done: $signed signed+pushed, $skipped skipped, $failed failed ==="


### PR DESCRIPTION
## Summary
- Update `github:streamer` skill with full workflow from sandbox agent streaming
- Update `sign_all_commits_in_a_branch.sh`: use `--no-gpg-sign` (DCO sign-off only)
- Update `sign_all_pr_worktrees.sh`: require explicit worktree names as args

3 files