### PR TITLE
feat: internal registry via kagenti-ui-config and dashboards API

### DIFF
--- a/charts/kagenti/templates/ui-routes-job.yaml
+++ b/charts/kagenti/templates/ui-routes-job.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.components.ui.enabled .Values.openshift }}
+{{- $internalReg := .Values.ui.internalContainerImageRegistryUrl | default "image-registry.openshift-image-registry.svc.cluster.local:5000" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -165,6 +166,9 @@ data:
       configmap_yaml+=$'\n'
       configmap_yaml+="  $key: \"$value\""
     done
+
+    configmap_yaml+=$'\n'
+    configmap_yaml+="  INTERNAL_CONTAINER_IMAGE_REGISTRY_URL: \"{{ $internalReg }}\""
 
     echo "$configmap_yaml" | kubectl apply -f -
     if [[ $? -eq 0 ]]; then

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.components.ui.enabled }}
+{{- $defaultInternalReg := ternary "image-registry.openshift-image-registry.svc.cluster.local:5000" "registry.cr-system.svc.cluster.local:5000" .Values.openshift }}
+{{- $internalReg := .Values.ui.internalContainerImageRegistryUrl | default $defaultInternalReg }}
 {{- if not .Values.openshift }}
 # ConfigMap for dashboard URLs (non-OpenShift only)
 # In OpenShift, this ConfigMap is created by the ui-routes-job
@@ -21,6 +23,7 @@ data:
   MCP_INSPECTOR_URL: "http://mcp-inspector.{{ .Values.ui.domainName }}:8080"
   MCP_PROXY_FULL_ADDRESS: "http://mcp-proxy.{{ .Values.ui.domainName }}:8080"
   KEYCLOAK_CONSOLE_URL: "http://keycloak.{{ .Values.ui.domainName }}:8080/admin/{{ .Values.keycloak.realm }}/console/"
+  INTERNAL_CONTAINER_IMAGE_REGISTRY_URL: {{ $internalReg | quote }}
 ---
 {{- end }}
 # Backend Service Account
@@ -147,6 +150,12 @@ spec:
                   name: "{{ .Values.ui.configmap }}"
                   key: "KEYCLOAK_CONSOLE_URL"
                   optional: {{ (not .Values.openshift) }}
+            - name: INTERNAL_CONTAINER_IMAGE_REGISTRY_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ .Values.ui.configmap }}"
+                  key: "INTERNAL_CONTAINER_IMAGE_REGISTRY_URL"
+                  optional: true
             {{- if .Values.uiOAuthSecret.useServiceAccountCA }}
             - name: SSL_CERT_FILE
               valueFrom:

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -72,6 +72,8 @@ ui:
   # Backend API external access
   api:
     hostname: kagenti-api.localtest.me
+  # In-cluster registry FQDN (empty = Kind vs OpenShift default in chart / CM)
+  internalContainerImageRegistryUrl: ""
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend

--- a/docs/install.md
+++ b/docs/install.md
@@ -158,6 +158,17 @@ Note: The wrapper provides convenience features (path resolution for env/secret 
 >
 > Both Ollama (local models) and OpenAI are supported as LLM backends. See the [Local Models Guide](local-models.md) for setup details.
 
+### In-cluster image registry (`kagenti-ui-config`)
+
+The ConfigMap **`kagenti-ui-config`** includes **`INTERNAL_CONTAINER_IMAGE_REGISTRY_URL`** (set by the Helm chart). The backend reads it via environment variables and exposes the value as **`internalRegistryUrl`** on `GET /api/v1/config/dashboards` for the Import Agent/Tool UI.
+
+| Platform | Default FQDN |
+|----------|----------------|
+| Kind (`openshift: false`) | `registry.cr-system.svc.cluster.local:5000` |
+| OpenShift (`openshift: true`) | `image-registry.openshift-image-registry.svc.cluster.local:5000` |
+
+On OpenShift, use the **fully qualified** internal registry hostname (`.svc.cluster.local`), not the short `*.svc` form. Override with Helm value **`ui.internalContainerImageRegistryUrl`**. See [issue #975](https://github.com/kagenti/kagenti/issues/975).
+
 ### Pre-Installation Steps
 
 #### 1. Remove Cert Manager (if installed)

--- a/docs/new-tool.md
+++ b/docs/new-tool.md
@@ -88,7 +88,7 @@ You can override the strategy in the "Build Configuration" section if needed.
 
 #### Registry Configuration
 
-- **Registry URL**: Where to push the built image (e.g., `registry.cr-system.svc.cluster.local:5000` for internal, `quay.io/myorg` for external)
+- **Registry URL**: Where to push the built image. The UI default comes from `GET /api/v1/config/dashboards` (`internalRegistryUrl`, sourced from `kagenti-ui-config` / `INTERNAL_CONTAINER_IMAGE_REGISTRY_URL`). Kind: `registry.cr-system.svc.cluster.local:5000`; OpenShift FQDN: `image-registry.openshift-image-registry.svc.cluster.local:5000`. External example: `quay.io/myorg`.
 - **Registry Secret**: Name of the Kubernetes Secret containing registry credentials (required for external registries)
 - **Image Tag**: Version tag for the image (default: `v0.0.1`)
 

--- a/kagenti/backend/README.md
+++ b/kagenti/backend/README.md
@@ -105,7 +105,7 @@ Once running, access the OpenAPI documentation:
 - `POST /api/v1/chat/{namespace}/{name}/stream` - Stream chat with A2A agent (Server-Sent Events)
 
 ### Configuration
-- `GET /api/v1/config/dashboards` - Get dashboard URLs for observability tools (Phoenix, Kiali, MCP Inspector, Keycloak)
+- `GET /api/v1/config/dashboards` - Dashboard URLs (Phoenix, Kiali, MCP Inspector, Keycloak) and `internalRegistryUrl` from `kagenti-ui-config`
 
 ## Environment Variables
 
@@ -113,6 +113,7 @@ Once running, access the OpenAPI documentation:
 |----------|---------|-------------|
 | `DEBUG` | `false` | Enable debug mode |
 | `DOMAIN_NAME` | `localtest.me` | Domain for service URLs |
+| `INTERNAL_CONTAINER_IMAGE_REGISTRY_URL` | (from CM; default Kind FQDN if unset) | In-cluster registry; set in `kagenti-ui-config` by Helm |
 | `CORS_ORIGINS` | `["http://localhost:3000"]` | Allowed CORS origins |
 
 ## Docker

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -9,8 +9,10 @@ import re
 from functools import lru_cache
 from typing import List, Optional
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_KIND_DEFAULT_INTERNAL_REGISTRY = "registry.cr-system.svc.cluster.local:5000"
 
 
 class Settings(BaseSettings):
@@ -38,6 +40,12 @@ class Settings(BaseSettings):
         "http://localhost:3000",
         "http://localhost:8080",
     ]
+
+    @field_validator("internal_container_image_registry_url", mode="after")
+    @classmethod
+    def _internal_registry_non_empty(cls, v: str) -> str:
+        s = (v or "").strip()
+        return s if s else _KIND_DEFAULT_INTERNAL_REGISTRY
 
     @model_validator(mode="after")
     def _add_domain_cors_origin(self) -> "Settings":
@@ -76,6 +84,9 @@ class Settings(BaseSettings):
     mcp_inspector_url: str = ""
     mcp_proxy_full_address: str = ""
     keycloak_console_url: str = ""
+
+    # From kagenti-ui-config (INTERNAL_CONTAINER_IMAGE_REGISTRY_URL)
+    internal_container_image_registry_url: str = _KIND_DEFAULT_INTERNAL_REGISTRY
 
     # Authentication settings - from kagenti-ui-oauth-secret
     enable_auth: bool = False  # Set to True to enable Keycloak auth

--- a/kagenti/backend/app/models/responses.py
+++ b/kagenti/backend/app/models/responses.py
@@ -75,6 +75,7 @@ class DashboardConfigResponse(BaseModel):
     mcpProxy: str
     keycloakConsole: str
     domainName: str
+    internalRegistryUrl: str = ""
 
 
 class MCPToolInfo(BaseModel):

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -51,7 +51,6 @@ from app.core.constants import (
     SHIPWRIGHT_BUILDS_PLURAL,
     SHIPWRIGHT_BUILDRUNS_PLURAL,
     SHIPWRIGHT_CLUSTER_BUILD_STRATEGIES_PLURAL,
-    DEFAULT_INTERNAL_REGISTRY,
     # Workload type constants
     WORKLOAD_TYPE_DEPLOYMENT,
     WORKLOAD_TYPE_STATEFULSET,
@@ -1780,7 +1779,7 @@ def _build_agent_shipwright_build_manifest(
     that converts CreateAgentRequest to the shared function's parameters.
     """
     # Determine registry URL
-    registry_url = request.registryUrl or DEFAULT_INTERNAL_REGISTRY
+    registry_url = request.registryUrl or settings.internal_container_image_registry_url
 
     # Build source config
     source_config = BuildSourceConfig(

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -24,8 +24,8 @@ async def get_dashboard_config() -> DashboardConfigResponse:
     Get dashboard URLs for observability tools.
 
     Returns URLs for Phoenix (traces), Kiali (network), MCP Inspector/Proxy,
-    and Keycloak console. URLs are read from environment variables that are
-    populated from the kagenti-ui-config ConfigMap.
+    Keycloak console, and in-cluster registry (Import / Shipwright). Values
+    come from environment variables populated from kagenti-ui-config.
     """
     domain = settings.domain_name
 
@@ -39,4 +39,5 @@ async def get_dashboard_config() -> DashboardConfigResponse:
             or f"{settings.effective_keycloak_url}/admin/{settings.effective_keycloak_realm}/console/"
         ),
         domainName=domain,
+        internalRegistryUrl=settings.internal_container_image_registry_url,
     )

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -44,7 +44,6 @@ from app.core.constants import (
     SHIPWRIGHT_CRD_VERSION,
     SHIPWRIGHT_BUILDS_PLURAL,
     SHIPWRIGHT_BUILDRUNS_PLURAL,
-    DEFAULT_INTERNAL_REGISTRY,
     # SPIRE identity constants
     KAGENTI_SPIRE_LABEL,
     KAGENTI_SPIRE_ENABLED_VALUE,
@@ -446,7 +445,7 @@ def _build_tool_shipwright_build_manifest(
     that converts CreateToolRequest to the shared function's parameters.
     """
     # Determine registry URL
-    registry_url = request.registryUrl or DEFAULT_INTERNAL_REGISTRY
+    registry_url = request.registryUrl or settings.internal_container_image_registry_url
 
     # Build source config
     source_config = BuildSourceConfig(

--- a/kagenti/backend/app/services/shipwright.py
+++ b/kagenti/backend/app/services/shipwright.py
@@ -17,6 +17,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
+from app.core.config import settings
 from app.core.constants import (
     APP_KUBERNETES_IO_CREATED_BY,
     APP_KUBERNETES_IO_NAME,
@@ -76,8 +77,10 @@ def select_build_strategy(registry_url: str, requested_strategy: Optional[str] =
     Returns:
         The build strategy name to use
     """
+    reg = registry_url.rstrip("/")
+    configured = settings.internal_container_image_registry_url.rstrip("/")
     is_internal_registry = (
-        registry_url == DEFAULT_INTERNAL_REGISTRY or "svc.cluster.local" in registry_url
+        reg == DEFAULT_INTERNAL_REGISTRY or reg == configured or "svc.cluster.local" in registry_url
     )
 
     # If a strategy was explicitly requested, use it unless it's secure for internal registry

--- a/kagenti/backend/tests/test_dashboard_config.py
+++ b/kagenti/backend/tests/test_dashboard_config.py
@@ -42,12 +42,16 @@ class TestDashboardConfigPhoenixToggle:
                 mock_settings.domain_name = "localtest.me"
                 mock_settings.effective_keycloak_url = "http://keycloak.localtest.me:8080"
                 mock_settings.effective_keycloak_realm = "kagenti"
+                mock_settings.internal_container_image_registry_url = (
+                    "registry.cr-system.svc.cluster.local:5000"
+                )
 
                 response = client.get("/api/v1/config/dashboards")
                 assert response.status_code == 200
                 data = response.json()
                 assert data["traces"] == ""
                 assert "phoenix" not in data["traces"]
+                assert data["internalRegistryUrl"] == "registry.cr-system.svc.cluster.local:5000"
 
     def test_traces_dashboard_url_non_empty(self, client):
         """When TRACES_DASHBOARD_URL is set, it should be returned."""
@@ -63,8 +67,15 @@ class TestDashboardConfigPhoenixToggle:
                 mock_settings.domain_name = "localtest.me"
                 mock_settings.effective_keycloak_url = "http://keycloak.localtest.me:8080"
                 mock_settings.effective_keycloak_realm = "kagenti"
+                mock_settings.internal_container_image_registry_url = (
+                    "image-registry.openshift-image-registry.svc.cluster.local:5000"
+                )
 
                 response = client.get("/api/v1/config/dashboards")
                 assert response.status_code == 200
                 data = response.json()
                 assert data["traces"] == phoenix_url
+                assert (
+                    data["internalRegistryUrl"]
+                    == "image-registry.openshift-image-registry.svc.cluster.local:5000"
+                )

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 IBM Corp.
 // Licensed under the Apache License, Version 2.0
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidEnvVarName, isValidContainerImage, isValidImageTag } from '../utils/validation';
 import {
@@ -34,9 +34,9 @@ import {
   Checkbox,
 } from '@patternfly/react-core';
 import { TrashIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { agentService, ShipwrightBuildConfig } from '@/services/api';
+import { agentService, configService, ShipwrightBuildConfig } from '@/services/api';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
 import { EnvImportModal } from '@/components/EnvImportModal';
 import { BuildStrategySelector } from '@/components/BuildStrategySelector';
@@ -60,8 +60,9 @@ const FRAMEWORKS = [
   { value: 'Python', label: 'Python (Custom)' },
 ];
 
-const REGISTRY_OPTIONS = [
-  { value: 'local', label: 'Local Registry (In-Cluster)', url: 'registry.cr-system.svc.cluster.local:5000' },
+const KIND_DEFAULT_INTERNAL_REGISTRY = 'registry.cr-system.svc.cluster.local:5000';
+
+const EXTERNAL_REGISTRY_OPTIONS = [
   { value: 'quay', label: 'Quay.io', url: 'quay.io' },
   { value: 'dockerhub', label: 'Docker Hub', url: 'docker.io' },
   { value: 'github', label: 'GitHub Container Registry', url: 'ghcr.io' },
@@ -98,6 +99,20 @@ interface ServicePort {
 
 export const ImportAgentPage: React.FC = () => {
   const navigate = useNavigate();
+
+  const { data: dashboardConfig } = useQuery({
+    queryKey: ['dashboards'],
+    queryFn: () => configService.getDashboards(),
+  });
+  const localRegistryUrl =
+    dashboardConfig?.internalRegistryUrl?.trim() || KIND_DEFAULT_INTERNAL_REGISTRY;
+  const registryOptions = useMemo(
+    () => [
+      { value: 'local', label: 'Local Registry (In-Cluster)', url: localRegistryUrl },
+      ...EXTERNAL_REGISTRY_OPTIONS,
+    ],
+    [localRegistryUrl],
+  );
 
   // Deployment method
   const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
@@ -345,7 +360,7 @@ export const ImportAgentPage: React.FC = () => {
   };
 
   const getRegistryUrl = () => {
-    const registry = REGISTRY_OPTIONS.find((r) => r.value === registryType);
+    const registry = registryOptions.find((r) => r.value === registryType);
     if (!registry) return '';
     if (registryType === 'local') return registry.url;
     return registryNamespace ? `${registry.url}/${registryNamespace}` : registry.url;
@@ -649,7 +664,7 @@ export const ImportAgentPage: React.FC = () => {
                       value={registryType}
                       onChange={(_e, value) => setRegistryType(value)}
                     >
-                      {REGISTRY_OPTIONS.map((reg) => (
+                      {registryOptions.map((reg) => (
                         <FormSelectOption key={reg.value} value={reg.value} label={reg.label} />
                       ))}
                     </FormSelect>

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 IBM Corp.
 // Licensed under the Apache License, Version 2.0
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidEnvVarName, isValidContainerImage, isValidImageTag } from '../utils/validation';
 import {
@@ -34,9 +34,9 @@ import {
   Radio,
 } from '@patternfly/react-core';
 import { TrashIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { toolService, ShipwrightBuildConfig } from '@/services/api';
+import { configService, toolService, ShipwrightBuildConfig } from '@/services/api';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
 import { EnvImportModal, EnvVar } from '@/components/EnvImportModal';
 import { BuildStrategySelector } from '@/components/BuildStrategySelector';
@@ -59,8 +59,9 @@ const TOOL_EXAMPLES = [
   { value: 'mcp/cloud_storage_tool', label: 'Cloud Storage Tool' },
 ];
 
-const REGISTRY_OPTIONS = [
-  { value: 'local', label: 'Local Registry (In-Cluster)', url: 'registry.cr-system.svc.cluster.local:5000' },
+const KIND_DEFAULT_INTERNAL_REGISTRY = 'registry.cr-system.svc.cluster.local:5000';
+
+const EXTERNAL_REGISTRY_OPTIONS = [
   { value: 'quay', label: 'Quay.io', url: 'quay.io' },
   { value: 'dockerhub', label: 'Docker Hub', url: 'docker.io' },
   { value: 'github', label: 'GitHub Container Registry', url: 'ghcr.io' },
@@ -81,6 +82,20 @@ interface ServicePort {
 
 export const ImportToolPage: React.FC = () => {
   const navigate = useNavigate();
+
+  const { data: dashboardConfig } = useQuery({
+    queryKey: ['dashboards'],
+    queryFn: () => configService.getDashboards(),
+  });
+  const localRegistryUrl =
+    dashboardConfig?.internalRegistryUrl?.trim() || KIND_DEFAULT_INTERNAL_REGISTRY;
+  const registryOptions = useMemo(
+    () => [
+      { value: 'local', label: 'Local Registry (In-Cluster)', url: localRegistryUrl },
+      ...EXTERNAL_REGISTRY_OPTIONS,
+    ],
+    [localRegistryUrl],
+  );
 
   // Deployment method
   const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
@@ -209,7 +224,7 @@ export const ImportToolPage: React.FC = () => {
 
   // Build registry URL from configuration
   const getRegistryUrl = () => {
-    const registry = REGISTRY_OPTIONS.find((r) => r.value === registryType);
+    const registry = registryOptions.find((r) => r.value === registryType);
     if (!registry) return '';
     if (registryType === 'local') {
       return registry.url;
@@ -640,7 +655,7 @@ export const ImportToolPage: React.FC = () => {
                       value={registryType}
                       onChange={(_e, value) => setRegistryType(value)}
                     >
-                      {REGISTRY_OPTIONS.map((registry) => (
+                      {registryOptions.map((registry) => (
                         <FormSelectOption
                           key={registry.value}
                           value={registry.value}

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -602,6 +602,7 @@ export interface DashboardConfig {
   mcpProxy: string;
   keycloakConsole: string;
   domainName: string;
+  internalRegistryUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Helm: optional `ui.internalContainerImageRegistryUrl`; CM key `INTERNAL_CONTAINER_IMAGE_REGISTRY_URL` (Kind static + OCP ui-routes-job); backend Deployment optional env from CM.
- Backend: `internal_container_image_registry_url` setting; Shipwright default registry + internal-registry check; `internalRegistryUrl` on `GET /api/v1/config/dashboards`.
- UI: Import agent/tool pages use dashboards config with Kind fallback.
- Docs/tests: install, new-tool, backend README, `test_dashboard_config`.

## Context
Closes / relates to internal registry correctness for OpenShift vs Kind (issue #975).

