### PR TITLE
ci: add actionlint to catch workflow script injection on PRs

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -3,9 +3,15 @@
 # Measures repository security posture and provides recommendations.
 # Results are uploaded to GitHub Security tab and OpenSSF Scorecard API.
 #
-# NOTE: Scorecard only works on 'schedule' and 'push' triggers, NOT 'pull_request'
-# This is a GitHub/Scorecard limitation for result publishing.
-# See: https://github.com/ossf/scorecard-action#workflow-restrictions
+# Triggers:
+# - schedule/push: Full analysis with result publishing to OpenSSF API
+# - pull_request: Analysis only — catches Dangerous-Workflow (script
+#   injection) before merge. Publishing disabled (no OIDC on PRs).
+#
+# TODO: pull_request trigger is experimental per Scorecard docs.
+#   If it causes issues (fork PRs, permissions), disable pull_request
+#   and rely on actionlint in security-scans.yaml for PR coverage.
+#   See: https://github.com/ossf/scorecard-action#workflow-restrictions
 #
 # Token Requirements:
 # - No external tokens needed
@@ -22,6 +28,9 @@ on:
     - cron: '0 6 * * 1'
   # Run on push to main
   push:
+    branches: [main]
+  # Run on PRs to catch Dangerous-Workflow before merge
+  pull_request:
     branches: [main]
   # Allow manual trigger
   workflow_dispatch:
@@ -50,8 +59,8 @@ jobs:
         with:
           results_file: scorecard.sarif
           results_format: sarif
-          # Publish results to OpenSSF API (enables badge)
-          publish_results: true
+          # Only publish to OpenSSF API on push/schedule (not PRs — no OIDC token)
+          publish_results: ${{ github.event_name != 'pull_request' }}
 
       - name: Upload SARIF to Security tab
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98  # v4

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -452,6 +452,26 @@ jobs:
   # Phase D: Advanced Security
   # ============================================================================
 
+  # GitHub Actions Workflow Lint (actionlint)
+  # Catches script injection (${{ github.event.* }} in run: blocks),
+  # invalid workflow syntax, and other workflow issues.
+  # Fails on critical issues (expression injection = critical).
+  actionlint:
+    name: Workflow Lint (actionlint)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43  # v1.71.0
+        with:
+          fail_on_error: true
+          # Only report issues on lines changed in the PR (not pre-existing)
+          filter_mode: diff_context
+          reporter: github-pr-review
+
   # CodeQL - Free for public repositories on GitHub.com
   # License: https://github.com/github/codeql/blob/main/LICENSE
   # "If the Open Source Codebase is hosted and maintained on GitHub.com,


### PR DESCRIPTION
## Problem

PR #933 introduced a command injection vulnerability in `e2e-hypershift-pr.yaml` by parsing `${{ github.event.comment.body }}` in a bash `run:` block. CodeQL passed because it only scans Python, not workflow YAML. The vulnerability was only caught by OpenSSF Scorecard **post-merge** on main (alert [#188](https://github.com/kagenti/kagenti/security/code-scanning/188)).

## Gap in CI

| Check | Scans workflow injection? | Runs on PR? | Blocks merge? |
|-------|--------------------------|-------------|---------------|
| CodeQL | No (Python only) | Yes | Yes |
| Scorecard | Yes (Dangerous-Workflow) | **No (main only)** | No |
| Bandit | No (Python only) | Yes | Yes |
| **No check catches workflow injection on PRs** | | | |

## Fix

### 1. actionlint (reliable)

Add [actionlint](https://github.com/rhysd/actionlint) as a blocking PR check in `security-scans.yaml`:
- Detects expression injection (`${{ github.event.* }}` in `run:` blocks)
- Validates workflow syntax
- Reports inline on PR via reviewdog
- **Fails the check on errors** (`fail_on_error: true`)

### 2. Scorecard on PRs (experimental)

Add `pull_request` trigger to the existing Scorecard workflow:
- Runs Dangerous-Workflow analysis on PRs (catches injection patterns)
- Disables OpenSSF API publishing on PRs (no OIDC token in PR context)
- Marked as TODO/experimental — if it causes issues with fork PRs or permissions, we can disable it and rely on actionlint alone

## What this catches

Both checks would have flagged this unsafe pattern:

```yaml
# UNSAFE — injectable via crafted comment body
run: |
  COMMENT="${{ github.event.comment.body }}"
```

The safe alternative:

```yaml
# SAFE — comment body accessed in JavaScript context
uses: actions/github-script@v8
with:
  script: |
    const body = context.payload.comment.body;
```

## Test plan
- [ ] actionlint check appears in PR checks and passes
- [ ] Scorecard check appears in PR checks and passes
- [ ] Verify actionlint would flag `${{ github.event.comment.body }}` in a shell `run:` block