### PR TITLE
docs: add Agentic Runtime documentation

### DIFF
--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -103,6 +103,8 @@ flowchart TB
 | [Security](./security.md) | Defense-in-depth layers, Landlock, composable profiles, Istio Ambient |
 | [Zero-Secret Agents](./zero-secret-agents.md) | Three pillars: Budget Proxy + AuthBridge + Vault = no leaked secrets |
 | [Sandboxing Models](./sandboxing-models.md) | Isolation spectrum: minimal to maximum, use cases, three non-negotiable pillars |
+| [Sandboxing Layers](./sandboxing-layers.md) | Technical reference: OS, runtime, container, network layer details |
+| [Use Cases](./use-cases.md) | Agent types: coding, DevOps, tool-calling, multi-agent — profiles & skills |
 | [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |
 | [Multi-Framework Runtime](./multi-framework.md) | Framework adapters: LangGraph, OpenCode, Claude SDK, CrewAI, AG2 *(WIP)* |
 | [API Reference](./api-reference.md) | Backend routes: sandbox, sessions, events, deploy, sidecars, budget |

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -101,6 +101,7 @@ flowchart TB
 | [Pluggable Architecture](./pluggability.md) | 9 pluggable layers, contracts, standards landscape (AG-UI, MCP, OTel) |
 | [Configuration](./configuration.md) | Feature flags, Helm values, environment variables |
 | [Security](./security.md) | Defense-in-depth layers, Landlock, composable profiles, Istio Ambient |
+| [Zero-Secret Agents](./zero-secret-agents.md) | Three pillars: Budget Proxy + AuthBridge + Vault = no leaked secrets |
 | [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |
 | [Multi-Framework Runtime](./multi-framework.md) | Framework adapters: LangGraph, OpenCode, Claude SDK, CrewAI, AG2 *(WIP)* |
 | [API Reference](./api-reference.md) | Backend routes: sandbox, sessions, events, deploy, sidecars, budget |

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -103,7 +103,6 @@ flowchart TB
 | [Security](./security.md) | Defense-in-depth layers, Landlock, composable profiles, Istio Ambient |
 | [Zero-Secret Agents](./zero-secret-agents.md) | Three pillars: Budget Proxy + AuthBridge + Vault = no leaked secrets |
 | [Sandboxing Models](./sandboxing-models.md) | Isolation spectrum: minimal to maximum, use cases, three non-negotiable pillars |
-| [Sandboxing Layers](./sandboxing-layers.md) | Technical reference: OS, runtime, container, network layer details |
 | [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |
 | [Multi-Framework Runtime](./multi-framework.md) | Framework adapters: LangGraph, OpenCode, Claude SDK, CrewAI, AG2 *(WIP)* |
 | [API Reference](./api-reference.md) | Backend routes: sandbox, sessions, events, deploy, sidecars, budget |

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -97,6 +97,7 @@ flowchart TB
 |----------|-------------|
 | [Concepts](./concepts.md) | Core concepts: sessions, reasoning loops, event pipeline, graph card, sidecars |
 | [Quick Start](./quickstart.md) | Deploy a sandbox agent on Kind in 5 minutes |
+| [A2A Integration](./a2a-integration.md) | A2A protocol: proxied vs direct access, extensions, SDK version |
 | [Configuration](./configuration.md) | Feature flags, Helm values, environment variables |
 | [Security](./security.md) | Defense-in-depth layers, Landlock, composable profiles, Istio Ambient |
 | [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -98,6 +98,7 @@ flowchart TB
 | [Concepts](./concepts.md) | Core concepts: sessions, reasoning loops, event pipeline, graph card, sidecars |
 | [Quick Start](./quickstart.md) | Deploy a sandbox agent on Kind in 5 minutes |
 | [A2A Integration](./a2a-integration.md) | A2A protocol: proxied vs direct access, extensions, SDK version |
+| [Pluggable Architecture](./pluggability.md) | 9 pluggable layers, contracts, standards landscape (AG-UI, MCP, OTel) |
 | [Configuration](./configuration.md) | Feature flags, Helm values, environment variables |
 | [Security](./security.md) | Defense-in-depth layers, Landlock, composable profiles, Istio Ambient |
 | [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -104,6 +104,7 @@ flowchart TB
 | [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |
 | [Multi-Framework Runtime](./multi-framework.md) | Framework adapters: LangGraph, OpenCode, Claude SDK, CrewAI, AG2 *(WIP)* |
 | [API Reference](./api-reference.md) | Backend routes: sandbox, sessions, events, deploy, sidecars, budget |
+| [TUI Integration](./tui.md) | Terminal client: agent chat, sessions, HITL, dev workflows, CI mode |
 | [Deployment](./deployment.md) | Manifests, platform base, database, budget proxy, deploy scripts |
 | [Troubleshooting](./troubleshooting.md) | Common issues, debugging, log locations |
 

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -102,6 +102,8 @@ flowchart TB
 | [Configuration](./configuration.md) | Feature flags, Helm values, environment variables |
 | [Security](./security.md) | Defense-in-depth layers, Landlock, composable profiles, Istio Ambient |
 | [Zero-Secret Agents](./zero-secret-agents.md) | Three pillars: Budget Proxy + AuthBridge + Vault = no leaked secrets |
+| [Sandboxing Models](./sandboxing-models.md) | Isolation spectrum: minimal to maximum, use cases, three non-negotiable pillars |
+| [Sandboxing Layers](./sandboxing-layers.md) | Technical reference: OS, runtime, container, network layer details |
 | [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |
 | [Multi-Framework Runtime](./multi-framework.md) | Framework adapters: LangGraph, OpenCode, Claude SDK, CrewAI, AG2 *(WIP)* |
 | [API Reference](./api-reference.md) | Backend routes: sandbox, sessions, events, deploy, sidecars, budget |

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -105,6 +105,7 @@ flowchart TB
 | [Multi-Framework Runtime](./multi-framework.md) | Framework adapters: LangGraph, OpenCode, Claude SDK, CrewAI, AG2 *(WIP)* |
 | [API Reference](./api-reference.md) | Backend routes: sandbox, sessions, events, deploy, sidecars, budget |
 | [TUI Integration](./tui.md) | Terminal client: agent chat, sessions, HITL, dev workflows, CI mode |
+| [Operator Alignment](./operator-alignment.md) | AgentRuntime CR, script→CR migration, composable security in CRDs |
 | [Deployment](./deployment.md) | Manifests, platform base, database, budget proxy, deploy scripts |
 | [Troubleshooting](./troubleshooting.md) | Common issues, debugging, log locations |
 

--- a/docs/agentic-runtime/README.md
+++ b/docs/agentic-runtime/README.md
@@ -1,0 +1,171 @@
+# Agentic Runtime
+
+The Agentic Runtime extends Kagenti with secure, isolated environments for
+running AI coding agents. Agents operate in Kubernetes pods with composable
+security layers, persistent workspaces, and human-in-the-loop approval gates.
+
+The runtime is **framework-neutral** — any agent framework that speaks
+[A2A JSON-RPC 2.0](https://google.github.io/A2A/) gets the full platform
+feature set for free: authentication, authorization, budget enforcement,
+observability, and service mesh encryption.
+
+> **Status:** Active development. See [PR Dashboard](#pr-dashboard) for merge progress.
+> **Epic:** [#820](https://github.com/kagenti/kagenti/issues/820)
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TB
+    engineer(["Engineer"])
+
+    subgraph platform["kagenti-system namespace"]
+        direction TB
+
+        subgraph frontend["Frontend"]
+            ui["React UI<br/><small>Agent catalog, sessions, wizard,<br/>loop cards, file browser, LLM analytics</small>"]
+        end
+
+        subgraph backend_group["Backend"]
+            backend["FastAPI Backend<br/><small>Chat proxy, session API, deploy API,<br/>SSE streaming, loop event persistence</small>"]
+            litellm["LiteLLM Proxy<br/><small>Model routing, spend tracking,<br/>virtual keys</small>"]
+        end
+
+        subgraph auth["Auth & Identity"]
+            keycloak["Keycloak<br/><small>OIDC provider, JWT issuer</small>"]
+            spire["SPIRE<br/><small>Workload identity (SPIFFE)</small>"]
+        end
+
+        subgraph observability["Observability"]
+            otel["OTEL Collector<br/><small>Trace collection, multi-backend export</small>"]
+            phoenix["Phoenix<br/><small>LLM observability, token analytics</small>"]
+        end
+    end
+
+    subgraph gateway["gateway-system / mcp-system"]
+        direction TB
+        mcpgw["MCP Gateway<br/><small>Envoy proxy, tool discovery,<br/>request routing, OAuth</small>"]
+        mcptools["MCP Servers<br/><small>Weather, Slack, Fetch,<br/>custom tools</small>"]
+    end
+
+    subgraph team1["team1 namespace (per agent namespace)"]
+        direction TB
+
+        subgraph agent_pod["Sandbox Agent Pod"]
+            authbridge["AuthBridge sidecar<br/><small>Envoy: JWT validation (inbound),<br/>OAuth2 token exchange (outbound)</small>"]
+            agent["Agent Container<br/><small>Framework-neutral: LangGraph, OpenCode, ...<br/>Composable security, Landlock isolation</small>"]
+        end
+
+        egress["Egress Proxy<br/><small>Squid domain allowlist</small>"]
+        budgetproxy["LLM Budget Proxy<br/><small>Per-session 402 enforcement</small>"]
+
+        subgraph team1_db["postgres-sessions StatefulSet"]
+            sessions_db[("DB: sessions<br/><small>sessions, events, tasks,<br/>checkpoints tables</small>")]
+            budget_db[("DB: llm_budget<br/><small>llm_calls,<br/>budget_limits tables</small>")]
+        end
+    end
+
+    llm(["LLM Providers<br/><small>OpenAI, Anthropic, vLLM, Ollama</small>"])
+    tools(["External Tools<br/><small>GitHub, PyPI, APIs</small>"])
+
+    engineer -->|"HTTPS"| ui
+    ui -->|"REST + SSE (mTLS)"| backend
+    backend -->|"A2A + JWT (mTLS)"| authbridge
+    authbridge -->|"validated"| agent
+    agent -->|"asyncpg (mTLS)"| sessions_db
+    agent -->|"HTTP (mTLS)"| budgetproxy
+    budgetproxy -->|"asyncpg (mTLS)"| budget_db
+    budgetproxy -->|"HTTP (mTLS)"| litellm
+    agent -->|"MCP (mTLS)"| mcpgw
+    mcpgw -->|"HTTP"| mcptools
+    agent -->|"HTTP proxy (mTLS)"| egress
+    egress -->|"HTTPS"| tools
+    litellm -->|"HTTPS"| llm
+    backend -->|"OIDC (mTLS)"| keycloak
+    otel -->|"OTLP (mTLS)"| phoenix
+```
+
+> All internal edges use **Istio Ambient mTLS** (ztunnel) -- zero-config,
+> no sidecars. External edges use HTTPS.
+
+---
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Concepts](./concepts.md) | Core concepts: sessions, reasoning loops, event pipeline, graph card, sidecars |
+| [Quick Start](./quickstart.md) | Deploy a sandbox agent on Kind in 5 minutes |
+| [Configuration](./configuration.md) | Feature flags, Helm values, environment variables |
+| [Security](./security.md) | Defense-in-depth layers, Landlock, composable profiles, Istio Ambient |
+| [Writing Agents](./agents.md) | Agent authoring: graph structure, tools, event serialization, graph card |
+| [Multi-Framework Runtime](./multi-framework.md) | Framework adapters: LangGraph, OpenCode, Claude SDK, CrewAI, AG2 *(WIP)* |
+| [API Reference](./api-reference.md) | Backend routes: sandbox, sessions, events, deploy, sidecars, budget |
+| [Deployment](./deployment.md) | Manifests, platform base, database, budget proxy, deploy scripts |
+| [Troubleshooting](./troubleshooting.md) | Common issues, debugging, log locations |
+
+---
+
+## Key Design Decisions
+
+| Area | Design | Rationale |
+|------|--------|-----------|
+| Framework neutrality | A2A JSON-RPC 2.0 composability boundary | Any framework gets full platform features via plugin contract |
+| Feature flags | `KAGENTI_FEATURE_FLAG_*` gates all sandbox routes | Zero footprint when disabled; gradual rollout |
+| Composable security | Layers L1-L8, assembled by wizard into named profiles | Operators choose exactly which layers to enable per agent |
+| LLM budget | Per-namespace proxy between agent and LiteLLM | Enforces per-session token budgets at the network layer (HTTP 402) |
+| DB isolation | Per-namespace PostgreSQL; target: schema-per-agent | Agents cannot read each other's checkpoints |
+| Event pipeline | Background consumer + gap-fill reconnect | Events persisted independently of UI connection |
+| Graph card | Self-describing `/.well-known/agent-graph-card.json` | UI renders graph views without hardcoded agent knowledge |
+| Service mesh | Istio Ambient (no sidecars) | Zero-overhead mTLS between all pods |
+
+---
+
+## PR Dashboard
+
+### Merge Strategy
+
+```
+Phase 1: #996 (feature flags) -- merge first
+Phase 2 (parallel): #979, #980, #984, #985, #986-#990, #993, #182-#184
+Phase 3 (sequential): #981 -> #983 -> #982 (backend chain)
+Phase 4: #991, #992 (tests, flags on)
+```
+
+### kagenti/kagenti
+
+| PR | Title | Phase |
+|----|-------|-------|
+| [#996](https://github.com/kagenti/kagenti/pull/996) | Feature flags (SANDBOX, INTEGRATIONS, TRIGGERS) | 1 |
+| [#979](https://github.com/kagenti/kagenti/pull/979) | Infrastructure -- CI, Helm, Ansible, scripts | 2 |
+| [#980](https://github.com/kagenti/kagenti/pull/980) | Skills -- portable LOG_DIR | 2 |
+| [#984](https://github.com/kagenti/kagenti/pull/984) | LLM budget proxy | 2 |
+| [#985](https://github.com/kagenti/kagenti/pull/985) | Sandbox deployments & platform base | 2 |
+| [#986](https://github.com/kagenti/kagenti/pull/986) | UI types, API, utilities | 2 |
+| [#987](https://github.com/kagenti/kagenti/pull/987) | Sandbox core UI components | 2 |
+| [#988](https://github.com/kagenti/kagenti/pull/988) | Graph visualization views | 2 |
+| [#989](https://github.com/kagenti/kagenti/pull/989) | Supporting UI -- files, events, metrics | 2 |
+| [#990](https://github.com/kagenti/kagenti/pull/990) | Pages & navigation | 2 |
+| [#993](https://github.com/kagenti/kagenti/pull/993) | UI build config, cleanup | 2 |
+| [#981](https://github.com/kagenti/kagenti/pull/981) | Session DB (PostgreSQL) | 3 |
+| [#983](https://github.com/kagenti/kagenti/pull/983) | Sidecar agent lifecycle | 3 |
+| [#982](https://github.com/kagenti/kagenti/pull/982) | Sandbox API routes | 3 |
+| [#991](https://github.com/kagenti/kagenti/pull/991) | UI E2E tests | 4 |
+| [#992](https://github.com/kagenti/kagenti/pull/992) | Backend E2E tests | 4 |
+
+### kagenti/agent-examples
+
+| PR | Title | Phase |
+|----|-------|-------|
+| [#182](https://github.com/kagenti/agent-examples/pull/182) | Sandbox agent core | 2 |
+| [#183](https://github.com/kagenti/agent-examples/pull/183) | Agent test suite | 2 |
+| [#184](https://github.com/kagenti/agent-examples/pull/184) | Agent packaging | 2 |
+
+---
+
+## Design Documents
+
+For internal design history and architecture decisions, see the
+[design documents index](../plans/2026-03-16-issue-820-sandbox-agent-design-v3.md#72-sub-design-document-index)
+in the plans directory.

--- a/docs/agentic-runtime/a2a-integration.md
+++ b/docs/agentic-runtime/a2a-integration.md
@@ -1,0 +1,272 @@
+# A2A Protocol Integration
+
+The Agentic Runtime uses the [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/)
+as its composability boundary. This document covers how agents communicate,
+the two access models (proxied vs direct), and our A2A extensions.
+
+> **A2A SDK:** `a2a-sdk >= 0.2.5` (server-side). Spec: v1.0.0 (2026-03-12).
+> We use the SDK on agents only; the backend uses raw JSON-RPC via httpx.
+> See [detailed design](../plans/2026-03-17-a2a-integration-design.md) for
+> SDK upgrade analysis and extension design.
+
+---
+
+## Communication Models
+
+Agents are A2A-compliant HTTP services. There are two ways to reach them:
+
+### Model 1: Proxied via Backend (Default)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant UI as Kagenti UI
+    participant Backend as FastAPI Backend
+    participant AB as AuthBridge Sidecar
+    participant Agent as Agent Container
+
+    User->>UI: Send message
+    UI->>Backend: POST /api/v1/sandbox/{ns}/chat/stream<br/>Authorization: Bearer {oidc_token}
+    Backend->>Backend: Validate JWT, enforce RBAC
+    Backend->>Backend: Resolve agent URL<br/>http://{name}.{ns}.svc.cluster.local:8000
+    Backend->>AB: POST / (A2A JSON-RPC)<br/>method: message/stream<br/>Authorization: Bearer {token}
+    AB->>AB: Validate inbound JWT
+    AB->>Agent: Forward (validated)
+    Agent-->>Backend: SSE stream (events)
+    Backend-->>Backend: Persist events (background consumer)
+    Backend-->>Backend: Upsert session metadata
+    Backend-->>UI: SSE stream (forwarded events)
+```
+
+**What you get:**
+- Keycloak JWT validation + RBAC enforcement (`ROLE_OPERATOR`)
+- Session persistence (PostgreSQL `sessions` + `events` tables)
+- Background event consumer (survives UI disconnect)
+- Gap-fill reconnect (events table)
+- Session history aggregation
+- Sidecar agent fan-out
+- Agent card caching and discovery
+- Feature flag gating
+- File browser (pods/exec)
+- Budget tracking UI integration
+
+### Model 2: Direct A2A Access
+
+```mermaid
+sequenceDiagram
+    participant Client as External A2A Client
+    participant AB as AuthBridge Sidecar
+    participant Agent as Agent Container
+
+    Client->>AB: POST / (A2A JSON-RPC)<br/>method: message/stream
+    AB->>AB: Validate JWT (if configured)
+    AB->>Agent: Forward
+    Agent-->>Client: SSE stream (events)
+```
+
+An external system can call the agent directly using standard A2A protocol,
+bypassing the Kagenti backend entirely. This requires network access to the
+agent's Kubernetes Service.
+
+**Direct access URL:**
+```
+http://{agent-name}.{namespace}.svc.cluster.local:8000
+```
+
+**What you get:**
+- Pure A2A protocol compliance
+- Framework-neutral agent invocation
+- AuthBridge JWT validation (if sidecar injected)
+- Istio Ambient mTLS encryption
+- Agent's own task store (in-memory or PostgreSQL)
+- Full SSE event stream with EVENT_CATALOG events
+- AgentGraphCard at `/.well-known/agent-graph-card.json`
+- Agent card at `/.well-known/agent-card.json`
+
+**What you lose:**
+- No session persistence in Kagenti's `sessions`/`events` tables
+- No RBAC enforcement (backend `ROLE_OPERATOR` check)
+- No background event consumer (events lost on disconnect)
+- No gap-fill reconnect
+- No sidecar agent observation
+- No file browser
+- No budget tracking UI
+- No feature flag gating
+
+### When to Use Each Model
+
+| Use Case | Model | Why |
+|----------|-------|-----|
+| Kagenti UI user | Proxied | Full platform features, session history, budget UI |
+| External A2A client (another agent) | Direct | Standard A2A interop, client manages own state |
+| CI/CD pipeline calling agent | Direct | Lightweight, no UI needed, script-friendly |
+| Multi-platform agent mesh | Direct | Each platform manages own RBAC and budget |
+| Agent-to-agent delegation | Direct | `delegate` tool calls peer agents via A2A |
+| Custom dashboard / external UI | Either | Proxied if you want Kagenti sessions, direct for custom state |
+
+---
+
+## A2A Protocol Details
+
+### JSON-RPC Request Format
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "request-uuid",
+  "method": "message/stream",
+  "params": {
+    "message": {
+      "role": "user",
+      "parts": [{"kind": "text", "text": "Analyze this codebase"}],
+      "messageId": "msg-uuid",
+      "contextId": "session-uuid"
+    }
+  }
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `method` | `message/stream` for streaming, `message/send` for non-streaming |
+| `contextId` | Groups multiple tasks into a session (A2A core spec, not extension) |
+| `messageId` | Unique per message |
+| `parts` | Content parts (text, file, data) |
+
+### SSE Response Events
+
+The agent streams A2A events plus our EVENT_CATALOG events:
+
+```
+data: {"result":{"id":"task-uuid","contextId":"session-uuid","status":{"state":"working"}}}
+
+data: {"result":{"status":{"state":"working","message":{"parts":[{"kind":"text","text":"{\"type\":\"planner_output\",...}"}]}}}}
+
+data: {"result":{"status":{"state":"completed"}}}
+
+data: [DONE]
+```
+
+A2A task lifecycle states:
+
+| State | Meaning |
+|-------|---------|
+| `submitted` | Task acknowledged |
+| `working` | Being processed |
+| `completed` | Finished successfully |
+| `failed` | Finished with error |
+| `input-required` | Needs user input (HITL) |
+
+### Agent Discovery
+
+Agents expose `/.well-known/agent-card.json` per the A2A spec:
+
+```json
+{
+  "name": "sandbox-legion",
+  "description": "LangGraph coding agent with persistent sessions",
+  "version": "1.0.0",
+  "url": "http://sandbox-legion.team1.svc.cluster.local:8000",
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "urn:kagenti:agent-graph-card:v1",
+        "description": "Processing graph topology and event schemas",
+        "required": false,
+        "params": {"endpoint": "/.well-known/agent-graph-card.json"}
+      }
+    ]
+  },
+  "skills": [
+    {
+      "id": "coding",
+      "name": "Coding Agent",
+      "description": "Plan-execute-reflect coding with shell, file, and web tools"
+    }
+  ]
+}
+```
+
+The backend discovers agents by fetching this endpoint. It tries port 8080
+first (AuthBridge sidecar), falls back to 8000 (direct).
+
+---
+
+## A2A Extensions
+
+### Registered Extensions
+
+| Extension | URI | Status | Purpose |
+|-----------|-----|--------|---------|
+| **AgentGraphCard** | `urn:kagenti:agent-graph-card:v1` | Shipped | Graph topology + event catalog |
+| **Session metadata** | -- | Planned | Session persistence, budget, ownership |
+
+### AgentGraphCard Extension
+
+Our primary A2A extension. Agents declare it in their `AgentCard.capabilities.extensions[]`
+and expose the endpoint at `/.well-known/agent-graph-card.json`.
+
+```
+URI: urn:kagenti:agent-graph-card:v1
+Endpoint: /.well-known/agent-graph-card.json
+Required: false
+```
+
+The graph card contains:
+- **event_catalog** -- every event type the agent can emit, with categories and fields
+- **topology** -- the agent's processing graph (nodes, edges, entry_node)
+- **common_event_fields** -- fields present on every streamed event
+
+This enables framework-neutral UI rendering. See [Concepts](./concepts.md#agentgraphcard).
+
+### Session Context Extension (Planned)
+
+A2A v1.0 has `context_id` as a core field (not an extension) for grouping
+tasks into sessions. However, session **metadata** (owner, budget limits,
+model override, title) is Kagenti-specific.
+
+Planned extension to expose session metadata via A2A:
+
+```
+URI: urn:kagenti:session-metadata:v1 (planned)
+Purpose: Session persistence, ownership, budget limits
+Storage: Message.metadata["urn:kagenti:session-metadata:v1/session"]
+```
+
+This would allow direct A2A clients to read/write session metadata without
+going through the Kagenti backend.
+
+---
+
+## SDK Version Analysis
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| A2A Spec | v1.0.0 (2026-03-12) | Major rewrite from v0.3 |
+| a2a-sdk (PyPI) | 0.3.25 stable / 1.0.0a0 alpha | We use `>=0.2.5` |
+| Our pinned | `>=0.2.0` (backend), `>=0.2.5` (tests) | Pre-v1.0 API |
+
+**SDK v0.2 vs v1.0 breaking changes:**
+- Enum values: `"completed"` -> `"TASK_STATE_COMPLETED"`
+- Part types: separate `TextPart`/`FilePart` -> unified `Part` with `oneof`
+- Agent card: restructured `capabilities` and `supportedInterfaces`
+- Proto package: `a2a.v1` -> `lf.a2a.v1`
+
+**Upgrade path:** The `1.0.0a0` alpha SDK is available. Upgrade requires
+updating all A2A type imports and enum references. See
+[detailed design](../plans/2026-03-17-a2a-integration-design.md) for
+the migration plan.
+
+---
+
+## Port Discovery
+
+| Port | Used By | When |
+|------|---------|------|
+| 8080 | AuthBridge sidecar (Envoy) | Agents with `kagenti.io/inject: enabled` |
+| 8000 | Direct agent container | Sandbox agents, platform base agents |
+
+The backend tries 8080 first, falls back to 8000 on connection error.
+Direct A2A clients should use the agent's Kubernetes Service, which maps
+to the correct port.

--- a/docs/agentic-runtime/a2a-integration.md
+++ b/docs/agentic-runtime/a2a-integration.md
@@ -193,6 +193,113 @@ first (AuthBridge sidecar), falls back to 8000 (direct).
 
 ---
 
+## The Content Format Gap
+
+A2A defines **how agents communicate** (JSON-RPC, SSE, task lifecycle) but
+is **intentionally agnostic about what they say**. This is both a strength
+and a gap that AgentGraphCard fills.
+
+### What A2A Prescribes
+
+A2A streaming sends two event types carrying `Part` content:
+
+```mermaid
+flowchart TB
+    subgraph stream["SSE Stream"]
+        TSU["TaskStatusUpdateEvent<br/><small>task_id, context_id,<br/>status.message.parts[]</small>"]
+        TAU["TaskArtifactUpdateEvent<br/><small>task_id, context_id,<br/>artifact.parts[]</small>"]
+    end
+
+    subgraph part["Part (oneof content)"]
+        text["text: string<br/><small>Free-form. No schema.<br/>Plain text, markdown,<br/>JSON, anything.</small>"]
+        data["data: Value<br/><small>Structured JSON.<br/>No required schema.</small>"]
+        raw["raw: bytes / url: string<br/><small>Binary or file reference</small>"]
+    end
+
+    stream --> part
+```
+
+The `Part.text` field is a free-form string. A2A says nothing about what
+goes inside. There is **no type discriminator, no schema, no content
+contract**. The optional `media_type` is a hint, not enforced.
+
+### The Problem
+
+A client receiving a `Part.text` has no way to know what it contains:
+
+```mermaid
+flowchart LR
+    subgraph agents["Two Different Agents"]
+        OurAgent["Instrumented Agent<br/><small>Sends: {\"type\":\"tool_call\",<br/>\"name\":\"shell\",\"args\":\"ls\"}</small>"]
+        ExtAgent["External Agent<br/><small>Sends: I found 3 issues<br/>in the codebase...</small>"]
+    end
+
+    subgraph client["Client Receives Part.text"]
+        Q{"Is this JSON?<br/>What schema?<br/>How to render?"}
+    end
+
+    OurAgent --> Q
+    ExtAgent --> Q
+    Q --> Problem["Without prior knowledge<br/>of the agent's event format,<br/>the client can only show raw text"]
+```
+
+A2A provides the **transport** but not the **content contract**. The client
+must already know the agent's event schema to render structured reasoning
+(tool calls, plan steps, reflector decisions, graph views).
+
+### How AgentGraphCard Fills the Gap
+
+```mermaid
+flowchart TB
+    subgraph step1["1. Discovery"]
+        Fetch["Fetch agent card"]
+        Check{"Has extension<br/>urn:kagenti:agent-graph-card:v1?"}
+        FetchGC["Fetch graph card endpoint"]
+        PlainMode["Plain A2A mode<br/>(render as chat)"]
+    end
+
+    subgraph step2["2. Content Contract"]
+        Catalog["event_catalog<br/><small>12 event types, 7 categories<br/>fields + debug_fields per type</small>"]
+        Topo["topology<br/><small>nodes, edges, entry_node<br/>for graph visualization</small>"]
+    end
+
+    subgraph step3["3. Structured Rendering"]
+        Parse["Parse Part.text as JSON"]
+        Match["Match 'type' field<br/>against event_catalog"]
+        Render["Category-specific rendering:<br/>loop cards, tool calls,<br/>graph views, decision badges"]
+    end
+
+    Fetch --> Check
+    Check -->|"yes"| FetchGC --> Catalog & Topo
+    Check -->|"no"| PlainMode
+    Catalog --> Parse --> Match --> Render
+```
+
+The graph card is a **self-describing content contract** that tells clients:
+- What event types exist (`event_catalog` with 12 types)
+- What category each belongs to (reasoning, execution, tool_output, decision, terminal, meta, interaction)
+- What fields each event has (with types and descriptions)
+- How the agent's processing graph looks (`topology` with nodes + edges)
+- Which common fields appear on every event (type, loop_id, event_index, node_visit, model, tokens)
+
+Without the graph card, a client can only show raw text. With it, a client
+can render rich UI: graph views, loop cards, tool call panels, budget tracking.
+
+### Two-Tier Rendering
+
+This creates a natural two-tier model for any A2A client:
+
+| Agent Type | Detection | Rendering |
+|-----------|-----------|-----------|
+| **Instrumented** (has graph card) | `urn:kagenti:agent-graph-card:v1` in agent card extensions | Graph views, loop cards, step rendering, topology DAG |
+| **Plain A2A** (no graph card) | Extension absent | Chat bubbles with status badges |
+
+Both types get: sessions, task lifecycle, multi-turn via `context_id`.
+Instrumented agents additionally get: structured event rendering, graph
+visualization, event persistence with categories.
+
+---
+
 ## A2A Extensions
 
 ### Registered Extensions

--- a/docs/agentic-runtime/a2a-integration.md
+++ b/docs/agentic-runtime/a2a-integration.md
@@ -300,6 +300,66 @@ visualization, event persistence with categories.
 
 ---
 
+## Event Data Format — TextPart vs DataPart
+
+### Current: JSON Strings in TextPart (v0)
+
+Today, EVENT_CATALOG events are serialized as NDJSON strings and wrapped in
+`TextPart`. This means structured data is **double-encoded** (JSON inside JSON):
+
+```json
+{"parts": [{"kind": "text", "text": "{\"type\":\"tool_call\",\"name\":\"shell\"}"}]}
+```
+
+The backend must split by `\n`, `json.loads()` each line, and check for
+`loop_id` to distinguish events from plain text. This is fragile and adds
+~30% wire overhead from JSON escaping.
+
+### Planned: Structured DataPart (v1)
+
+A2A SDK has `DataPart(data=dict)` — a native structured JSON container.
+Each event becomes a separate Part with no string encoding:
+
+```json
+{"parts": [
+  {"kind": "data", "data": {"type": "tool_call", "name": "shell", "event_index": 5}},
+  {"kind": "data", "data": {"type": "tool_result", "name": "shell", "output": "..."}},
+  {"kind": "text", "text": "Executed shell command ls -la"}
+]}
+```
+
+**DataParts** carry structured events for instrumented clients.
+**TextPart** carries a human-readable summary for plain A2A clients.
+Both in the same message — backward compatible.
+
+| Approach | Wire Size | Parsing | Type Safety |
+|----------|----------|---------|-------------|
+| TextPart + NDJSON (current) | ~3KB/event | Manual split + json.loads | None |
+| DataPart (planned) | ~2KB/event | `get_data_parts()` from SDK | `kind == "data"` discriminator |
+| Protobuf via gRPC (future) | ~400B/event | Generated stubs | Compile-time from .proto |
+
+### Transport: SSE vs gRPC
+
+A2A v1.0 supports both JSON-RPC/SSE and gRPC/protobuf. We use SSE today.
+
+| Dimension | SSE (current) | gRPC (future option) |
+|-----------|--------------|---------------------|
+| Browser support | Native (`fetch`) | Needs grpc-web proxy or Connect |
+| Wire size | ~2-5KB/event (JSON) | ~400B/event (protobuf binary) |
+| Debugging | Easy (curl, dev tools) | Harder (grpcurl, binary) |
+| Schema | None (runtime) | Compile-time from .proto |
+| Infrastructure | Nothing extra | Envoy or Connect runtime |
+| React support | Native | `@connectrpc/connect-web` (mature) |
+
+**Recommendation:** Switch to DataPart now (small change, 33% savings).
+Define protobuf schema for EVENT_CATALOG (type safety from .proto).
+Evaluate gRPC only when session history transfer exceeds ~1000 events.
+
+See [detailed design](../plans/2026-03-17-a2a-integration-design.md#7-textpart-vs-datapart--should-we-switch)
+for migration code examples and protobuf schema design.
+
+---
+
 ## A2A Extensions
 
 ### Registered Extensions

--- a/docs/agentic-runtime/agents.md
+++ b/docs/agentic-runtime/agents.md
@@ -1,0 +1,275 @@
+# Writing Agents
+
+This guide covers how to write a sandbox agent for the Kagenti Agentic Runtime.
+
+---
+
+## Architecture
+
+Every sandbox agent runs as an A2A (Agent-to-Agent) service inside a
+Kubernetes pod. The platform provides infrastructure layers (auth, security,
+workspace, budget) while the agent provides business logic.
+
+```
++-----------------------------------------------+
+|  Platform Base (entrypoint.py)                 |
+|  - Plugin loading (AGENT_MODULE env var)       |
+|  - WorkspaceManager (per-context isolation)    |
+|  - PermissionChecker (ALLOW/DENY/HITL)         |
+|  - SourcesConfig (capabilities)                |
+|  - A2A server (Starlette + Uvicorn)            |
++-----------------------------------------------+
+|  Agent Plugin (your code)                      |
+|  - get_agent_card() -> AgentCard               |
+|  - build_executor() -> AgentExecutor           |
++-----------------------------------------------+
+```
+
+## Plugin Contract
+
+Every agent framework adapter must export two functions:
+
+### `get_agent_card(host, port) -> AgentCard`
+
+Returns A2A metadata describing your agent:
+
+```python
+from a2a.types import AgentCard, AgentCapabilities, AgentSkill
+
+def get_agent_card(host: str, port: int) -> AgentCard:
+    return AgentCard(
+        name="My Agent",
+        description="A coding agent that does X",
+        version="1.0.0",
+        url=f"http://{host}:{port}/",
+        capabilities=AgentCapabilities(streaming=True),
+        skills=[
+            AgentSkill(
+                id="my_skill",
+                name="My Skill",
+                description="What this agent does",
+                tags=["coding", "shell"],
+            )
+        ],
+    )
+```
+
+### `build_executor(workspace_manager, permission_checker, sources_config) -> AgentExecutor`
+
+Returns an executor that handles requests with platform services injected:
+
+```python
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+
+def build_executor(workspace_manager, permission_checker, sources_config, **kwargs):
+    return MyExecutor(workspace_manager, permission_checker, sources_config)
+
+class MyExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        user_input = context.get_user_input()
+        context_id = context.current_task.context_id
+
+        # 1. Resolve workspace
+        workspace = self._workspace_manager.ensure_workspace(context_id)
+
+        # 2. Run your agent logic
+        result = await self._run_agent(user_input, workspace)
+
+        # 3. Emit A2A events
+        task_updater = TaskUpdater(event_queue, context.current_task.id, context_id)
+        await task_updater.update_status(TaskState.working, ...)
+        await task_updater.add_artifact([TextPart(text=result)])
+        await task_updater.complete()
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        pass  # Optional: handle cancellation
+```
+
+## Instrumentation Contract
+
+Beyond the plugin contract, agents should implement two instrumentation
+components to enable the full UI experience (graph views, event persistence):
+
+### FrameworkEventSerializer
+
+Translates your framework's native events into the universal EVENT_CATALOG
+format (see [Concepts](./concepts.md#event-categories)):
+
+```python
+from abc import ABC, abstractmethod
+
+class FrameworkEventSerializer(ABC):
+    @abstractmethod
+    def serialize(self, key: str, value: dict) -> str:
+        """Translate a framework event into EVENT_CATALOG JSON line(s).
+
+        Args:
+            key: Framework-specific event identifier
+            value: Event payload
+
+        Returns:
+            Newline-delimited JSON. Each line must include {"type": "..."}
+        """
+```
+
+Each JSON line must include the common event fields:
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | string | Yes -- event type from catalog |
+| `loop_id` | string | Yes -- unique per reasoning loop invocation |
+| `langgraph_node` | string | Yes -- logical processing stage name |
+| `node_visit` | int | Yes -- monotonic counter |
+| `event_index` | int | Yes -- global sequence number |
+| `model` | string | If LLM call |
+| `prompt_tokens` | int | If LLM call |
+| `completion_tokens` | int | If LLM call |
+
+### AgentGraphCard
+
+Expose a graph card at `/.well-known/agent-graph-card.json` describing your
+agent's event catalog and graph topology:
+
+```python
+def build_graph_card(compiled_graph, agent_id="my_agent"):
+    return {
+        "id": agent_id,
+        "framework": "my_framework",
+        "version": "1.0",
+        "event_catalog": {
+            "planner_output": {
+                "category": "reasoning",
+                "description": "Agent created a plan",
+                "has_llm_call": True,
+                "fields": {"steps": "List[str]"},
+            },
+            "tool_call": {
+                "category": "execution",
+                "description": "Tool invoked",
+                "has_llm_call": False,
+                "fields": {"name": "str", "args": "str"},
+            },
+            # ... other event types
+        },
+        "common_event_fields": { ... },
+        "topology": {
+            "nodes": {
+                "planner": "Creates plan from user request",
+                "executor": "Runs tools",
+                "reporter": "Final answer",
+            },
+            "edges": [
+                {"source": "__start__", "target": "planner"},
+                {"source": "planner", "target": "executor"},
+                {"source": "executor", "target": "reporter"},
+                {"source": "reporter", "target": "__end__"},
+            ],
+            "entry_node": "planner",
+        },
+    }
+```
+
+The LangGraph reference implementation introspects the compiled graph
+programmatically via `compiled_graph.get_graph()`. For simpler frameworks
+(ReAct loops), a static topology is sufficient.
+
+## Dockerfile
+
+Agents are built on the platform base image:
+
+```dockerfile
+FROM kagenti-agent-base:latest
+
+# Install your framework
+RUN pip install my-framework
+
+# Copy your agent code
+COPY agents/my_agent/ /app/my_agent/
+
+# Set the plugin module
+ENV AGENT_MODULE=my_agent.plugin
+
+# Platform base entrypoint handles everything else
+CMD ["python", "-m", "platform_base.entrypoint"]
+```
+
+The base image provides:
+- Python 3.12-slim
+- Platform base modules (workspace, permissions, sources, entrypoint)
+- A2A SDK
+- `/workspace` directory
+- Non-root user (UID 1001)
+
+## Kubernetes Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-agent
+  namespace: team1
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: agent
+          image: my-agent:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: AGENT_MODULE
+              value: my_agent.plugin
+            - name: LLM_API_BASE
+              value: http://llm-budget-proxy:8080
+            - name: LLM_MODEL
+              value: llama-4-scout-17b
+            - name: TASK_STORE_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-sessions-secret
+                  key: connection-string
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+      volumes:
+        - name: workspace
+          emptyDir:
+            sizeLimit: 5Gi
+```
+
+## Reference: LangGraph Agent Structure
+
+The reference sandbox agent (`a2a/sandbox_agent/`) demonstrates the full
+implementation:
+
+```
+sandbox_agent/
+├── agent.py              # A2A server entry point
+├── graph.py              # LangGraph state & graph builder
+├── reasoning.py          # Plan-execute-reflect nodes (1700+ lines)
+├── executor.py           # Shell execution with permission checks
+├── permissions.py        # Permission validator
+├── budget.py             # Token/iteration/time limits
+├── event_serializer.py   # LangGraph -> EVENT_CATALOG (697 lines)
+├── event_schema.py       # Event type definitions
+├── graph_card.py         # AgentGraphCard builder (580 lines)
+├── observability.py      # OpenTelemetry setup
+├── workspace.py          # Per-context workspace manager
+├── landlock_ctypes.py    # Landlock LSM wrapper (193 lines)
+├── landlock_probe.py     # Kernel capability probe
+├── subagents.py          # Explore & delegate tools
+├── plan_store.py         # Plan persistence
+├── prompts.py            # System prompts
+└── sources.py            # Configuration
+```
+
+See the [Multi-Framework Runtime](./multi-framework.md) guide for adapting
+other frameworks.

--- a/docs/agentic-runtime/api-reference.md
+++ b/docs/agentic-runtime/api-reference.md
@@ -1,0 +1,148 @@
+# API Reference
+
+All routes are gated behind feature flags. When `KAGENTI_FEATURE_FLAG_SANDBOX`
+is `false`, these routes do not exist.
+
+---
+
+## Sandbox Sessions
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/sandbox/{namespace}/sessions` | List sessions with pagination and search |
+| GET | `/api/v1/sandbox/{namespace}/sessions/{context_id}` | Get session with full history and artifacts |
+| GET | `/api/v1/sandbox/{namespace}/sessions/{context_id}/chain` | Get session lineage chain (parent/child) |
+| GET | `/api/v1/sandbox/{namespace}/sessions/{context_id}/history` | Paginated session history |
+| DELETE | `/api/v1/sandbox/{namespace}/sessions/{context_id}` | Delete session (owner or admin only) |
+| POST | `/api/v1/sandbox/{namespace}/sessions/{context_id}/kill` | Cancel running session |
+| POST | `/api/v1/sandbox/{namespace}/cleanup` | Mark stale tasks as failed (TTL-based) |
+
+## Sandbox Chat & Streaming
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/sandbox/{namespace}/chat` | Send message to agent via A2A JSON-RPC |
+| POST | `/api/v1/sandbox/{namespace}/chat/stream` | Stream agent response via SSE |
+| GET | `/api/v1/sandbox/{namespace}/sessions/{session_id}/subscribe` | Subscribe to running session event stream |
+
+## Sandbox Events
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/sandbox/{namespace}/events` | Get paginated events for a session/task |
+| GET | `/api/v1/sandbox/{namespace}/tasks/paginated` | Get paginated task summaries |
+
+## Sandbox Agents
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/sandbox/{namespace}/agents` | List agent deployments with session counts |
+| GET | `/api/v1/sandbox/{namespace}/agent-card/{agent_name}` | Proxy A2A agent card from agent pod |
+| GET | `/api/v1/sandbox/{namespace}/agents/{agent_name}/pod-status` | Get pod status, events, resources |
+| GET | `/api/v1/sandbox/{namespace}/pods/{agent_name}/metrics` | Get CPU/memory metrics |
+| GET | `/api/v1/sandbox/{namespace}/pods/{agent_name}/events` | Get Kubernetes events for agent pods |
+
+## Sandbox Deployment
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/sandbox/defaults` | Get backend default sandbox creation values |
+| POST | `/api/v1/sandbox/{namespace}/create` | Deploy new sandbox agent |
+| DELETE | `/api/v1/sandbox/{namespace}/{name}` | Delete sandbox agent and resources |
+| GET | `/api/v1/sandbox/{namespace}/{name}/config` | Get wizard config from deployment annotations |
+| PUT | `/api/v1/sandbox/{namespace}/{name}` | Update sandbox configuration |
+
+## File Browser
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/sandbox/{namespace}/files/{agent_name}` | Browse files in agent pod |
+| GET | `/api/v1/sandbox/{namespace}/files/{agent_name}/list` | List directory contents |
+| GET | `/api/v1/sandbox/{namespace}/files/{agent_name}/content` | Read file content |
+| GET | `/api/v1/sandbox/{namespace}/files/{agent_name}/{context_id}` | Browse session workspace |
+| GET | `/api/v1/sandbox/{namespace}/stats/{agent_name}` | Get storage statistics |
+
+## Sidecar Management
+
+Gated behind `KAGENTI_FEATURE_FLAG_SANDBOX`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/sidecar/{namespace}` | Deploy sidecar to namespace |
+| GET | `/api/v1/sidecar/{namespace}/{pod_name}/logs` | Get sidecar logs |
+| POST | `/api/v1/sidecar/{namespace}/{pod_name}/health` | Check sidecar health |
+| POST | `/api/v1/sidecar/{namespace}/{pod_name}/restart` | Restart sidecar pod |
+| PUT | `/api/v1/sidecar/{namespace}/{pod_name}/config` | Update sidecar config |
+| GET | `/api/v1/sidecar/{namespace}/{pod_name}/ready` | Check sidecar readiness |
+
+## Token Usage & LLM Keys
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/token-usage/{namespace}` | Get token usage stats |
+| GET | `/api/v1/token-usage/{namespace}/{agent_name}` | Get usage for specific agent |
+| GET | `/api/v1/llm/{namespace}` | Get namespace LLM keys |
+| POST | `/api/v1/llm/teams/{namespace}` | Create LLM key team |
+| POST | `/api/v1/llm/keys/{namespace}` | Create new LLM key |
+| GET | `/api/v1/llm/{namespace}/{key_name}` | Get key details |
+| DELETE | `/api/v1/llm/{namespace}/{key_name}` | Delete LLM key |
+| GET | `/api/v1/llm/{namespace}/agent-models` | Get per-agent model overrides |
+| GET | `/api/v1/models` | List available LLM models |
+
+## Triggers
+
+Gated behind `KAGENTI_FEATURE_FLAG_TRIGGERS`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/sandbox/trigger` | Create sandbox from trigger event |
+
+## Configuration
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/config/features` | Get enabled feature flags |
+
+---
+
+## SSE Event Format
+
+When streaming via `/chat/stream` or `/subscribe`, events are sent as
+Server-Sent Events with JSON payloads:
+
+```
+event: message
+data: {"type": "planner_output", "loop_id": "abc123", "langgraph_node": "planner", ...}
+
+event: message
+data: {"type": "tool_call", "loop_id": "abc123", "langgraph_node": "executor", ...}
+
+event: message
+data: {"type": "reporter_output", "loop_id": "abc123", "langgraph_node": "reporter", ...}
+```
+
+Each event includes the common fields defined in
+[Concepts](./concepts.md#event-categories).
+
+## Error Responses
+
+Standard error format:
+
+```json
+{
+  "detail": "Session not found",
+  "status_code": 404
+}
+```
+
+Budget exceeded (from LLM Budget Proxy):
+
+```json
+{
+  "error": {
+    "type": "budget_exceeded",
+    "tokens_used": 1050000,
+    "tokens_budget": 1000000
+  }
+}
+```

--- a/docs/agentic-runtime/concepts.md
+++ b/docs/agentic-runtime/concepts.md
@@ -1,0 +1,184 @@
+# Concepts
+
+This document explains the core concepts of the Kagenti Agentic Runtime.
+
+---
+
+## Sessions
+
+A **session** is a multi-turn conversation between a user and a sandbox agent.
+Each session has a unique `context_id` (UUID) that persists across messages
+within the same conversation.
+
+- Sessions are stored in a per-namespace PostgreSQL database
+- Each message within a session creates an A2A **task** (submitted -> working -> completed/failed)
+- The UI groups tasks by `context_id` to show conversation history
+- Sessions track metadata: agent name, owner, model override, budget limits
+
+## Sandbox Agents
+
+A **sandbox agent** is an AI coding agent running in a Kubernetes pod with
+the platform's security and infrastructure layers. The agent receives user
+messages via the A2A protocol, reasons about the task, executes tools, and
+streams results back.
+
+Agents are deployed per-namespace (e.g. `team1`) with their own:
+- PostgreSQL database (sessions + LLM budget tracking)
+- Egress proxy (Squid domain allowlist)
+- LLM Budget Proxy (token enforcement)
+- Workspace volume (per-session file isolation)
+
+## Reasoning Loop
+
+The reference sandbox agent (LangGraph) uses a **plan-execute-reflect** loop
+with 5 nodes:
+
+```mermaid
+flowchart TD
+    Start([User message]) --> Router
+
+    Router{"Router<br/>Check plan_status"}
+    Router -->|"new"| Planner
+    Router -->|"resume"| Executor
+
+    subgraph Loop["Reasoning Loop (budget-bounded)"]
+        Planner["Planner<br/>Create numbered plan"] --> Executor
+        Executor["Executor<br/>Run tools + micro-reasoning"] --> Reflector
+        Reflector{"Reflector<br/>Assess progress"}
+        Reflector -->|"continue"| Executor
+        Reflector -->|"replan"| Planner
+        Reflector -->|"done"| Reporter
+    end
+
+    Reporter["Reporter<br/>Final answer"] --> End([Response])
+```
+
+1. **Router** checks `plan_status` to decide: start fresh or resume existing plan
+2. **Planner** decomposes the user request into numbered steps
+3. **Executor** runs plan steps with bound tools (shell, file_read, file_write, web_fetch, explore, delegate). After each tool call, **micro-reasoning** interprets the result before deciding the next action
+4. **Reflector** evaluates progress and decides: continue, replan, done, or request HITL approval
+5. **Reporter** synthesizes the final answer for the user
+
+Budget enforcement happens at every node via the LLM Budget Proxy (HTTP 402
+on exceed).
+
+## Event Pipeline
+
+The event pipeline streams reasoning loop events from agent to UI in real-time
+and persists them for historical reconstruction.
+
+**Six-stage flow:**
+
+1. **Agent emits events** -- typed JSON events (planner_output, tool_call,
+   tool_result, reflector_decision, reporter_output, etc.) with monotonic
+   `event_index` and `langgraph_node` annotations
+2. **AgentGraphCard** -- agent exposes `/.well-known/agent-graph-card.json`
+   describing its event catalog and graph topology
+3. **SSE forwarding** -- backend proxies events to the UI via Server-Sent Events
+4. **Background consumer** -- standalone `asyncio.Task` persists every event
+   to the `events` table, independent of UI connection
+5. **Historical reconstruction** -- on session load, UI reconstructs from
+   events table (preferred), loop_events blob (fallback), or raw history
+6. **Gap-fill reconnect** -- on SSE disconnect, UI fetches missed events
+   from `GET /events?from_index=N` before resubscribing
+
+### Event Categories
+
+Events are organized into 7 categories:
+
+| Category | Event Types | UI Rendering |
+|----------|------------|-------------|
+| **reasoning** | planner_output, thinking, micro_reasoning, executor_step | Plan steps, thinking blocks |
+| **execution** | tool_call | Tool call cards |
+| **tool_output** | tool_result | Tool result display |
+| **decision** | reflector_decision, router_decision | Decision badges |
+| **terminal** | reporter_output, error | Final answer, error |
+| **meta** | budget_update, node_transition | Hidden from steps, used for graph counters |
+| **interaction** | hitl_request | HITL approval buttons |
+
+## AgentGraphCard
+
+The **AgentGraphCard** is a self-describing manifest exposed at
+`/.well-known/agent-graph-card.json`. It has two layers:
+
+1. **Event Catalog** -- every event type the agent can emit, with categories,
+   fields, and debug fields. The UI uses this to know what to render.
+2. **Topology** -- the agent's processing graph (nodes and edges). The UI
+   uses this to render the Topology Graph View without hardcoded knowledge
+   of the agent's structure.
+
+This enables framework-neutral graph visualization -- as long as an agent
+exposes a graph card, the UI can render its graph regardless of whether
+it's LangGraph, OpenCode, CrewAI, or any other framework.
+
+See [Writing Agents](./agents.md) for how to implement a graph card.
+
+## Feature Flags
+
+The Agentic Runtime is gated behind three feature flags:
+
+| Flag | What It Gates |
+|------|--------------|
+| `KAGENTI_FEATURE_FLAG_SANDBOX` | All sandbox routes, sessions, sidecars, RBAC, deploy API |
+| `KAGENTI_FEATURE_FLAG_INTEGRATIONS` | Integrations page |
+| `KAGENTI_FEATURE_FLAG_TRIGGERS` | Trigger management (cron, webhook, alert) |
+
+When disabled (default), the backend doesn't register sandbox routes and the
+UI hides sandbox pages. Zero footprint on the platform.
+
+See [Configuration](./configuration.md) for details.
+
+## LLM Budget Enforcement
+
+Token budgets prevent runaway consumption. A **per-namespace LLM Budget Proxy**
+intercepts all LLM calls between the agent and LiteLLM:
+
+- **Within budget**: forwards request to LiteLLM, records usage
+- **Exceeded**: returns HTTP 402 with structured error; agent gracefully stops
+
+Three enforcement scopes: per-session (default 1M tokens), per-agent daily
+(5M), per-agent monthly (50M).
+
+See [Deployment](./deployment.md) for budget proxy setup.
+
+## Human-in-the-Loop (HITL)
+
+HITL gates allow users to approve or deny dangerous operations before the
+agent executes them. When a tool requires approval:
+
+1. Agent emits `hitl_request` event with tool name, args, and risk level
+2. UI renders Approve/Deny buttons in the chat
+3. User clicks Approve or Deny
+4. Agent resumes with approval (executes tool) or denial (reflector replans)
+
+## Sidecar Agents
+
+Sidecar agents run alongside the primary sandbox agent and observe its
+behavior without modifying the agent code:
+
+- **Looper** -- auto-continue when agent pauses mid-task (partial)
+- **Hallucination Observer** -- monitor for hallucinated paths/APIs (designed)
+- **Context Guardian** -- track context window usage (designed)
+
+Sidecars subscribe to the same SSE event stream as the UI and can trigger
+HITL requests or inject messages.
+
+## Composable Security
+
+Security layers are composable -- operators toggle individual layers per agent:
+
+| Layer | Mechanism | Always On? |
+|-------|-----------|-----------|
+| L1 | Keycloak OIDC authentication | Yes |
+| L2 | Kubernetes RBAC per namespace | Yes |
+| L3 | Istio Ambient mTLS | Yes |
+| L4 | SecurityContext (non-root, drop ALL) | Toggle |
+| L5 | NetworkPolicy (default-deny) | Toggle |
+| L6 | Landlock filesystem isolation | Toggle |
+| L7 | Egress proxy (Squid allowlist) | Toggle |
+| L8 | HITL approval gates | Yes |
+
+Named profiles combine layers for common use cases: `legion` (dev),
+`basic` (trusted), `hardened` (production), `restricted` (third-party).
+
+See [Security](./security.md) for details.

--- a/docs/agentic-runtime/configuration.md
+++ b/docs/agentic-runtime/configuration.md
@@ -1,0 +1,176 @@
+# Configuration
+
+---
+
+## Feature Flags
+
+The Agentic Runtime is gated behind three feature flags that flow from Helm
+values through backend environment variables to the UI config endpoint.
+
+```
+Helm values.yaml          Backend env var                    UI config endpoint
+-----------------          ---------------                   ------------------
+featureFlags:              KAGENTI_FEATURE_FLAG_SANDBOX      GET /api/v1/config/features
+  sandbox: false    -->    KAGENTI_FEATURE_FLAG_INTEGRATIONS -->  { sandbox: bool,
+  integrations: false      KAGENTI_FEATURE_FLAG_TRIGGERS           integrations: bool,
+  triggers: false                                                  triggers: bool }
+```
+
+| Flag | What It Gates | Default | OCP |
+|------|--------------|---------|-----|
+| `SANDBOX` | All sandbox routes, sessions, sidecars, RBAC, deploy API | `false` | `true` |
+| `INTEGRATIONS` | Integrations page (external service connections) | `false` | `true` |
+| `TRIGGERS` | Trigger management (cron, webhook, alert -> agent) | `false` | `true` |
+
+### Backend Behavior
+
+When a flag is `false`, the backend skips importing the corresponding router
+modules. The routes simply don't exist -- no 403, no error, just not registered.
+
+Each feature-flagged module uses `try/except ImportError` so that missing
+dependencies (only installed when the feature is enabled) don't crash the
+backend.
+
+### RBAC Scoping
+
+When `SANDBOX` is `false`, the backend ClusterRole does NOT include
+pods/exec, secrets, or configmaps permissions. These are only added when the
+flag is enabled, preventing cluster-wide privilege escalation when sandbox
+is off.
+
+---
+
+## Helm Values
+
+Key values in `charts/kagenti/values.yaml`:
+
+### Feature Flags
+
+```yaml
+featureFlags:
+  sandbox: false
+  integrations: false
+  triggers: false
+```
+
+### Agent Namespaces
+
+```yaml
+agentNamespaces:
+  - team1
+  - team2
+```
+
+Each namespace gets:
+- Istio Ambient mesh enrollment
+- PostgreSQL `postgres-sessions` StatefulSet (when sandbox enabled)
+- RBAC roles for the backend service account
+
+---
+
+## Environment Variables
+
+### Backend (FastAPI)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KAGENTI_FEATURE_FLAG_SANDBOX` | Enable sandbox routes | `false` |
+| `KAGENTI_FEATURE_FLAG_INTEGRATIONS` | Enable integrations routes | `false` |
+| `KAGENTI_FEATURE_FLAG_TRIGGERS` | Enable trigger routes | `false` |
+| `KEYCLOAK_URL` | Keycloak OIDC provider URL | -- |
+| `KEYCLOAK_REALM` | Keycloak realm name | `kagenti` |
+
+### Sandbox Agent
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AGENT_MODULE` | Python module implementing plugin contract | -- |
+| `LLM_API_BASE` | LLM endpoint (usually budget proxy) | `http://llm-budget-proxy:8080` |
+| `LLM_MODEL` | Default LLM model | `llama-4-scout-17b` |
+| `SANDBOX_LANDLOCK` | Enable Landlock filesystem isolation | `false` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry collector endpoint | -- |
+| `TASK_STORE_DB_URL` | PostgreSQL connection for A2A task store | -- |
+| `WORKSPACE_ROOT` | Root directory for per-session workspaces | `/workspace` |
+| `SKILL_REPOS` | Comma-separated git URLs for skill loading | -- |
+
+### LLM Budget Proxy
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LITELLM_URL` | LiteLLM proxy endpoint | `http://litellm-proxy.kagenti-system:4000` |
+| `DATABASE_URL` | PostgreSQL connection for budget tracking | -- |
+
+### Egress Proxy (Squid)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ALLOWED_DOMAINS` | Space-separated domain allowlist | -- |
+
+---
+
+## Budget Limits
+
+Default budget limits inserted by the LLM Budget Proxy on startup:
+
+| Scope | Default | Window |
+|-------|---------|--------|
+| Per-session | 1,000,000 tokens | None (session-scoped) |
+| Per-agent daily | 5,000,000 tokens | 24h rolling |
+| Per-agent monthly | 50,000,000 tokens | 30d rolling |
+
+These can be overridden by inserting rows into the `budget_limits` table
+in the `llm_budget` database.
+
+---
+
+## Permission Rules
+
+Agent permissions are configured in `settings.json` using the three-tier
+system (ALLOW / DENY / HITL):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "shell(grep:*)",
+      "shell(find:*)",
+      "shell(cat:*)",
+      "file(read:/workspace/**)",
+      "file(write:/workspace/**)"
+    ],
+    "deny": [
+      "shell(rm:-rf *)",
+      "shell(curl:*)",
+      "network(outbound:*)"
+    ]
+  }
+}
+```
+
+Rules use `type(prefix:glob)` format. Commands not matching allow or deny
+rules default to HITL (human-in-the-loop approval).
+
+## Source Capabilities
+
+Agent capabilities are declared in `sources.json`:
+
+```json
+{
+  "package_managers": {
+    "pip": { "enabled": true, "blocked_packages": ["os", "subprocess"] }
+  },
+  "git": {
+    "enabled": true,
+    "allowed_remotes": ["github.com/kagenti/*"]
+  },
+  "web": {
+    "enabled": true,
+    "allowed_domains": ["api.github.com", "pypi.org"],
+    "blocked_domains": ["malware.example.com"]
+  },
+  "runtime": {
+    "max_execution_time_seconds": 300,
+    "max_memory_mb": 4096
+  }
+}
+```

--- a/docs/agentic-runtime/deployment.md
+++ b/docs/agentic-runtime/deployment.md
@@ -1,0 +1,206 @@
+# Deployment
+
+---
+
+## Components per Namespace
+
+Each agent namespace (e.g. `team1`) gets these components:
+
+| Component | Type | Purpose |
+|-----------|------|---------|
+| `postgres-sessions` | StatefulSet | Sessions DB + LLM budget DB |
+| `llm-budget-proxy` | Deployment | Per-session token enforcement |
+| Sandbox agent(s) | Deployment | Agent pods (one per variant) |
+| Egress proxy | Deployment | Squid domain allowlist (optional, per agent) |
+
+Platform-wide components in `kagenti-system`:
+
+| Component | Purpose |
+|-----------|---------|
+| `kagenti-backend` | FastAPI backend with sandbox routes |
+| `kagenti-ui` | React frontend |
+| `litellm-proxy` | Model routing and spend tracking |
+| `keycloak` | OIDC provider |
+| `kagenti-webhook` (in `kagenti-webhook-system`) | Mutating webhook that injects AuthBridge sidecars into agent pods |
+| `spire-server` / `spire-agent` | Workload identity |
+| `otel-collector` | Trace collection |
+| `phoenix` | LLM observability |
+
+---
+
+## Deploy Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `kind-full-test.sh` | Full platform on Kind (all components) |
+| `38-deploy-litellm.sh` | LiteLLM proxy to kagenti-system |
+| `76-deploy-sandbox-agents.sh` | Sandbox agents, PostgreSQL, budget proxy |
+| `35-deploy-agent-sandbox.sh` | Agent-sandbox CRDs (SandboxTemplate, SandboxClaim) |
+
+### 76-deploy-sandbox-agents.sh
+
+This is the main sandbox deployment script. It:
+
+1. Creates the `postgres-sessions` StatefulSet with two databases:
+   - `sessions` -- session metadata, events, tasks, checkpoints
+   - `llm_budget` -- LLM call tracking, budget limits
+2. Builds the LLM budget proxy image (OpenShift BuildConfig or local build)
+3. Deploys sandbox agent variant(s) with selected security profile
+4. Creates egress proxy if the profile includes L7
+
+---
+
+## Database Setup
+
+### PostgreSQL StatefulSet
+
+Each namespace gets a `postgres-sessions` StatefulSet deployed from
+`deployments/sandbox/postgres-sessions.yaml`:
+
+- User: `kagenti`
+- Password: from `postgres-sessions-secret` (default: `kagenti-sessions-dev`)
+- Databases: `sessions`, `llm_budget`
+- Storage: PVC (production) or emptyDir (dev)
+
+### Auto-Migration
+
+Tables are created automatically:
+
+| Tables | Created By | When |
+|--------|-----------|------|
+| `sessions`, `events` | Backend auto-migration | On backend startup |
+| `tasks` | A2A SDK `DatabaseTaskStore` | On first task creation |
+| `checkpoints`, `checkpoint_writes`, `checkpoint_blobs` | LangGraph `AsyncPostgresSaver.setup()` | On agent startup |
+| `llm_calls`, `budget_limits` | LLM Budget Proxy | On proxy startup |
+
+No manual schema setup is needed.
+
+### Connection Strings
+
+| Client | DSN |
+|--------|-----|
+| Backend | `postgresql://kagenti:<pw>@postgres-sessions.<ns>:5432/sessions` |
+| Agent | `postgresql://kagenti:<pw>@postgres-sessions.<ns>:5432/sessions` |
+| Budget Proxy | `postgresql://kagenti:<pw>@postgres-sessions.<ns>:5432/llm_budget` |
+
+SSL is disabled at the application level -- Istio Ambient ztunnel provides mTLS.
+
+---
+
+## LLM Budget Proxy
+
+Deployed from `deployments/sandbox/llm-budget-proxy.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-budget-proxy
+  namespace: team1
+spec:
+  containers:
+    - name: proxy
+      image: llm-budget-proxy:latest
+      env:
+        - name: LITELLM_URL
+          value: http://litellm-proxy.kagenti-system.svc.cluster.local:4000
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: postgres-sessions-secret
+              key: llm-budget-db-url
+      ports:
+        - containerPort: 8080
+      resources:
+        requests: { cpu: 50m, memory: 128Mi }
+        limits: { cpu: 200m, memory: 256Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-budget-proxy
+  namespace: team1
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+```
+
+Agents set `LLM_API_BASE=http://llm-budget-proxy:8080` to route all LLM
+calls through the proxy.
+
+---
+
+## Platform Base Image
+
+The platform base image (`deployments/sandbox/platform_base/`) provides
+common infrastructure for all framework adapters:
+
+```
+platform_base/
+├── entrypoint.py      # Plugin loader + A2A server bootstrap
+├── permissions.py     # Three-tier permission checker
+├── sources.py         # Capability declarations
+├── workspace.py       # Per-context workspace isolation
+└── requirements.txt   # Platform dependencies
+```
+
+Build the base image:
+
+```bash
+docker build -f deployments/sandbox/Dockerfile.base \
+  -t kagenti-agent-base:latest \
+  deployments/sandbox/
+```
+
+Framework adapters extend this image (see [Writing Agents](./agents.md)).
+
+---
+
+## Agent Manifests
+
+### Directory Structure
+
+```
+deployments/sandbox/
+├── agents/
+│   ├── legion/           # LangGraph persistent agent
+│   │   ├── Dockerfile
+│   │   ├── deployment.yaml
+│   │   └── ...
+│   └── opencode/         # OpenCode adapter (WIP)
+│       ├── Dockerfile
+│       ├── plugin.py
+│       └── deployment.yaml
+├── platform_base/        # Shared base image
+├── proxy/                # Squid egress proxy
+│   ├── Dockerfile
+│   ├── squid.conf
+│   └── entrypoint.sh
+├── llm-budget-proxy.yaml
+├── postgres-sessions.yaml
+├── sandbox_profile.py    # Security profile builder
+└── agent_server.py       # A2A server utilities
+```
+
+### Agent Container Resources
+
+| Container | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|-----------|------------|-----------|---------------|-------------|
+| Agent | 250m | 2 | 512Mi | 4Gi |
+| Egress Proxy | 50m | 200m | 128Mi | 256Mi |
+| Budget Proxy | 50m | 200m | 128Mi | 256Mi |
+
+---
+
+## Helm Chart
+
+The main Helm chart (`charts/kagenti/`) manages:
+
+- Feature flag env vars on backend and UI deployments
+- Agent namespace creation with Istio Ambient labels
+- PostgreSQL secrets in agent namespaces
+- RBAC roles scoped by feature flags
+
+Key template: `charts/kagenti/templates/agent-namespaces.yaml` creates
+per-namespace resources when `featureFlags.sandbox` is `true`.

--- a/docs/agentic-runtime/multi-framework.md
+++ b/docs/agentic-runtime/multi-framework.md
@@ -1,0 +1,250 @@
+# Multi-Framework Runtime
+
+> **Status: WIP** -- LangGraph is shipped. OpenCode adapter in progress.
+> Claude Agent SDK, OpenHands, CrewAI, AG2 are designed.
+
+The Agentic Runtime is framework-neutral. The platform owns infrastructure
+while agents provide business logic. This guide covers how different
+frameworks integrate via the instrumentation contract.
+
+---
+
+## Overview
+
+Every framework adapter bridges two contracts:
+
+1. **Plugin Contract** -- `get_agent_card()` + `build_executor()` -- makes the
+   agent an A2A service (see [Writing Agents](./agents.md))
+2. **Instrumentation Contract** -- `FrameworkEventSerializer` +
+   `AgentGraphCardBuilder` -- enables graph views, event persistence, and
+   debugging in the UI (see [Concepts](./concepts.md#agentgraphcard))
+
+```
++---------------------------------------------------------------+
+|  Platform Layer (always present)                               |
++---------------------------------------------------------------+
+|  Instrumentation Contract                                      |
+|  FrameworkEventSerializer     AgentGraphCardBuilder            |
++---------------------------------------------------------------+
+|  Framework Adapters                                            |
+|  LangGraph   OpenCode   Claude SDK   CrewAI   AG2   OpenHands |
++---------------------------------------------------------------+
+|  Agent Business Logic                                          |
++---------------------------------------------------------------+
+```
+
+---
+
+## Framework Status
+
+| Framework | Language | Plugin | Serializer | Graph Card | Status |
+|-----------|----------|--------|------------|------------|--------|
+| **LangGraph** | Python | Native | `LangGraphSerializer` | Introspects compiled graph | **Shipped** |
+| **OpenCode** | Go | `opencode/plugin.py` | Polling only (no events yet) | Static ReAct topology | **WIP** |
+| **Claude Agent SDK** | Python | Designed | Async iterator + hooks | Static ReAct topology | **Designed** |
+| **OpenHands** | Python | Designed | EventStream subscriber | Multi-node topology | **Designed** |
+| **CrewAI** | Python | Designed | BaseEventListener | Agent-per-node | **Designed** |
+| **AG2** | Python | Designed | AG-UI SSE or OTel spans | Multi-agent dynamic | **Designed** |
+
+---
+
+## LangGraph (Shipped)
+
+The reference implementation. LangGraph agents run natively in the platform
+base image with full instrumentation.
+
+**Interception:** `stream_mode='updates'` yields `(node_name, state_dict)` tuples.
+The `LangGraphSerializer` (697 lines) translates these into EVENT_CATALOG events.
+
+**Graph card:** `build_graph_card()` introspects `compiled_graph.get_graph()`
+to extract nodes and edges programmatically. Conditional edges appear as
+multiple edges from the same source.
+
+**Key files:**
+- `event_serializer.py` -- LangGraph -> EVENT_CATALOG translation
+- `graph_card.py` -- Graph introspection + event catalog
+- `event_schema.py` -- Event type dataclasses
+
+---
+
+## OpenCode (WIP)
+
+[OpenCode](https://opencode.ai/) is a Go-based coding agent CLI. It runs as
+a subprocess (`opencode serve`) with an HTTP API.
+
+**Current state:** `OpenCodeExecutor` starts OpenCode, creates sessions via
+REST, and polls for responses every 5 seconds. Emits only basic A2A task
+status updates -- no EVENT_CATALOG events.
+
+**WIP plan:**
+
+1. Replace polling with SSE client consuming OpenCode's `/event` stream
+2. Create `OpenCodeSerializer` mapping `entity.action` events:
+
+| OpenCode Event | EVENT_CATALOG Type | Category |
+|---------------|-------------------|----------|
+| `message.part.updated` | `thinking` | reasoning |
+| `tool.execute.before` | `tool_call` | execution |
+| `tool.execute.after` | `tool_result` | tool_output |
+| `session.idle` | `reporter_output` | terminal |
+| `session.error` | `error` | terminal |
+| `permission.asked` | `hitl_request` | interaction |
+
+3. Static topology (simple ReAct loop):
+```json
+{
+  "nodes": {
+    "assistant": "LLM reasoning and tool selection",
+    "tools": "Tool execution (shell, file, browser)"
+  },
+  "edges": [
+    {"source": "__start__", "target": "assistant"},
+    {"source": "assistant", "target": "tools"},
+    {"source": "tools", "target": "assistant"},
+    {"source": "assistant", "target": "__end__"}
+  ]
+}
+```
+
+**Key challenge:** OpenCode's SSE stream is session-scoped (all events on one
+stream). Must filter by `sessionID` to isolate events for the current A2A
+context.
+
+---
+
+## Claude Agent SDK (Designed)
+
+The [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python)
+wraps Claude Code's agent loop. `query()` returns an async iterator of
+typed messages.
+
+**Interception:** Async iterator yields 5 message types + 19 hook events.
+
+| Claude SDK Type | EVENT_CATALOG Type | Category |
+|----------------|-------------------|----------|
+| `AssistantMessage` (text) | `thinking` | reasoning |
+| `AssistantMessage` (tool_use) | `tool_call` | execution |
+| `UserMessage` (tool_result) | `tool_result` | tool_output |
+| `StreamEvent` (text delta) | `thinking` | reasoning |
+| `ResultMessage(success)` | `reporter_output` | terminal |
+| `ResultMessage(error_*)` | `error` | terminal |
+| `Notification(permission_prompt)` | `hitl_request` | interaction |
+
+**Hooks:** `PreToolUse` and `PostToolUse` fire out-of-band (not in context
+window). Can enrich tool_call/tool_result events with metadata.
+
+**Topology:** Static ReAct loop (same as OpenCode).
+
+---
+
+## CrewAI (Designed)
+
+[CrewAI](https://crewai.com/) uses a task-oriented multi-agent model with
+`BaseEventListener` for observation.
+
+**Interception:** `@bus.on(EventType)` decorators. Richest event taxonomy
+(40+ event types).
+
+| CrewAI Event | EVENT_CATALOG Type | Category |
+|-------------|-------------------|----------|
+| `LLMCallCompletedEvent` | `thinking` | reasoning |
+| `AgentExecutionStartedEvent` | `executor_step` | reasoning |
+| `TaskStartedEvent` | `planner_output` | reasoning |
+| `ToolUsageStartedEvent` | `tool_call` | execution |
+| `ToolUsageFinishedEvent` | `tool_result` | tool_output |
+| `TaskEvaluationEvent` | `reflector_decision` | decision |
+| `TaskCompletedEvent` | `reporter_output` | terminal |
+| `CrewKickoffFailedEvent` | `error` | terminal |
+
+**Topology:** Constructed from `Crew(agents, tasks, process)` definition.
+Each agent becomes a node; edges follow the process type (sequential or
+hierarchical).
+
+---
+
+## AG2 / AutoGen (Designed)
+
+[AG2](https://ag2.ai/) supports multi-agent conversations with native
+OpenTelemetry instrumentation.
+
+**Interception:** Three options:
+1. `AGUIStream` SSE events (AG-UI protocol) -- best for streaming
+2. `instrument_agent()` OTel spans -- best for observability
+3. Python logger (`ag2.event.processor`) -- most complete
+
+| AG-UI Event | EVENT_CATALOG Type | Category |
+|------------|-------------------|----------|
+| `TEXT_MESSAGE_CONTENT` | `thinking` | reasoning |
+| `TOOL_CALL_START` | `tool_call` | execution |
+| `TOOL_CALL_RESULT` | `tool_result` | tool_output |
+| `RUN_FINISHED` | `reporter_output` | terminal |
+| `RUN_ERROR` | `error` | terminal |
+| `STATE_SNAPSHOT` | `budget_update` | meta |
+
+**Topology:** Multi-agent with dynamic speaker selection. The graph card
+captures the declared topology; runtime deviations appear as
+`node_transition` events.
+
+**Key advantage:** AG2 has native OTel with GenAI semantic conventions.
+The adapter could consume OTel spans via a SpanProcessor rather than
+re-instrumenting.
+
+---
+
+## OpenHands (Designed)
+
+[OpenHands](https://openhands.dev/) (formerly OpenDevin) uses an
+event-sourced model with Action/Observation pairs.
+
+**Interception:** V0: `EventStreamSubscriber` callback. V1 SDK (target):
+WebSocket `ConversationStateUpdateEvent`.
+
+| OpenHands Event | EVENT_CATALOG Type | Category |
+|----------------|-------------------|----------|
+| `AgentThinkAction` | `thinking` | reasoning |
+| `CmdRunAction` | `tool_call` | execution |
+| `FileEditAction` | `tool_call` | execution |
+| `CmdOutputObservation` | `tool_result` | tool_output |
+| `AgentFinishAction` | `reporter_output` | terminal |
+| `ErrorObservation` | `error` | terminal |
+| `AgentDelegateAction` | `reflector_decision` | decision |
+| `UserRejectObservation` | `hitl_request` | interaction |
+
+**Topology:** Multi-node: controller, runtime, browser, delegate.
+
+---
+
+## Graph Card Generation
+
+Each framework has a different way to determine the topology:
+
+| Framework | Source | Method |
+|-----------|--------|--------|
+| LangGraph | `compiled_graph.get_graph()` | Programmatic introspection |
+| OpenCode | Static | Hardcoded ReAct topology |
+| Claude Agent SDK | Static | Hardcoded ReAct topology |
+| OpenHands | Agent class structure | Introspect action handlers |
+| CrewAI | `Crew(agents, tasks)` | Introspect crew definition |
+| AG2 | `GroupChat(agents)` | Introspect speaker transitions |
+
+**Static vs dynamic:**
+- **Static:** OpenCode, Claude SDK -- simple ReAct loops
+- **Semi-static:** LangGraph, CrewAI -- defined at build time
+- **Dynamic:** AG2, OpenHands -- may change during execution
+
+For dynamic topologies, the graph card captures the initial/declared
+structure. Runtime deviations appear as `node_transition` meta-events.
+
+---
+
+## Adding a New Framework
+
+1. Create `agents/my_framework/plugin.py` with `get_agent_card()` and
+   `build_executor()` (see [Writing Agents](./agents.md))
+2. Create `agents/my_framework/serializer.py` implementing
+   `FrameworkEventSerializer`
+3. Create `agents/my_framework/graph_card.py` implementing
+   `AgentGraphCardBuilder`
+4. Create `agents/my_framework/Dockerfile` extending `kagenti-agent-base`
+5. Set `AGENT_MODULE=my_framework.plugin` in the deployment
+6. Write parity tests verifying EVENT_CATALOG output

--- a/docs/agentic-runtime/operator-alignment.md
+++ b/docs/agentic-runtime/operator-alignment.md
@@ -1,0 +1,368 @@
+# Operator Alignment
+
+How the Agentic Runtime connects to the kagenti-operator CRDs and what
+needs to change to make agent deployment declarative.
+
+> **Epic:** [#862 — AgentRuntime CR](https://github.com/kagenti/kagenti/issues/862)
+> **Operator repo:** kagenti/kagenti-operator
+
+---
+
+## The Problem
+
+The Agentic Runtime is currently **script-driven** (imperative). The
+operator is **CR-driven** (declarative). They need to converge.
+
+```mermaid
+flowchart TB
+    subgraph today["Today: Two Parallel Paths"]
+        direction TB
+
+        subgraph scripts["Script Path (Agentic Runtime)"]
+            S1["76-deploy-sandbox-agents.sh"]
+            S2["Creates Deployment + Service"]
+            S3["Creates PostgreSQL StatefulSet"]
+            S4["Creates Budget Proxy"]
+            S5["sandbox_profile.py computes security"]
+            S1 --> S2 --> S3 --> S4
+            S5 --> S2
+        end
+
+        subgraph operator["CR Path (Operator)"]
+            O1["Agent CR"]
+            O2["Controller creates Deployment + Service"]
+            O3["AgentCard CR indexes agent card"]
+            O4["AgentBuild CR builds images"]
+            O1 --> O2
+            O3 -.-> O2
+        end
+    end
+
+    subgraph target["Target: Unified CR Path"]
+        direction TB
+        T1["AgentRuntime CR"]
+        T2["Agent CR (or Deployment)"]
+        T3["Controller manages labels + infra"]
+        T4["Webhook injects sidecars"]
+        T5["AgentCard indexes card + graph card"]
+
+        T1 -->|"targetRef"| T2
+        T1 --> T3
+        T3 -->|"labels"| T4
+        T5 -.->|"fetches"| T2
+    end
+```
+
+---
+
+## What the Operator Has Today
+
+| CRD | Purpose | Status |
+|-----|---------|--------|
+| **Agent** | Deployment wrapper (podTemplateSpec, imageSource, replicas, servicePorts) | Complete |
+| **AgentBuild** | Source-to-image via Tekton pipelines | Complete |
+| **AgentCard** | Indexes `/.well-known/agent-card.json` from agents | Complete |
+| **AgentRuntime** | Declarative sidecar injection + config | **Not yet implemented** (#862) |
+
+## What the Agentic Runtime Adds (Not in Operator)
+
+| Component | How It's Managed Today | Where It Should Live |
+|-----------|----------------------|---------------------|
+| Composable security (L4-L7) | `sandbox_profile.py` (Python, backend) | AgentRuntime CR `spec.security` |
+| PostgreSQL per namespace | `76-deploy-sandbox-agents.sh` (script) | Namespace CR or AgentRuntime controller |
+| LLM Budget Proxy per namespace | `76-deploy-sandbox-agents.sh` (script) | Namespace CR or AgentRuntime controller |
+| Egress Proxy per agent | `sandbox_profile.py` (script) | AgentRuntime CR `spec.security.egress` |
+| Feature flags | Helm values → backend env → UI config | Helm values (stay) |
+| Agent import wizard | Backend REST API → kubectl | Backend → creates Agent CR |
+| Event serialization | Agent-side `FrameworkEventSerializer` | Agent-side (stay) |
+| AgentGraphCard | Agent-side `/.well-known/agent-graph-card.json` | AgentCard CR could index it |
+| Session DB schema | Backend auto-migration on startup | Stay (backend concern) |
+
+---
+
+## Alignment Map
+
+### 1. Agent Deployment
+
+```mermaid
+flowchart LR
+    subgraph today_deploy["Today"]
+        Script["76-deploy script"] --> Deployment["kubectl create Deployment"]
+        Wizard["Import Wizard API"] --> Deployment
+    end
+
+    subgraph target_deploy["Target"]
+        AgentCR["Agent CR"] --> Controller["Agent Controller"]
+        Controller --> Deployment2["Creates Deployment"]
+        WizardCR["Import Wizard API"] --> AgentCR
+    end
+
+    today_deploy --> |"migrate"| target_deploy
+```
+
+**Today:** Scripts and the backend import wizard create raw Kubernetes
+Deployments. The operator has an `Agent` CRD that does the same thing
+declaratively, but the Agentic Runtime doesn't use it.
+
+**Target:** The import wizard should create `Agent` CRs. The operator
+controller creates the Deployment, Service, and RBAC. The backend
+watches Agent CRs for discovery instead of DNS-based resolution.
+
+**Changes needed:**
+- Backend import wizard: `POST /sandbox/{ns}/create` → creates Agent CR
+- Backend agent discovery: watch Agent CRs (or continue DNS, both work)
+- Deploy scripts: create Agent CRs instead of raw Deployments
+
+### 2. AuthBridge Injection
+
+```mermaid
+flowchart LR
+    subgraph today_auth["Today"]
+        Label["Manual label:<br/>kagenti.io/inject: enabled"] --> Webhook["Webhook injects sidecars"]
+    end
+
+    subgraph target_auth["Target (#862)"]
+        ARCR["AgentRuntime CR<br/>spec.identity"] --> Controller2["AgentRuntime Controller"]
+        Controller2 --> Label2["Applies label to PodTemplateSpec"]
+        Label2 --> Webhook2["Webhook injects sidecars"]
+    end
+
+    today_auth --> |"migrate"| target_auth
+```
+
+**This is well-designed in #862.** AgentRuntime CR replaces manual labels
+with declarative config. The webhook behavior stays the same — only the
+label management changes from manual to controller-driven.
+
+**Our docs impact:** `security.md` should mention AgentRuntime CR as the
+declarative way to configure AuthBridge instead of manual labels.
+
+### 3. Composable Security Profiles
+
+```mermaid
+flowchart TB
+    subgraph today_sec["Today: Python-driven"]
+        Profile["sandbox_profile.py"]
+        Profile --> |"SandboxProfile(secctx=True,<br/>landlock=True, proxy=True)"| Manifest["Builds Deployment YAML<br/>with security layers"]
+    end
+
+    subgraph target_sec["Target: CR-driven"]
+        ARCR2["AgentRuntime CR"]
+        ARCR2 --> |"spec.security.profile: hardened"| Controller3["Controller resolves profile"]
+        Controller3 --> |"Applies layers"| Labels3["Labels + annotations<br/>on PodTemplateSpec"]
+    end
+```
+
+**Gap in #862:** The AgentRuntime CR has `spec.identity` and `spec.trace`
+but **no `spec.security` section** for composable layers (L4-L7). This
+is critical for the Agentic Runtime.
+
+**Proposed addition to AgentRuntime spec:**
+
+```yaml
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: sandbox-legion
+  namespace: team1
+spec:
+  type: agent
+  targetRef:
+    kind: Deployment
+    name: sandbox-legion
+  security:
+    profile: hardened              # preset: legion|basic|hardened|restricted
+    # OR individual layer toggles:
+    securityContext: true           # L4: non-root, drop ALL
+    landlock: true                  # L6: per-tool-call filesystem isolation
+    egressProxy:                    # L7: Squid domain allowlist
+      enabled: true
+      allowedDomains:
+        - api.github.com
+        - pypi.org
+  identity:
+    spiffe:
+      trustDomain: kagenti.io
+    clientRegistration:
+      provider: keycloak
+      realm: kagenti
+  trace:
+    endpoint: otel-collector.kagenti-system:4317
+    sampling:
+      rate: 1.0
+```
+
+### 4. Per-Namespace Infrastructure
+
+```mermaid
+flowchart TB
+    subgraph today_ns["Today: Script creates per-namespace"]
+        Script2["76-deploy script"] --> PG["postgres-sessions StatefulSet"]
+        Script2 --> BP["llm-budget-proxy Deployment"]
+        Script2 --> Secrets["postgres-sessions-secret"]
+    end
+
+    subgraph target_ns["Target: CR or Helm manages"]
+        option_a["Option A: AgentRuntime controller<br/>detects first agent in namespace<br/>→ provisions infra automatically"]
+        option_b["Option B: Helm chart<br/>agent-namespaces.yaml already<br/>creates secrets + labels"]
+        option_c["Option C: New AgentNamespace CR<br/>explicit namespace provisioning"]
+    end
+```
+
+**Gap in #862:** No mechanism for per-namespace infrastructure (PostgreSQL,
+budget proxy). The AgentRuntime CR is per-workload, not per-namespace.
+
+**Options:**
+- **A: Controller auto-provisions** — When first AgentRuntime CR is created
+  in a namespace, controller ensures postgres + budget proxy exist. Simple
+  but implicit.
+- **B: Helm chart (current)** — `agent-namespaces.yaml` already creates
+  per-namespace resources. Works but requires Helm upgrade to add namespaces.
+- **C: AgentNamespace CRD** — Explicit namespace provisioning with quotas,
+  features, members. Matches the TUI's `kagenti team create` flow.
+
+**Recommendation:** Option B (Helm) for near-term, Option C for full
+declarative lifecycle. Option A is too magical.
+
+### 5. AgentCard + AgentGraphCard
+
+```mermaid
+flowchart LR
+    subgraph today_card["Today"]
+        Agent3["Agent exposes<br/>/.well-known/agent-card.json"]
+        Graph["Agent exposes<br/>/.well-known/agent-graph-card.json"]
+        Backend3["Backend fetches both<br/>via httpx at runtime"]
+    end
+
+    subgraph target_card["Target"]
+        AgentCardCR["AgentCard CR<br/>indexes agent-card.json<br/>(already exists)"]
+        GraphIndex["AgentCard CR also indexes<br/>agent-graph-card.json<br/>(if extension present)"]
+        Backend4["Backend reads from<br/>AgentCard CR status"]
+    end
+
+    today_card --> |"migrate"| target_card
+```
+
+**The operator already indexes agent cards** via the AgentCard CRD. But
+it doesn't index graph cards. The controller could check for the
+`urn:kagenti:agent-graph-card:v1` extension in the agent card, fetch the
+graph card endpoint, and cache it in the AgentCard status.
+
+**Changes needed in operator:**
+- AgentCard controller: if `extensions` contains graph card URI, also fetch
+  `/.well-known/agent-graph-card.json` and store in `status.graphCard`
+- Backend: read graph card from AgentCard CR status instead of runtime fetch
+
+---
+
+## What #862 Is Missing for Sandbox Agents
+
+| Missing from #862 | Why It Matters | Priority |
+|-------------------|---------------|----------|
+| `spec.security.profile` | Composable L4-L7 layers (secctx, landlock, egress proxy) | P0 |
+| `spec.security.egressProxy` | Per-agent Squid allowlist | P1 |
+| `spec.llm.model` | Default LLM model for the agent | P1 |
+| `spec.llm.budgetProxy` | Link to budget proxy service | P2 |
+| `spec.workspace.storage` | EmptyDir vs PVC for workspace | P2 |
+| `spec.workspace.ttlDays` | Workspace TTL | P2 |
+| Per-namespace infra provisioning | PostgreSQL, budget proxy, secrets | P1 |
+| Graph card indexing in AgentCard | Cache graph card in CR status | P2 |
+
+**What #862 already covers well:**
+- AuthBridge injection via labels (the core problem)
+- Config hash for rolling updates (clean GitOps)
+- Duck-typed targetRef (works with any workload kind)
+- Identity overrides (SPIFFE trust domain, Keycloak realm)
+- Trace config (OTel endpoint, sampling rate)
+- Finalizer handling (graceful cleanup)
+
+---
+
+## What Changes on Our Side
+
+### Docs Changes
+
+| File | Change |
+|------|--------|
+| `deployment.md` | Add CR-based deployment path alongside scripts |
+| `security.md` | Show AgentRuntime CR as declarative security config |
+| `configuration.md` | Add AgentRuntime CR as config mechanism |
+| `agents.md` | Show Agent CRD as deployment target |
+| `quickstart.md` | Keep script path (quickest for Kind dev) |
+
+### Code Changes (Future)
+
+| Component | Change | Priority |
+|-----------|--------|----------|
+| Import wizard | Create Agent CR instead of raw Deployment | P1 |
+| Backend agent discovery | Watch Agent/AgentCard CRs (optional, DNS still works) | P2 |
+| Deploy scripts | Create Agent CRs + AgentRuntime CRs | P1 |
+| `sandbox_profile.py` | Move logic to AgentRuntime controller (Go) | P2 |
+| TUI `kagenti team create` | Create AgentNamespace CR (if Option C) | P2 |
+
+---
+
+## The Full Picture
+
+```mermaid
+flowchart TB
+    subgraph user["User Actions"]
+        Deploy["Deploy agent<br/>(wizard or kubectl)"]
+        Config["Configure security<br/>(wizard or CR)"]
+        Provision["Provision namespace<br/>(TUI or Helm)"]
+    end
+
+    subgraph crs["Custom Resources"]
+        AgentCR["Agent CR<br/><small>podTemplateSpec, imageSource,<br/>replicas, servicePorts</small>"]
+        RuntimeCR["AgentRuntime CR<br/><small>targetRef, security profile,<br/>identity, trace, LLM config</small>"]
+        CardCR["AgentCard CR<br/><small>indexes agent-card.json<br/>+ agent-graph-card.json</small>"]
+    end
+
+    subgraph controllers["Controllers"]
+        AgentCtrl["Agent Controller<br/><small>Creates Deployment,<br/>Service, RBAC</small>"]
+        RuntimeCtrl["AgentRuntime Controller<br/><small>Applies labels,<br/>provisions infra</small>"]
+        CardCtrl["AgentCard Controller<br/><small>Fetches + caches<br/>agent/graph cards</small>"]
+    end
+
+    subgraph webhook_layer["Webhook"]
+        Webhook["AuthBridge Webhook<br/><small>Injects sidecars at<br/>Pod CREATE time</small>"]
+    end
+
+    subgraph runtime["Runtime"]
+        Pod["Agent Pod<br/><small>Agent + AuthBridge +<br/>spiffe-helper sidecars</small>"]
+        Infra["Namespace Infra<br/><small>PostgreSQL, budget proxy,<br/>egress proxy</small>"]
+    end
+
+    subgraph backend_layer["Platform"]
+        Backend5["Backend<br/><small>Reads AgentCard CRs<br/>Manages sessions/events</small>"]
+        UI2["UI / TUI<br/><small>Renders based on<br/>graph card from CR</small>"]
+    end
+
+    Deploy --> AgentCR
+    Config --> RuntimeCR
+    Provision --> Infra
+
+    AgentCR --> AgentCtrl --> Pod
+    RuntimeCR --> RuntimeCtrl
+    RuntimeCtrl -->|"labels"| Pod
+    RuntimeCtrl -->|"provisions"| Infra
+    Pod --> Webhook -->|"injects"| Pod
+    CardCR --> CardCtrl -->|"fetches card"| Pod
+
+    CardCtrl --> Backend5 --> UI2
+```
+
+---
+
+## Phased Convergence
+
+| Phase | What | Owner |
+|-------|------|-------|
+| **Now** | Script-based deployment works, docs describe current state | Agentic Runtime team |
+| **#862 Phase 1** | AgentRuntime CRD + controller for label management | Operator team |
+| **#862 Phase 2** | Webhook coordination (inject at Pod CREATE) | Extensions team |
+| **Post-#862** | Add `spec.security` to AgentRuntime for composable layers | Both teams |
+| **Post-#862** | Import wizard creates Agent CRs, not raw Deployments | Agentic Runtime team |
+| **Post-#862** | AgentCard controller indexes graph cards | Operator team |
+| **Post-#862** | Namespace provisioning (Helm or AgentNamespace CRD) | Platform team |
+| **Post-#862** | `sandbox_profile.py` logic moves to AgentRuntime controller | Both teams |

--- a/docs/agentic-runtime/operator-alignment.md
+++ b/docs/agentic-runtime/operator-alignment.md
@@ -64,6 +64,59 @@ flowchart TB
 | **AgentCard** | Indexes `/.well-known/agent-card.json` from agents | Complete |
 | **AgentRuntime** | Declarative sidecar injection + config | **Not yet implemented** (#862) |
 
+## What the Agentic Runtime Deploys Today
+
+### Per-Namespace Resources (created by deploy script)
+
+| Resource | Type | Purpose |
+|----------|------|---------|
+| `postgres-sessions` | StatefulSet + Service + PVC | Two databases: `sessions` (session/event/checkpoint tables) and `llm_budget` (call tracking + limits) |
+| `postgres-sessions-secret` | Secret | Connection strings for both databases |
+| `llm-budget-proxy` | Deployment + Service | Per-session token enforcement (HTTP 402) |
+| `authbridge-config` | ConfigMap | Keycloak token URL, issuer, audience |
+| `envoy-config` | ConfigMap | Envoy listener config for AuthBridge sidecar |
+| `litellm-virtual-keys` | Secret | Per-namespace LLM API key |
+
+### Per-Agent Resources (created by deploy script per variant)
+
+| Resource | Type | Purpose |
+|----------|------|---------|
+| Agent Deployment | Deployment | Agent pod (1 replica, workspace volume) |
+| Agent Service | Service | ClusterIP on port 8000 |
+| Egress Proxy | Deployment + Service | **Optional** — Squid domain allowlist (only for hardened/restricted profiles) |
+| Route | Route (OpenShift only) | External access with TLS edge termination |
+
+### Database Schemas (auto-created at startup, not by scripts)
+
+Each component creates its own tables — **the agent deploys its own DB schema**:
+
+| Component | Database | Tables Created | Created By |
+|-----------|----------|---------------|------------|
+| **Backend** | `sessions` | `sessions`, `events` | Auto-migration on backend startup |
+| **A2A SDK** | `sessions` | `tasks` | `DatabaseTaskStore` on first task |
+| **Agent (LangGraph)** | `sessions` | `langgraph_checkpoint`, `langgraph_checkpoint_blobs`, `langgraph_writes` | `AsyncPostgresSaver.setup()` on agent startup |
+| **Budget Proxy** | `llm_budget` | `llm_calls`, `budget_limits` | Auto-migration on proxy startup |
+
+This means **8 tables across 2 databases** are auto-created by 4 different
+components. No manual schema management. The operator needs to be aware that
+agents bring their own schema — it's not just a pod, it's a pod that
+provisions database tables on startup.
+
+### Per-Session Resources (created at runtime by agent)
+
+| Resource | Location | Purpose |
+|----------|----------|---------|
+| Workspace directory | `/workspace/{context_id}/` | Per-session file isolation |
+| Workspace subdirs | `scripts/`, `data/`, `repos/`, `output/` | Organized workspace |
+| Context metadata | `.context.json` | Created timestamp, TTL, disk usage |
+| Checkpoint rows | `langgraph_checkpoint` table | LangGraph state snapshots for session resume |
+
+### Skills (loaded at agent startup)
+
+Agents clone skill repos from `SKILL_REPOS` env var at startup. Skills
+are git repositories containing prompts, tools, and workflow definitions.
+This is agent-side and doesn't need operator support.
+
 ## What the Agentic Runtime Adds (Not in Operator)
 
 | Component | How It's Managed Today | Where It Should Live |
@@ -71,12 +124,16 @@ flowchart TB
 | Composable security (L4-L7) | `sandbox_profile.py` (Python, backend) | AgentRuntime CR `spec.security` |
 | PostgreSQL per namespace | `76-deploy-sandbox-agents.sh` (script) | Namespace CR or AgentRuntime controller |
 | LLM Budget Proxy per namespace | `76-deploy-sandbox-agents.sh` (script) | Namespace CR or AgentRuntime controller |
-| Egress Proxy per agent | `sandbox_profile.py` (script) | AgentRuntime CR `spec.security.egress` |
+| Egress Proxy per agent | `sandbox_profile.py` (optional, per profile) | AgentRuntime CR `spec.security.egressProxy` |
+| Agent DB schema (checkpoints) | Agent auto-creates tables on startup | Agent-side (stay — operator doesn't need to manage) |
+| Budget DB schema | Budget proxy auto-creates tables on startup | Budget proxy side (stay) |
+| Session DB schema | Backend auto-creates tables on startup | Backend side (stay) |
+| Workspace directories | Agent creates per-session at runtime | Agent-side (stay) |
 | Feature flags | Helm values → backend env → UI config | Helm values (stay) |
 | Agent import wizard | Backend REST API → kubectl | Backend → creates Agent CR |
 | Event serialization | Agent-side `FrameworkEventSerializer` | Agent-side (stay) |
 | AgentGraphCard | Agent-side `/.well-known/agent-graph-card.json` | AgentCard CR could index it |
-| Session DB schema | Backend auto-migration on startup | Stay (backend concern) |
+| Skills loading | Agent clones git repos at startup | Agent-side (stay) |
 
 ---
 

--- a/docs/agentic-runtime/operator-alignment.md
+++ b/docs/agentic-runtime/operator-alignment.md
@@ -29,10 +29,9 @@ flowchart TB
         end
 
         subgraph operator["CR Path (Operator)"]
-            O1["Agent CR"]
-            O2["Controller creates Deployment + Service"]
+            O1["AgentRuntime CR<br/><small>targetRef → Deployment</small>"]
+            O2["Controller applies labels"]
             O3["AgentCard CR indexes agent card"]
-            O4["AgentBuild CR builds images"]
             O1 --> O2
             O3 -.-> O2
         end
@@ -40,16 +39,16 @@ flowchart TB
 
     subgraph target["Target: Unified CR Path"]
         direction TB
-        T1["AgentRuntime CR"]
-        T2["Agent CR (or Deployment)"]
+        T1["Developer Deployment<br/><small>(clean, no kagenti labels)</small>"]
+        T2["AgentRuntime CR<br/><small>targetRef → Deployment</small>"]
         T3["Controller manages labels + infra"]
         T4["Webhook injects sidecars"]
         T5["AgentCard indexes card + graph card"]
 
-        T1 -->|"targetRef"| T2
-        T1 --> T3
+        T2 -->|"targetRef"| T1
+        T2 --> T3
         T3 -->|"labels"| T4
-        T5 -.->|"fetches"| T2
+        T5 -.->|"fetches"| T1
     end
 ```
 
@@ -59,10 +58,103 @@ flowchart TB
 
 | CRD | Purpose | Status |
 |-----|---------|--------|
-| **Agent** | Deployment wrapper (podTemplateSpec, imageSource, replicas, servicePorts) | Complete |
-| **AgentBuild** | Source-to-image via Tekton pipelines | Complete |
+| **AgentRuntime** | Declarative sidecar injection + config. `targetRef` points to a standard Deployment. | [Phase 1 PR](https://github.com/kagenti/kagenti-operator/pull/218) |
 | **AgentCard** | Indexes `/.well-known/agent-card.json` from agents | Complete |
-| **AgentRuntime** | Declarative sidecar injection + config | **Not yet implemented** (#862) |
+| **AgentBuild** | Source-to-image via Tekton pipelines | Complete |
+
+> **Note:** The [consolidated design (PR #770)](https://github.com/kagenti/kagenti/pull/770)
+> establishes that **AgentRuntime CR targets standard Deployments**.
+> Developers deploy a clean Deployment and create an AgentRuntime CR with
+> `targetRef` pointing to it. The controller applies labels, the webhook
+> injects sidecars. Developer manifests stay clean.
+
+## Deployed Structure (Controller-Managed)
+
+What a fully controller-managed agent namespace looks like:
+
+```mermaid
+flowchart TB
+    subgraph ns["team1 namespace"]
+        subgraph managed_by_cr["Managed by AgentRuntime CR"]
+            subgraph pod["sandbox-legion Pod"]
+                AB_S["AuthBridge sidecars<br/><small>envoy-proxy :15123/:15124<br/>spiffe-helper<br/>client-registration<br/>(injected by webhook)</small>"]
+                Agent["Agent Container :8000<br/><small>LangGraph reasoning loop<br/>auto-creates checkpoint tables</small>"]
+            end
+
+            EgressDep["Egress Proxy (optional)<br/><small>Squid :3128<br/>domain allowlist</small>"]
+        end
+
+        subgraph namespace_infra["Per-Namespace Infra (script/Helm today, controller future)"]
+            PG["postgres-sessions<br/><small>StatefulSet :5432<br/>2 databases</small>"]
+            BP["llm-budget-proxy<br/><small>Deployment :8080<br/>auto-creates budget tables</small>"]
+            Secrets["Secrets<br/><small>postgres-sessions-secret<br/>litellm-virtual-keys</small>"]
+            CMs["ConfigMaps<br/><small>authbridge-config<br/>envoy-config</small>"]
+        end
+
+        subgraph card["Managed by AgentCard CR"]
+            AC["AgentCard CR<br/><small>indexes agent-card.json<br/>+ graph-card.json (planned)</small>"]
+        end
+    end
+
+    subgraph webhook_ns["kagenti-webhook-system"]
+        Webhook["Webhook Controller<br/><small>Injects sidecars into<br/>labeled pods</small>"]
+    end
+
+    subgraph operator_ns["kagenti-operator-system"]
+        RuntimeCtrl2["AgentRuntime Controller<br/><small>Applies labels + config-hash<br/>to PodTemplateSpec</small>"]
+        CardCtrl2["AgentCard Controller<br/><small>Fetches card from agent</small>"]
+    end
+
+    RuntimeCtrl2 -->|"labels + hash"| pod
+    Webhook -->|"injects sidecars"| pod
+    CardCtrl2 -->|"GET /.well-known/"| Agent
+    Agent -->|"asyncpg"| PG
+    BP -->|"asyncpg"| PG
+    Agent -->|"HTTP"| BP
+    Agent -->|"HTTP_PROXY"| EgressDep
+```
+
+## Database Access Model
+
+Who can access what — isolation boundaries per database and table:
+
+```mermaid
+flowchart TB
+    subgraph pg["postgres-sessions StatefulSet (port 5432)"]
+        subgraph sessions_db["Database: sessions"]
+            T_sessions["sessions table<br/><small>Written by: Backend<br/>Read by: Backend, UI</small>"]
+            T_events["events table<br/><small>Written by: Backend (consumer)<br/>Read by: Backend, UI</small>"]
+            T_tasks["tasks table<br/><small>Written by: A2A SDK (in agent)<br/>Read by: Backend</small>"]
+            T_ckpt["langgraph_checkpoint<br/><small>Written by: Agent<br/>Read by: Agent only</small>"]
+            T_blobs["langgraph_checkpoint_blobs<br/><small>Written by: Agent<br/>Read by: Agent only</small>"]
+            T_writes["langgraph_writes<br/><small>Written by: Agent<br/>Read by: Agent only</small>"]
+        end
+
+        subgraph budget_db["Database: llm_budget"]
+            T_calls["llm_calls<br/><small>Written by: Budget Proxy<br/>Read by: Budget Proxy, Backend</small>"]
+            T_limits["budget_limits<br/><small>Written by: Budget Proxy (defaults)<br/>Read by: Budget Proxy</small>"]
+        end
+    end
+
+    Backend["Backend<br/><small>kagenti-system</small>"]
+    Consumer["Background Consumer<br/><small>asyncio.Task in backend</small>"]
+    AgentPod["Agent Pod<br/><small>team1</small>"]
+    BudgetProxy["Budget Proxy<br/><small>team1</small>"]
+
+    Backend -->|"upsert"| T_sessions
+    Consumer -->|"INSERT"| T_events
+    AgentPod -->|"checkpoint writes"| T_ckpt & T_blobs & T_writes
+    AgentPod -->|"task CRUD (A2A SDK)"| T_tasks
+    BudgetProxy -->|"INSERT per LLM call"| T_calls
+    BudgetProxy -->|"read limits"| T_limits
+    Backend -->|"read usage"| T_calls
+```
+
+**Current:** All components use the same `kagenti` DB user with full access
+to all tables in their database. Application-level isolation only.
+
+**Target:** Schema-per-agent with scoped DB users (see
+[deployment.md](./deployment.md) — Current vs Target Schema Isolation).
 
 ## What the Agentic Runtime Deploys Today
 
@@ -130,7 +222,7 @@ This is agent-side and doesn't need operator support.
 | Session DB schema | Backend auto-creates tables on startup | Backend side (stay) |
 | Workspace directories | Agent creates per-session at runtime | Agent-side (stay) |
 | Feature flags | Helm values → backend env → UI config | Helm values (stay) |
-| Agent import wizard | Backend REST API → kubectl | Backend → creates Agent CR |
+| Agent import wizard | Backend REST API → kubectl | Backend → creates Deployment + AgentRuntime CR |
 | Event serialization | Agent-side `FrameworkEventSerializer` | Agent-side (stay) |
 | AgentGraphCard | Agent-side `/.well-known/agent-graph-card.json` | AgentCard CR could index it |
 | Skills loading | Agent clones git repos at startup | Agent-side (stay) |
@@ -149,26 +241,28 @@ flowchart LR
     end
 
     subgraph target_deploy["Target"]
-        AgentCR["Agent CR"] --> Controller["Agent Controller"]
-        Controller --> Deployment2["Creates Deployment"]
-        WizardCR["Import Wizard API"] --> AgentCR
+        Dep2["Deployment<br/>(clean manifest)"]
+        ARCR["AgentRuntime CR<br/>targetRef → Deployment"]
+        Controller["AgentRuntime Controller<br/>applies labels + hash"]
+        WizardCR["Import Wizard API"] --> Dep2
+        WizardCR --> ARCR
+        ARCR --> Controller
     end
 
     today_deploy --> |"migrate"| target_deploy
 ```
 
 **Today:** Scripts and the backend import wizard create raw Kubernetes
-Deployments. The operator has an `Agent` CRD that does the same thing
-declaratively, but the Agentic Runtime doesn't use it.
+Deployments with manual `kagenti.io/*` labels.
 
-**Target:** The import wizard should create `Agent` CRs. The operator
-controller creates the Deployment, Service, and RBAC. The backend
-watches Agent CRs for discovery instead of DNS-based resolution.
+**Target:** The import wizard creates a clean Deployment (no kagenti labels)
+plus an AgentRuntime CR with `targetRef` pointing to it. The controller
+applies labels and config-hash, the webhook injects sidecars.
 
 **Changes needed:**
-- Backend import wizard: `POST /sandbox/{ns}/create` → creates Agent CR
-- Backend agent discovery: watch Agent CRs (or continue DNS, both work)
-- Deploy scripts: create Agent CRs instead of raw Deployments
+- Backend import wizard: `POST /sandbox/{ns}/create` → creates Deployment + AgentRuntime CR
+- Deploy scripts: create Deployments + AgentRuntime CRs
+- Backend agent discovery: watch AgentCard CRs (or continue DNS, both work)
 
 ### 2. AuthBridge Injection
 
@@ -344,16 +438,16 @@ graph card endpoint, and cache it in the AgentCard status.
 | `deployment.md` | Add CR-based deployment path alongside scripts |
 | `security.md` | Show AgentRuntime CR as declarative security config |
 | `configuration.md` | Add AgentRuntime CR as config mechanism |
-| `agents.md` | Show Agent CRD as deployment target |
+| `agents.md` | Show Deployment + AgentRuntime CRD as deployment target |
 | `quickstart.md` | Keep script path (quickest for Kind dev) |
 
 ### Code Changes (Future)
 
 | Component | Change | Priority |
 |-----------|--------|----------|
-| Import wizard | Create Agent CR instead of raw Deployment | P1 |
+| Import wizard | Create Deployment + AgentRuntime CR instead of raw Deployment | P1 |
 | Backend agent discovery | Watch Agent/AgentCard CRs (optional, DNS still works) | P2 |
-| Deploy scripts | Create Agent CRs + AgentRuntime CRs | P1 |
+| Deploy scripts | Create Deployments + AgentRuntime CRs | P1 |
 | `sandbox_profile.py` | Move logic to AgentRuntime controller (Go) | P2 |
 | TUI `kagenti team create` | Create AgentNamespace CR (if Option C) | P2 |
 
@@ -369,15 +463,14 @@ flowchart TB
         Provision["Provision namespace<br/>(TUI or Helm)"]
     end
 
-    subgraph crs["Custom Resources"]
-        AgentCR["Agent CR<br/><small>podTemplateSpec, imageSource,<br/>replicas, servicePorts</small>"]
-        RuntimeCR["AgentRuntime CR<br/><small>targetRef, security profile,<br/>identity, trace, LLM config</small>"]
+    subgraph workloads["Workloads"]
+        Dep["Deployment<br/><small>Clean manifest,<br/>no kagenti labels</small>"]
+        RuntimeCR["AgentRuntime CR<br/><small>targetRef → Deployment<br/>security, identity, trace</small>"]
         CardCR["AgentCard CR<br/><small>indexes agent-card.json<br/>+ agent-graph-card.json</small>"]
     end
 
     subgraph controllers["Controllers"]
-        AgentCtrl["Agent Controller<br/><small>Creates Deployment,<br/>Service, RBAC</small>"]
-        RuntimeCtrl["AgentRuntime Controller<br/><small>Applies labels,<br/>provisions infra</small>"]
+        RuntimeCtrl["AgentRuntime Controller<br/><small>Applies labels + hash,<br/>provisions infra</small>"]
         CardCtrl["AgentCard Controller<br/><small>Fetches + caches<br/>agent/graph cards</small>"]
     end
 
@@ -395,11 +488,12 @@ flowchart TB
         UI2["UI / TUI<br/><small>Renders based on<br/>graph card from CR</small>"]
     end
 
-    Deploy --> AgentCR
+    Deploy --> Dep
+    Deploy --> RuntimeCR
     Config --> RuntimeCR
     Provision --> Infra
 
-    AgentCR --> AgentCtrl --> Pod
+    RuntimeCR -->|"targetRef"| Dep
     RuntimeCR --> RuntimeCtrl
     RuntimeCtrl -->|"labels"| Pod
     RuntimeCtrl -->|"provisions"| Infra
@@ -419,7 +513,7 @@ flowchart TB
 | **#862 Phase 1** | AgentRuntime CRD + controller for label management | Operator team |
 | **#862 Phase 2** | Webhook coordination (inject at Pod CREATE) | Extensions team |
 | **Post-#862** | Add `spec.security` to AgentRuntime for composable layers | Both teams |
-| **Post-#862** | Import wizard creates Agent CRs, not raw Deployments | Agentic Runtime team |
+| **Post-#862** | Import wizard creates Deployment + AgentRuntime CR | Agentic Runtime team |
 | **Post-#862** | AgentCard controller indexes graph cards | Operator team |
 | **Post-#862** | Namespace provisioning (Helm or AgentNamespace CRD) | Platform team |
 | **Post-#862** | `sandbox_profile.py` logic moves to AgentRuntime controller | Both teams |

--- a/docs/agentic-runtime/operator-alignment.md
+++ b/docs/agentic-runtime/operator-alignment.md
@@ -70,7 +70,11 @@ flowchart TB
 
 ## Deployed Structure (Controller-Managed)
 
-What a fully controller-managed agent namespace looks like:
+**Diagram 1: Namespace layout** — What a fully controller-managed agent
+namespace looks like. Shows which resources are managed by AgentRuntime CR
+(agent pod with sidecars, optional egress proxy), which are per-namespace
+infra (PostgreSQL, budget proxy, secrets), and which controllers manage what
+from their respective system namespaces.
 
 ```mermaid
 flowchart TB
@@ -116,45 +120,132 @@ flowchart TB
 
 ## Database Access Model
 
-Who can access what — isolation boundaries per database and table:
+### Current State: Shared User, Single Schema
+
+**Diagram 2: Current DB access** — All components connect as the same
+`kagenti` user with full access to all tables. No DB-level isolation
+between agents.
 
 ```mermaid
 flowchart TB
-    subgraph pg["postgres-sessions StatefulSet (port 5432)"]
-        subgraph sessions_db["Database: sessions"]
-            T_sessions["sessions table<br/><small>Written by: Backend<br/>Read by: Backend, UI</small>"]
-            T_events["events table<br/><small>Written by: Backend (consumer)<br/>Read by: Backend, UI</small>"]
-            T_tasks["tasks table<br/><small>Written by: A2A SDK (in agent)<br/>Read by: Backend</small>"]
-            T_ckpt["langgraph_checkpoint<br/><small>Written by: Agent<br/>Read by: Agent only</small>"]
-            T_blobs["langgraph_checkpoint_blobs<br/><small>Written by: Agent<br/>Read by: Agent only</small>"]
-            T_writes["langgraph_writes<br/><small>Written by: Agent<br/>Read by: Agent only</small>"]
+    subgraph pg["postgres-sessions.team1 (port 5432)"]
+        subgraph sessions_db["Database: sessions — Schema: public"]
+            T_sessions["public.sessions"]
+            T_events["public.events"]
+            T_tasks["public.tasks"]
+            T_ckpt["public.langgraph_checkpoint"]
+            T_blobs["public.langgraph_checkpoint_blobs"]
+            T_writes["public.langgraph_writes"]
         end
 
-        subgraph budget_db["Database: llm_budget"]
-            T_calls["llm_calls<br/><small>Written by: Budget Proxy<br/>Read by: Budget Proxy, Backend</small>"]
-            T_limits["budget_limits<br/><small>Written by: Budget Proxy (defaults)<br/>Read by: Budget Proxy</small>"]
+        subgraph budget_db["Database: llm_budget — Schema: public"]
+            T_calls["public.llm_calls"]
+            T_limits["public.budget_limits"]
         end
     end
 
-    Backend["Backend<br/><small>kagenti-system</small>"]
-    Consumer["Background Consumer<br/><small>asyncio.Task in backend</small>"]
-    AgentPod["Agent Pod<br/><small>team1</small>"]
-    BudgetProxy["Budget Proxy<br/><small>team1</small>"]
+    User_K["DB User: kagenti<br/><small>Password: postgres-sessions-secret<br/>FULL ACCESS to all tables</small>"]
 
-    Backend -->|"upsert"| T_sessions
-    Consumer -->|"INSERT"| T_events
-    AgentPod -->|"checkpoint writes"| T_ckpt & T_blobs & T_writes
-    AgentPod -->|"task CRUD (A2A SDK)"| T_tasks
-    BudgetProxy -->|"INSERT per LLM call"| T_calls
-    BudgetProxy -->|"read limits"| T_limits
-    Backend -->|"read usage"| T_calls
+    User_K --> sessions_db
+    User_K --> budget_db
+
+    Backend["Backend"] -->|"user: kagenti"| User_K
+    Agent["Agent"] -->|"user: kagenti"| User_K
+    BudgetProxy["Budget Proxy"] -->|"user: kagenti"| User_K
 ```
 
-**Current:** All components use the same `kagenti` DB user with full access
-to all tables in their database. Application-level isolation only.
+**Problem:** A compromised agent can read sessions from other agents,
+read budget limits, and even modify event records. No DB-level isolation.
 
-**Target:** Schema-per-agent with scoped DB users (see
-[deployment.md](./deployment.md) — Current vs Target Schema Isolation).
+### Target State: Schema-Per-Agent, Scoped Users
+
+**Diagram 3: Target DB access** — Each agent gets its own PostgreSQL
+schema (`{namespace}_{agent_name}`) and DB user (`kagenti_{agent}`).
+Platform tables stay in `public` schema. Agents can only access their own
+schema + read their own rows in `public.sessions` via Row-Level Security.
+
+```mermaid
+flowchart TB
+    subgraph pg2["postgres-sessions.team1 (port 5432)"]
+        subgraph sessions_db2["Database: sessions"]
+            subgraph schema_shared["Schema: public (platform-owned)"]
+                S_sessions["sessions<br/><small>Owner: kagenti_backend</small>"]
+                S_events["events<br/><small>Owner: kagenti_backend</small>"]
+            end
+
+            subgraph schema_legion["Schema: team1_sandbox_legion"]
+                L_tasks["tasks<br/><small>Owner: kagenti_legion</small>"]
+                L_ckpt["langgraph_checkpoint<br/><small>Owner: kagenti_legion</small>"]
+                L_blobs["langgraph_checkpoint_blobs<br/><small>Owner: kagenti_legion</small>"]
+                L_writes["langgraph_writes<br/><small>Owner: kagenti_legion</small>"]
+            end
+
+            subgraph schema_rca["Schema: team1_rca_agent"]
+                R_tasks["tasks<br/><small>Owner: kagenti_rca</small>"]
+                R_ckpt["langgraph_checkpoint<br/><small>Owner: kagenti_rca</small>"]
+            end
+        end
+
+        subgraph budget_db2["Database: llm_budget"]
+            subgraph schema_budget["Schema: public"]
+                B_calls["llm_calls<br/><small>Owner: kagenti_budget</small>"]
+                B_limits["budget_limits<br/><small>Owner: kagenti_budget</small>"]
+            end
+        end
+    end
+
+    subgraph users["DB Users (scoped GRANT)"]
+        U_backend["kagenti_backend<br/><small>sessions: RW public.sessions, public.events<br/>llm_budget: READ public.llm_calls</small>"]
+        U_legion["kagenti_legion<br/><small>sessions: RW team1_sandbox_legion.*<br/>READ public.sessions (own context_id only via RLS)</small>"]
+        U_rca["kagenti_rca<br/><small>sessions: RW team1_rca_agent.*<br/>READ public.sessions (own context_id only via RLS)</small>"]
+        U_budget["kagenti_budget<br/><small>llm_budget: RW public.*</small>"]
+    end
+
+    U_backend --> schema_shared
+    U_legion --> schema_legion
+    U_rca --> schema_rca
+    U_budget --> schema_budget
+```
+
+### Schema Naming Convention
+
+| Component | Schema Name | Pattern |
+|-----------|------------|---------|
+| Platform (backend) | `public` | Fixed |
+| Agent `sandbox-legion` in `team1` | `team1_sandbox_legion` | `{namespace}_{agent_name}` |
+| Agent `rca-agent` in `team1` | `team1_rca_agent` | `{namespace}_{agent_name}` |
+| Agent `sandbox-legion` in `team2` | `team2_sandbox_legion` | `{namespace}_{agent_name}` |
+| Budget proxy | `public` (in `llm_budget` DB) | Fixed |
+
+### DB User Access Matrix
+
+| DB User | Created By | Sessions DB Access | LLM Budget DB Access |
+|---------|-----------|-------------------|---------------------|
+| `kagenti_backend` | Helm chart | `public.sessions` RW, `public.events` RW | `public.llm_calls` READ |
+| `kagenti_{agent}` | Wizard / AgentRuntime controller | `{ns}_{agent}.*` RW, `public.sessions` READ (RLS: own context_id) | None |
+| `kagenti_budget` | Deploy script / controller | None | `public.*` RW |
+
+**How agents are scoped:**
+- Each agent's `search_path` is set to its own schema: `SET search_path TO team1_sandbox_legion`
+- Agent's checkpoint/task tables are in its own schema — invisible to other agents
+- Agent can READ `public.sessions` but only rows matching its own `context_id` (via Row-Level Security)
+- Agent **cannot** read other agents' checkpoints, tasks, or events
+
+**How users are created:**
+- **Current:** Helm chart creates single `kagenti` user
+- **Target:** Import wizard (or AgentRuntime controller) creates per-agent user with `CREATE ROLE kagenti_{agent} WITH LOGIN PASSWORD '...'` and `GRANT` on the agent's schema
+- Password stored in a per-agent Secret: `{agent}-db-secret`
+- With Vault (Pillar 3): dynamic credentials replace static passwords
+
+### Migration Path
+
+| Phase | Schema | Users | Isolation |
+|-------|--------|-------|-----------|
+| **Current** | Single `public` per database | Single `kagenti` user | Application-level (context_id filtering) |
+| **Phase 1** | Create `{ns}_{agent}` schemas | Single `kagenti` user with search_path | Schema-level (tables separated) |
+| **Phase 2** | Same | Per-agent `kagenti_{agent}` users with GRANT | User-level (GRANT scoping) |
+| **Phase 3** | Same | Same + Row-Level Security on `public.sessions` | Row-level (RLS policies) |
+| **Phase 4** | Same | Vault dynamic credentials (1h TTL per pod) | Credential-level (ephemeral, auto-revoked) |
 
 ## What the Agentic Runtime Deploys Today
 

--- a/docs/agentic-runtime/operator-alignment.md
+++ b/docs/agentic-runtime/operator-alignment.md
@@ -118,6 +118,8 @@ flowchart TB
     Agent -->|"HTTP_PROXY"| EgressDep
 ```
 
+
+
 ## Database Access Model
 
 ### Current State: Shared User, Single Schema

--- a/docs/agentic-runtime/pluggability.md
+++ b/docs/agentic-runtime/pluggability.md
@@ -1,0 +1,378 @@
+# Pluggable Architecture
+
+The Agentic Runtime is designed around **pluggable layers** with explicit
+contracts at each boundary. This enables swapping agent frameworks, security
+profiles, LLM providers, tools, and even UI rendering — without changing
+platform code.
+
+---
+
+## Pluggability Map
+
+```mermaid
+flowchart TB
+    subgraph ui_layer["UI Layer"]
+        direction LR
+        UI["React UI"]
+        UIPlugin["UI Plugin Contract<br/><small>AgentGraphCard, AG-UI events,<br/>OTel GenAI attributes</small>"]
+    end
+
+    subgraph platform_layer["Platform Layer"]
+        direction LR
+        Backend["FastAPI Backend"]
+        EventPipeline["Event Pipeline<br/><small>FrameworkEventSerializer</small>"]
+        Auth["Identity<br/><small>Keycloak + AuthBridge</small>"]
+        Observability["Observability<br/><small>OTel + Phoenix/MLflow</small>"]
+    end
+
+    subgraph infra_layer["Infrastructure Layer"]
+        direction LR
+        Security["Composable Security<br/><small>L1-L8 toggles</small>"]
+        Budget["LLM Budget Proxy"]
+        TaskStore["Task Store<br/><small>InMemory / PostgreSQL</small>"]
+        LLM["LLM Provider<br/><small>LiteLLM: 75+ providers</small>"]
+    end
+
+    subgraph agent_layer["Agent Layer"]
+        direction LR
+        Plugin["Plugin Contract<br/><small>AGENT_MODULE env var</small>"]
+        Tools["Tool System<br/><small>MCP Gateway + labels</small>"]
+    end
+
+    UI --> UIPlugin --> Backend
+    Backend --> EventPipeline & Auth & Observability
+    Backend --> Security & Budget & TaskStore & LLM
+    Backend --> Plugin --> Tools
+```
+
+---
+
+## Layer 1: Agent Framework
+
+**Contract:** Two functions exported from any Python module.
+
+```python
+def get_agent_card(host: str, port: int) -> AgentCard
+def build_executor(workspace_manager, permission_checker, sources_config) -> AgentExecutor
+```
+
+**Plug mechanism:** Set `AGENT_MODULE=my_framework.plugin` as env var.
+The platform base image loads it via `importlib.import_module()` at startup.
+
+**Implementations:**
+
+| Framework | Module | Status |
+|-----------|--------|--------|
+| LangGraph | `sandbox_agent.graph` | Shipped |
+| OpenCode | `opencode.plugin` | WIP |
+| Claude Agent SDK | -- | Designed |
+| CrewAI / AG2 / OpenHands | -- | Designed |
+
+Adding a new framework means writing one Python file with two functions.
+The platform handles everything else: A2A server, workspace, permissions,
+auth, budget, observability.
+
+## Layer 2: Event Serialization
+
+**Contract:** `FrameworkEventSerializer` abstract base class.
+
+```python
+class FrameworkEventSerializer(ABC):
+    @abstractmethod
+    def serialize(self, key: str, value: dict) -> str: ...
+```
+
+Each framework adapter translates native events into EVENT_CATALOG format.
+The UI renders events based on their `type` and `category` — it doesn't
+need to know which framework produced them.
+
+**This is the key to framework-neutral UI rendering.** A `tool_call` event
+looks the same whether it came from LangGraph, OpenCode, or CrewAI.
+
+## Layer 3: Composable Security
+
+**Contract:** Boolean toggles assembled by `SandboxProfile`:
+
+```python
+profile = SandboxProfile(secctx=True, landlock=True, proxy=True)
+manifest = profile.build_deployment(agent_name, namespace)
+```
+
+Each layer is independently toggleable:
+
+| Toggle | What It Adds |
+|--------|-------------|
+| `secctx` | SecurityContext (non-root, drop ALL, read-only FS) |
+| `landlock` | Landlock LSM init container + env var |
+| `proxy` | Squid egress proxy sidecar + env vars |
+
+Named profiles (`legion`, `basic`, `hardened`, `restricted`) are presets.
+The wizard UI allows custom combinations.
+
+## Layer 4: Task Store
+
+**Contract:** A2A SDK `TaskStore` interface.
+
+**Plug mechanism:** `TASK_STORE_DB_URL` env var. If set, uses PostgreSQL.
+If absent, uses in-memory store.
+
+```python
+def create_task_store():
+    db_url = os.environ.get("TASK_STORE_DB_URL", "")
+    if db_url:
+        return DatabaseTaskStore(create_async_engine(db_url))
+    return InMemoryTaskStore()
+```
+
+## Layer 5: LLM Provider
+
+**Contract:** OpenAI-compatible HTTP endpoint.
+
+**Plug mechanism:** LiteLLM Proxy routes to 75+ providers. Agents point
+`LLM_API_BASE` at the budget proxy, which forwards to LiteLLM.
+
+Any provider that exposes `/v1/chat/completions` works: OpenAI, Anthropic,
+vLLM, Ollama, MAAS, Azure, AWS Bedrock, Google Vertex.
+
+## Layer 6: Tool System
+
+**Contract:** MCP (Model Context Protocol) tool interface.
+
+**Plug mechanism:** Kubernetes labels for discovery. MCP Gateway routes
+tool calls. Agents call tools via single `/mcp` URL.
+
+```yaml
+labels:
+  kagenti.io/type: tool
+  kagenti.io/protocol: mcp
+  kagenti.io/transport: streamable-http
+```
+
+Any HTTP service with MCP endpoints becomes a tool automatically.
+
+## Layer 7: Identity
+
+**Contract:** Keycloak OIDC + optional SPIFFE workload identity.
+
+Two modes per agent pod (controlled by `kagenti.io/spire` label):
+- `enabled` — SPIFFE identity via SPIRE, token exchange for service-to-service
+- `disabled` — Static client ID (development fallback)
+
+AuthBridge sidecar handles both transparently.
+
+## Layer 8: Observability
+
+**Contract:** OpenTelemetry SDK + configurable exporters.
+
+Agents emit OTel traces. The collector routes to:
+- Phoenix (LLM-specific trace visualization)
+- MLflow (experiment tracking)
+- Jaeger (distributed tracing)
+
+Configuration via `OTEL_EXPORTER_OTLP_ENDPOINT`. Wrapped in try/except
+so observability never breaks the agent.
+
+## Layer 9: UI Rendering
+
+**Contract:** Agent card + optional AgentGraphCard extension.
+
+The UI adapts rendering based on what the agent declares:
+
+```mermaid
+flowchart TB
+    Fetch["Fetch agent card<br/>/.well-known/agent-card.json"]
+    Check{"Has GraphCard<br/>extension?"}
+    Rich["Rich Rendering<br/><small>Graph views, loop cards,<br/>event-category rendering,<br/>topology DAG, animations</small>"]
+    Basic["Basic Rendering<br/><small>Chat bubbles,<br/>status badges,<br/>no graph views</small>"]
+
+    Fetch --> Check
+    Check -->|"yes: fetch graph card"| Rich
+    Check -->|"no"| Basic
+```
+
+**Graceful degradation:**
+- No graph card → default topology, basic event rendering
+- No event catalog → render all events as text
+- No topology → no graph view tab (chat-only)
+
+---
+
+## Standards Landscape
+
+The AI agent ecosystem has several complementary standards. Kagenti uses
+A2A and MCP as core protocols, with AgentGraphCard as our own extension.
+Other standards map to potential future integration.
+
+```mermaid
+flowchart TB
+    subgraph protocols["Protocol Layer (communication)"]
+        A2A["A2A<br/><small>Agent-to-Agent<br/>Google/AAIF<br/>JSON-RPC + SSE</small>"]
+        MCP["MCP<br/><small>Agent-to-Tool<br/>Anthropic/AAIF<br/>JSON-RPC</small>"]
+    end
+
+    subgraph ui_protocols["UI Layer (presentation)"]
+        AGUI["AG-UI<br/><small>Agent-to-User<br/>CopilotKit<br/>32 event types</small>"]
+        GC["AgentGraphCard<br/><small>Agent-to-UI<br/>Kagenti<br/>Event catalog + topology</small>"]
+    end
+
+    subgraph observability_standards["Observability Layer"]
+        OTelGenAI["OTel GenAI<br/><small>CNCF/OpenTelemetry<br/>Span attributes for LLM</small>"]
+        OpenInf["OpenInference<br/><small>Arize/Phoenix<br/>LLM trace conventions</small>"]
+    end
+
+    A2A -->|"agent calls agent"| A2A
+    A2A -->|"agent calls tool"| MCP
+    A2A -->|"agent streams to UI"| AGUI
+    A2A -->|"agent introspection"| GC
+    A2A -->|"traces"| OTelGenAI
+    OTelGenAI --> OpenInf
+```
+
+### Standard Comparison
+
+| Standard | What It Defines | Kagenti Use | Status |
+|----------|----------------|-------------|--------|
+| **A2A** | Agent-to-agent communication | Core protocol (agent server + backend calls) | Active |
+| **MCP** | Agent-to-tool interface | MCP Gateway for tool discovery + routing | Active |
+| **AgentGraphCard** | Event schema + graph topology | UI rendering contract for instrumented agents | Shipped |
+| **AG-UI** | Agent-to-user UI events | Potential UI plugin standard (32 event types, A2A bridge) | Evaluate |
+| **OTel GenAI** | LLM observability attributes | Token counts, model info, latency in traces | Active |
+| **OpenInference** | LLM trace conventions | Phoenix trace rendering (graph.node attributes) | Active |
+
+### AG-UI — Potential UI Plugin Standard
+
+[AG-UI](https://docs.ag-ui.com/) defines 32 typed events for agent-to-user
+communication. It already has an [A2A bridge](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/a2a)
+that converts A2A events to AG-UI events.
+
+**Relevant event categories:**
+
+| AG-UI Category | Events | Maps to Our |
+|---------------|--------|-------------|
+| Lifecycle | RUN_STARTED, RUN_FINISHED, RUN_ERROR | meta (node_transition) |
+| Text Messages | TEXT_MESSAGE_START/CONTENT/END | reasoning (planner_output, thinking) |
+| Tool Calls | TOOL_CALL_START/ARGS/END/RESULT | execution + tool_output |
+| State | STATE_SNAPSHOT, STATE_DELTA | meta (budget_update) |
+| Reasoning | REASONING_START/CONTENT/END | reasoning (micro_reasoning) |
+| Custom | CUSTOM, RAW | Any EVENT_CATALOG type |
+
+**How it would work with Kagenti:**
+
+```mermaid
+flowchart LR
+    Agent["Agent<br/><small>LangGraph events</small>"]
+    Serializer["FrameworkEventSerializer<br/><small>EVENT_CATALOG events</small>"]
+    Bridge["AG-UI Bridge<br/><small>Map EVENT_CATALOG<br/>to AG-UI events</small>"]
+    UI["React UI<br/><small>AG-UI consumer<br/>+ custom renderers</small>"]
+
+    Agent --> Serializer --> Bridge --> UI
+```
+
+Our `EVENT_CATALOG` events would map to AG-UI events:
+- `planner_output` → `TEXT_MESSAGE_START` + `TEXT_MESSAGE_CONTENT` + `TEXT_MESSAGE_END`
+- `tool_call` → `TOOL_CALL_START` + `TOOL_CALL_ARGS` + `TOOL_CALL_END`
+- `tool_result` → `TOOL_CALL_RESULT`
+- `budget_update` → `STATE_DELTA`
+- Agent-specific events → `CUSTOM` (name: event type, value: payload)
+
+**Benefit:** Any AG-UI compatible frontend (CopilotKit, custom React apps)
+could render Kagenti agent sessions out of the box. External UIs wouldn't
+need to understand our EVENT_CATALOG directly — they'd consume standard
+AG-UI events.
+
+**Trade-off:** AG-UI's 32 event types are simpler than our 12-type
+EVENT_CATALOG with 7 categories. We'd lose some granularity in the
+standard mapping (reflector_decision, micro_reasoning have no AG-UI
+equivalent). The `CUSTOM` event type is the escape hatch for rich
+rendering.
+
+### MCP Tool Metadata for UI
+
+MCP tool definitions include UI-relevant metadata:
+
+```json
+{
+  "name": "shell",
+  "title": "Shell Command",
+  "description": "Execute shell commands in workspace",
+  "inputSchema": { "type": "object", "properties": {"command": {"type": "string"}} },
+  "annotations": {
+    "destructiveHint": true,
+    "readOnlyHint": false,
+    "openWorldHint": true
+  }
+}
+```
+
+The `annotations` field drives UI decisions:
+- `destructiveHint: true` → show confirmation dialog
+- `readOnlyHint: true` → skip HITL approval
+- `openWorldHint: true` → show network access badge
+
+### OTel GenAI for Observability UI
+
+OTel GenAI semantic conventions provide standard attributes for dashboards:
+
+| Attribute | UI Component |
+|-----------|-------------|
+| `gen_ai.request.model` | Model badge |
+| `gen_ai.usage.input_tokens` | Token counter |
+| `gen_ai.usage.output_tokens` | Token counter |
+| `gen_ai.operation.name` | Step label |
+| `gen_ai.agent.name` | Agent badge |
+
+These attributes power the LLM Analytics tab and budget displays
+without inventing custom schemas.
+
+---
+
+## The Plugin Vision
+
+The pluggable architecture creates a **contract-driven stack** where
+each layer can be swapped independently:
+
+```mermaid
+flowchart TB
+    subgraph swap_agent["Swap Agent Framework"]
+        LG["LangGraph"] -.-> OC["OpenCode"]
+        OC -.-> CS["Claude SDK"]
+        CS -.-> CR["CrewAI"]
+    end
+
+    subgraph swap_llm["Swap LLM Provider"]
+        Ollama["Ollama"] -.-> MAAS["MAAS"]
+        MAAS -.-> OpenAI["OpenAI"]
+        OpenAI -.-> Anthropic["Anthropic"]
+    end
+
+    subgraph swap_tools["Swap Tools"]
+        Weather["Weather MCP"] -.-> GitHub["GitHub MCP"]
+        GitHub -.-> Custom["Custom MCP"]
+    end
+
+    subgraph swap_ui["Swap UI Rendering"]
+        GraphCard["AgentGraphCard<br/>(rich rendering)"]
+        AGUI["AG-UI<br/>(standard events)"]
+        Plain["Plain A2A<br/>(chat only)"]
+    end
+
+    subgraph swap_security["Swap Security Profile"]
+        Legion["Legion<br/>(minimal)"]
+        Hardened["Hardened<br/>(L1-L8)"]
+        Restricted["Restricted<br/>(+ source policy)"]
+    end
+
+    swap_agent --> |"Plugin contract"| Platform["Platform<br/>(unchanged)"]
+    swap_llm --> |"OpenAI-compatible"| Platform
+    swap_tools --> |"MCP protocol"| Platform
+    swap_ui --> |"Graph card / AG-UI"| Platform
+    swap_security --> |"SandboxProfile"| Platform
+```
+
+Each arrow represents a **contract boundary**. As long as the contract
+is satisfied, any implementation works. The platform doesn't need to
+know what's behind the contract.
+
+**Key principle:** The platform provides the infrastructure contracts.
+Agents provide business logic. UI provides rendering. Each can evolve
+independently.

--- a/docs/agentic-runtime/quickstart.md
+++ b/docs/agentic-runtime/quickstart.md
@@ -1,0 +1,84 @@
+# Quick Start
+
+Deploy a sandbox agent on a local Kind cluster in 5 minutes.
+
+---
+
+## Prerequisites
+
+- Docker Desktop running
+- `kubectl`, `helm`, `uv` installed
+- Clone the kagenti repo
+
+## 1. Deploy the Platform
+
+```bash
+# Full platform deployment (creates Kind cluster, installs all components)
+./.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy
+```
+
+This deploys: Keycloak, Istio Ambient, SPIRE, AuthBridge webhook, LiteLLM,
+Phoenix, OTEL Collector, MCP Gateway, and the Kagenti backend + UI.
+
+## 2. Enable Feature Flags
+
+Feature flags are disabled by default. To enable the Agentic Runtime:
+
+```bash
+# Edit the Helm values to enable sandbox features
+# In charts/kagenti/values.yaml:
+#   featureFlags:
+#     sandbox: true
+#     integrations: true
+#     triggers: true
+
+# Or pass at install time:
+helm upgrade kagenti charts/kagenti \
+  --set featureFlags.sandbox=true \
+  --set featureFlags.integrations=true \
+  --set featureFlags.triggers=true
+```
+
+## 3. Deploy a Sandbox Agent
+
+```bash
+# Deploy sandbox agents with PostgreSQL, budget proxy, and egress proxy
+./.github/scripts/kagenti-operator/76-deploy-sandbox-agents.sh
+```
+
+This creates in the `team1` namespace:
+- `postgres-sessions` StatefulSet (sessions + llm_budget databases)
+- `llm-budget-proxy` Deployment (token enforcement)
+- Sandbox agent Deployment(s) with selected security profile
+
+## 4. Access the UI
+
+```bash
+# Show all service URLs
+./.github/scripts/local-setup/show-services.sh
+```
+
+Open http://kagenti-ui.localtest.me:8080 and log in with `admin/admin`.
+
+Navigate to the **Sandboxes** page to see deployed agents, then open a
+session to start chatting.
+
+## 5. Send a Message
+
+In the sandbox session view:
+1. Select an agent from the catalog
+2. Type a message (e.g. "Analyze the file structure of this workspace")
+3. Watch the reasoning loop in real-time:
+   - Planner creates a numbered plan
+   - Executor runs tools (shell commands, file reads)
+   - Reflector decides whether to continue or finish
+   - Reporter synthesizes the final answer
+
+The Graph View tab shows the agent's processing graph with live animations.
+
+## Next Steps
+
+- [Configuration](./configuration.md) -- feature flags, Helm values, env vars
+- [Security](./security.md) -- composable security layers, Landlock
+- [Writing Agents](./agents.md) -- create your own sandbox agent
+- [Deployment](./deployment.md) -- production deployment, database setup

--- a/docs/agentic-runtime/sandboxing-layers.md
+++ b/docs/agentic-runtime/sandboxing-layers.md
@@ -1,0 +1,314 @@
+# Sandboxing Layers — Technical Reference
+
+A layer-by-layer technical reference for the Kagenti agent sandboxing
+architecture. Companion to the [Sandboxing Strategy](./sandboxing-strategy.md)
+(use-case-driven) and [Security](./security.md) (L1-L8 summary).
+
+---
+
+## Layer Architecture
+
+```mermaid
+flowchart TB
+    subgraph os_layer["Layer 1: Operating System"]
+        direction LR
+        Landlock["Landlock LSM<br/><small>Filesystem scoping<br/>Per-tool-call fork</small>"]
+        Seccomp["seccomp<br/><small>Syscall filtering<br/>RuntimeDefault profile</small>"]
+        SELinux["SELinux<br/><small>MAC enforcement<br/>OpenShift SCC</small>"]
+    end
+
+    subgraph runtime_layer["Layer 2: Application Runtime"]
+        direction LR
+        Permissions["PermissionChecker<br/><small>ALLOW / DENY / HITL<br/>per command prefix</small>"]
+        CodeAudit["Code Audit<br/><small>events table persistence<br/>full args + output</small>"]
+        Limits["Resource Limits<br/><small>CPU, memory, timeout<br/>per sources.json</small>"]
+    end
+
+    subgraph container_layer["Layer 3: Container / Orchestration"]
+        direction LR
+        SecCtx["SecurityContext<br/><small>non-root, drop ALL,<br/>readOnlyRootFS, seccomp</small>"]
+        ZeroSecret["Zero-Secret<br/><small>Budget Proxy +<br/>AuthBridge + Vault</small>"]
+        Persona["Persona Separation<br/><small>ROLE_OPERATOR vs<br/>ROLE_ADMIN via RBAC</small>"]
+    end
+
+    subgraph network_layer["Layer 4: Network"]
+        direction LR
+        NetPol["NetworkPolicy<br/><small>deny-all egress<br/>+ DNS allow</small>"]
+        EgressProxy["Egress Proxy<br/><small>Squid domain allowlist<br/>per-agent config</small>"]
+        Mesh["Istio Ambient<br/><small>ztunnel mTLS<br/>zero-config</small>"]
+    end
+
+    os_layer --> runtime_layer --> container_layer --> network_layer
+```
+
+---
+
+## Layer 1: Operating System
+
+### Landlock LSM
+
+Kernel-level filesystem access control. Kagenti uses pure ctypes syscalls
+(zero external dependencies) to apply Landlock restrictions per tool call.
+
+| Aspect | Detail |
+|--------|--------|
+| Implementation | `landlock_ctypes.py` (193 lines), raw syscalls via Python `ctypes` |
+| ABI support | v1, v2, v3 (adapts to kernel version) |
+| Architecture | x86_64 and aarch64 syscall numbers |
+| Application model | Fork per tool call → apply Landlock → execute → exit |
+| Write scope | `/workspace/{context_id}/` only |
+| Read scope | System libraries, Python packages |
+| Startup probe | Forks child to test kernel support. Pod fails assertively if unavailable. |
+| Overhead | ~7ms per tool call |
+| Irreversibility | Once applied, restrictions cannot be lifted (kernel guarantee) |
+
+**Key design:** Landlock is applied per-tool-call in a forked subprocess,
+not per-pod. This means the agent process itself is not Landlock-restricted
+(it needs to read its own code), but every tool execution is isolated.
+
+### seccomp
+
+Syscall filtering via Linux seccomp-BPF. Applied via pod SecurityContext.
+
+| Aspect | Detail |
+|--------|--------|
+| Profile | `RuntimeDefault` (Kubernetes default seccomp profile) |
+| Custom profiles | Not yet. `RuntimeDefault` blocks most dangerous syscalls. |
+| Application | `securityContext.seccompProfile.type: RuntimeDefault` |
+
+### SELinux
+
+Mandatory Access Control via SELinux. On OpenShift, enforced through
+Security Context Constraints (SCCs).
+
+| Aspect | Detail |
+|--------|--------|
+| OpenShift | SCCs enforce SELinux labels. Agents use `kagenti-authbridge` SCC. |
+| Kind / vanilla K8s | SELinux not enforced (typically permissive or disabled). |
+| Custom policy | Not custom-profiled. Uses platform-default SELinux types. |
+| Future | Agent-specific SELinux policy for finer-grained MAC. |
+
+---
+
+## Layer 2: Application Runtime
+
+### PermissionChecker
+
+Three-tier permission system for tool/command execution. Configured via
+`settings.json` per agent.
+
+```
+Rule format: type(prefix:glob)
+
+Examples:
+  allow: shell(grep:*)         # allow grep with any args
+  allow: file(read:/workspace/**)  # allow reading workspace
+  deny:  shell(rm:-rf *)       # block rm -rf
+  deny:  network(outbound:*)   # block all network
+  # Everything else → HITL (human approval)
+```
+
+| Tier | Behavior |
+|------|----------|
+| ALLOW | Execute immediately |
+| DENY | Reject immediately |
+| HITL | Pause execution, wait for human approval |
+
+Interpreter bypass detection: `bash -c "curl ..."` is caught even if
+`curl` is denied — the checker detects shell wrappers.
+
+### Code Audit Trail
+
+Every tool call is persisted in the `events` table with full context:
+
+| Field | Content |
+|-------|---------|
+| `event_type` | `tool_call` or `tool_result` |
+| `langgraph_node` | Which graph node initiated the call |
+| `payload.name` | Tool name (e.g. `shell`) |
+| `payload.args` | Full arguments (e.g. `ls -la /workspace`) |
+| `payload.output` | Full output (truncated to 2000 chars) |
+| `payload.status` | `success` or `error` |
+
+This creates the forensic trail needed for compliance. Every action the
+agent took is recorded, attributable, and queryable.
+
+**Gap:** Generated code is captured as tool_call args (shell commands, file
+writes) but not security-scanned before execution. Pre-execution scanning
+is an open problem.
+
+### Resource Limits
+
+Declared in `sources.json`, enforced by the platform:
+
+| Limit | Default | Enforcement |
+|-------|---------|-------------|
+| `max_execution_time_seconds` | 300 | Per-command timeout |
+| `max_memory_mb` | 4096 | Container memory limit |
+| `max_session_tokens` | 1,000,000 | Budget Proxy (HTTP 402) |
+| `max_daily_tokens` | 5,000,000 | Budget Proxy (rolling window) |
+
+---
+
+## Layer 3: Container / Orchestration
+
+### SecurityContext (L4)
+
+Applied via pod spec. Drops all Linux capabilities and enforces non-root.
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+  capabilities:
+    drop: [ALL]
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+| Control | Effect |
+|---------|--------|
+| `runAsNonRoot: true` | Cannot run as root (UID 0) |
+| `drop: [ALL]` | No Linux capabilities (no mount, no raw socket, no chown) |
+| `readOnlyRootFilesystem` | Cannot write to container image filesystem |
+| `allowPrivilegeEscalation: false` | Cannot gain more privileges than parent |
+| `seccompProfile: RuntimeDefault` | Blocks dangerous syscalls |
+
+### Zero-Secret Credential Architecture
+
+Three components ensure the agent container has zero long-lived secrets:
+
+| Component | What It Replaces | How |
+|-----------|-----------------|-----|
+| **LLM Budget Proxy** | `OPENAI_API_KEY` env var | Agent calls localhost:8080. Proxy holds LiteLLM key. |
+| **AuthBridge sidecar** | `GITHUB_TOKEN` etc in env var | Envoy intercepts outbound. SPIFFE→OAuth exchange. |
+| **Vault** (planned) | `DB_PASSWORD` in secret | SPIFFE auth → dynamic 1h PostgreSQL credentials. |
+
+See [Zero-Secret Agents](./zero-secret-agents.md) for complete architecture.
+
+### Persona Separation
+
+| Persona | Role | What They Can Do |
+|---------|------|-----------------|
+| **Consumer** (developer/user) | `ROLE_OPERATOR` | Invoke agents, view sessions, chat |
+| **Security Admin** | `ROLE_ADMIN` | Configure security profiles, manage namespaces, view all sessions |
+| **Platform** (controller) | Service account | Apply labels, inject sidecars, manage CRDs |
+
+Today this is enforced via Keycloak RBAC. Future: AgentRuntime CR (#862)
+separates deployment (consumer) from security configuration (admin).
+
+---
+
+## Layer 4: Network
+
+### NetworkPolicy (L5)
+
+Default-deny egress baseline for all agent namespaces:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all-egress
+  namespace: team1
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to: []
+      ports:
+        - port: 53    # DNS only
+          protocol: UDP
+```
+
+Agents can only reach:
+- DNS (port 53) — for service discovery
+- Other pods in the same namespace — via explicit allow rules
+- Egress proxy — for approved outbound traffic
+
+### Egress Proxy (L7) — Squid
+
+Per-agent Squid proxy enforcing domain allowlist:
+
+| Aspect | Detail |
+|--------|--------|
+| Deployment | Separate Deployment per agent (`{agent}-egress-proxy`) |
+| Port | 3128 (agent sets `HTTP_PROXY=http://localhost:3128`) |
+| Allowlist | `ALLOWED_DOMAINS` env var (space-separated) |
+| Default domains | `.anthropic.com`, `.openai.com`, `.pypi.org`, `.github.com` |
+| Methods | GET, POST, HEAD, CONNECT on ports 80, 443 |
+| Default policy | Deny all unlisted domains |
+| Bypass | `NO_PROXY=localhost,127.0.0.1,.svc,.cluster.local` (K8s services) |
+
+**Why Squid, not NetworkPolicy alone?** NetworkPolicy operates at L3/L4
+(IP + port). Squid operates at L7 (domain names). An agent could bypass
+IP-based rules by resolving different IPs for the same domain. Squid's
+domain-based filtering catches this.
+
+### Istio Ambient Mesh (L3)
+
+Zero-config mTLS for all pod-to-pod traffic:
+
+| Aspect | Detail |
+|--------|--------|
+| Mode | Ambient (no sidecars — ztunnel handles L4) |
+| Enrollment | Namespace label `istio.io/dataplane-mode: ambient` |
+| mTLS | Automatic between all enrolled pods |
+| L7 policies | Waypoint proxies (one per namespace, on-demand) |
+| AuthorizationPolicy | MLflow `/v1/traces` restricted to otel-collector identity |
+| Target | STRICT mode + deny-all baseline with per-service ALLOW |
+
+**All internal communication is encrypted.** Application-level SSL is
+disabled (not needed — ztunnel handles encryption transparently).
+
+---
+
+## Cross-Layer Integration
+
+```mermaid
+flowchart TB
+    subgraph request["Inbound Request"]
+        User["User sends message"]
+    end
+
+    subgraph l1["L1: Auth"]
+        Keycloak["Keycloak validates JWT"]
+    end
+
+    subgraph l2["L2: RBAC"]
+        RBAC["Backend checks ROLE_OPERATOR"]
+    end
+
+    subgraph l3["L3: mTLS"]
+        Istio["ztunnel encrypts traffic"]
+    end
+
+    subgraph l1_auth["L1: AuthBridge"]
+        AB["Sidecar validates inbound JWT"]
+    end
+
+    subgraph l4["L4: SecurityContext"]
+        SC["Agent runs as non-root, no capabilities"]
+    end
+
+    subgraph l6["L6: Landlock"]
+        LL["Tool call forked with Landlock<br/>Write only to /workspace/{session}"]
+    end
+
+    subgraph l7["L7: Egress"]
+        Squid2["Outbound → Squid allowlist"]
+    end
+
+    subgraph l8["L8: HITL"]
+        HITL2["Dangerous command?<br/>Wait for human approval"]
+    end
+
+    User --> l1 --> l2 --> l3 --> l1_auth --> l4 --> l8 --> l6 --> l7
+```
+
+Each layer is independent. If one fails open (e.g. Landlock unavailable),
+the others still contain the blast radius. This is defense-in-depth — no
+single layer is sufficient, and the combination is stronger than any
+individual control.

--- a/docs/agentic-runtime/sandboxing-models.md
+++ b/docs/agentic-runtime/sandboxing-models.md
@@ -1,0 +1,283 @@
+# Sandboxing Models
+
+Different workloads require different levels of isolation. This guide explains
+the sandboxing spectrum — from minimal safe configurations for trusted internal
+agents to maximum isolation for executing untrusted, AI-generated code on
+bare metal.
+
+> **Related:** [Security](./security.md) for layer details,
+> [Zero-Secret Agents](./zero-secret-agents.md) for the credential architecture.
+
+---
+
+## The Sandboxing Spectrum
+
+```mermaid
+flowchart LR
+    subgraph minimal["Minimal Safe"]
+        M["L1-L3, L8<br/><small>Auth + RBAC + mTLS + HITL<br/>Trusted internal agents<br/>Deterministic tool loops</small>"]
+    end
+
+    subgraph standard["Standard"]
+        S["L1-L5, L8<br/><small>+ SecurityContext + NetworkPolicy<br/>Internal agents with<br/>network restrictions</small>"]
+    end
+
+    subgraph hardened["Hardened"]
+        H["L1-L8<br/><small>+ Landlock + Egress Proxy<br/>Agents executing<br/>LLM-generated code</small>"]
+    end
+
+    subgraph maximum["Maximum"]
+        X["L1-L8 + Vault + CoCo<br/><small>+ Confidential Computing<br/>Untrusted third-party agents<br/>Regulated environments</small>"]
+    end
+
+    minimal -->|"more isolation"| standard -->|"more isolation"| hardened -->|"more isolation"| maximum
+```
+
+---
+
+## Four Use Cases
+
+### Use Case 1: Deterministic Agent (Fixed Tool Loop)
+
+An agent following a predictable pattern — call a weather API, format the
+response, return to user. No code generation. Behavior is auditable.
+
+```mermaid
+flowchart TB
+    subgraph agent["Deterministic Agent"]
+        Loop["Fixed loop:<br/>receive → call tool → format → respond"]
+    end
+
+    subgraph controls["Required Controls"]
+        Auth["L1: Authentication<br/><small>Who can invoke this agent?</small>"]
+        RBAC["L2: RBAC<br/><small>Which namespace/tools allowed?</small>"]
+        mTLS["L3: mTLS<br/><small>Encrypted internal traffic</small>"]
+        ZeroSecret["Zero-Secret<br/><small>Agent has no raw credentials.<br/>AuthBridge exchanges tokens.<br/>Budget Proxy holds LLM key.</small>"]
+        Egress["Egress Control<br/><small>Agent can only reach<br/>approved API endpoints</small>"]
+    end
+
+    agent --> controls
+```
+
+**Profile:** `basic` (L1-L5, L8)
+
+**Why not less?** Even a deterministic agent can be socially engineered through
+prompt manipulation to misuse its tool access. An agent with GitHub access
+could be persuaded to leak repository information. Zero-secret architecture
+ensures there are no credentials to exfiltrate, and the egress proxy limits
+what endpoints the agent can reach.
+
+**Why not more?** Landlock filesystem isolation adds overhead (~7ms per tool call)
+that isn't necessary when the agent doesn't generate or execute code. The
+agent's behavior is predictable and auditable through conventional means.
+
+### Use Case 2: AI-Generated Code Execution
+
+An agent that writes and executes code produced by an LLM. The code is
+late-bound, non-deterministic, and potentially adversarial. This is where
+the security model fundamentally changes.
+
+```mermaid
+flowchart TB
+    subgraph agent2["Code-Generating Agent"]
+        Write["LLM generates Python/Shell code"]
+        Execute["Agent executes generated code"]
+        Write --> Execute
+    end
+
+    subgraph controls2["Required Controls (ALL layers)"]
+        direction TB
+        Auth2["L1-L3: Auth + RBAC + mTLS"]
+        SecCtx["L4: SecurityContext<br/><small>non-root, drop ALL caps,<br/>readOnlyRootFilesystem, seccomp</small>"]
+        NetPol["L5: NetworkPolicy<br/><small>deny-all egress by default</small>"]
+        Landlock["L6: Landlock<br/><small>Per-tool-call filesystem isolation.<br/>Write only to /workspace/{session}.<br/>Cannot read other sessions.</small>"]
+        Proxy["L7: Egress Proxy<br/><small>Domain allowlist via Squid.<br/>No unapproved outbound traffic.</small>"]
+        HITL["L8: HITL<br/><small>Human approves dangerous commands<br/>before execution.</small>"]
+        ZS2["Zero-Secret<br/><small>No credentials to exfiltrate.<br/>Budget Proxy caps LLM spend.</small>"]
+        Audit["Audit Trail<br/><small>Every tool call persisted with<br/>args + output in events table.</small>"]
+    end
+
+    agent2 --> controls2
+```
+
+**Profile:** `hardened` (L1-L8)
+
+**Why all layers?** Generated code can attempt to:
+- Read files from other sessions → **Landlock** prevents cross-session access
+- Establish reverse shells → **Egress Proxy** blocks unauthorized outbound
+- Exfiltrate secrets from environment → **Zero-Secret** means nothing to steal
+- Mine cryptocurrency → **Budget Proxy** caps compute via token limits
+- Escalate privileges → **SecurityContext** drops all capabilities
+
+**Audit requirement:** Every tool call (shell command, file write, web fetch) is
+persisted in the `events` table with full arguments and output. This creates
+the forensic trail needed for compliance (SOC 2, FedRAMP).
+
+### Use Case 3: Tool Execution (MCP Services)
+
+An agent invoking pre-defined tools via MCP (Model Context Protocol). The tools
+are deterministic, but the agent's selection and parameterization is LLM-driven.
+
+```mermaid
+flowchart TB
+    subgraph agent3["Tool-Calling Agent"]
+        Select["LLM selects tool + parameters"]
+        Call["Agent calls MCP tool via Gateway"]
+        Select --> Call
+    end
+
+    subgraph controls3["Required Controls"]
+        ToolACL["Tool Access Control<br/><small>Which tools can this agent invoke?<br/>MCP Gateway enforces policy.</small>"]
+        ParamVal["Parameter Validation<br/><small>MCP tool inputSchema validates<br/>all parameters before execution.</small>"]
+        RateLimit["Rate Limiting<br/><small>Budget Proxy limits LLM calls.<br/>Tool-level rate limits (planned).</small>"]
+        CredProxy["Credential Routing<br/><small>AuthBridge exchanges tokens<br/>for tool authentication.<br/>Agent never sees tool credentials.</small>"]
+        AuditLog["Audit Logging<br/><small>All tool invocations persisted<br/>with parameters + results.</small>"]
+    end
+
+    agent3 --> controls3
+```
+
+**Profile:** `basic` or `hardened` depending on tool sensitivity
+
+**Key control:** MCP Gateway enforces which tools each agent can invoke. Tool
+metadata (`annotations.destructiveHint`, `readOnlyHint`) drives UI decisions
+(confirm before destructive operations, skip approval for read-only).
+
+### Use Case 4: Untrusted / Third-Party Agents
+
+Agents imported from external sources where the code hasn't been reviewed.
+Maximum isolation — assume the agent is adversarial.
+
+```mermaid
+flowchart TB
+    subgraph agent4["Third-Party Agent"]
+        Unknown["Unknown code<br/>Unreviewed behavior<br/>Potentially adversarial"]
+    end
+
+    subgraph controls4["Maximum Isolation"]
+        direction TB
+        AllLayers["L1-L8: All layers active"]
+        SourcePolicy["Source Policy<br/><small>Restrict package managers,<br/>git remotes, web domains.<br/>sources.json enforcement.</small>"]
+        ZS4["Zero-Secret (all 3 pillars)<br/><small>Budget Proxy: no LLM keys<br/>AuthBridge: no service tokens<br/>Vault: no DB passwords</small>"]
+        CoCo["Confidential Computing (future)<br/><small>Hardware-backed trust boundary.<br/>Agent can't access host memory.</small>"]
+        PreScan["Pre-Execution Scan (future)<br/><small>Security scan generated code<br/>before execution.</small>"]
+    end
+
+    agent4 --> controls4
+```
+
+**Profile:** `restricted` (L1-L8 + source policy)
+
+**Future:** Confidential computing (Kata Containers / CoCo) adds hardware-backed
+isolation where even the cluster administrator cannot access the agent's memory.
+
+---
+
+## The Three Non-Negotiable Pillars
+
+Regardless of sandboxing profile, three properties must **always** hold:
+
+```mermaid
+flowchart TB
+    subgraph pillar1["Pillar 1: No Credentials"]
+        P1["Agent container has<br/>ZERO long-lived secrets"]
+        P1a["LLM keys → Budget Proxy"]
+        P1b["Service tokens → AuthBridge"]
+        P1c["DB passwords → Vault"]
+        P1 --> P1a & P1b & P1c
+    end
+
+    subgraph pillar2["Pillar 2: No Unproxied Egress"]
+        P2["All outbound traffic goes<br/>through controlled proxies"]
+        P2a["LLM calls → Budget Proxy<br/>(budget enforcement)"]
+        P2b["Service calls → AuthBridge<br/>(token exchange)"]
+        P2c["Web access → Squid Proxy<br/>(domain allowlist)"]
+        P2 --> P2a & P2b & P2c
+    end
+
+    subgraph pillar3["Pillar 3: Full Audit Trail"]
+        P3["Every action is recorded<br/>and attributable"]
+        P3a["Tool calls → events table<br/>(args + output)"]
+        P3b["LLM calls → llm_calls table<br/>(tokens + cost)"]
+        P3c["File changes → workspace<br/>(per-session isolation)"]
+        P3 --> P3a & P3b & P3c
+    end
+
+    pillar1 --- pillar2 --- pillar3
+```
+
+**Pillar 1: No Credentials** — A compromised agent cannot exfiltrate any secret
+usable outside its own session. See [Zero-Secret Agents](./zero-secret-agents.md).
+
+**Pillar 2: No Unproxied Egress** — The agent cannot reach any endpoint without
+going through a proxy that enforces policy (budget, domain allowlist, token
+exchange). A reverse shell cannot bypass the egress proxy.
+
+**Pillar 3: Full Audit Trail** — Every tool call, LLM call, and file change is
+persisted with full context. This creates the forensic trail needed for
+compliance frameworks (SOC 2, FedRAMP, HIPAA).
+
+**These three pillars are independent of the sandboxing profile.** A `legion`
+agent (minimal isolation) and a `restricted` agent (maximum isolation) both
+must satisfy all three.
+
+---
+
+## Profile Comparison
+
+| Capability | `legion` | `basic` | `hardened` | `restricted` |
+|-----------|---------|---------|-----------|-------------|
+| Authentication (L1) | Yes | Yes | Yes | Yes |
+| RBAC (L2) | Yes | Yes | Yes | Yes |
+| mTLS (L3) | Yes | Yes | Yes | Yes |
+| SecurityContext (L4) | -- | Yes | Yes | Yes |
+| NetworkPolicy (L5) | -- | Yes | Yes | Yes |
+| Landlock (L6) | -- | -- | Yes | Yes |
+| Egress Proxy (L7) | -- | -- | Yes | Yes |
+| HITL (L8) | Yes | Yes | Yes | Yes |
+| Source Policy | -- | -- | -- | Yes |
+| **Zero-Secret** | **Yes** | **Yes** | **Yes** | **Yes** |
+| **Egress Proxy** | *planned* | *planned* | **Yes** | **Yes** |
+| **Audit Trail** | **Yes** | **Yes** | **Yes** | **Yes** |
+
+---
+
+## Deployment Model: Shared Pod vs Pod-per-Session
+
+| Model | Isolation | Overhead | Use Case |
+|-------|----------|----------|----------|
+| **Shared pod** (current) | Workspace dirs + Landlock | Low (one pod per agent) | Multiple sessions in one agent pod, separated by workspace + Landlock |
+| **Pod-per-session** (future) | Full pod isolation | High (one pod per session) | Sensitive data processing, compliance environments |
+
+The current model uses **Landlock per-tool-call** to isolate sessions within a
+shared pod. Each session gets its own workspace directory at `/workspace/{context_id}/`.
+Landlock restricts tool call execution to that directory — the agent cannot read
+other sessions' workspaces.
+
+For environments processing personal or sensitive data, pod-per-session provides
+full kernel-level isolation. This is achieved by creating a new agent pod for
+each session, with a dedicated workspace volume.
+
+---
+
+## Platform Coverage
+
+| Layer | Kubernetes / OpenShift | Podman (local) | Gap |
+|-------|----------------------|----------------|-----|
+| L1 Auth | Keycloak + AuthBridge | -- | Local auth TBD |
+| L2 RBAC | K8s RBAC | -- | No RBAC on Podman |
+| L3 mTLS | Istio Ambient | -- | No mesh on Podman |
+| L4 SecurityContext | Pod securityContext | Podman `--security-opt` | Similar controls |
+| L5 NetworkPolicy | K8s NetworkPolicy | -- | **Open problem** |
+| L6 Landlock | Landlock LSM (in-pod) | Landlock LSM (in-container) | Works on both |
+| L7 Egress Proxy | Squid sidecar + iptables | Squid container + pod network | Needs work |
+| L8 HITL | Backend API + UI | TUI | Works on both |
+| Zero-Secret | Budget Proxy + AuthBridge + Vault | -- | Local secret mgmt TBD |
+
+**Network isolation on developer laptops** is the hardest unsolved problem.
+Kubernetes NetworkPolicy has no equivalent in Podman. The current mitigation
+is Landlock (filesystem) + Squid (egress), which work in both environments.
+
+**Policy portability** — defining one policy that works across Podman and
+Kubernetes — is the subject of active upstream work in the Kubernetes Agentic
+Networking proposal.

--- a/docs/agentic-runtime/security.md
+++ b/docs/agentic-runtime/security.md
@@ -1,0 +1,194 @@
+# Security
+
+The Agentic Runtime uses a defense-in-depth model with 8 composable security
+layers. Layers L1-L3 and L8 are always on. Layers L4-L7 are toggles exposed
+through the import wizard.
+
+---
+
+## Defense-in-Depth Layers
+
+| Layer | Mechanism | Threat Addressed | Overhead |
+|-------|-----------|-----------------|----------|
+| **L1** Keycloak + AuthBridge | OIDC JWT auth. AuthBridge sidecar validates inbound JWTs and exchanges outbound tokens via OAuth2 (RFC 8693). Injected by mutating webhook. | Unauthorized access, token forgery | Zero (sidecar) |
+| **L2** RBAC | Kubernetes RBAC per namespace + feature flag scoping | Privilege escalation | Zero |
+| **L3** mTLS | Istio Ambient ztunnel | Network eavesdropping, spoofing | Zero (ambient) |
+| **L4** SecurityContext | non-root, drop ALL caps, seccomp, readOnlyRootFilesystem | Container breakout | Zero |
+| **L5** NetworkPolicy | Default-deny + DNS allow | Lateral movement | Zero |
+| **L6** Landlock | Per-tool-call Landlock via ctypes (zero deps). Startup probe verifies kernel. Pod fails if unavailable. | Filesystem escape | ~7ms/call |
+| **L7** Egress Proxy | Squid domain allowlist (separate Deployment) | Data exfiltration | ~50MB RAM |
+| **L8** HITL | Approval gates for dangerous operations | Unchecked autonomy | Human latency |
+
+---
+
+## Composable Security Profiles
+
+Security layers are assembled by the wizard into named profiles. The
+naming pattern reflects active layers:
+
+```
+sandbox-legion                         # legion profile (L1-L3, L8 only)
+sandbox-legion-secctx                  # + L4 SecurityContext
+sandbox-legion-secctx-landlock         # + L4 + L6 Landlock
+sandbox-legion-secctx-landlock-proxy   # + L4 + L6 + L7 Egress Proxy (= hardened)
+```
+
+### Profiles
+
+| Profile | Active Layers | Use Case |
+|---------|--------------|----------|
+| `legion` | L1-L3, L8 | Local dev, rapid prototyping, persistent sessions |
+| `basic` | L1-L5, L8 | Trusted internal agents |
+| `hardened` | L1-L8 | Production agents running own code |
+| `restricted` | L1-L8 + source policy | Imported / third-party agents |
+
+The wizard UI allows operators to toggle individual layers regardless of
+profile, creating custom combinations.
+
+---
+
+## Landlock Filesystem Isolation
+
+[Landlock](https://landlock.io/) is a Linux security module that restricts
+filesystem access at the process level. The Agentic Runtime uses Landlock
+to isolate each tool call to the agent's workspace directory.
+
+### Implementation
+
+- **Pure ctypes** -- `landlock_ctypes.py` (193 lines) makes raw syscalls
+  via Python's `ctypes` module. Zero external dependencies.
+- **Architecture-aware** -- supports x86_64 and aarch64 syscall numbers
+- **ABI v1/v2/v3** -- handles kernel version differences
+- **Irreversible** -- once applied, Landlock restrictions cannot be undone
+
+### How It Works
+
+1. On startup, `landlock_probe.py` forks a child process to test kernel
+   Landlock support. If the kernel doesn't support Landlock, the pod
+   **fails assertively** (no silent degradation).
+
+2. For each tool call, the executor forks a new subprocess with Landlock
+   applied:
+   - Write access: only the session workspace (`/workspace/{context_id}/`)
+   - Read access: system libraries, Python packages
+   - No access: other sessions' workspaces, host filesystem
+
+3. The overhead is ~7ms per tool call (fork + Landlock setup).
+
+### Environment Variable
+
+Set `SANDBOX_LANDLOCK=true` on the agent container to enable Landlock.
+The startup probe will verify kernel support and fail the pod if unavailable.
+
+---
+
+## AuthBridge — Zero-Trust Agent Identity
+
+AuthBridge provides transparent authentication for agent pods via a
+**sidecar pattern**. It is NOT a standalone service — it is injected into
+agent pods by a mutating admission webhook.
+
+### How It Works
+
+1. A **mutating webhook** (`kagenti-webhook-system`) watches for workloads
+   in namespaces labeled `kagenti-enabled: "true"`
+2. When a pod has the label `kagenti.io/inject: enabled`, the webhook
+   injects sidecar containers:
+   - **proxy-init** (init container) — sets up iptables traffic redirection
+   - **envoy-proxy** — Envoy sidecar handling auth on two ports
+   - **kagenti-client-registration** — registers workload with Keycloak
+   - **spiffe-helper** (optional, if `kagenti.io/spire: enabled`) — fetches
+     SPIFFE credentials from SPIRE
+3. All traffic is intercepted transparently via iptables — the agent code
+   is completely unaware of AuthBridge
+
+### Traffic Flow
+
+```
+Inbound:  Backend -> envoy-proxy:15124 -> JWT validation -> agent container
+Outbound: agent container -> envoy-proxy:15123 -> OAuth2 token exchange -> target service
+```
+
+- **Inbound (port 15124):** Validates JWT signatures using JWKS from Keycloak.
+  Rejects invalid tokens with HTTP 401.
+- **Outbound (port 15123):** Performs RFC 8693 OAuth2 token exchange with
+  Keycloak. The agent's SPIFFE identity (or static client ID) is exchanged
+  for a scoped access token.
+
+### Pod Labels
+
+| Label | Value | Effect |
+|-------|-------|--------|
+| `kagenti.io/inject` | `enabled` | Enables AuthBridge sidecar injection |
+| `kagenti.io/inject` | `disabled` | Skips injection |
+| `kagenti.io/spire` | `enabled` | Uses SPIFFE-based identity |
+| `kagenti.io/spire` | `disabled` | Uses static client ID |
+
+### Namespace Configuration
+
+Each agent namespace has two ConfigMaps created by the Helm chart:
+- `authbridge-config` — Keycloak token URL, issuer, target audience/scopes
+- `envoy-config` — Envoy listener configuration for both ports
+
+---
+
+## RBAC Scoping
+
+When `KAGENTI_FEATURE_FLAG_SANDBOX` is `false`, the backend ClusterRole
+does NOT include:
+- `pods/exec` (used for file browsing and agent introspection)
+- `secrets` access (used for PostgreSQL credentials)
+- `configmaps` access (used for agent configuration)
+
+These permissions are only added when the sandbox flag is enabled. This
+prevents cluster-wide privilege escalation when the Agentic Runtime is
+not in use.
+
+---
+
+## Service Mesh -- Istio Ambient
+
+All agent namespaces are enrolled in Istio Ambient mesh with automatic mTLS.
+No sidecars -- ztunnel handles L4 encryption, waypoint proxies handle L7.
+
+```mermaid
+flowchart LR
+    subgraph external["External HTTPS"]
+        user["User"]
+    end
+
+    subgraph mesh["Istio Ambient Mesh (auto mTLS)"]
+        backend["kagenti-backend<br/>EXTERNAL route"]
+        agent["sandbox-agent<br/>INTERNAL only"]
+        budget["llm-budget-proxy<br/>INTERNAL only"]
+        litellm["litellm<br/>INTERNAL only"]
+        pg[("postgres-sessions<br/>INTERNAL only")]
+    end
+
+    user -->|"HTTPS (Route)"| backend
+    backend -->|"A2A + JWT (mTLS)"| agent
+    agent -->|"HTTP (mTLS)"| budget
+    budget -->|"HTTP (mTLS)"| litellm
+    agent -->|"asyncpg (mTLS)"| pg
+```
+
+**Key points:**
+- Agents, budget proxy, LiteLLM, and PostgreSQL are **internal-only**
+- Only `kagenti-ui`, `kagenti-backend`, `keycloak`, `mlflow`, `phoenix` have external routes
+- SSL is disabled at the application level -- Istio ztunnel provides mTLS
+- Target: STRICT mTLS mode + deny-all baseline with per-service ALLOW policies
+
+---
+
+## Egress Proxy
+
+Each agent can optionally have a **Squid egress proxy** that restricts
+outbound HTTP(S) traffic to an allowlist of domains.
+
+- Deployed as a separate Deployment (`{agent}-egress-proxy`)
+- Agent's `HTTP_PROXY`/`HTTPS_PROXY` env vars point to the proxy
+- Only domains in `ALLOWED_DOMAINS` can be reached
+- All other outbound traffic is blocked
+
+This prevents data exfiltration and unauthorized API calls from agent
+workspaces.

--- a/docs/agentic-runtime/security.md
+++ b/docs/agentic-runtime/security.md
@@ -4,6 +4,15 @@ The Agentic Runtime uses a defense-in-depth model with 8 composable security
 layers. Layers L1-L3 and L8 are always on. Layers L4-L7 are toggles exposed
 through the import wizard.
 
+**Key milestone: [Zero-Secret Agents](./zero-secret-agents.md)** — three pillars
+eliminate all long-lived secrets from agent containers:
+1. **LLM Budget Proxy** (shipped) — agent has no LLM API keys
+2. **AuthBridge sidecar** (shipped) — agent has no service tokens
+3. **Vault integration** (planned) — agent has no database passwords
+
+When complete, a compromised agent cannot exfiltrate any credential usable
+beyond its own budget-bounded, time-limited session.
+
 ---
 
 ## Defense-in-Depth Layers

--- a/docs/agentic-runtime/troubleshooting.md
+++ b/docs/agentic-runtime/troubleshooting.md
@@ -1,0 +1,188 @@
+# Troubleshooting
+
+---
+
+## Agent Pod Not Starting
+
+### Landlock probe failure
+
+**Symptom:** Pod fails with `Landlock not supported by kernel`.
+
+**Cause:** `SANDBOX_LANDLOCK=true` but the node kernel doesn't support Landlock
+(requires Linux 5.13+). The startup probe is assertive -- it fails the pod
+rather than silently degrading.
+
+**Fix:** Either upgrade the node kernel or set `SANDBOX_LANDLOCK=false` in the
+agent deployment.
+
+### PostgreSQL connection refused
+
+**Symptom:** Agent logs show `connection refused` to `postgres-sessions`.
+
+**Cause:** The `postgres-sessions` StatefulSet hasn't started yet, or the
+secret `postgres-sessions-secret` doesn't exist.
+
+**Check:**
+```bash
+kubectl get statefulset postgres-sessions -n team1
+kubectl get secret postgres-sessions-secret -n team1
+```
+
+**Fix:** Run `76-deploy-sandbox-agents.sh` which creates the StatefulSet and
+secrets.
+
+---
+
+## SSE Streaming Issues
+
+### Events not appearing in UI
+
+**Symptom:** Agent is processing but the UI shows no events.
+
+**Check:**
+1. Verify the background event consumer is running:
+   ```bash
+   kubectl logs deploy/kagenti-backend -n kagenti-system | grep "consumer"
+   ```
+2. Check the events table:
+   ```bash
+   kubectl exec -n team1 statefulset/postgres-sessions -- \
+     psql -U kagenti sessions -c "SELECT COUNT(*) FROM events"
+   ```
+
+**Common causes:**
+- Backend can't reach the agent pod (check Istio mTLS, NetworkPolicy)
+- Agent pod is not emitting SSE events (check agent logs)
+- Feature flag `SANDBOX` is not enabled
+
+### Gap in event history
+
+**Symptom:** Some events are missing when loading session history.
+
+**Cause:** The gap-fill mechanism fetches events from `?from_index=N` but
+the events table may have index gaps if the background consumer was
+temporarily unavailable.
+
+**Fix:** The UI automatically falls back to the `loop_events` blob in
+task metadata, then to raw history. If events are permanently lost,
+the session history may be incomplete but functional.
+
+---
+
+## Budget Proxy Issues
+
+### Agent stops with "Budget Exceeded"
+
+**Symptom:** Agent gracefully stops mid-task with a budget exceeded message.
+
+**This is expected behavior.** The LLM Budget Proxy returned HTTP 402.
+
+**Check current usage:**
+```bash
+kubectl exec -n team1 statefulset/postgres-sessions -- \
+  psql -U kagenti llm_budget -c \
+  "SELECT session_id, SUM(total_tokens) FROM llm_calls GROUP BY session_id"
+```
+
+**Increase limit:**
+```bash
+kubectl exec -n team1 statefulset/postgres-sessions -- \
+  psql -U kagenti llm_budget -c \
+  "UPDATE budget_limits SET max_tokens = 2000000 WHERE scope = 'session'"
+```
+
+### Budget proxy not recording calls
+
+**Symptom:** `llm_calls` table is empty but agent is making LLM calls.
+
+**Cause:** Agent's `LLM_API_BASE` is pointing directly to LiteLLM instead
+of the budget proxy.
+
+**Check:** Verify the agent deployment has:
+```yaml
+env:
+  - name: LLM_API_BASE
+    value: http://llm-budget-proxy:8080
+```
+
+---
+
+## File Browser Issues
+
+### "Failed to browse files"
+
+**Symptom:** File browser shows an error.
+
+**Cause:** Backend needs `pods/exec` permission to browse agent pod files.
+This permission is only granted when `KAGENTI_FEATURE_FLAG_SANDBOX` is `true`.
+
+**Check:**
+```bash
+kubectl auth can-i create pods/exec -n team1 \
+  --as system:serviceaccount:kagenti-system:kagenti-backend
+```
+
+---
+
+## Sidecar Issues
+
+### Sidecar not starting
+
+**Symptom:** Sidecar deployment exists but pod isn't running.
+
+**Check:**
+```bash
+kubectl describe pod -n team1 -l app=looper-sidecar
+kubectl logs -n team1 -l app=looper-sidecar
+```
+
+---
+
+## Database Issues
+
+### "relation does not exist"
+
+**Symptom:** Backend logs show `relation "sessions" does not exist`.
+
+**Cause:** Auto-migration hasn't run yet. It runs on backend startup.
+
+**Fix:** Restart the backend:
+```bash
+kubectl rollout restart deploy/kagenti-backend -n kagenti-system
+```
+
+### Stale connection pool
+
+**Symptom:** Agent intermittently fails with connection errors to PostgreSQL.
+
+**Cause:** The asyncpg connection pool went stale (e.g. after PostgreSQL
+pod restart).
+
+**Fix:** The agent has `_ensure_checkpointer()` which auto-reconnects.
+If it persists, restart the agent pod.
+
+---
+
+## Log Locations
+
+| Component | How to Access |
+|-----------|--------------|
+| Backend | `kubectl logs deploy/kagenti-backend -n kagenti-system` |
+| Agent | `kubectl logs deploy/<agent-name> -n team1` |
+| Budget Proxy | `kubectl logs deploy/llm-budget-proxy -n team1` |
+| Egress Proxy | `kubectl logs deploy/<agent>-egress-proxy -n team1` |
+| PostgreSQL | `kubectl logs statefulset/postgres-sessions -n team1` |
+| LiteLLM | `kubectl logs deploy/litellm-proxy -n kagenti-system` |
+
+### Useful Filters
+
+```bash
+# Agent reasoning events
+kubectl logs deploy/sandbox-legion -n team1 | grep "event_type"
+
+# Budget proxy decisions
+kubectl logs deploy/llm-budget-proxy -n team1 | grep "budget"
+
+# Backend SSE proxy errors
+kubectl logs deploy/kagenti-backend -n kagenti-system | grep "SSE\|consumer"
+```

--- a/docs/agentic-runtime/tui.md
+++ b/docs/agentic-runtime/tui.md
@@ -1,0 +1,209 @@
+# TUI Integration
+
+The Kagenti TUI (`kagenti` binary) is a Go/Bubbletea terminal client that
+provides the same agent interaction capabilities as the React UI, plus
+developer workflows (cluster management, testing, releases) that don't
+exist in the web UI.
+
+---
+
+## Two Clients, Same Backend
+
+```mermaid
+flowchart TB
+    subgraph clients["Clients"]
+        WebUI["React Web UI<br/><small>Browser-based<br/>Rich graph views<br/>File browser<br/>LLM analytics</small>"]
+        TUI["Go TUI<br/><small>Terminal-based<br/>SSE streaming<br/>Agent chat<br/>Dev workflows</small>"]
+        CLI["CLI mode<br/><small>kagenti --auto<br/>Non-interactive<br/>CI pipelines</small>"]
+    end
+
+    subgraph backend["Backend API"]
+        API["FastAPI Backend<br/><small>/api/v1/sandbox/*<br/>/api/v1/chat/*<br/>/api/v1/agents/*</small>"]
+    end
+
+    subgraph agents["Agents"]
+        Agent["Sandbox Agent<br/><small>A2A protocol</small>"]
+    end
+
+    WebUI -->|"REST + SSE (mTLS)"| API
+    TUI -->|"REST + SSE (mTLS)"| API
+    CLI -->|"REST (mTLS)"| API
+    API -->|"A2A JSON-RPC (mTLS)"| Agent
+```
+
+Both clients consume the same API. The Agentic Runtime features
+(sessions, events, budget, HITL) work identically in both.
+
+---
+
+## TUI Command Map
+
+The TUI serves three modes:
+
+```
+kagenti                             # Interactive TUI (Bubbletea)
+kagenti <command>                   # CLI mode (non-interactive)
+kagenti <command> --auto            # CI mode (no prompts)
+```
+
+### Production Commands (API-only)
+
+These use the backend HTTP API, same as the web UI:
+
+| Command | What It Does | Runtime Feature |
+|---------|-------------|-----------------|
+| `kagenti agents` | List agents in namespace | Agent discovery |
+| `kagenti chat` | SSE streaming chat session | Sessions, events, HITL |
+| `kagenti deploy agent` | Deploy agent via wizard | Import wizard |
+| `kagenti login` | OAuth device code flow | Keycloak auth |
+| `kagenti status` | Platform health dashboard | -- |
+| `kagenti teams` | List/create/delete namespaces | Team provisioning |
+
+### Developer Commands (Shell + API)
+
+These shell out to scripts and tools (not API-only):
+
+| Command | What It Does |
+|---------|-------------|
+| `kagenti cluster create` | Create Kind/HyperShift cluster + deploy platform |
+| `kagenti cluster destroy` | Tear down cluster |
+| `kagenti test` | Full E2E with dependency overrides |
+| `kagenti run <phase>` | Re-run individual test phase |
+| `kagenti release` | Multi-repo tag + wait CI + bump chart |
+
+---
+
+## Agentic Runtime in the TUI
+
+The TUI expands from basic text chat to full sandbox session management:
+
+```mermaid
+flowchart LR
+    subgraph before["Before Runtime"]
+        A1["agents → chat\n(plain text streaming)"]
+    end
+
+    subgraph after["With Runtime"]
+        B1["agents → sessions\n(list, resume, history)"]
+        B2["sessions → sandbox chat\n(loop cards: plan → tool → reflect)"]
+        B3["chat → HITL\n(approve/deny in terminal)"]
+        B4["chat → budget\n(token usage display)"]
+        B5["chat → files\n(workspace browser)"]
+    end
+
+    before --> after
+```
+
+### SSE Streaming in Terminal
+
+The TUI already implements SSE streaming for agent chat via Bubbletea's
+message-based architecture. Each SSE line becomes a Bubbletea `Msg`:
+
+```
+Agent event stream → readNextLine() Cmd → Bubbletea Update → Render
+```
+
+This same pattern extends to Agentic Runtime events:
+
+| EVENT_CATALOG Type | TUI Rendering |
+|-------------------|---------------|
+| `planner_output` | Indented plan steps with step numbers |
+| `tool_call` | `[tool] shell: ls -la` with syntax highlighting |
+| `tool_result` | Truncated output with `[+]` expand toggle |
+| `reflector_decision` | Status line: `[reflect] continue (step 2/5)` |
+| `reporter_output` | Final answer in markdown (glamour renderer) |
+| `budget_update` | Status bar: `tokens: 45k/1M` |
+| `hitl_request` | Prompt: `[A]pprove / [D]eny: shell rm -rf /tmp/*` |
+
+### HITL in Terminal
+
+HITL gates work naturally in terminal mode:
+
+```
+⚠ Agent requests approval:
+  Tool: shell
+  Args: rm -rf /tmp/old_workspace
+  Risk: destructive
+
+  [a] Approve  [d] Deny  [i] Inspect args
+```
+
+In `--auto` mode, HITL gates auto-deny by default (configurable).
+
+### Graph Card in TUI
+
+The TUI can fetch the AgentGraphCard and render a simplified topology:
+
+```
+Graph: router → planner → executor → reflector → reporter
+                    ↑          │
+                    └──────────┘ (replan)
+
+Active: executor [step 2/5] ●
+```
+
+Full graph visualization is better suited to the web UI. The TUI focuses
+on text-based step tracking and status indicators.
+
+---
+
+## CI Integration
+
+The same `kagenti` binary runs in GitHub Actions with `--auto` flags:
+
+```yaml
+# Single-step mode
+- name: Deploy & Test
+  run: kagenti test --auto --platform kind --build-core
+
+# Or individual phases (visible in GitHub Actions UI)
+- name: Create cluster
+  run: kagenti cluster create --platform kind
+- name: Install platform
+  run: kagenti run install
+- name: Build deps
+  run: kagenti run build-deps --build-core
+- name: Run E2E
+  run: kagenti run e2e
+```
+
+State flows between steps via `$GITHUB_ENV`. The `kagenti` binary
+detects CI mode and writes structured output to `$GITHUB_STEP_SUMMARY`.
+
+---
+
+## Developer Workflow with Runtime
+
+The `kagenti test` command now includes Agentic Runtime components:
+
+```mermaid
+flowchart TD
+    Config["kagenti test\n--build-core"] --> Build["Build deps\n+ platform-base\n+ sandbox-agent\n+ llm-budget-proxy"]
+    Build --> Install["Install platform\n+ feature flags enabled\n+ postgres-sessions\n+ budget proxy"]
+    Install --> Deploy["Deploy agents\n+ sandbox-legion\n+ weather-agent"]
+    Deploy --> E2E["Run E2E\n+ sandbox session tests\n+ graph card tests\n+ budget tests"]
+    E2E --> Result{"Pass?"}
+    Result -->|"yes"| Release["kagenti release"]
+    Result -->|"no"| Retry["Fix → kagenti test"]
+```
+
+### Team Provisioning with Runtime
+
+`kagenti team create` provisions a full namespace with runtime components:
+
+```
+$ kagenti team create my-team
+
+Creating namespace: my-team
+  ✅ Namespace created
+  ✅ Istio Ambient labels applied
+  ✅ AuthBridge config (envoy-config, authbridge-config)
+  ✅ PostgreSQL StatefulSet (sessions + llm_budget)
+  ✅ LLM Budget Proxy
+  ✅ RBAC bindings
+  ✅ Secrets (postgres, litellm)
+  ⏳ Waiting for postgres-sessions ready...
+  ✅ Team my-team ready
+
+Use: kagenti --ns my-team agents
+```

--- a/docs/agentic-runtime/use-cases.md
+++ b/docs/agentic-runtime/use-cases.md
@@ -1,8 +1,47 @@
 # Use Cases
 
 What agents do on the Kagenti Agentic Runtime — from coding assistants
-to DevOps automation. Each use case maps to a sandboxing profile, a set
-of tools, and a skill pack configuration.
+to DevOps automation. Each use case maps to a sandboxing profile, explicit
+MCP tool configuration, and HITL approval policies.
+
+---
+
+## MCP Tool Approval Model
+
+Every unsafe action flows through MCP tools with three approval levels.
+User approval is **identity-bound** — the approving user's OAuth identity
+is attached to the action, creating accountability and an audit trail.
+
+```mermaid
+flowchart LR
+    Agent["Agent calls<br/>MCP tool"]
+    Gateway["MCP Gateway<br/>checks policy"]
+
+    Gateway -->|"auto-approve"| Execute["Execute immediately<br/><small>Read-only, safe operations</small>"]
+    Gateway -->|"user-approve"| OAuth["OAuth popup<br/><small>User reviews action<br/>User identity attached<br/>to the execution</small>"]
+    Gateway -->|"deny"| Block["Blocked<br/><small>Not allowed for this agent</small>"]
+
+    OAuth -->|"approved + signed"| Execute2["Execute with<br/>user's identity"]
+    OAuth -->|"denied"| Block2["Agent informed,<br/>replans"]
+```
+
+**Three approval levels:**
+
+| Level | When | User Action | Identity |
+|-------|------|-------------|----------|
+| **auto-approve** | Read-only, safe operations (list, get, read) | None | Agent's SPIFFE identity |
+| **user-approve** | Write operations (create, update, push, send) | OAuth popup — review + approve | **User's OAuth identity** attached to the action |
+| **deny** | Dangerous or out-of-scope operations | None (blocked by policy) | N/A |
+
+**User approval with OAuth identity** means:
+- The user sees exactly what the agent wants to do (tool name, parameters)
+- The user clicks "Approve" in an OAuth consent popup
+- The action executes with **the user's scoped OAuth token**, not the agent's
+- The audit trail records: who approved, when, what parameters
+- The external service (GitHub, Slack) sees the user's identity as the actor
+
+This is critical for compliance — an agent creating a PR on GitHub does so
+**as the approving user**, not as a service account.
 
 ---
 
@@ -11,33 +50,33 @@ of tools, and a skill pack configuration.
 ```mermaid
 flowchart TB
     subgraph coding["Coding Agents"]
-        C1["RCA Agent<br/><small>Root cause analysis<br/>on live clusters</small>"]
-        C2["Sandbox Legion<br/><small>Plan-execute-reflect<br/>coding with tools</small>"]
-        C3["Code Review Agent<br/><small>PR analysis,<br/>security audit</small>"]
+        C1["RCA Agent"]
+        C2["Sandbox Legion"]
+        C3["Code Review Agent"]
     end
 
     subgraph devops["DevOps Agents"]
-        D1["CI/CD Agent<br/><small>Build, test, deploy<br/>multi-repo coordination</small>"]
-        D2["Cluster Health Agent<br/><small>Monitor pods, services,<br/>certificates, resources</small>"]
-        D3["Incident Response Agent<br/><small>Alert triage,<br/>automated remediation</small>"]
+        D1["CI/CD Agent"]
+        D2["Cluster Health Agent"]
+        D3["Incident Response Agent"]
     end
 
     subgraph tool_agents["Tool-Calling Agents"]
-        T1["Weather Agent<br/><small>MCP tool invocation<br/>deterministic loop</small>"]
-        T2["GitHub Agent<br/><small>Issue triage, PR review,<br/>release coordination</small>"]
-        T3["Integration Agent<br/><small>Slack, Jira, PagerDuty<br/>workflow automation</small>"]
+        T1["Weather Agent"]
+        T2["GitHub Agent"]
+        T3["Integration Agent"]
     end
 
     subgraph future["Future"]
-        F1["Security Agent<br/><small>CVE scanning,<br/>compliance auditing</small>"]
-        F2["Data Analysis Agent<br/><small>MLflow analytics,<br/>trace analysis</small>"]
-        F3["Multi-Agent Orchestration<br/><small>Agent-to-agent delegation,<br/>parallel task execution</small>"]
+        F1["Security Agent"]
+        F2["Data Analysis Agent"]
+        F3["Multi-Agent Orchestrator"]
     end
 
-    coding --> |"hardened"| Profile1["L1-L8 + audit trail"]
-    devops --> |"hardened"| Profile1
-    tool_agents --> |"basic"| Profile2["L1-L5 + zero-secret"]
-    future --> |"restricted"| Profile3["L1-L8 + source policy"]
+    coding -->|"hardened"| Profile1["L1-L8 + audit"]
+    devops -->|"hardened"| Profile1
+    tool_agents -->|"basic"| Profile2["L1-L5 + zero-secret"]
+    future -->|"restricted"| Profile3["L1-L8 + source policy"]
 ```
 
 ---
@@ -46,68 +85,95 @@ flowchart TB
 
 ### RCA Agent (Root Cause Analysis)
 
-Investigates failures on live Kubernetes clusters. Reads logs, checks pod
-status, analyzes events, and produces a root cause report.
+Investigates failures on live Kubernetes clusters.
 
 | Aspect | Detail |
 |--------|--------|
 | **Framework** | LangGraph (plan-execute-reflect) |
-| **Profile** | `hardened` (executes kubectl/oc commands) |
-| **Tools** | `shell` (kubectl, oc), `file_read`, `web_fetch` |
+| **Profile** | `hardened` |
 | **Skills** | `rca:kind`, `rca:hypershift`, `k8s:pods`, `k8s:logs` |
-| **Egress** | Cluster API only (no external) |
-| **HITL** | Approve before `kubectl delete`, `kubectl scale` |
-| **Sessions** | Multi-turn — iterative investigation across messages |
-| **Budget** | 500K tokens per session (analysis-heavy) |
+| **Egress** | Cluster API only |
+| **Budget** | 500K tokens/session |
 
-**Example flow:**
-```
-User: "The weather agent is failing on sandbox47"
-  → Planner: 3 steps (check pods, read logs, analyze events)
-  → Executor: kubectl get pods, kubectl logs, kubectl describe
-  → Reflector: root cause identified (image pull error)
-  → Reporter: "The weather-agent pod is in ImagePullBackOff..."
-```
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-kubernetes-read` | `kubectl get pods`, `kubectl describe`, `kubectl logs`, `kubectl get events` | auto-approve |
+| `mcp-kubernetes-write` | `kubectl delete pod`, `kubectl scale`, `kubectl rollout restart` | **user-approve** (OAuth — action runs as approving user) |
+| `mcp-file-read` | Read files from agent workspace | auto-approve |
+| `mcp-fetch` | Fetch cluster API endpoints | auto-approve |
 
 ### Sandbox Legion (General Coding)
 
-Full-featured coding agent with persistent sessions, file operations,
-shell execution, and multi-turn conversations.
+Full-featured coding agent with persistent sessions.
 
 | Aspect | Detail |
 |--------|--------|
 | **Framework** | LangGraph (plan-execute-reflect with micro-reasoning) |
-| **Profile** | `hardened` (executes generated code) |
-| **Tools** | `shell`, `file_read`, `file_write`, `web_fetch`, `explore`, `delegate` |
-| **Skills** | Loaded from git repos via `SKILL_REPOS` env var |
-| **Egress** | pypi.org, github.com, api.github.com (configurable) |
-| **HITL** | Approve before destructive shell commands |
-| **Sessions** | Persistent (PostgreSQL checkpoints, resume across restarts) |
-| **Budget** | 1M tokens per session, 5M daily, 50M monthly |
-| **Workspace** | Per-session at `/workspace/{context_id}/` with Landlock isolation |
+| **Profile** | `hardened` |
+| **Skills** | Loaded from git repos via `SKILL_REPOS` |
+| **Egress** | pypi.org, github.com, api.github.com |
+| **Budget** | 1M tokens/session, 5M daily |
+| **Workspace** | `/workspace/{context_id}/` with Landlock |
 
-**Why hardened?** The agent generates and executes shell commands and Python
-code. Generated code is non-deterministic and potentially adversarial.
-Landlock isolates each tool call to the session workspace. Egress proxy
-restricts outbound traffic to approved domains.
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-shell` | Execute shell commands in workspace | auto-approve for safe commands (`ls`, `cat`, `grep`, `find`, `python`). **user-approve** for destructive (`rm`, `chmod`, `curl`, `wget`). deny for system commands (`sudo`, `mount`, `iptables`). |
+| `mcp-file-read` | Read files in workspace + system libs | auto-approve |
+| `mcp-file-write` | Write files in workspace only | auto-approve (Landlock enforces scope) |
+| `mcp-git-read` | `git clone`, `git log`, `git diff`, `git status` | auto-approve |
+| `mcp-git-write` | `git commit`, `git push`, `git branch`, `git tag` | **user-approve** (OAuth — commit/push runs as user) |
+| `mcp-github-read` | List repos, PRs, issues, reviews | auto-approve |
+| `mcp-github-write` | Create PR, create issue, post comment, merge PR, close issue | **user-approve** (OAuth — PR created as approving user) |
+| `mcp-fetch` | HTTP GET to allowed domains | auto-approve (egress proxy enforces domains) |
+| `mcp-pypi` | `pip install` from allowed packages | auto-approve (source policy blocks dangerous packages) |
+
+**Example approval flow:**
+```
+Agent: "I need to push these changes to the feature branch"
+  → calls mcp-git-write: git push origin feat/fix-bug-123
+
+  ┌─────────────────────────────────────────────┐
+  │  Approve Agent Action                       │
+  │                                             │
+  │  Tool: mcp-git-write                        │
+  │  Action: git push origin feat/fix-bug-123   │
+  │  Repository: kagenti/kagenti                │
+  │                                             │
+  │  This will push as: lsmola@redhat.com       │
+  │                                             │
+  │  [Approve]  [Deny]  [Always approve pushes] │
+  └─────────────────────────────────────────────┘
+
+  → User clicks Approve
+  → OAuth token exchange: user's scoped token used for push
+  → Git push runs with user's identity
+  → Audit: lsmola approved git push at 2026-03-19T14:23:00Z
+```
 
 ### Code Review Agent
 
-Analyzes pull requests for quality, security, conventions, and test coverage.
+Analyzes pull requests for quality, security, and conventions.
 
 | Aspect | Detail |
 |--------|--------|
 | **Framework** | LangGraph or Claude Agent SDK |
-| **Profile** | `basic` (reads code, doesn't execute) |
-| **Tools** | `file_read`, `web_fetch` (GitHub API) |
+| **Profile** | `basic` (read-only) |
 | **Skills** | `github:pr-review`, `test:review`, `cve:scan` |
 | **Egress** | api.github.com only |
-| **HITL** | None needed (read-only) |
-| **Budget** | 200K tokens per review |
+| **Budget** | 200K tokens/review |
 
-**Why basic, not hardened?** The agent only reads files and calls GitHub API.
-It doesn't execute generated code. The reduced profile avoids Landlock
-overhead on a read-heavy workload.
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-github-read` | Get PR diff, list files, read comments, list checks | auto-approve |
+| `mcp-github-write` | Post review comment, submit review, request changes | **user-approve** (OAuth — review posted as user) |
+| `mcp-file-read` | Read PR files | auto-approve |
+| `mcp-fetch` | Fetch GitHub API, NVD API (for CVE checks) | auto-approve |
 
 ---
 
@@ -115,113 +181,149 @@ overhead on a read-heavy workload.
 
 ### CI/CD Agent
 
-Coordinates multi-repository builds, tests, and releases. Runs E2E tests
-with dependency overrides.
+Coordinates multi-repository builds, tests, and releases.
 
 | Aspect | Detail |
 |--------|--------|
 | **Framework** | LangGraph |
-| **Profile** | `hardened` (executes build scripts) |
-| **Tools** | `shell` (git, gh, helm, kubectl), `file_read`, `file_write` |
-| **Skills** | `ci:status`, `ci:monitoring`, `tdd:kind`, `tdd:hypershift` |
-| **Egress** | github.com, registry access, cluster API |
-| **HITL** | Approve before `git push`, `helm upgrade`, tag creation |
-| **Sessions** | Long-running (test cycles can take 30+ minutes) |
-| **Budget** | 2M tokens per session (complex multi-step workflows) |
+| **Profile** | `hardened` |
+| **Skills** | `ci:status`, `ci:monitoring`, `tdd:kind` |
+| **Egress** | github.com, container registries, cluster API |
+| **Budget** | 2M tokens/session |
 
-**Example flow:**
-```
-User: "Run E2E tests on Kind with extensions from main"
-  → Planner: 5 steps (create cluster, build deps, install, deploy, test)
-  → Executor: kind-full-test.sh --build kagenti-extensions=main
-  → Reflector: 35 passed, 0 failed
-  → Reporter: "All tests passed. Ready for release."
-```
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-shell` | `make build`, `make test`, `pytest`, `go test` | auto-approve (build commands) |
+| `mcp-git-read` | Clone repos, read logs, diff branches | auto-approve |
+| `mcp-git-write` | `git tag`, `git push --tags` | **user-approve** (OAuth — tag as user) |
+| `mcp-github-read` | Check CI status, list runs, read artifacts | auto-approve |
+| `mcp-github-write` | Create release PR, post CI summary comment | **user-approve** (OAuth — PR as user) |
+| `mcp-helm` | `helm template` (render), `helm lint` | auto-approve |
+| `mcp-helm-write` | `helm upgrade`, `helm install` | **user-approve** (OAuth — deploy as user. **Cannot be auto-approved.**) |
+| `mcp-kubernetes-read` | Check deployment status, pod health | auto-approve |
+| `mcp-kubernetes-write` | Apply manifests, create namespaces | **user-approve** |
+| `mcp-registry` | Push images to container registry | **user-approve** (OAuth — push as user) |
 
 ### Cluster Health Agent
 
-Continuously monitors cluster health — pods, services, certificates,
-resource usage. Alerts on anomalies.
+Monitors cluster health — read-only, no approvals needed.
 
 | Aspect | Detail |
 |--------|--------|
-| **Framework** | LangGraph (simple observe-report loop) |
-| **Profile** | `basic` (read-only cluster access) |
-| **Tools** | `shell` (kubectl get, kubectl describe — read only) |
-| **Skills** | `k8s:health`, `k8s:pods`, `k8s:logs` |
-| **Egress** | Cluster API only |
-| **HITL** | None (read-only) |
-| **Budget** | 100K tokens per check |
+| **Framework** | LangGraph (observe-report loop) |
+| **Profile** | `basic` (read-only) |
+| **Budget** | 100K tokens/check |
+
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-kubernetes-read` | Get pods, services, nodes, events, certificates | auto-approve |
+| `mcp-prometheus` | Query metrics (CPU, memory, request rate) | auto-approve |
+| `mcp-alertmanager-read` | List active alerts | auto-approve |
 
 ### Incident Response Agent
 
-Responds to alerts — triages, investigates, and optionally remediates.
-Escalates to human via HITL for destructive actions.
+Triages alerts and optionally remediates with human approval.
 
 | Aspect | Detail |
 |--------|--------|
 | **Framework** | LangGraph |
-| **Profile** | `hardened` (may execute remediation commands) |
-| **Tools** | `shell`, `web_fetch` (PagerDuty/Slack API) |
+| **Profile** | `hardened` |
 | **Skills** | `rca:kind`, `rca:hypershift`, `k8s:live-debugging` |
-| **Egress** | Cluster API, PagerDuty, Slack |
-| **HITL** | **Required** before any remediation (scale, restart, delete) |
-| **Sessions** | Multi-turn — investigation → remediation → verification |
-| **Budget** | 1M tokens per incident |
+| **Budget** | 1M tokens/incident |
+
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-kubernetes-read` | Get pods, logs, events, describe | auto-approve |
+| `mcp-kubernetes-write` | Restart pod, scale deployment, cordon node | **user-approve** (OAuth — **cannot be auto-approved** for remediation) |
+| `mcp-pagerduty-read` | Get incident details, list alerts | auto-approve |
+| `mcp-pagerduty-write` | Acknowledge incident, add note | **user-approve** (OAuth — ack as user) |
+| `mcp-slack-read` | Read channel messages (for context) | auto-approve |
+| `mcp-slack-write` | Post incident update, notify channel | **user-approve** (OAuth — post as user) |
 
 ---
 
 ## Tool-Calling Agents
 
-### Weather Agent (Reference Implementation)
+### Weather Agent (Reference)
 
-The simplest agent — deterministic tool loop. Calls a weather MCP tool,
-formats the response, returns to user.
+Simplest agent — deterministic tool loop, no approvals.
 
 | Aspect | Detail |
 |--------|--------|
-| **Framework** | LangGraph (single-node ReAct) |
-| **Profile** | `legion` (minimal, trusted) |
-| **Tools** | `weather` MCP tool (via MCP Gateway) |
-| **Egress** | MCP Gateway only (internal) |
-| **HITL** | None |
-| **Budget** | 50K tokens per session |
+| **Profile** | `legion` |
+| **Budget** | 50K tokens/session |
 
-**Why legion?** Fully deterministic. Fixed tool set. No code generation.
-Predictable behavior. The three non-negotiable pillars (zero-secret,
-egress control, audit trail) still apply.
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-weather` | Get current weather, forecast | auto-approve |
 
 ### GitHub Agent
 
-Manages GitHub repositories — issue triage, PR review, release coordination,
-weekly reports.
+Manages GitHub repositories with identity-bound write operations.
 
 | Aspect | Detail |
 |--------|--------|
 | **Framework** | LangGraph |
-| **Profile** | `basic` (API calls, no code execution) |
-| **Tools** | `web_fetch` (GitHub API via AuthBridge token exchange) |
-| **Skills** | `github:issues`, `github:prs`, `github:last-week`, `github:pr-review` |
-| **Egress** | api.github.com only |
-| **HITL** | Approve before creating/closing issues, posting comments |
-| **Budget** | 300K tokens per session |
+| **Profile** | `basic` |
+| **Skills** | `github:issues`, `github:prs`, `github:last-week` |
+| **Budget** | 300K tokens/session |
 
-**Zero-secret critical:** AuthBridge exchanges SPIFFE identity for a scoped
-GitHub token. The agent never possesses a `GITHUB_TOKEN`. Even if the agent
-is socially engineered via prompt manipulation, there's no credential to leak.
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-github-read` | List repos, PRs, issues, reviews, CI checks, releases | auto-approve |
+| `mcp-github-write-safe` | Create draft PR, create issue (draft), add label, assign reviewer | user-approve (can be set to **auto-approve** by admin) |
+| `mcp-github-write-destructive` | Merge PR, close issue, delete branch, create release | **user-approve** (OAuth — **cannot be auto-approved**) |
+| `mcp-github-comment` | Post PR review, issue comment | user-approve (can be set to auto-approve) |
+
+**Auto-approve policy:** An admin can configure certain write operations
+as auto-approved for trusted agents:
+
+```yaml
+# MCP Gateway tool policy for github-agent in team1
+tools:
+  mcp-github-read:
+    approval: auto
+  mcp-github-write-safe:
+    approval: auto          # admin opted in
+  mcp-github-write-destructive:
+    approval: user-required  # cannot be overridden to auto
+  mcp-github-comment:
+    approval: auto          # admin opted in — agent can comment freely
+```
+
+Some operations have `approval: user-required` which **cannot be changed
+to auto-approve** even by admins. These are the operations where the
+user's identity is essential (merge, delete, release).
 
 ### Integration Agent
 
-Connects to external services (Slack, Jira, PagerDuty) for workflow automation.
+Connects to Slack, Jira, PagerDuty.
 
 | Aspect | Detail |
 |--------|--------|
-| **Framework** | Any (OpenCode, Claude SDK, custom) |
-| **Profile** | `basic` (API calls via AuthBridge) |
-| **Tools** | MCP tools for each service (via MCP Gateway) |
-| **Egress** | Service-specific domains via egress proxy |
-| **HITL** | Approve before sending messages, creating tickets |
-| **Budget** | 200K tokens per workflow |
+| **Profile** | `basic` |
+| **Budget** | 200K tokens/workflow |
+
+**MCP Tools:**
+
+| MCP Tool | Operations | Approval |
+|----------|-----------|----------|
+| `mcp-slack-read` | List channels, read messages, search | auto-approve |
+| `mcp-slack-write` | Post message, update message, react | **user-approve** (OAuth — post as user) |
+| `mcp-jira-read` | List issues, search, get status | auto-approve |
+| `mcp-jira-write` | Create issue, transition status, add comment | **user-approve** (OAuth — create as user) |
+| `mcp-pagerduty-read` | List incidents, get on-call | auto-approve |
+| `mcp-pagerduty-write` | Acknowledge, escalate, create incident | **user-approve** |
 
 ---
 
@@ -229,68 +331,71 @@ Connects to external services (Slack, Jira, PagerDuty) for workflow automation.
 
 ### Security Agent
 
-Automated CVE scanning, dependency auditing, compliance checking.
-Reads code and dependencies, produces reports.
-
-| Aspect | Detail |
-|--------|--------|
-| **Framework** | LangGraph or AG2 |
-| **Profile** | `restricted` (untrusted scan targets) |
-| **Tools** | `shell` (trivy, grype), `file_read`, `web_fetch` (NVD API) |
-| **Skills** | `cve:scan`, `cve:brainstorm` |
-| **Egress** | NVD, GitHub advisory database only |
-| **Source policy** | Blocked packages, restricted git remotes |
+| **MCP Tools:** | `mcp-trivy` (auto), `mcp-grype` (auto), `mcp-nvd-read` (auto), `mcp-github-advisory` (auto), `mcp-github-write` (create security advisory — **user-approve, cannot auto**) |
 
 ### Data Analysis Agent
 
-Analyzes MLflow traces, LLM observability data, and platform metrics.
-Produces reports and visualizations.
-
-| Aspect | Detail |
-|--------|--------|
-| **Framework** | LangGraph or CrewAI (multi-agent for complex analysis) |
-| **Profile** | `basic` (read-only data access) |
-| **Tools** | `web_fetch` (MLflow API, Phoenix API), `file_write` (reports) |
-| **Egress** | MLflow, Phoenix (internal services) |
+| **MCP Tools:** | `mcp-mlflow-read` (auto), `mcp-phoenix-read` (auto), `mcp-prometheus` (auto), `mcp-file-write` (auto — reports only) |
 
 ### Multi-Agent Orchestration
-
-An orchestrator agent delegates tasks to specialized sub-agents.
-Each sub-agent has its own sandboxing profile.
 
 ```mermaid
 flowchart TB
     Orchestrator["Orchestrator Agent<br/><small>Profile: basic<br/>Delegates via A2A</small>"]
 
-    Orchestrator -->|"A2A"| Coder["Coding Agent<br/><small>Profile: hardened<br/>Writes + executes code</small>"]
-    Orchestrator -->|"A2A"| Reviewer["Review Agent<br/><small>Profile: basic<br/>Reads code only</small>"]
-    Orchestrator -->|"A2A"| Deployer["Deploy Agent<br/><small>Profile: hardened<br/>kubectl + helm</small>"]
-
-    Coder -->|"result"| Orchestrator
-    Reviewer -->|"result"| Orchestrator
-    Deployer -->|"result"| Orchestrator
+    Orchestrator -->|"A2A"| Coder["Coding Agent<br/><small>mcp-shell, mcp-git-write<br/>user-approve for push</small>"]
+    Orchestrator -->|"A2A"| Reviewer["Review Agent<br/><small>mcp-github-read (auto)<br/>mcp-github-comment (user-approve)</small>"]
+    Orchestrator -->|"A2A"| Deployer["Deploy Agent<br/><small>mcp-helm-write (user-approve)<br/>mcp-kubernetes-write (user-approve)</small>"]
 ```
 
-Each sub-agent runs in its own pod with its own sandboxing profile.
-The orchestrator uses the `delegate` tool which calls peer agents via A2A.
-AuthBridge handles inter-agent authentication transparently.
+Each sub-agent has its own MCP tool configuration and approval policies.
+The orchestrator cannot escalate — if a sub-agent needs user approval,
+the approval request bubbles up to the user regardless of the orchestrator.
 
 ---
 
-## Skills & Use Case Mapping
+## Approval Policy Tiers
 
-Skills are loaded from git repos at agent startup via `SKILL_REPOS`.
-Each skill defines prompts, tools, and workflows for a specific task.
+```mermaid
+flowchart TD
+    subgraph never_auto["Cannot Be Auto-Approved (user-required)"]
+        NA1["mcp-git-write: push to remote"]
+        NA2["mcp-github-write: merge PR, delete branch, create release"]
+        NA3["mcp-helm-write: helm upgrade, helm install"]
+        NA4["mcp-kubernetes-write: delete, scale (production)"]
+        NA5["mcp-slack-write: post to #general or public channels"]
+        NA6["mcp-registry: push image to production registry"]
+    end
 
-| Skill Category | Skills | Use Cases |
-|---------------|--------|-----------|
-| **Kubernetes** | `k8s:health`, `k8s:pods`, `k8s:logs` | RCA, Cluster Health, Incident Response |
-| **CI/CD** | `ci:status`, `ci:monitoring`, `tdd:kind`, `tdd:hypershift` | CI/CD Agent |
-| **GitHub** | `github:issues`, `github:prs`, `github:pr-review`, `github:last-week` | GitHub Agent, Code Review |
-| **Security** | `cve:scan`, `cve:brainstorm` | Security Agent |
-| **RCA** | `rca:kind`, `rca:hypershift`, `rca:ci` | RCA Agent, Incident Response |
-| **Deployment** | `kagenti:deploy`, `kagenti:operator`, `helm:debug` | CI/CD Agent, Deploy Agent |
-| **Testing** | `test:write`, `test:review`, `test:run-kind` | CI/CD Agent, Code Review |
+    subgraph admin_configurable["Admin Can Set to Auto-Approve"]
+        AC1["mcp-github-write-safe: create draft PR, create issue"]
+        AC2["mcp-github-comment: post review, comment"]
+        AC3["mcp-jira-write: create issue, add comment"]
+        AC4["mcp-slack-write: post to agent-specific channels"]
+        AC5["mcp-shell: safe commands (ls, cat, grep, python)"]
+    end
+
+    subgraph always_auto["Always Auto-Approved"]
+        AA1["All mcp-*-read tools"]
+        AA2["mcp-file-read, mcp-file-write (workspace only)"]
+        AA3["mcp-fetch (egress proxy enforces domains)"]
+        AA4["mcp-weather, mcp-prometheus"]
+    end
+```
+
+---
+
+## Skills & MCP Tool Mapping
+
+| Skill | MCP Tools Used | Approval Pattern |
+|-------|---------------|-----------------|
+| `rca:kind` | `mcp-kubernetes-read` (auto), `mcp-kubernetes-write` (user) | Investigate auto, remediate user-approve |
+| `github:pr-review` | `mcp-github-read` (auto), `mcp-github-comment` (user/auto) | Read auto, comment configurable |
+| `ci:status` | `mcp-github-read` (auto) | All auto |
+| `tdd:kind` | `mcp-shell` (auto/user), `mcp-kubernetes-read` (auto), `mcp-git-write` (user) | Build auto, push user-approve |
+| `cve:scan` | `mcp-trivy` (auto), `mcp-nvd-read` (auto) | All auto |
+| `kagenti:deploy` | `mcp-helm-write` (user), `mcp-kubernetes-write` (user) | All user-approve |
+| `k8s:health` | `mcp-kubernetes-read` (auto), `mcp-prometheus` (auto) | All auto |
 
 ---
 
@@ -302,14 +407,15 @@ flowchart TD
 
     Start --> Q1{"Executes<br/>generated code?"}
     Q1 -->|"yes"| Q2{"Trusted<br/>source?"}
-    Q1 -->|"no"| Q3{"Calls external<br/>services?"}
+    Q1 -->|"no"| Q3{"Has write<br/>MCP tools?"}
 
-    Q2 -->|"yes (internal)"| Hardened["hardened<br/><small>L1-L8</small>"]
-    Q2 -->|"no (third-party)"| Restricted["restricted<br/><small>L1-L8 + source policy</small>"]
+    Q2 -->|"yes (internal)"| Hardened["hardened<br/><small>L1-L8<br/>write tools: user-approve</small>"]
+    Q2 -->|"no (third-party)"| Restricted["restricted<br/><small>L1-L8 + source policy<br/>all writes: user-approve</small>"]
 
-    Q3 -->|"yes"| Basic["basic<br/><small>L1-L5 + zero-secret</small>"]
-    Q3 -->|"no (internal only)"| Legion["legion<br/><small>L1-L3 + zero-secret</small>"]
+    Q3 -->|"yes"| Basic["basic<br/><small>L1-L5<br/>write tools: user-approve</small>"]
+    Q3 -->|"no (read-only)"| Legion["legion<br/><small>L1-L3<br/>all tools: auto-approve</small>"]
 ```
 
-**Always apply:** Zero-secret (3 pillars), egress control, audit trail.
-These are non-negotiable regardless of profile.
+**Always apply:** Zero-secret (3 pillars), egress proxy, audit trail.
+**Always enforce:** Write MCP tools require user-approve (with OAuth identity).
+**Never auto-approve:** Push, merge, delete, deploy, post to public channels.

--- a/docs/agentic-runtime/use-cases.md
+++ b/docs/agentic-runtime/use-cases.md
@@ -1,0 +1,315 @@
+# Use Cases
+
+What agents do on the Kagenti Agentic Runtime — from coding assistants
+to DevOps automation. Each use case maps to a sandboxing profile, a set
+of tools, and a skill pack configuration.
+
+---
+
+## Use Case Map
+
+```mermaid
+flowchart TB
+    subgraph coding["Coding Agents"]
+        C1["RCA Agent<br/><small>Root cause analysis<br/>on live clusters</small>"]
+        C2["Sandbox Legion<br/><small>Plan-execute-reflect<br/>coding with tools</small>"]
+        C3["Code Review Agent<br/><small>PR analysis,<br/>security audit</small>"]
+    end
+
+    subgraph devops["DevOps Agents"]
+        D1["CI/CD Agent<br/><small>Build, test, deploy<br/>multi-repo coordination</small>"]
+        D2["Cluster Health Agent<br/><small>Monitor pods, services,<br/>certificates, resources</small>"]
+        D3["Incident Response Agent<br/><small>Alert triage,<br/>automated remediation</small>"]
+    end
+
+    subgraph tool_agents["Tool-Calling Agents"]
+        T1["Weather Agent<br/><small>MCP tool invocation<br/>deterministic loop</small>"]
+        T2["GitHub Agent<br/><small>Issue triage, PR review,<br/>release coordination</small>"]
+        T3["Integration Agent<br/><small>Slack, Jira, PagerDuty<br/>workflow automation</small>"]
+    end
+
+    subgraph future["Future"]
+        F1["Security Agent<br/><small>CVE scanning,<br/>compliance auditing</small>"]
+        F2["Data Analysis Agent<br/><small>MLflow analytics,<br/>trace analysis</small>"]
+        F3["Multi-Agent Orchestration<br/><small>Agent-to-agent delegation,<br/>parallel task execution</small>"]
+    end
+
+    coding --> |"hardened"| Profile1["L1-L8 + audit trail"]
+    devops --> |"hardened"| Profile1
+    tool_agents --> |"basic"| Profile2["L1-L5 + zero-secret"]
+    future --> |"restricted"| Profile3["L1-L8 + source policy"]
+```
+
+---
+
+## Coding Agents
+
+### RCA Agent (Root Cause Analysis)
+
+Investigates failures on live Kubernetes clusters. Reads logs, checks pod
+status, analyzes events, and produces a root cause report.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph (plan-execute-reflect) |
+| **Profile** | `hardened` (executes kubectl/oc commands) |
+| **Tools** | `shell` (kubectl, oc), `file_read`, `web_fetch` |
+| **Skills** | `rca:kind`, `rca:hypershift`, `k8s:pods`, `k8s:logs` |
+| **Egress** | Cluster API only (no external) |
+| **HITL** | Approve before `kubectl delete`, `kubectl scale` |
+| **Sessions** | Multi-turn — iterative investigation across messages |
+| **Budget** | 500K tokens per session (analysis-heavy) |
+
+**Example flow:**
+```
+User: "The weather agent is failing on sandbox47"
+  → Planner: 3 steps (check pods, read logs, analyze events)
+  → Executor: kubectl get pods, kubectl logs, kubectl describe
+  → Reflector: root cause identified (image pull error)
+  → Reporter: "The weather-agent pod is in ImagePullBackOff..."
+```
+
+### Sandbox Legion (General Coding)
+
+Full-featured coding agent with persistent sessions, file operations,
+shell execution, and multi-turn conversations.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph (plan-execute-reflect with micro-reasoning) |
+| **Profile** | `hardened` (executes generated code) |
+| **Tools** | `shell`, `file_read`, `file_write`, `web_fetch`, `explore`, `delegate` |
+| **Skills** | Loaded from git repos via `SKILL_REPOS` env var |
+| **Egress** | pypi.org, github.com, api.github.com (configurable) |
+| **HITL** | Approve before destructive shell commands |
+| **Sessions** | Persistent (PostgreSQL checkpoints, resume across restarts) |
+| **Budget** | 1M tokens per session, 5M daily, 50M monthly |
+| **Workspace** | Per-session at `/workspace/{context_id}/` with Landlock isolation |
+
+**Why hardened?** The agent generates and executes shell commands and Python
+code. Generated code is non-deterministic and potentially adversarial.
+Landlock isolates each tool call to the session workspace. Egress proxy
+restricts outbound traffic to approved domains.
+
+### Code Review Agent
+
+Analyzes pull requests for quality, security, conventions, and test coverage.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph or Claude Agent SDK |
+| **Profile** | `basic` (reads code, doesn't execute) |
+| **Tools** | `file_read`, `web_fetch` (GitHub API) |
+| **Skills** | `github:pr-review`, `test:review`, `cve:scan` |
+| **Egress** | api.github.com only |
+| **HITL** | None needed (read-only) |
+| **Budget** | 200K tokens per review |
+
+**Why basic, not hardened?** The agent only reads files and calls GitHub API.
+It doesn't execute generated code. The reduced profile avoids Landlock
+overhead on a read-heavy workload.
+
+---
+
+## DevOps Agents
+
+### CI/CD Agent
+
+Coordinates multi-repository builds, tests, and releases. Runs E2E tests
+with dependency overrides.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph |
+| **Profile** | `hardened` (executes build scripts) |
+| **Tools** | `shell` (git, gh, helm, kubectl), `file_read`, `file_write` |
+| **Skills** | `ci:status`, `ci:monitoring`, `tdd:kind`, `tdd:hypershift` |
+| **Egress** | github.com, registry access, cluster API |
+| **HITL** | Approve before `git push`, `helm upgrade`, tag creation |
+| **Sessions** | Long-running (test cycles can take 30+ minutes) |
+| **Budget** | 2M tokens per session (complex multi-step workflows) |
+
+**Example flow:**
+```
+User: "Run E2E tests on Kind with extensions from main"
+  → Planner: 5 steps (create cluster, build deps, install, deploy, test)
+  → Executor: kind-full-test.sh --build kagenti-extensions=main
+  → Reflector: 35 passed, 0 failed
+  → Reporter: "All tests passed. Ready for release."
+```
+
+### Cluster Health Agent
+
+Continuously monitors cluster health — pods, services, certificates,
+resource usage. Alerts on anomalies.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph (simple observe-report loop) |
+| **Profile** | `basic` (read-only cluster access) |
+| **Tools** | `shell` (kubectl get, kubectl describe — read only) |
+| **Skills** | `k8s:health`, `k8s:pods`, `k8s:logs` |
+| **Egress** | Cluster API only |
+| **HITL** | None (read-only) |
+| **Budget** | 100K tokens per check |
+
+### Incident Response Agent
+
+Responds to alerts — triages, investigates, and optionally remediates.
+Escalates to human via HITL for destructive actions.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph |
+| **Profile** | `hardened` (may execute remediation commands) |
+| **Tools** | `shell`, `web_fetch` (PagerDuty/Slack API) |
+| **Skills** | `rca:kind`, `rca:hypershift`, `k8s:live-debugging` |
+| **Egress** | Cluster API, PagerDuty, Slack |
+| **HITL** | **Required** before any remediation (scale, restart, delete) |
+| **Sessions** | Multi-turn — investigation → remediation → verification |
+| **Budget** | 1M tokens per incident |
+
+---
+
+## Tool-Calling Agents
+
+### Weather Agent (Reference Implementation)
+
+The simplest agent — deterministic tool loop. Calls a weather MCP tool,
+formats the response, returns to user.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph (single-node ReAct) |
+| **Profile** | `legion` (minimal, trusted) |
+| **Tools** | `weather` MCP tool (via MCP Gateway) |
+| **Egress** | MCP Gateway only (internal) |
+| **HITL** | None |
+| **Budget** | 50K tokens per session |
+
+**Why legion?** Fully deterministic. Fixed tool set. No code generation.
+Predictable behavior. The three non-negotiable pillars (zero-secret,
+egress control, audit trail) still apply.
+
+### GitHub Agent
+
+Manages GitHub repositories — issue triage, PR review, release coordination,
+weekly reports.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph |
+| **Profile** | `basic` (API calls, no code execution) |
+| **Tools** | `web_fetch` (GitHub API via AuthBridge token exchange) |
+| **Skills** | `github:issues`, `github:prs`, `github:last-week`, `github:pr-review` |
+| **Egress** | api.github.com only |
+| **HITL** | Approve before creating/closing issues, posting comments |
+| **Budget** | 300K tokens per session |
+
+**Zero-secret critical:** AuthBridge exchanges SPIFFE identity for a scoped
+GitHub token. The agent never possesses a `GITHUB_TOKEN`. Even if the agent
+is socially engineered via prompt manipulation, there's no credential to leak.
+
+### Integration Agent
+
+Connects to external services (Slack, Jira, PagerDuty) for workflow automation.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | Any (OpenCode, Claude SDK, custom) |
+| **Profile** | `basic` (API calls via AuthBridge) |
+| **Tools** | MCP tools for each service (via MCP Gateway) |
+| **Egress** | Service-specific domains via egress proxy |
+| **HITL** | Approve before sending messages, creating tickets |
+| **Budget** | 200K tokens per workflow |
+
+---
+
+## Future Use Cases
+
+### Security Agent
+
+Automated CVE scanning, dependency auditing, compliance checking.
+Reads code and dependencies, produces reports.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph or AG2 |
+| **Profile** | `restricted` (untrusted scan targets) |
+| **Tools** | `shell` (trivy, grype), `file_read`, `web_fetch` (NVD API) |
+| **Skills** | `cve:scan`, `cve:brainstorm` |
+| **Egress** | NVD, GitHub advisory database only |
+| **Source policy** | Blocked packages, restricted git remotes |
+
+### Data Analysis Agent
+
+Analyzes MLflow traces, LLM observability data, and platform metrics.
+Produces reports and visualizations.
+
+| Aspect | Detail |
+|--------|--------|
+| **Framework** | LangGraph or CrewAI (multi-agent for complex analysis) |
+| **Profile** | `basic` (read-only data access) |
+| **Tools** | `web_fetch` (MLflow API, Phoenix API), `file_write` (reports) |
+| **Egress** | MLflow, Phoenix (internal services) |
+
+### Multi-Agent Orchestration
+
+An orchestrator agent delegates tasks to specialized sub-agents.
+Each sub-agent has its own sandboxing profile.
+
+```mermaid
+flowchart TB
+    Orchestrator["Orchestrator Agent<br/><small>Profile: basic<br/>Delegates via A2A</small>"]
+
+    Orchestrator -->|"A2A"| Coder["Coding Agent<br/><small>Profile: hardened<br/>Writes + executes code</small>"]
+    Orchestrator -->|"A2A"| Reviewer["Review Agent<br/><small>Profile: basic<br/>Reads code only</small>"]
+    Orchestrator -->|"A2A"| Deployer["Deploy Agent<br/><small>Profile: hardened<br/>kubectl + helm</small>"]
+
+    Coder -->|"result"| Orchestrator
+    Reviewer -->|"result"| Orchestrator
+    Deployer -->|"result"| Orchestrator
+```
+
+Each sub-agent runs in its own pod with its own sandboxing profile.
+The orchestrator uses the `delegate` tool which calls peer agents via A2A.
+AuthBridge handles inter-agent authentication transparently.
+
+---
+
+## Skills & Use Case Mapping
+
+Skills are loaded from git repos at agent startup via `SKILL_REPOS`.
+Each skill defines prompts, tools, and workflows for a specific task.
+
+| Skill Category | Skills | Use Cases |
+|---------------|--------|-----------|
+| **Kubernetes** | `k8s:health`, `k8s:pods`, `k8s:logs` | RCA, Cluster Health, Incident Response |
+| **CI/CD** | `ci:status`, `ci:monitoring`, `tdd:kind`, `tdd:hypershift` | CI/CD Agent |
+| **GitHub** | `github:issues`, `github:prs`, `github:pr-review`, `github:last-week` | GitHub Agent, Code Review |
+| **Security** | `cve:scan`, `cve:brainstorm` | Security Agent |
+| **RCA** | `rca:kind`, `rca:hypershift`, `rca:ci` | RCA Agent, Incident Response |
+| **Deployment** | `kagenti:deploy`, `kagenti:operator`, `helm:debug` | CI/CD Agent, Deploy Agent |
+| **Testing** | `test:write`, `test:review`, `test:run-kind` | CI/CD Agent, Code Review |
+
+---
+
+## Sandboxing Profile Selection Guide
+
+```mermaid
+flowchart TD
+    Start["What does the agent do?"]
+
+    Start --> Q1{"Executes<br/>generated code?"}
+    Q1 -->|"yes"| Q2{"Trusted<br/>source?"}
+    Q1 -->|"no"| Q3{"Calls external<br/>services?"}
+
+    Q2 -->|"yes (internal)"| Hardened["hardened<br/><small>L1-L8</small>"]
+    Q2 -->|"no (third-party)"| Restricted["restricted<br/><small>L1-L8 + source policy</small>"]
+
+    Q3 -->|"yes"| Basic["basic<br/><small>L1-L5 + zero-secret</small>"]
+    Q3 -->|"no (internal only)"| Legion["legion<br/><small>L1-L3 + zero-secret</small>"]
+```
+
+**Always apply:** Zero-secret (3 pillars), egress control, audit trail.
+These are non-negotiable regardless of profile.

--- a/docs/agentic-runtime/zero-secret-agents.md
+++ b/docs/agentic-runtime/zero-secret-agents.md
@@ -1,0 +1,269 @@
+# Zero-Secret Agents
+
+The most critical security property of the Agentic Runtime: **the agent
+container has zero access to long-lived secrets**. Even if an agent is
+compromised (prompt injection, code execution exploit), there are no
+credentials to exfiltrate.
+
+---
+
+## The Three Pillars
+
+Three components achieve zero-secret agents. Each handles a different
+class of secret that the agent would otherwise need:
+
+```mermaid
+flowchart TB
+    subgraph agent_pod["Agent Pod (zero long-lived secrets)"]
+        Agent["Agent Container<br/><small>No API keys, no passwords,<br/>no tokens in env vars</small>"]
+    end
+
+    subgraph pillar1["Pillar 1: LLM Budget Proxy"]
+        BP["Budget Proxy<br/><small>Has: LiteLLM API key<br/>Agent calls: localhost:8080<br/>Agent sees: HTTP responses only</small>"]
+    end
+
+    subgraph pillar2["Pillar 2: AuthBridge Sidecar"]
+        AB["AuthBridge (Envoy)<br/><small>Has: SPIFFE SVID<br/>Exchanges: SVID → scoped OAuth token<br/>Agent sees: nothing (iptables redirect)</small>"]
+    end
+
+    subgraph pillar3["Pillar 3: Vault (planned)"]
+        V["Vault Agent Sidecar<br/><small>Has: SPIFFE auth to Vault<br/>Delivers: short-lived DB creds<br/>Agent sees: ephemeral files</small>"]
+    end
+
+    Agent -->|"LLM calls"| BP
+    Agent -->|"external calls"| AB
+    Agent -->|"DB creds"| V
+
+    BP -->|"has API key"| LLM["LiteLLM → LLM Provider"]
+    AB -->|"has SVID"| Services["External Services"]
+    V -->|"has Vault token"| Vault["Vault → PostgreSQL"]
+```
+
+### Pillar 1: LLM Budget Proxy — No LLM API Keys
+
+**Status: Shipped** ([#984](https://github.com/kagenti/kagenti/pull/984))
+
+| Without | With |
+|---------|------|
+| Agent has `OPENAI_API_KEY` in env var | Agent has `LLM_API_BASE=http://llm-budget-proxy:8080` |
+| Compromised agent → leaked API key → unlimited spend | Compromised agent → no key to steal, budget enforced |
+
+The agent calls the budget proxy at `localhost:8080`. The proxy holds the
+LiteLLM virtual key and forwards to LiteLLM. The agent never sees any
+LLM API key. Even if the agent is compromised, it can only make LLM calls
+through the proxy — which enforces per-session budgets (HTTP 402 on exceed).
+
+### Pillar 2: AuthBridge — No Service Tokens
+
+**Status: Shipped** (kagenti-extensions webhook)
+
+| Without | With |
+|---------|------|
+| Agent has `GITHUB_TOKEN` in env var | AuthBridge exchanges SPIFFE SVID → scoped OAuth token |
+| Compromised agent → leaked token → full repo access | Compromised agent → no token to steal |
+
+AuthBridge is an Envoy sidecar injected by mutating webhook. Iptables
+redirect all outbound traffic through Envoy. The sidecar performs RFC 8693
+OAuth2 token exchange: the agent's SPIFFE identity (X.509 certificate
+from SPIRE) is exchanged for a short-lived, scoped OAuth token. The agent
+container never possesses any service credential.
+
+### Pillar 3: Vault — No Database Passwords
+
+**Status: Planned**
+
+| Without | With |
+|---------|------|
+| Agent has `DB_PASSWORD=kagenti-sessions-dev` in env var | Vault issues ephemeral credentials (1h TTL, unique per pod) |
+| Compromised agent → leaked shared password → all namespace data | Compromised agent → credential expires in 1h, scoped to one agent |
+
+Today, the PostgreSQL password is a shared secret in `postgres-sessions-secret`.
+With Vault, each agent pod gets unique, short-lived database credentials:
+
+```mermaid
+flowchart LR
+    subgraph pod["Agent Pod"]
+        Sidecar["Vault Agent Sidecar<br/><small>Authenticates to Vault<br/>via SPIFFE SVID</small>"]
+        Agent2["Agent Container<br/><small>Reads /vault/secrets/db-creds<br/>Username + password</small>"]
+        Sidecar -->|"writes to tmpfs"| Agent2
+    end
+
+    subgraph vault["Vault"]
+        DBEngine["Database Secrets Engine<br/><small>CREATE ROLE with 1h TTL<br/>per-namespace policies</small>"]
+    end
+
+    subgraph db["PostgreSQL"]
+        PG["postgres-sessions<br/><small>Accepts dynamic users<br/>Vault revokes on expiry</small>"]
+    end
+
+    Sidecar -->|"SPIFFE auth"| vault
+    vault -->|"CREATE ROLE"| PG
+    Agent2 -->|"connect with<br/>ephemeral creds"| PG
+```
+
+---
+
+## Vault Integration Plan
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph vault_ns["vault namespace"]
+        VaultServer["Vault Server<br/><small>HA with Raft backend<br/>or dev mode for Kind</small>"]
+        VSO["Vault Secrets Operator<br/><small>Syncs secrets to K8s<br/>Manages dynamic creds</small>"]
+    end
+
+    subgraph spire_ns["spire namespace"]
+        SPIRE["SPIRE Server<br/><small>Issues SVIDs</small>"]
+    end
+
+    subgraph team1["team1 namespace"]
+        subgraph agent_pod2["Agent Pod"]
+            VaultSidecar["Vault Sidecar<br/><small>SPIFFE auth<br/>Secret refresh</small>"]
+            AgentC["Agent Container"]
+        end
+        PG2["postgres-sessions"]
+    end
+
+    SPIRE -->|"issues SVID"| VaultSidecar
+    VaultSidecar -->|"SPIFFE auth"| VaultServer
+    VaultServer -->|"dynamic creds"| PG2
+    VaultSidecar -->|"/vault/secrets/"| AgentC
+    VSO -->|"syncs"| team1
+```
+
+### Vault Engines
+
+| Engine | Purpose | Agent Access |
+|--------|---------|-------------|
+| **Database** | Ephemeral PostgreSQL credentials (1h TTL) | Read file `/vault/secrets/db-creds` |
+| **KV v2** | Static config (non-secret data) | Read file `/vault/secrets/config` |
+| **Transit** | Token signing without key exposure | API call → get signature (never see key) |
+| **PKI** | TLS certificates for mTLS | Handled by SPIRE (existing) |
+
+### Authentication: SPIFFE
+
+Vault authenticates agents via SPIFFE SVIDs (leveraging existing SPIRE
+deployment):
+
+```
+SPIFFE ID: spiffe://kagenti.io/ns/team1/sa/sandbox-legion
+    ↓ (X.509 certificate)
+Vault SPIFFE Auth Method
+    ↓ (maps SPIFFE ID → Vault role)
+Vault Role: team1-agent-readonly
+    ↓ (scoped policies)
+Policy: read database/creds/team1-*, encrypt transit/team1-key
+```
+
+No Kubernetes ServiceAccount tokens needed. The same SVID that provides
+Istio Ambient mTLS also authenticates to Vault.
+
+### Per-Namespace Policies
+
+```hcl
+# Policy: team1-agent
+path "database/creds/team1-readonly" {
+  capabilities = ["read"]
+}
+
+path "transit/encrypt/team1-key" {
+  capabilities = ["update"]
+}
+
+path "transit/decrypt/team1-key" {
+  capabilities = ["update"]
+}
+
+# Deny everything else
+path "*" {
+  capabilities = ["deny"]
+}
+```
+
+### Deployment Options
+
+| Approach | Mechanism | Agent Sees | Best For |
+|----------|-----------|-----------|----------|
+| **Vault Sidecar Injector** | Annotation-triggered sidecar | Files at `/vault/secrets/` | Existing SPIFFE pods |
+| **Vault Secrets Operator (VSO)** | CRD syncs to K8s Secrets | Standard K8s Secret | New deployments, K8s-native |
+
+**Recommendation:** VSO for new deployments (lower overhead, one operator
+per cluster vs one sidecar per pod). Sidecar for agents that need Transit
+engine access (crypto operations without K8s Secret intermediary).
+
+### Implementation Phases
+
+| Phase | What | Priority |
+|-------|------|----------|
+| 1 | Deploy Vault (dev mode for Kind, HA for production) | P1 |
+| 2 | Configure SPIFFE auth method (use existing SPIRE) | P1 |
+| 3 | Database secrets engine for postgres-sessions | P1 |
+| 4 | Migrate agents from shared password → dynamic credentials | P1 |
+| 5 | VSO CRDs for per-namespace credential delivery | P2 |
+| 6 | Transit engine for token signing (future) | P2 |
+| 7 | Remove all hardcoded passwords from Helm/scripts | P1 |
+
+---
+
+## Secret Audit: What Changes
+
+| Secret | Today | With All Three Pillars | Agent Sees? |
+|--------|-------|----------------------|-------------|
+| LLM API key | Env var on agent pod | Budget Proxy holds key | **No** |
+| Keycloak client secret | AuthBridge ConfigMap | AuthBridge sidecar exchanges SVID | **No** |
+| PostgreSQL password | `postgres-sessions-secret` (shared) | Vault dynamic creds (1h TTL, unique) | **Ephemeral file** |
+| MCP tool tokens | Env var or secret mount | AuthBridge outbound exchange | **No** |
+| Git credentials | Env var on agent pod | Vault KV + sidecar delivery | **Ephemeral file** |
+| PyPI/npm tokens | Env var on agent pod | Vault KV + sidecar delivery | **Ephemeral file** |
+| OTEL auth token | Env var on collector | Backend-side only (not on agent) | **No** |
+
+After all three pillars:
+- **Zero long-lived secrets** in agent container env vars
+- **Zero shared passwords** across namespaces
+- **Ephemeral-only credentials** with automatic expiry and revocation
+- **No credential to exfiltrate** that works beyond the agent's own session
+
+---
+
+## Threat Model: Compromised Agent
+
+What happens when an agent is compromised (prompt injection, code execution):
+
+| Attack Vector | Without Zero-Secret | With Zero-Secret |
+|--------------|--------------------|--------------------|
+| Read env vars | Gets API keys, DB passwords | Gets nothing useful |
+| Read filesystem | Gets mounted secrets | Gets expired/expiring credentials |
+| Call LLM | Unlimited with stolen key | Budget-capped via proxy (HTTP 402) |
+| Call external services | Full access with stolen token | No token to steal (AuthBridge handles) |
+| Access database | Shared password → all namespace data | Ephemeral creds → auto-revoked, scoped |
+| Lateral movement | Stolen creds work on other pods | Creds are pod-unique, short-lived |
+
+**The zero-secret architecture transforms a credential theft from a
+persistent breach into a time-bounded, scope-limited incident.**
+
+---
+
+## Milestone Tracking
+
+```mermaid
+flowchart LR
+    P1["Pillar 1: Budget Proxy<br/>SHIPPED<br/><small>Agent has no LLM keys</small>"]
+    P2["Pillar 2: AuthBridge<br/>SHIPPED<br/><small>Agent has no service tokens</small>"]
+    P3["Pillar 3: Vault<br/>PLANNED<br/><small>Agent has no DB passwords</small>"]
+    DONE["Zero-Secret Agent<br/><small>No long-lived secrets<br/>in agent container</small>"]
+
+    P1 -->|"done"| DONE
+    P2 -->|"done"| DONE
+    P3 -->|"planned"| DONE
+```
+
+**When all three pillars are complete, we can make the assertion:**
+
+> No long-lived credential exists in the agent container. A compromised
+> agent cannot exfiltrate any secret usable beyond its own budget-bounded,
+> time-limited session.
+
+This is the security foundation for running untrusted third-party agents
+in the `restricted` profile.


### PR DESCRIPTION
## Summary

Adds `docs/agentic-runtime/` with 10 hand-written documentation files for the Agentic Runtime (sandbox agent platform). This is the K9 documentation PR from the streaming PR split.

### Files

| File | Lines | Content |
|------|-------|---------|
| README.md | 171 | Overview, C4 architecture diagram, doc index, PR dashboard |
| concepts.md | 184 | Sessions, reasoning loop, event pipeline, graph card, HITL, sidecars |
| quickstart.md | 84 | Deploy sandbox agent on Kind in 5 minutes |
| configuration.md | 176 | Feature flags, Helm values, env vars, budget limits, permissions |
| security.md | 194 | Defense-in-depth (L1-L8), Landlock, AuthBridge sidecar, Istio Ambient |
| agents.md | 275 | Plugin contract, instrumentation contract, Dockerfile, K8s manifest |
| multi-framework.md | 250 | LangGraph (shipped), OpenCode (WIP), Claude SDK/CrewAI/AG2 (designed) |
| api-reference.md | 148 | 40+ backend routes, SSE format, error responses |
| deployment.md | 206 | Components, deploy scripts, database, budget proxy, platform base |
| troubleshooting.md | 188 | Common issues, debugging, log locations |

### Key decisions

- AuthBridge shown as **injected sidecar** (mutating webhook), not standalone service
- All diagram edges show **protocol + encryption** (mTLS for internal, HTTPS for external)
- No Service Mesh block in diagrams — Istio Ambient is transparent infrastructure
- Multi-framework section marked **WIP** — only LangGraph shipped, OpenCode in progress

### What this is NOT

- NOT a dump of plan/passover files
- NOT auto-generated API docs
- IS hand-written user/operator documentation

Refs: #820

## Test plan

- [ ] Verify all internal links resolve between docs
- [ ] Verify mermaid diagrams render on GitHub
- [ ] Review architecture accuracy against deployed cluster
- [ ] Review API routes against actual backend code

Generated with [Claude Code](https://claude.com/claude-code)