### PR TITLE
cleanup: remove legacy environments ConfigMap

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -102,103 +102,6 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ (printf "{\"auths\":{\"quay.io\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" $.Values.secrets.quayUser $.Values.secrets.quayToken (printf "%s:%s" $.Values.secrets.quayUser $.Values.secrets.quayToken | b64enc)) | b64enc }}
 ---
-# ——————————————————————————————————————————————————————————————————————————————
-#  ConfigMap for Environment Variables in Namespace: {{ . }}
-# ——————————————————————————————————————————————————————————————————————————————
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: environments
-  namespace: {{ . }}
-  labels:
-    {{- include "kagenti.labels" $root | nindent 4 }}
-data:
-  ollama: |
-    [
-      {"name": "LLM_API_BASE", "value": "http://host.docker.internal:11434/v1"},
-      {"name": "LLM_API_KEY", "value": "dummy"},
-      {"name": "LLM_MODEL", "value": "llama3.2:3b-instruct-fp16"}
-    ]
-  openai: |
-    [
-      {
-        "name": "OPENAI_API_KEY",
-        "valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}
-      },
-      {
-        "name": "LLM_API_KEY",
-        "valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}
-      },
-      {"name": "LLM_API_BASE", "value": "https://llama-4-scout-17b-16e-w4a16-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"},
-      {"name": "LLM_MODEL", "value": "llama-4-scout-17b-16e-w4a16"}
-    ]
-  mcp-weather: |
-    [
-      {"name": "MCP_URL", "value": "http://mcp-weather-tool-proxy:8000/mcp"}
-    ]
-  mcp-slack: |
-    [
-      {"name": "MCP_URL", "value": "http://mcp-slack-tool-proxy:8000/mcp"}
-    ]
-  slack-researcher-config: |
-    [
-      {"name": "EXTRA_HEADERS", "value": "{}"},
-      {"name": "MODEL_TEMPERATURE", "value": "0"},
-      {"name": "MAX_PLAN_STEPS", "value": "6"},
-      {"name": "SERVICE_PORT", "value": "8000"},
-      {"name": "LOG_LEVEL", "value": "INFO"}
-    ]
-  slack-researcher-auth-config: |
-    [
-      {
-        "name": "CLIENT_SECRET",
-        "valueFrom": {"secretKeyRef": {"name": "kagenti-keycloak-client-secret", "key": "client-secret"}}
-      },
-      {
-        "name": "ISSUER",
-        "value": "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
-      },
-      {
-        "name": "JWKS_URI",
-        "value": "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/{{ $root.Values.keycloak.realm }}/protocol/openid-connect/certs"
-      },
-      {
-        "name": "AUDIENCE",
-        "value": "{{ $root.Values.agentOAuthSecret.spiffePrefix }}/slack-researcher"
-      }
-    ]
-  mcp-slack-config: |
-    [
-      {
-        "name": "SLACK_BOT_TOKEN",
-        "valueFrom": {"secretKeyRef": {"name": "slack-secret", "key": "bot-token"}}
-      }
-    ]
-  mcp-slack-auth-config: |
-    [
-      {
-        "name": "ISSUER",
-        "value": "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
-      },
-      {
-        "name": "JWKS_URI",
-        "value": "http://keycloak-service.keycloak.svc.cluster.local:8080/realms/{{ $root.Values.keycloak.realm }}/protocol/openid-connect/certs"
-      },
-      {
-        "name": "AUDIENCE",
-        "value": "{{ $root.Values.agentOAuthSecret.spiffePrefix }}/slack-tool"
-      },
-      {
-        "name": "ADMIN_SLACK_BOT_TOKEN",
-        "valueFrom": {"secretKeyRef": {"name": "slack-secret", "key": "admin-bot-token"}}
-      },
-      {
-        "name": "ADMIN_SCOPE_NAME",
-        "value": "slack-full-access"
-      }
-    ]
-  SPIRE_ENABLED: {{ if $root.Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
----
 {{- if not $root.Values.keycloak.adminExistingSecret }}
 # ——————————————————————————————————————————————————————————————————————————————
 #  Secret for Keycloak Admin Credentials in Namespace: {{ . }}
@@ -237,6 +140,7 @@ data:
   # Set explicitly when the internal KEYCLOAK_URL differs from the frontend URL
   # that appears in token "iss" claims (split-horizon DNS).
   ISSUER: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
+  SPIRE_ENABLED: {{ if $root.Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
 ---
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for Envoy in Namespace: {{ . }}

--- a/charts/kagenti/templates/agent-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/agent-oauth-secret-job.yaml
@@ -23,10 +23,10 @@ rules:
     resources: ["secrets"]
     resourceNames: [{{ .Values.keycloak.adminSecretName | quote }}]
     verbs: ["get"]
-  # Rule 2: Permissions to WRITE/UPDATE secrets and configmaps in target namespaces
+  # Rule 2: Permissions to WRITE/UPDATE secrets in target namespaces
   # The Job can only use these permissions in namespaces where a RoleBinding is created
   - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
+    resources: ["secrets"]
     verbs: ["get", "create", "update", "patch"]
 ---
 # RoleBinding for KEYCLOAK namespace (Read Access)
@@ -48,7 +48,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 # RoleBindings for TARGET write namespaces (Write Access)
-# This MUST be deployed in every namespace where the Job needs to create/update secrets and configmaps
+# This MUST be deployed in every namespace where the Job needs to create/update secrets
 {{- if .Values.agentNamespaces }}
 {{- range .Values.agentNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -113,10 +113,6 @@ spec:
         {{- end }}
         - name: SPIFFE_PREFIX
           value: {{ .Values.agentOAuthSecret.spiffePrefix }}
-        {{- if .Values.agentOAuthSecret.updateEnvConfigMaps }}
-        - name: UPDATE_ENV_CONFIGMAPS
-          value: "true"
-        {{- end }}
         # Create a test user in the configured realm for UI/MLflow login
         # Password is auto-generated and stored in kagenti-test-user secret
         - name: CREATE_KEYCLOAK_TEST_USER

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -108,7 +108,6 @@ agentOAuthSecret:
   # and will usually not validate external OpenShift route certificates.
   useServiceAccountCA: false
   spiffePrefix: spiffe://localtest.me/sa
-  updateEnvConfigMaps: true
   clientName: kagenti-keycloak-client
 
 # ------------------------------------------------------------------

--- a/docs/demos/demo-file-organizer-agent.md
+++ b/docs/demos/demo-file-organizer-agent.md
@@ -27,9 +27,10 @@ To deploy the File Organizer Agent:
 
 1. Navigate to [Import New Agent](http://kagenti-ui.localtest.me:8080/Import_New_Agent#import-new-agent) in the Kagenti UI.
 2. In the **Select Namespace to Deploy Agent** drop-down, choose the `<namespace>` where you'd like to deploy the agent. (These namespaces are defined in your `.env` file.)
-3. Under [**Select Environment Variable Sets**](http://kagenti-ui.localtest.me:8080/Import_New_Agent#select-environment-variable-sets):
-   - `ollama` or `openai`
-4. Under [**Environment Variable**](http://kagenti-ui.localtest.me:8080/Import_New_Agent#select-environment-variable-sets), select:
+3. Under **Environment Variables**, configure LLM settings using one of these methods:
+   - Click **Import .env File** and import `.env.openai` or `.env.ollama` from the agent examples repo, **or**
+   - Manually add env vars: `LLM_API_BASE`, `LLM_API_KEY`, and `LLM_MODEL` (see [Using Local Models](../local-models.md) for values)
+4. Under **Environment Variables**, also add:
    - Click `Add Environment Variable`
    - Under `Name` put `BUCKET_URI` and under `Value` put the URI of your cloud storage bucket (e.g., `s3://my-bucket-name/` for AWS S3)
 5. In the **Agent Source Repository URL** field, use the default:

--- a/docs/demos/demo-generic-agent.md
+++ b/docs/demos/demo-generic-agent.md
@@ -29,9 +29,10 @@ To deploy the Generic Agent:
 
 1. Navigate to [Import New Agent](http://kagenti-ui.localtest.me:8080/Import_New_Agent#import-new-agent) in the Kagenti UI.
 2. In the **Select Namespace to Deploy Agent** drop-down, choose the `<namespace>` where you'd like to deploy the agent. (These namespaces are defined in your `.env` file.)
-3. Under [**Select Environment Variable Sets**](http://kagenti-ui.localtest.me:8080/Import_New_Agent#select-environment-variable-sets):
-   - `ollama` or `openai`
-4. Under [**Environment Variable**](http://kagenti-ui.localtest.me:8080/Import_New_Agent#environment-variables), add the following environment variable:
+3. Under **Environment Variables**, configure LLM settings using one of these methods:
+   - Click **Import .env File** and import `.env.openai` or `.env.ollama` from the agent examples repo, **or**
+   - Manually add env vars: `LLM_API_BASE`, `LLM_API_KEY`, and `LLM_MODEL` (see [Using Local Models](../local-models.md) for values)
+4. Under **Environment Variables**, also add the following:
    - Click `Add Environment Variable`
    - Under `Name` put `MCP_URLS` and under `Value` put `http://movie-tool:8000/mcp, http://flight-tool:8000/mcp`
 5. In the **Agent Source Repository URL** field, use the default:

--- a/docs/demos/demo-image-agent.md
+++ b/docs/demos/demo-image-agent.md
@@ -29,9 +29,9 @@ To deploy the Image Agent:
 
 1. Navigate to [Import New Agent](http://kagenti-ui.localtest.me:8080/Import_New_Agent#import-new-agent) in the Kagenti UI.
 2. In the **Select Namespace to Deploy Agent** drop-down, choose the `<namespace>` where you'd like to deploy the agent. (These namespaces are defined in your `.env` file.)
-3. Under [**Select Environment Variable Sets**](http://kagenti-ui.localtest.me:8080/Import_New_Agent#select-environment-variable-sets), select:
-   - `mcp-image`
-   - `ollama` or `openai`
+3. Under **Environment Variables**, configure LLM settings using one of these methods:
+   - Click **Import .env File** and import `.env.openai` or `.env.ollama` from the agent examples repo, **or**
+   - Manually add env vars: `LLM_API_BASE`, `LLM_API_KEY`, and `LLM_MODEL` (see [Using Local Models](../local-models.md) for values)
 4. In the **Agent Source Repository URL** field, use the default:
    <https://github.com/kagenti/agent-examples>
    Or use a custom repository accessible using the GitHub ID specified in your `.env` file.

--- a/docs/demos/demo-slack-research-agent.md
+++ b/docs/demos/demo-slack-research-agent.md
@@ -81,14 +81,14 @@ To log in and import agents you can use the [default credentials](../install.md#
 
 1. Navigate to [Import New Agent](http://kagenti-ui.localtest.me:8080/Import_New_Agent#import-new-agent) in the Kagenti UI.
 2. In the **Select Namespace to Deploy Agent** drop-down, choose the `<namespace>` where you'd like to deploy the agent. (These namespaces are defined in your `.env` file.)
-3. Under [**Select Environment Variable Sets**](http://kagenti-ui.localtest.me:8080/Import_New_Agent#select-environment-variable-sets), select:
+3. Under **Environment Variables**, configure the required env vars. You can import `.env` files from the agent examples repo or add them manually:
 
-   - `mcp-slack`
-   - `slack-researcher-config`
-   - `slack-researcher-auth-config`
-   - `ollama` or `openai`
+   - **LLM settings**: Import `.env.openai` or `.env.ollama`, or manually set `LLM_API_BASE`, `LLM_API_KEY`, and `LLM_MODEL`
+   - **MCP Slack URL**: `MCP_URL` = `http://mcp-slack-tool-proxy:8000/mcp`
+   - **Researcher config**: `EXTRA_HEADERS` = `{}`, `MODEL_TEMPERATURE` = `0`, `MAX_PLAN_STEPS` = `6`, `SERVICE_PORT` = `8000`, `LOG_LEVEL` = `INFO`
+   - **Auth config**: `CLIENT_SECRET` (from `kagenti-keycloak-client-secret` secret), `ISSUER`, `JWKS_URI`, `AUDIENCE` — see the [auth demo README](../../kagenti/auth/auth_demo/README.md) for values
 
-4. Depending on the LLM provider you need to do a following:
+4. Depending on the LLM provider you need to do the following:
 
    - If using `ollama`, note that it uses `granite3.3:8b`, so you may need to run locally:
 
@@ -125,9 +125,9 @@ To deploy the Slack Tool using Shipwright:
 1. Navigate to [Import New Tool](http://kagenti-ui.localtest.me:8080/Import_New_Tool#import-new-tool) in the UI.
 2. Select the same `<namespace>` as used for the agent.
 3. Select "Build from source" as the deployment method.
-4. In the **Select Environment Variable Sets** section, select:
-   - `mcp-slack-config`
-   - `mcp-slack-auth-config`
+4. Under **Environment Variables**, configure the required env vars for the tool:
+   - **Slack config**: `SLACK_BOT_TOKEN` (from `slack-secret` secret)
+   - **Auth config**: `ISSUER`, `JWKS_URI`, `AUDIENCE`, `ADMIN_SLACK_BOT_TOKEN` (from `slack-secret` secret), `ADMIN_SCOPE_NAME` = `slack-full-access`
 5. Use the same source repository:
    <https://github.com/kagenti/agent-examples>
 6. Choose the `main` branch or your preferred branch.

--- a/docs/developer/kind.md
+++ b/docs/developer/kind.md
@@ -319,7 +319,7 @@ Each agent namespace receives:
 
 | Resource | Purpose |
 |----------|---------|
-| `environments` ConfigMap | 8 environment presets (ollama, openai, mcp-weather, etc.) |
+| `authbridge-config` ConfigMap | AuthBridge + SPIRE configuration |
 | `github-token-secret` | GitHub credentials |
 | `github-shipwright-secret` | Build authentication |
 | `ghcr-secret` | GHCR registry pull |

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -23,16 +23,14 @@ Kagenti agents use three environment variables to configure their LLM backend:
 | `LLM_API_KEY` | API key | `dummy` (Ollama ignores this) | Your OpenAI API key |
 | `LLM_MODEL` | Model identifier | `qwen2.5:3b` | `gpt-4o-mini-2024-07-18` |
 
-When deploying agents through the Kagenti UI, you select an **environment variable set** (`ollama` or `openai`) that populates these values automatically. No code changes are needed to switch between backends.
+When deploying agents through the Kagenti UI or TUI, you select an LLM preset (`ollama` or `openai`) that populates these values automatically. No code changes are needed to switch between backends.
 
 ## How It Works
 
-Kagenti pre-configures two environment variable sets in each agent namespace via a ConfigMap:
+Kagenti provides two ways to configure LLM environment variables when deploying agents:
 
-- **`ollama`** - Points to a local Ollama instance with a default model
-- **`openai`** - Points to the OpenAI API using credentials from the `openai-secret`
-
-These are defined in the `environments` ConfigMap (see `charts/kagenti/templates/agent-namespaces.yaml`). When you import an agent through the UI, you choose which environment set to apply.
+- **UI (ui-v2)**: Import a `.env` file (e.g. `.env.openai` or `.env.ollama`) from GitHub, or manually add env vars in the deploy form.
+- **TUI**: Select the `openai` or `ollama` preset, which injects the appropriate env vars directly into the deployment spec.
 
 ---
 
@@ -139,19 +137,11 @@ Deploy Ollama as a Kubernetes Deployment within the cluster so agents can reach 
    kubectl exec -n kagenti-system deploy/ollama -- ollama pull qwen2.5:3b
    ```
 
-3. **Update the `ollama` environment set** to point to the in-cluster service. Edit the `environments` ConfigMap in each agent namespace (e.g., `team1`):
-
-   ```bash
-   kubectl edit configmap environments -n team1
-   ```
-
-   Change the `LLM_API_BASE` value from `http://host.docker.internal:11434/v1` to:
+3. **Configure the agent's `LLM_API_BASE`** to point to the in-cluster service. When deploying an agent via the UI or TUI, set `LLM_API_BASE` to:
 
    ```
    http://ollama.kagenti-system.svc.cluster.local:11434/v1
    ```
-
-   Or override via Helm values when installing the chart. See [Customizing the Ollama Endpoint](#customizing-the-ollama-endpoint) below.
 
 ### Option 2: Use an External Ollama Server
 
@@ -182,16 +172,13 @@ For production OpenShift deployments, consider:
 
 ### Customizing the Ollama Endpoint
 
-The default `ollama` environment set points to `http://host.docker.internal:11434/v1`, which works for Kind but not for OpenShift. After deploying Kagenti, update the `environments` ConfigMap in each agent namespace to point to your Ollama service:
+The default `ollama` preset points to `http://host.docker.internal:11434/v1`, which works for Kind but not for OpenShift. When deploying agents on OpenShift, set `LLM_API_BASE` to the in-cluster Ollama service URL:
 
-```bash
-# For each agent namespace (e.g., team1, team2)
-kubectl get configmap environments -n team1 -o yaml | \
-  sed 's|http://host.docker.internal:11434/v1|http://ollama.kagenti-system.svc.cluster.local:11434/v1|' | \
-  kubectl apply -f -
+```
+http://ollama.kagenti-system.svc.cluster.local:11434/v1
 ```
 
-This updates `LLM_API_BASE` so agents in that namespace reach the in-cluster Ollama service. Repeat for each agent namespace.
+You can set this via the UI (add it as an env var when deploying the agent) or the TUI (use `--env LLM_API_BASE=http://ollama.kagenti-system.svc.cluster.local:11434/v1`).
 
 ---
 
@@ -249,7 +236,7 @@ Then check the host gateway IP:
 docker network inspect kind | grep Gateway
 ```
 
-Update the `LLM_API_BASE` in the ConfigMap to use that gateway IP.
+Set `LLM_API_BASE` to use that gateway IP when deploying the agent.
 
 ### Model too slow or out of memory
 
@@ -261,7 +248,7 @@ Update the `LLM_API_BASE` in the ConfigMap to use that gateway IP.
 
 **Symptom**: Agent tries to call OpenAI instead of Ollama (or vice versa).
 
-**Fix**: When importing an agent in the Kagenti UI, verify you selected the correct environment variable set (`ollama` or `openai`). You can check the running pod's environment:
+**Fix**: When deploying an agent, verify you selected the correct LLM preset (`ollama` or `openai`) or imported the correct `.env` file. You can check the running pod's environment:
 
 ```bash
 kubectl exec -n team1 <agent-pod> -- env | grep LLM_

--- a/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
+++ b/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
@@ -444,25 +444,6 @@ def create_secrets(**kwargs):
     # Setup Keycloak demo realm, user, and agent client (pass v1_api for secret reading)
     kagenti_keycloak_client_secret = setup_keycloak(v1_api)
 
-    # Optionally update the 'environments' ConfigMap in each namespace with Keycloak info
-    update_envs = parse_bool(get_optional_env("UPDATE_ENV_CONFIGMAPS", "false"))
-    typer.echo(f"Update environments ConfigMaps: {update_envs}")
-    if update_envs:
-        # Compute admin credentials to write into ConfigMaps
-        admin_username, admin_password = get_keycloak_admin_credentials(v1_api)
-        # Reuse shared env config to ensure consistency with setup_keycloak
-        base_url, demo_realm_name, _, _ = get_keycloak_env_config()
-        try:
-            update_environments_configmaps(
-                v1_api,
-                admin_username,
-                admin_password,
-                base_url,
-                demo_realm_name,
-            )
-        except Exception as e:
-            typer.secho(f"Failed to update 'environments' ConfigMaps: {e}", fg="yellow")
-
     # Distribute client secret to agent namespaces
     namespaces_str = os.getenv("AGENT_NAMESPACES", "")
     if not namespaces_str:
@@ -501,81 +482,6 @@ def create_secrets(**kwargs):
                     err=True,
                 )
                 raise
-
-
-def update_environments_configmaps(
-    v1_api: client.CoreV1Api,
-    admin_username: str,
-    admin_password: str,
-    base_url: str,
-    realm_name: str,
-    timeout: int = 120,
-    interval: int = 5,
-) -> None:
-    """Wait for and update the `environments` ConfigMap in each agent namespace.
-
-    Writes the following keys into the ConfigMap `data`:
-      - KEYCLOAK_URL
-      - KEYCLOAK_REALM
-      - KEYCLOAK_ADMIN_USERNAME
-      - KEYCLOAK_ADMIN_PASSWORD
-
-    The function will wait up to `timeout` seconds for the ConfigMap to exist in
-    each namespace, polling every `interval` seconds.
-    """
-    namespaces_str = os.getenv("AGENT_NAMESPACES", "")
-    if not namespaces_str:
-        typer.echo("No AGENT_NAMESPACES set; skipping ConfigMap updates")
-        return
-
-    agent_namespaces = [ns.strip() for ns in namespaces_str.split(",") if ns.strip()]
-    cm_name = "environments"
-
-    for ns in agent_namespaces:
-        typer.echo(
-            f"Waiting for ConfigMap '{cm_name}' in namespace '{ns}' (timeout {timeout}s)..."
-        )
-        start_time = time.monotonic()
-        cm = None
-        while time.monotonic() - start_time < timeout:
-            try:
-                cm = v1_api.read_namespaced_config_map(cm_name, ns)
-                break
-            except ApiException as e:
-                if getattr(e, "status", None) == 404:
-                    time.sleep(interval)
-                    continue
-                else:
-                    raise
-
-        if cm is None:
-            typer.secho(
-                f"ConfigMap '{cm_name}' not found in namespace '{ns}' after {timeout}s; skipping",
-                fg="yellow",
-            )
-            continue
-
-        patch_body = {
-            "data": {
-                "KEYCLOAK_URL": base_url,
-                "KEYCLOAK_REALM": realm_name,
-                "KEYCLOAK_ADMIN_USERNAME": admin_username,
-                "KEYCLOAK_ADMIN_PASSWORD": admin_password,
-            }
-        }
-
-        try:
-            v1_api.patch_namespaced_config_map(cm_name, ns, patch_body)
-            typer.echo(
-                f"Patched ConfigMap '{cm_name}' in namespace '{ns}' with Keycloak settings"
-            )
-        except ApiException as e:
-            typer.secho(
-                f"Failed to patch ConfigMap '{cm_name}' in '{ns}': {e}",
-                fg="red",
-                err=True,
-            )
-            raise
 
 
 def main() -> None:

--- a/kagenti/tui/internal/helpers/helpers.go
+++ b/kagenti/tui/internal/helpers/helpers.go
@@ -12,7 +12,6 @@ import (
 )
 
 // LLMPresetEnvVars returns environment variables for a given LLM environment preset.
-// These match the "environments" ConfigMap entries deployed by the Helm chart.
 func LLMPresetEnvVars(preset, modelOverride string) []api.EnvVar {
 	secretRef := func(secretName, key string) *api.EnvVarSource {
 		return &api.EnvVarSource{

--- a/kagenti/tui/internal/ui/views/deployagent.go
+++ b/kagenti/tui/internal/ui/views/deployagent.go
@@ -277,7 +277,7 @@ func (v *DeployAgentView) buildForm() {
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("LLM Environment").
-				Description("Injects env vars from the 'environments' ConfigMap in the namespace").
+				Description("Injects LLM provider env vars into the agent deployment").
 				Options(
 					huh.NewOption("OpenAI (from openai-secret)", "openai"),
 					huh.NewOption("Ollama (local)", "ollama"),


### PR DESCRIPTION
## Summary

- Remove the legacy `environments` ConfigMap from agent namespaces — it was created for the old Streamlit UI's "Select Environment Variable Sets" feature which no longer exists
- Nothing reads this ConfigMap at runtime: ui-v2 uses `.env` file imports, TUI hardcodes presets via `LLMPresetEnvVars()`
- Move `SPIRE_ENABLED` to the existing `authbridge-config` ConfigMap
- Remove `update_environments_configmaps()` from agent-oauth-secret job (wrote Keycloak keys already available in `authbridge-config` and `keycloak-admin-secret`)
- Tighten RBAC: remove `configmaps` from ClusterRole (job only needs secrets now)
- Update docs to reference `.env` file workflow instead of the removed ConfigMap

## Test plan

- [ ] `helm template` — verify no `environments` ConfigMap rendered, `authbridge-config` has `SPIRE_ENABLED`
- [ ] Deploy to Kind cluster
- [ ] Deploy an agent via ui-v2 with `.env.openai` import — verify env vars injected correctly
- [ ] Deploy an agent via TUI with `openai` and `ollama` presets — verify env vars injected correctly
- [ ] Run E2E tests: `uv run pytest kagenti/tests/e2e/ -v`
- [ ] Verify agent-oauth-secret job completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
