### PR TITLE
docs: Update example version tag to v0.5.1 in Ansible README

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -205,9 +205,9 @@ charts:
     values:
       ui:
         frontend:
-          tag: "v0.5.0"  # Replace with your desired version
+          tag: "v0.5.1"  # Replace with your desired version
         backend:
-          tag: "v0.5.0"  # Replace with your desired version
+          tag: "v0.5.1"  # Replace with your desired version
 
 ## Notes / tips
 - Chart paths referenced in the values are relative to the `deployments/ansible`


### PR DESCRIPTION
## Summary

- Update the example image tag override in the Ansible README from `v0.5.0` to `v0.5.1`, reflecting the latest patch release

## Test plan

- [ ] Verify README renders correctly on GitHub