### PR TITLE
fix: Pin webhook sidecar image tags to v0.4.0-alpha.8

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -152,6 +152,19 @@ keycloak:
   autoBootstrapRealm: true
 
 # ------------------------------------------------------------------
+#  Kagenti Webhook Configuration
+# ------------------------------------------------------------------
+# Pin sidecar image tags to the webhook chart version to prevent
+# breakage when :latest is updated by newer kagenti-extensions builds.
+# These MUST be updated together with the chart version in Chart.yaml.
+kagenti-webhook-chart:
+  defaults:
+    images:
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.8
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.8
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.4.0-alpha.8
+
+# ------------------------------------------------------------------
 #  Kagenti Operator Configuration
 # ------------------------------------------------------------------
 kagenti-operator-chart:


### PR DESCRIPTION
## Summary

- Pin sidecar image tags (`envoy-with-processor`, `proxy-init`, `client-registration`) to `:v0.4.0-alpha.8` in the kagenti Helm chart's webhook subchart overrides, instead of relying on `:latest`
- After kagenti-extensions PR #250 changed the build workflow to push `:latest` on every merge to main, the floating tag picked up a newer `proxy-init` image that requires a `POD_IP` environment variable — which the `v0.4.0-alpha.8` webhook does not inject
- This breaks all v0.5.0 deployments with: `ERROR: POD_IP environment variable is not set`

## Root cause

1. `kagenti-webhook-chart v0.4.0-alpha.8` defaults sidecar images to `:latest`
2. kagenti-extensions PR #250 (`ci/build-latest-on-merge`) changed the build workflow to overwrite `:latest` on every push to main
3. PR #242 (`feat/remove-privileged-init`) landed on main after the v0.4.0-alpha.8 tag, adding a `POD_IP` requirement to `init-iptables.sh`
4. The next main build pushed a `proxy-init:latest` that requires `POD_IP`, but the v0.4.0-alpha.8 webhook doesn't inject it

## Test plan

- [ ] Deploy kagenti with this fix on a Kind cluster
- [ ] Verify weather-agent pod starts successfully (proxy-init completes without `POD_IP` error)
- [ ] Verify `kubectl describe pod` shows sidecar images tagged `:v0.4.0-alpha.8` instead of `:latest`