### PR TITLE
✨ AgentCard signing and verification UI integration

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -206,6 +206,14 @@ spec:
                   key: master-key
                   optional: true
             {{- end }}
+            {{- if .Values.spire.trustDomain }}
+            - name: SPIRE_TRUST_DOMAIN
+              value: {{ .Values.spire.trustDomain | quote }}
+            {{- end }}
+            {{- if .Values.agentcard }}
+            - name: AGENTCARD_SIGNER_IMAGE
+              value: {{ .Values.agentcard.signerImage | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.ui.backend.resources | nindent 12 }}
           livenessProbe:
@@ -347,6 +355,9 @@ rules:
   - apiGroups: ["agent.kagenti.dev"]
     resources: ["agents"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["agent.kagenti.dev"]
+    resources: ["agentcards"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
   # Shipwright build resources for building agents and tools from source
   - apiGroups: ["shipwright.io"]
     resources: ["builds", "buildruns"]
@@ -357,9 +368,16 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
+  # ConfigMaps, ServiceAccounts, Roles, RoleBindings for AgentCard signing lifecycle
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "create", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -286,6 +286,11 @@ spec:
         - name: frontend
           image: "{{ .Values.ui.frontend.image }}:{{ .Values.ui.frontend.tag }}"
           imagePullPolicy: IfNotPresent
+          env:
+            - name: DNS_RESOLVER
+              value: {{ .Values.ui.frontend.dnsResolver | default "172.30.0.10" | quote }}
+            - name: BACKEND_HOST
+              value: "kagenti-backend.{{ .Values.ui.namespace }}.svc.cluster.local"
           ports:
             - name: http
               containerPort: 8080

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -121,6 +121,8 @@ spec:
               value: "{{ .Values.featureFlags.integrations }}"
             - name: KAGENTI_FEATURE_FLAG_TRIGGERS
               value: "{{ .Values.featureFlags.triggers }}"
+            - name: KAGENTI_FEATURE_FLAG_AGENTCARD_SIGNING
+              value: "{{ .Values.featureFlags.agentcardSigning }}"
             - name: KEYCLOAK_URL
               value: {{ .Values.keycloak.url | quote }}
             # Dashboard URLs from ConfigMap (populated by ui-routes-job)

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -70,6 +70,9 @@ ui:
   frontend:
     image: ghcr.io/kagenti/kagenti/ui-v2
     tag: latest
+    # DNS resolver IP for nginx upstream resolution.
+    # OpenShift: 172.30.0.10 (default), Kind/vanilla K8s: 10.96.0.10
+    dnsResolver: "172.30.0.10"
     resources:
       limits:
         cpu: 100m

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -8,6 +8,7 @@ featureFlags:
   sandbox: false
   integrations: false
   triggers: false
+  agentcardSigning: false
 
 # ------------------------------------------------------------------
 #  Control Panel: Enable or disable components here
@@ -281,4 +282,4 @@ spire:
 agentcard:
   # Init-container image used to sign agent cards with SPIRE SVIDs.
   # Pin to a release tag once CI publishes to GHCR (kagenti/kagenti-operator#234).
-  signerImage: "ghcr.io/kagenti/agentcard-signer:latest"
+  signerImage: "ghcr.io/kagenti/kagenti-operator/agentcard-signer:latest"

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -269,3 +269,13 @@ mlflowOAuthSecret:
 # ------------------------------------------------------------------
 spire:
   enabled: true
+  # SPIRE trust domain (required for AgentCard identity binding)
+  trustDomain: ""
+
+# ------------------------------------------------------------------
+#  AgentCard configs
+# ------------------------------------------------------------------
+agentcard:
+  # Init-container image used to sign agent cards with SPIRE SVIDs.
+  # Pin to a release tag once CI publishes to GHCR (kagenti/kagenti-operator#234).
+  signerImage: "ghcr.io/kagenti/agentcard-signer:latest"

--- a/kagenti/.dockerignore
+++ b/kagenti/.dockerignore
@@ -36,6 +36,9 @@ examples/
 .gitleaks.toml
 .pre-commit-config.yaml
 
+# Node modules (must not override npm install in Docker)
+**/node_modules/
+
 # Build artifacts
 *.egg-info/
 dist/

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -52,6 +52,16 @@ class Settings(BaseSettings):
     crd_version: str = "v1alpha1"
     agents_plural: str = "agents"
 
+    # AgentCard signing settings
+    # Pin to a release tag once CI publishes to GHCR (kagenti/kagenti-operator#234)
+    agentcard_signer_image: str = "ghcr.io/kagenti/agentcard-signer:latest"
+    agentcard_sign_timeout: str = "30s"
+    agentcard_signer_cpu_request: str = "10m"
+    agentcard_signer_cpu_limit: str = "100m"
+    agentcard_signer_mem_request: str = "32Mi"
+    agentcard_signer_mem_limit: str = "64Mi"
+    spire_trust_domain: str = ""
+
     # Shipwright build settings
     shipwright_default_strategy: str = "buildah-insecure-push"  # Default for dev
     shipwright_default_timeout: str = "15m"

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -54,7 +54,7 @@ class Settings(BaseSettings):
 
     # AgentCard signing settings
     # Pin to a release tag once CI publishes to GHCR (kagenti/kagenti-operator#234)
-    agentcard_signer_image: str = "ghcr.io/kagenti/agentcard-signer:latest"
+    agentcard_signer_image: str = "ghcr.io/kagenti/kagenti-operator/agentcard-signer:latest"
     agentcard_sign_timeout: str = "30s"
     agentcard_signer_cpu_request: str = "10m"
     agentcard_signer_cpu_limit: str = "100m"
@@ -79,6 +79,7 @@ class Settings(BaseSettings):
     kagenti_feature_flag_sandbox: bool = False
     kagenti_feature_flag_integrations: bool = False
     kagenti_feature_flag_triggers: bool = False
+    kagenti_feature_flag_agentcard_signing: bool = False
 
     # Label settings
     kagenti_label_prefix: str = "kagenti.io/"

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -12,6 +12,24 @@ CRD_GROUP = settings.crd_group
 CRD_VERSION = settings.crd_version
 AGENTS_PLURAL = settings.agents_plural
 
+# AgentCard CRD Definitions
+AGENTCARD_CRD_GROUP = settings.crd_group
+AGENTCARD_CRD_VERSION = settings.crd_version
+AGENTCARD_PLURAL = "agentcards"
+AGENTCARD_SIGNER_IMAGE = settings.agentcard_signer_image
+AGENTCARD_SIGN_TIMEOUT = settings.agentcard_sign_timeout
+AGENTCARD_SIGNER_RESOURCES = {
+    "requests": {
+        "cpu": settings.agentcard_signer_cpu_request,
+        "memory": settings.agentcard_signer_mem_request,
+    },
+    "limits": {
+        "cpu": settings.agentcard_signer_cpu_limit,
+        "memory": settings.agentcard_signer_mem_limit,
+    },
+}
+SPIRE_TRUST_DOMAIN = settings.spire_trust_domain
+
 # Labels - Keys
 KAGENTI_TYPE_LABEL = settings.kagenti_type_label
 KAGENTI_PROTOCOL_LABEL = settings.kagenti_protocol_label  # deprecated; use PROTOCOL_LABEL_PREFIX

--- a/kagenti/backend/app/models/responses.py
+++ b/kagenti/backend/app/models/responses.py
@@ -27,12 +27,46 @@ class AgentSummary(BaseModel):
     labels: ResourceLabels
     workloadType: Optional[str] = None
     createdAt: Optional[str] = None
+    hasAgentCard: bool = False
+    verified: Optional[bool] = None
+    bound: Optional[bool] = None
 
 
 class AgentListResponse(BaseModel):
     """Response for listing agents."""
 
     items: List[AgentSummary]
+
+
+class AgentCardCondition(BaseModel):
+    """A single condition from AgentCard status."""
+
+    type: str
+    status: str
+    reason: Optional[str] = None
+    message: Optional[str] = None
+    lastTransitionTime: Optional[str] = None
+
+
+class AgentCardStatusResponse(BaseModel):
+    """Response for AgentCard verification and identity status."""
+
+    found: bool = False
+    verified: Optional[bool] = None
+    bound: Optional[bool] = None
+    synced: Optional[bool] = None
+    spiffeId: Optional[str] = None
+    expectedSpiffeId: Optional[str] = None
+    trustDomain: Optional[str] = None
+    signatureKeyId: Optional[str] = None
+    lastSyncTime: Optional[str] = None
+    cardId: Optional[str] = None
+    networkPolicyState: Optional[str] = None
+    conditions: Optional[List[AgentCardCondition]] = None
+    card: Optional[dict] = None
+    bindingReason: Optional[str] = None
+    bindingMessage: Optional[str] = None
+    verificationDetails: Optional[str] = None
 
 
 class ToolSummary(BaseModel):

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2245,87 +2245,144 @@ def _build_selector_labels(request: "CreateAgentRequest") -> Dict[str, str]:
     }
 
 
+def _cleanup_signing_resource(
+    kube: KubernetesService, namespace: str, kind: str, resource_name: str
+) -> None:
+    """Best-effort cleanup of a single signing resource (ignores 404)."""
+    try:
+        if kind == "ServiceAccount":
+            kube.delete_service_account(namespace=namespace, name=resource_name)
+        elif kind == "ConfigMap":
+            kube.delete_configmap(namespace=namespace, name=resource_name)
+        elif kind == "Role":
+            kube.delete_role(namespace=namespace, name=resource_name)
+        elif kind == "RoleBinding":
+            kube.delete_role_binding(namespace=namespace, name=resource_name)
+        logger.info(f"Rolled back {kind} '{resource_name}' in {namespace}")
+    except ApiException as e:
+        if e.status != 404:
+            logger.warning(f"Failed to roll back {kind} '{resource_name}': {e.reason}")
+
+
 def _create_signing_resources(
     kube: KubernetesService,
     name: str,
     namespace: str,
     request: "CreateAgentRequest",
 ) -> None:
-    """Create ConfigMap and ServiceAccount required for AgentCard signing.
-    Must be called BEFORE workload creation."""
+    """Create ConfigMap, ServiceAccount, Role, and RoleBinding for AgentCard signing.
+
+    Must be called BEFORE workload creation. On failure, any partially-created
+    resources are cleaned up to avoid orphans.
+    """
     port = DEFAULT_IN_CLUSTER_PORT
     if request.servicePorts and len(request.servicePorts) > 0:
         port = request.servicePorts[0].targetPort
 
-    sa_body = {
-        "apiVersion": "v1",
-        "kind": "ServiceAccount",
-        "metadata": {"name": f"{name}-sa", "namespace": namespace},
-    }
-    try:
-        kube.create_service_account(namespace=namespace, body=sa_body)
-        logger.info(f"Created ServiceAccount '{name}-sa' in namespace '{namespace}'")
-    except ApiException as e:
-        if e.status == 409:
-            logger.info(f"ServiceAccount '{name}-sa' already exists, reusing")
-        else:
-            raise
+    created: list[tuple[str, str]] = []
 
-    card_json = json.dumps({
-        "name": name,
-        "description": f"Agent '{name}'",
-        "url": f"http://{name}.{namespace}.svc.cluster.local:{port}",
-        "version": "1.0.0",
-        "capabilities": {"streaming": False, "pushNotifications": False},
-        "defaultInputModes": ["text/plain"],
-        "defaultOutputModes": ["text/plain"],
-        "skills": [],
-    })
-    cm_body = {
-        "apiVersion": "v1",
-        "kind": "ConfigMap",
-        "metadata": {"name": f"{name}-card-unsigned", "namespace": namespace},
-        "data": {"agent.json": card_json},
-    }
     try:
-        kube.create_configmap(namespace=namespace, body=cm_body)
-        logger.info(f"Created ConfigMap '{name}-card-unsigned' in namespace '{namespace}'")
-    except ApiException as e:
-        if e.status == 409:
-            logger.info(f"ConfigMap '{name}-card-unsigned' already exists, reusing")
-        else:
-            raise
+        sa_body = {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {"name": f"{name}-sa", "namespace": namespace},
+        }
+        try:
+            kube.create_service_account(namespace=namespace, body=sa_body)
+            logger.info(f"Created ServiceAccount '{name}-sa' in namespace '{namespace}'")
+            created.append(("ServiceAccount", f"{name}-sa"))
+        except ApiException as e:
+            if e.status == 409:
+                logger.info(f"ServiceAccount '{name}-sa' already exists, reusing")
+            else:
+                raise
 
-    role_body = {
-        "apiVersion": "rbac.authorization.k8s.io/v1",
-        "kind": "Role",
-        "metadata": {"name": f"{name}-card-writer", "namespace": namespace},
-        "rules": [{"apiGroups": [""], "resources": ["configmaps"], "verbs": ["get", "create", "update"]}],
-    }
-    try:
-        kube.create_role(namespace=namespace, body=role_body)
-        logger.info(f"Created Role '{name}-card-writer' in namespace '{namespace}'")
-    except ApiException as e:
-        if e.status == 409:
-            logger.info(f"Role '{name}-card-writer' already exists, reusing")
-        else:
-            raise
+        card_json = json.dumps(
+            {
+                "name": name,
+                "description": f"Agent '{name}'",
+                "url": f"http://{name}.{namespace}.svc.cluster.local:{port}",
+                "version": "1.0.0",
+                "capabilities": {"streaming": False, "pushNotifications": False},
+                "defaultInputModes": ["text/plain"],
+                "defaultOutputModes": ["text/plain"],
+                "skills": [],
+            }
+        )
+        cm_body = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": f"{name}-card-unsigned", "namespace": namespace},
+            "data": {"agent.json": card_json},
+        }
+        try:
+            kube.create_configmap(namespace=namespace, body=cm_body)
+            logger.info(f"Created ConfigMap '{name}-card-unsigned' in namespace '{namespace}'")
+            created.append(("ConfigMap", f"{name}-card-unsigned"))
+        except ApiException as e:
+            if e.status == 409:
+                logger.info(f"ConfigMap '{name}-card-unsigned' already exists, reusing")
+            else:
+                raise
 
-    rolebinding_body = {
-        "apiVersion": "rbac.authorization.k8s.io/v1",
-        "kind": "RoleBinding",
-        "metadata": {"name": f"{name}-card-writer", "namespace": namespace},
-        "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": f"{name}-card-writer"},
-        "subjects": [{"kind": "ServiceAccount", "name": f"{name}-sa", "namespace": namespace}],
-    }
-    try:
-        kube.create_role_binding(namespace=namespace, body=rolebinding_body)
-        logger.info(f"Created RoleBinding '{name}-card-writer' in namespace '{namespace}'")
-    except ApiException as e:
-        if e.status == 409:
-            logger.info(f"RoleBinding '{name}-card-writer' already exists, reusing")
-        else:
-            raise
+        unsigned_cm = f"{name}-card-unsigned"
+        signed_cm = f"{name}-card-signed"
+        role_body = {
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "kind": "Role",
+            "metadata": {"name": f"{name}-card-writer", "namespace": namespace},
+            "rules": [
+                {
+                    "apiGroups": [""],
+                    "resources": ["configmaps"],
+                    "resourceNames": [unsigned_cm, signed_cm],
+                    "verbs": ["get", "update"],
+                },
+                {
+                    "apiGroups": [""],
+                    "resources": ["configmaps"],
+                    "verbs": ["create"],
+                },
+            ],
+        }
+        try:
+            kube.create_role(namespace=namespace, body=role_body)
+            logger.info(f"Created Role '{name}-card-writer' in namespace '{namespace}'")
+            created.append(("Role", f"{name}-card-writer"))
+        except ApiException as e:
+            if e.status == 409:
+                logger.info(f"Role '{name}-card-writer' already exists, reusing")
+            else:
+                raise
+
+        rolebinding_body = {
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "kind": "RoleBinding",
+            "metadata": {"name": f"{name}-card-writer", "namespace": namespace},
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "Role",
+                "name": f"{name}-card-writer",
+            },
+            "subjects": [{"kind": "ServiceAccount", "name": f"{name}-sa", "namespace": namespace}],
+        }
+        try:
+            kube.create_role_binding(namespace=namespace, body=rolebinding_body)
+            logger.info(f"Created RoleBinding '{name}-card-writer' in namespace '{namespace}'")
+            created.append(("RoleBinding", f"{name}-card-writer"))
+        except ApiException as e:
+            if e.status == 409:
+                logger.info(f"RoleBinding '{name}-card-writer' already exists, reusing")
+            else:
+                raise
+
+    except Exception:
+        logger.error(
+            f"Signing resource creation failed for '{name}', rolling back {len(created)} resource(s)"
+        )
+        for kind, resource_name in reversed(created):
+            _cleanup_signing_resource(kube, namespace, kind, resource_name)
+        raise
 
 
 def _inject_signing_into_manifest(manifest: dict, name: str) -> None:
@@ -2335,6 +2392,13 @@ def _inject_signing_into_manifest(manifest: dict, name: str) -> None:
     signed card both to a shared emptyDir volume and to a Kubernetes ConfigMap
     (``{name}-card-signed``).  The operator reads the ConfigMap directly,
     falling back to HTTP fetch for agents that don't use signing.
+
+    ``istio.io/dataplane-mode=none`` disables Istio ambient mesh for this pod.
+    This is required because the SPIRE CSI driver volume (``csi.spiffe.io``)
+    conflicts with Istio ambient's ztunnel-based traffic capture — the
+    init-container needs direct access to the SPIRE agent socket before the
+    mesh dataplane is ready. Without this label the init-container hangs
+    waiting for a socket that ztunnel intercepts.
     """
     pod_spec = manifest["spec"]["template"]["spec"]
     pod_labels = manifest["spec"]["template"]["metadata"].setdefault("labels", {})
@@ -2342,37 +2406,51 @@ def _inject_signing_into_manifest(manifest: dict, name: str) -> None:
 
     pod_spec["serviceAccountName"] = f"{name}-sa"
 
-    pod_spec.setdefault("initContainers", []).append({
-        "name": "sign-agentcard",
-        "image": AGENTCARD_SIGNER_IMAGE,
-        "imagePullPolicy": "Always",
-        "env": [
-            {"name": "SPIFFE_ENDPOINT_SOCKET", "value": "unix:///run/spire/agent-sockets/spire-agent.sock"},
-            {"name": "UNSIGNED_CARD_PATH", "value": "/etc/agentcard/agent.json"},
-            {"name": "AGENT_CARD_PATH", "value": "/app/.well-known/agent-card.json"},
-            {"name": "SIGN_TIMEOUT", "value": AGENTCARD_SIGN_TIMEOUT},
-            {"name": "AGENT_NAME", "value": name},
-            {"name": "POD_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}},
-        ],
-        "volumeMounts": [
-            {"name": "spire-agent-socket", "mountPath": "/run/spire/agent-sockets", "readOnly": True},
-            {"name": "unsigned-card", "mountPath": "/etc/agentcard", "readOnly": True},
-            {"name": "signed-card", "mountPath": "/app/.well-known"},
-        ],
-        "securityContext": {
-            "runAsNonRoot": True,
-            "readOnlyRootFilesystem": True,
-            "allowPrivilegeEscalation": False,
-            "capabilities": {"drop": ["ALL"]},
-        },
-        "resources": AGENTCARD_SIGNER_RESOURCES,
-    })
+    pod_spec.setdefault("initContainers", []).append(
+        {
+            "name": "sign-agentcard",
+            "image": AGENTCARD_SIGNER_IMAGE,
+            "imagePullPolicy": "Always",
+            "env": [
+                {
+                    "name": "SPIFFE_ENDPOINT_SOCKET",
+                    "value": "unix:///run/spire/agent-sockets/spire-agent.sock",
+                },
+                {"name": "UNSIGNED_CARD_PATH", "value": "/etc/agentcard/agent.json"},
+                {"name": "AGENT_CARD_PATH", "value": "/app/.well-known/agent-card.json"},
+                {"name": "SIGN_TIMEOUT", "value": AGENTCARD_SIGN_TIMEOUT},
+                {"name": "AGENT_NAME", "value": name},
+                {
+                    "name": "POD_NAMESPACE",
+                    "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}},
+                },
+            ],
+            "volumeMounts": [
+                {
+                    "name": "spire-agent-socket",
+                    "mountPath": "/run/spire/agent-sockets",
+                    "readOnly": True,
+                },
+                {"name": "unsigned-card", "mountPath": "/etc/agentcard", "readOnly": True},
+                {"name": "signed-card", "mountPath": "/app/.well-known"},
+            ],
+            "securityContext": {
+                "runAsNonRoot": True,
+                "readOnlyRootFilesystem": True,
+                "allowPrivilegeEscalation": False,
+                "capabilities": {"drop": ["ALL"]},
+            },
+            "resources": AGENTCARD_SIGNER_RESOURCES,
+        }
+    )
 
-    pod_spec.setdefault("volumes", []).extend([
-        {"name": "spire-agent-socket", "csi": {"driver": "csi.spiffe.io", "readOnly": True}},
-        {"name": "unsigned-card", "configMap": {"name": f"{name}-card-unsigned"}},
-        {"name": "signed-card", "emptyDir": {"medium": "Memory", "sizeLimit": "1Mi"}},
-    ])
+    pod_spec.setdefault("volumes", []).extend(
+        [
+            {"name": "spire-agent-socket", "csi": {"driver": "csi.spiffe.io", "readOnly": True}},
+            {"name": "unsigned-card", "configMap": {"name": f"{name}-card-unsigned"}},
+            {"name": "signed-card", "emptyDir": {"medium": "Memory", "sizeLimit": "1Mi"}},
+        ]
+    )
 
     pod_spec["containers"][0].setdefault("volumeMounts", []).append(
         {"name": "signed-card", "mountPath": "/app/.well-known", "readOnly": True}
@@ -2399,9 +2477,8 @@ async def _schedule_identity_binding_patch(
         return
 
     import asyncio
-    import time
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     def _do_patch():
         card_name = f"{name}-deployment-card"
@@ -2420,6 +2497,8 @@ async def _schedule_identity_binding_patch(
                 break
             except ApiException as e:
                 if e.status == 404 and attempt < 9:
+                    import time
+
                     time.sleep(3)
                     continue
                 break
@@ -2457,10 +2536,14 @@ async def _schedule_identity_binding_patch(
                     plural=AGENTCARD_PLURAL,
                     body=card_body,
                 )
-                logger.info(f"Created AgentCard '{card_name}' with identity binding (trustDomain: {SPIRE_TRUST_DOMAIN})")
+                logger.info(
+                    f"Created AgentCard '{card_name}' with identity binding (trustDomain: {SPIRE_TRUST_DOMAIN})"
+                )
             except ApiException as e:
                 if e.status == 409:
-                    logger.info(f"AgentCard '{card_name}' appeared concurrently, will patch instead")
+                    logger.info(
+                        f"AgentCard '{card_name}' appeared concurrently, will patch instead"
+                    )
                 else:
                     logger.error(f"Failed to create AgentCard '{card_name}': {e}")
                     return
@@ -2483,11 +2566,13 @@ async def _schedule_identity_binding_patch(
                 name=card_name,
                 body=patch_body,
             )
-            logger.info(f"Patched AgentCard '{card_name}' with identity binding (trustDomain: {SPIRE_TRUST_DOMAIN})")
+            logger.info(
+                f"Patched AgentCard '{card_name}' with identity binding (trustDomain: {SPIRE_TRUST_DOMAIN})"
+            )
         except ApiException as e:
             logger.error(f"Failed to patch AgentCard '{card_name}' with identity binding: {e}")
 
-    loop.run_in_executor(None, _do_patch)
+    await loop.run_in_executor(None, _do_patch)
 
 
 def _build_deployment_manifest(
@@ -2548,6 +2633,7 @@ def _build_deployment_manifest(
 
     if request.startCommand:
         import shlex
+
         container_spec["command"] = shlex.split(request.startCommand)
 
     manifest = {
@@ -3016,7 +3102,11 @@ async def create_agent(
             if request.createHttpRoute:
                 message += " HTTPRoute will be created after the build completes."
 
-        if request.signingEnabled and request.spireEnabled and request.workloadType != WORKLOAD_TYPE_JOB:
+        if (
+            request.signingEnabled
+            and request.spireEnabled
+            and request.workloadType != WORKLOAD_TYPE_JOB
+        ):
             await _schedule_identity_binding_patch(kube, request.name, request.namespace)
         return CreateAgentResponse(
             success=True,

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -674,7 +674,7 @@ async def list_agents(
                     agentcard_lookup[target_name] = ac
         except ApiException as e:
             if e.status not in (404, 403):
-                logger.warning(f"Failed to list AgentCards: {e.reason}")
+                logger.warning("Failed to list AgentCards: %s", e.reason)
 
         for agent in agents:
             ac = agentcard_lookup.get(agent.name)
@@ -716,7 +716,7 @@ async def get_agentcard_status(
         )
     except ApiException as e:
         if e.status not in (404, 403):
-            logger.warning(f"Failed to list AgentCards: {e.reason}")
+            logger.warning("Failed to list AgentCards: %s", e.reason)
         return AgentCardStatusResponse(found=False)
 
     matched = None
@@ -960,7 +960,7 @@ async def delete_agent(
         if e.status == 404:
             pass
         else:
-            logger.warning(f"Failed to delete ConfigMap '{name}-card-unsigned': {e.reason}")
+            logger.warning("Failed to delete ConfigMap '%s-card-unsigned': %s", name, e.reason)
 
     # Delete signing ServiceAccount (if exists)
     try:
@@ -970,7 +970,7 @@ async def delete_agent(
         if e.status == 404:
             pass
         else:
-            logger.warning(f"Failed to delete ServiceAccount '{name}-sa': {e.reason}")
+            logger.warning("Failed to delete ServiceAccount '%s-sa': %s", name, e.reason)
 
     # Delete signing RBAC Role (if exists)
     try:
@@ -980,7 +980,7 @@ async def delete_agent(
         if e.status == 404:
             pass
         else:
-            logger.warning(f"Failed to delete Role '{name}-card-writer': {e.reason}")
+            logger.warning("Failed to delete Role '%s-card-writer': %s", name, e.reason)
 
     # Delete signing RBAC RoleBinding (if exists)
     try:
@@ -990,7 +990,7 @@ async def delete_agent(
         if e.status == 404:
             pass
         else:
-            logger.warning(f"Failed to delete RoleBinding '{name}-card-writer': {e.reason}")
+            logger.warning("Failed to delete RoleBinding '%s-card-writer': %s", name, e.reason)
 
     # Delete signed card ConfigMap (if exists)
     try:
@@ -1000,7 +1000,7 @@ async def delete_agent(
         if e.status == 404:
             pass
         else:
-            logger.warning(f"Failed to delete ConfigMap '{name}-card-signed': {e.reason}")
+            logger.warning("Failed to delete ConfigMap '%s-card-signed': %s", name, e.reason)
 
     # Delete AgentCard CRs matching this agent by targetRef.name
     try:
@@ -1027,10 +1027,10 @@ async def delete_agent(
                     messages.append(f"AgentCard '{ac_name}' deleted")
                 except ApiException as e:
                     if e.status != 404:
-                        logger.warning(f"Failed to delete AgentCard '{ac_name}': {e.reason}")
+                        logger.warning("Failed to delete AgentCard '%s': %s", ac_name, e.reason)
     except ApiException as e:
         if e.status not in (404, 403):
-            logger.warning(f"Failed to list AgentCards for cleanup: {e.reason}")
+            logger.warning("Failed to list AgentCards for cleanup: %s", e.reason)
 
     # Legacy cleanup: Delete the Agent CR if it exists
     try:
@@ -2258,10 +2258,10 @@ def _cleanup_signing_resource(
             kube.delete_role(namespace=namespace, name=resource_name)
         elif kind == "RoleBinding":
             kube.delete_role_binding(namespace=namespace, name=resource_name)
-        logger.info(f"Rolled back {kind} '{resource_name}' in {namespace}")
+        logger.info("Rolled back %s '%s' in %s", kind, resource_name, namespace)
     except ApiException as e:
         if e.status != 404:
-            logger.warning(f"Failed to roll back {kind} '{resource_name}': {e.reason}")
+            logger.warning("Failed to roll back %s '%s': %s", kind, resource_name, e.reason)
 
 
 def _create_signing_resources(
@@ -2289,11 +2289,11 @@ def _create_signing_resources(
         }
         try:
             kube.create_service_account(namespace=namespace, body=sa_body)
-            logger.info(f"Created ServiceAccount '{name}-sa' in namespace '{namespace}'")
+            logger.info("Created ServiceAccount '%s-sa' in namespace '%s'", name, namespace)
             created.append(("ServiceAccount", f"{name}-sa"))
         except ApiException as e:
             if e.status == 409:
-                logger.info(f"ServiceAccount '{name}-sa' already exists, reusing")
+                logger.info("ServiceAccount '%s-sa' already exists, reusing", name)
             else:
                 raise
 
@@ -2317,11 +2317,15 @@ def _create_signing_resources(
         }
         try:
             kube.create_configmap(namespace=namespace, body=cm_body)
-            logger.info(f"Created ConfigMap '{name}-card-unsigned' in namespace '{namespace}'")
+            logger.info(
+                "Created ConfigMap '%s-card-unsigned' in namespace '%s'",
+                name,
+                namespace,
+            )
             created.append(("ConfigMap", f"{name}-card-unsigned"))
         except ApiException as e:
             if e.status == 409:
-                logger.info(f"ConfigMap '{name}-card-unsigned' already exists, reusing")
+                logger.info("ConfigMap '%s-card-unsigned' already exists, reusing", name)
             else:
                 raise
 
@@ -2347,11 +2351,11 @@ def _create_signing_resources(
         }
         try:
             kube.create_role(namespace=namespace, body=role_body)
-            logger.info(f"Created Role '{name}-card-writer' in namespace '{namespace}'")
+            logger.info("Created Role '%s-card-writer' in namespace '%s'", name, namespace)
             created.append(("Role", f"{name}-card-writer"))
         except ApiException as e:
             if e.status == 409:
-                logger.info(f"Role '{name}-card-writer' already exists, reusing")
+                logger.info("Role '%s-card-writer' already exists, reusing", name)
             else:
                 raise
 
@@ -2368,17 +2372,23 @@ def _create_signing_resources(
         }
         try:
             kube.create_role_binding(namespace=namespace, body=rolebinding_body)
-            logger.info(f"Created RoleBinding '{name}-card-writer' in namespace '{namespace}'")
+            logger.info(
+                "Created RoleBinding '%s-card-writer' in namespace '%s'",
+                name,
+                namespace,
+            )
             created.append(("RoleBinding", f"{name}-card-writer"))
         except ApiException as e:
             if e.status == 409:
-                logger.info(f"RoleBinding '{name}-card-writer' already exists, reusing")
+                logger.info("RoleBinding '%s-card-writer' already exists, reusing", name)
             else:
                 raise
 
     except Exception:
         logger.error(
-            f"Signing resource creation failed for '{name}', rolling back {len(created)} resource(s)"
+            "Signing resource creation failed for '%s', rolling back %s resource(s)",
+            name,
+            len(created),
         )
         for kind, resource_name in reversed(created):
             _cleanup_signing_resource(kube, namespace, kind, resource_name)
@@ -2504,7 +2514,10 @@ async def _schedule_identity_binding_patch(
                 break
 
         if not card_found:
-            logger.info(f"AgentCard '{card_name}' not auto-created, creating with identity binding")
+            logger.info(
+                "AgentCard '%s' not auto-created, creating with identity binding",
+                card_name,
+            )
             card_body = {
                 "apiVersion": f"{AGENTCARD_CRD_GROUP}/{AGENTCARD_CRD_VERSION}",
                 "kind": "AgentCard",
@@ -2545,7 +2558,7 @@ async def _schedule_identity_binding_patch(
                         f"AgentCard '{card_name}' appeared concurrently, will patch instead"
                     )
                 else:
-                    logger.error(f"Failed to create AgentCard '{card_name}': {e}")
+                    logger.error("Failed to create AgentCard '%s': %s", card_name, e)
                     return
             else:
                 return
@@ -2570,7 +2583,11 @@ async def _schedule_identity_binding_patch(
                 f"Patched AgentCard '{card_name}' with identity binding (trustDomain: {SPIRE_TRUST_DOMAIN})"
             )
         except ApiException as e:
-            logger.error(f"Failed to patch AgentCard '{card_name}' with identity binding: {e}")
+            logger.error(
+                "Failed to patch AgentCard '%s' with identity binding: %s",
+                card_name,
+                e,
+            )
 
     await loop.run_in_executor(None, _do_patch)
 

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -68,11 +68,21 @@ from app.core.constants import (
     DEFAULT_KEYCLOAK_REALM,
     DEFAULT_SPIFFE_HELPER_CONF,
     DEFAULT_ENVOY_YAML,
+    # AgentCard constants
+    AGENTCARD_CRD_GROUP,
+    AGENTCARD_CRD_VERSION,
+    AGENTCARD_PLURAL,
+    AGENTCARD_SIGNER_IMAGE,
+    AGENTCARD_SIGN_TIMEOUT,
+    AGENTCARD_SIGNER_RESOURCES,
+    SPIRE_TRUST_DOMAIN,
 )
 from app.core.config import settings
 from app.models.responses import (
     AgentSummary,
     AgentListResponse,
+    AgentCardCondition,
+    AgentCardStatusResponse,
     ResourceLabels,
     DeleteResponse,
 )
@@ -222,6 +232,8 @@ class CreateAgentRequest(BaseModel):
     authBridgeEnabled: bool = True
     # SPIRE identity (spiffe-helper sidecar injection)
     spireEnabled: bool = False
+    # AgentCard signing (init-container + unsigned card ConfigMap)
+    signingEnabled: bool = False
 
     # Shipwright build configuration
     shipwrightConfig: Optional[ShipwrightBuildConfig] = None
@@ -647,6 +659,33 @@ async def list_agents(
                 if e.status not in (404, 403):
                     logger.warning(f"Failed to list legacy Agent CRDs: {e.reason}")
 
+        # Enrich with AgentCard verification status
+        agentcard_lookup: Dict[str, dict] = {}
+        try:
+            agentcards = kube.list_custom_resources(
+                group=AGENTCARD_CRD_GROUP,
+                version=AGENTCARD_CRD_VERSION,
+                namespace=namespace,
+                plural=AGENTCARD_PLURAL,
+            )
+            for ac in agentcards:
+                target_name = ac.get("spec", {}).get("targetRef", {}).get("name")
+                if target_name:
+                    agentcard_lookup[target_name] = ac
+        except ApiException as e:
+            if e.status not in (404, 403):
+                logger.warning(f"Failed to list AgentCards: {e.reason}")
+
+        for agent in agents:
+            ac = agentcard_lookup.get(agent.name)
+            if ac:
+                agent.hasAgentCard = True
+                ac_status = ac.get("status", {})
+                agent.verified = ac_status.get("validSignature")
+                binding = ac_status.get("bindingStatus")
+                if binding:
+                    agent.bound = binding.get("bound")
+
         return AgentListResponse(items=agents)
 
     except ApiException as e:
@@ -656,6 +695,90 @@ async def list_agents(
                 detail="Permission denied. Check RBAC configuration.",
             )
         raise HTTPException(status_code=e.status, detail=str(e.reason))
+
+
+@router.get(
+    "/{namespace}/{name}/agentcard",
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_agentcard_status(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> AgentCardStatusResponse:
+    """Get AgentCard verification and identity status for an agent."""
+    try:
+        agentcards = kube.list_custom_resources(
+            group=AGENTCARD_CRD_GROUP,
+            version=AGENTCARD_CRD_VERSION,
+            namespace=namespace,
+            plural=AGENTCARD_PLURAL,
+        )
+    except ApiException as e:
+        if e.status not in (404, 403):
+            logger.warning(f"Failed to list AgentCards: {e.reason}")
+        return AgentCardStatusResponse(found=False)
+
+    matched = None
+    for ac in agentcards:
+        target_ref = ac.get("spec", {}).get("targetRef", {})
+        if target_ref.get("name") == name:
+            matched = ac
+            break
+
+    if not matched:
+        return AgentCardStatusResponse(found=False)
+
+    status = matched.get("status", {})
+    spec = matched.get("spec", {})
+    binding = status.get("bindingStatus") or {}
+    identity_binding = spec.get("identityBinding") or {}
+
+    synced = None
+    for cond in status.get("conditions", []):
+        if cond.get("type") == "Synced":
+            synced = cond.get("status") == "True"
+            break
+
+    verified = status.get("validSignature")
+    network_policy = "none"
+    if verified is True:
+        network_policy = "permissive"
+    elif identity_binding.get("enforceMode") == "strict" and verified is not True:
+        network_policy = "restrictive"
+
+    conditions = None
+    raw_conditions = status.get("conditions")
+    if raw_conditions:
+        conditions = [
+            AgentCardCondition(
+                type=c.get("type", ""),
+                status=c.get("status", ""),
+                reason=c.get("reason"),
+                message=c.get("message"),
+                lastTransitionTime=c.get("lastTransitionTime"),
+            )
+            for c in raw_conditions
+        ]
+
+    return AgentCardStatusResponse(
+        found=True,
+        verified=verified,
+        bound=binding.get("bound"),
+        synced=synced,
+        spiffeId=status.get("signatureSpiffeId"),
+        expectedSpiffeId=status.get("expectedSpiffeID"),
+        trustDomain=identity_binding.get("trustDomain"),
+        signatureKeyId=status.get("signatureKeyId"),
+        lastSyncTime=status.get("lastSyncTime"),
+        cardId=status.get("cardId"),
+        networkPolicyState=network_policy,
+        conditions=conditions,
+        card=status.get("card"),
+        bindingReason=binding.get("reason"),
+        bindingMessage=binding.get("message"),
+        verificationDetails=status.get("signatureVerificationDetails"),
+    )
 
 
 @router.get("/{namespace}/{name}", dependencies=[Depends(require_roles(ROLE_VIEWER))])
@@ -828,6 +951,86 @@ async def delete_agent(
             pass
         else:
             logger.warning(f"Failed to delete Service '{name}': {e.reason}")
+
+    # Delete signing ConfigMap (if exists)
+    try:
+        kube.delete_configmap(namespace=namespace, name=f"{name}-card-unsigned")
+        messages.append(f"ConfigMap '{name}-card-unsigned' deleted")
+    except ApiException as e:
+        if e.status == 404:
+            pass
+        else:
+            logger.warning(f"Failed to delete ConfigMap '{name}-card-unsigned': {e.reason}")
+
+    # Delete signing ServiceAccount (if exists)
+    try:
+        kube.delete_service_account(namespace=namespace, name=f"{name}-sa")
+        messages.append(f"ServiceAccount '{name}-sa' deleted")
+    except ApiException as e:
+        if e.status == 404:
+            pass
+        else:
+            logger.warning(f"Failed to delete ServiceAccount '{name}-sa': {e.reason}")
+
+    # Delete signing RBAC Role (if exists)
+    try:
+        kube.delete_role(namespace=namespace, name=f"{name}-card-writer")
+        messages.append(f"Role '{name}-card-writer' deleted")
+    except ApiException as e:
+        if e.status == 404:
+            pass
+        else:
+            logger.warning(f"Failed to delete Role '{name}-card-writer': {e.reason}")
+
+    # Delete signing RBAC RoleBinding (if exists)
+    try:
+        kube.delete_role_binding(namespace=namespace, name=f"{name}-card-writer")
+        messages.append(f"RoleBinding '{name}-card-writer' deleted")
+    except ApiException as e:
+        if e.status == 404:
+            pass
+        else:
+            logger.warning(f"Failed to delete RoleBinding '{name}-card-writer': {e.reason}")
+
+    # Delete signed card ConfigMap (if exists)
+    try:
+        kube.delete_configmap(namespace=namespace, name=f"{name}-card-signed")
+        messages.append(f"ConfigMap '{name}-card-signed' deleted")
+    except ApiException as e:
+        if e.status == 404:
+            pass
+        else:
+            logger.warning(f"Failed to delete ConfigMap '{name}-card-signed': {e.reason}")
+
+    # Delete AgentCard CRs matching this agent by targetRef.name
+    try:
+        agentcards = kube.list_custom_resources(
+            group=AGENTCARD_CRD_GROUP,
+            version=AGENTCARD_CRD_VERSION,
+            namespace=namespace,
+            plural=AGENTCARD_PLURAL,
+        )
+        for ac in agentcards:
+            target_name = ac.get("spec", {}).get("targetRef", {}).get("name")
+            if target_name == name:
+                ac_name = ac.get("metadata", {}).get("name")
+                if not ac_name:
+                    continue
+                try:
+                    kube.delete_custom_resource(
+                        group=AGENTCARD_CRD_GROUP,
+                        version=AGENTCARD_CRD_VERSION,
+                        namespace=namespace,
+                        plural=AGENTCARD_PLURAL,
+                        name=ac_name,
+                    )
+                    messages.append(f"AgentCard '{ac_name}' deleted")
+                except ApiException as e:
+                    if e.status != 404:
+                        logger.warning(f"Failed to delete AgentCard '{ac_name}': {e.reason}")
+    except ApiException as e:
+        if e.status not in (404, 403):
+            logger.warning(f"Failed to list AgentCards for cleanup: {e.reason}")
 
     # Legacy cleanup: Delete the Agent CR if it exists
     try:
@@ -1905,6 +2108,7 @@ def _build_agent_shipwright_build_manifest(
         "workloadType": request.workloadType,  # Store workload type for finalization
         "authBridgeEnabled": request.authBridgeEnabled,
         "spireEnabled": request.spireEnabled,
+        "signingEnabled": request.signingEnabled,
     }
     # Add env vars if present
     if request.envVars:
@@ -2041,6 +2245,251 @@ def _build_selector_labels(request: "CreateAgentRequest") -> Dict[str, str]:
     }
 
 
+def _create_signing_resources(
+    kube: KubernetesService,
+    name: str,
+    namespace: str,
+    request: "CreateAgentRequest",
+) -> None:
+    """Create ConfigMap and ServiceAccount required for AgentCard signing.
+    Must be called BEFORE workload creation."""
+    port = DEFAULT_IN_CLUSTER_PORT
+    if request.servicePorts and len(request.servicePorts) > 0:
+        port = request.servicePorts[0].targetPort
+
+    sa_body = {
+        "apiVersion": "v1",
+        "kind": "ServiceAccount",
+        "metadata": {"name": f"{name}-sa", "namespace": namespace},
+    }
+    try:
+        kube.create_service_account(namespace=namespace, body=sa_body)
+        logger.info(f"Created ServiceAccount '{name}-sa' in namespace '{namespace}'")
+    except ApiException as e:
+        if e.status == 409:
+            logger.info(f"ServiceAccount '{name}-sa' already exists, reusing")
+        else:
+            raise
+
+    card_json = json.dumps({
+        "name": name,
+        "description": f"Agent '{name}'",
+        "url": f"http://{name}.{namespace}.svc.cluster.local:{port}",
+        "version": "1.0.0",
+        "capabilities": {"streaming": False, "pushNotifications": False},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [],
+    })
+    cm_body = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": f"{name}-card-unsigned", "namespace": namespace},
+        "data": {"agent.json": card_json},
+    }
+    try:
+        kube.create_configmap(namespace=namespace, body=cm_body)
+        logger.info(f"Created ConfigMap '{name}-card-unsigned' in namespace '{namespace}'")
+    except ApiException as e:
+        if e.status == 409:
+            logger.info(f"ConfigMap '{name}-card-unsigned' already exists, reusing")
+        else:
+            raise
+
+    role_body = {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "Role",
+        "metadata": {"name": f"{name}-card-writer", "namespace": namespace},
+        "rules": [{"apiGroups": [""], "resources": ["configmaps"], "verbs": ["get", "create", "update"]}],
+    }
+    try:
+        kube.create_role(namespace=namespace, body=role_body)
+        logger.info(f"Created Role '{name}-card-writer' in namespace '{namespace}'")
+    except ApiException as e:
+        if e.status == 409:
+            logger.info(f"Role '{name}-card-writer' already exists, reusing")
+        else:
+            raise
+
+    rolebinding_body = {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "RoleBinding",
+        "metadata": {"name": f"{name}-card-writer", "namespace": namespace},
+        "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": f"{name}-card-writer"},
+        "subjects": [{"kind": "ServiceAccount", "name": f"{name}-sa", "namespace": namespace}],
+    }
+    try:
+        kube.create_role_binding(namespace=namespace, body=rolebinding_body)
+        logger.info(f"Created RoleBinding '{name}-card-writer' in namespace '{namespace}'")
+    except ApiException as e:
+        if e.status == 409:
+            logger.info(f"RoleBinding '{name}-card-writer' already exists, reusing")
+        else:
+            raise
+
+
+def _inject_signing_into_manifest(manifest: dict, name: str) -> None:
+    """Inject signing init-container, volumes, and mounts.
+
+    The init-container signs the agent card using a SPIFFE SVID and writes the
+    signed card both to a shared emptyDir volume and to a Kubernetes ConfigMap
+    (``{name}-card-signed``).  The operator reads the ConfigMap directly,
+    falling back to HTTP fetch for agents that don't use signing.
+    """
+    pod_spec = manifest["spec"]["template"]["spec"]
+    pod_labels = manifest["spec"]["template"]["metadata"].setdefault("labels", {})
+    pod_labels["istio.io/dataplane-mode"] = "none"
+
+    pod_spec["serviceAccountName"] = f"{name}-sa"
+
+    pod_spec.setdefault("initContainers", []).append({
+        "name": "sign-agentcard",
+        "image": AGENTCARD_SIGNER_IMAGE,
+        "imagePullPolicy": "Always",
+        "env": [
+            {"name": "SPIFFE_ENDPOINT_SOCKET", "value": "unix:///run/spire/agent-sockets/spire-agent.sock"},
+            {"name": "UNSIGNED_CARD_PATH", "value": "/etc/agentcard/agent.json"},
+            {"name": "AGENT_CARD_PATH", "value": "/app/.well-known/agent-card.json"},
+            {"name": "SIGN_TIMEOUT", "value": AGENTCARD_SIGN_TIMEOUT},
+            {"name": "AGENT_NAME", "value": name},
+            {"name": "POD_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}},
+        ],
+        "volumeMounts": [
+            {"name": "spire-agent-socket", "mountPath": "/run/spire/agent-sockets", "readOnly": True},
+            {"name": "unsigned-card", "mountPath": "/etc/agentcard", "readOnly": True},
+            {"name": "signed-card", "mountPath": "/app/.well-known"},
+        ],
+        "securityContext": {
+            "runAsNonRoot": True,
+            "readOnlyRootFilesystem": True,
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+        },
+        "resources": AGENTCARD_SIGNER_RESOURCES,
+    })
+
+    pod_spec.setdefault("volumes", []).extend([
+        {"name": "spire-agent-socket", "csi": {"driver": "csi.spiffe.io", "readOnly": True}},
+        {"name": "unsigned-card", "configMap": {"name": f"{name}-card-unsigned"}},
+        {"name": "signed-card", "emptyDir": {"medium": "Memory", "sizeLimit": "1Mi"}},
+    ])
+
+    pod_spec["containers"][0].setdefault("volumeMounts", []).append(
+        {"name": "signed-card", "mountPath": "/app/.well-known", "readOnly": True}
+    )
+
+
+async def _schedule_identity_binding_patch(
+    kube: KubernetesService,
+    name: str,
+    namespace: str,
+) -> None:
+    """Ensure AgentCard exists with identity binding.
+
+    The operator's sync controller normally auto-creates the AgentCard when it
+    detects the Deployment. We poll briefly for it to appear. If it doesn't
+    (e.g. due to RBAC issues in the sync controller), we create it ourselves
+    so that identity binding is always configured.
+
+    Runs blocking K8s API calls in a thread pool executor to avoid blocking
+    the event loop.
+    """
+    if not SPIRE_TRUST_DOMAIN:
+        logger.warning("SPIRE_TRUST_DOMAIN not set, skipping identity binding patch")
+        return
+
+    import asyncio
+    import time
+
+    loop = asyncio.get_event_loop()
+
+    def _do_patch():
+        card_name = f"{name}-deployment-card"
+        card_found = False
+
+        for attempt in range(10):
+            try:
+                kube.get_custom_resource(
+                    group=AGENTCARD_CRD_GROUP,
+                    version=AGENTCARD_CRD_VERSION,
+                    namespace=namespace,
+                    plural=AGENTCARD_PLURAL,
+                    name=card_name,
+                )
+                card_found = True
+                break
+            except ApiException as e:
+                if e.status == 404 and attempt < 9:
+                    time.sleep(3)
+                    continue
+                break
+
+        if not card_found:
+            logger.info(f"AgentCard '{card_name}' not auto-created, creating with identity binding")
+            card_body = {
+                "apiVersion": f"{AGENTCARD_CRD_GROUP}/{AGENTCARD_CRD_VERSION}",
+                "kind": "AgentCard",
+                "metadata": {
+                    "name": card_name,
+                    "namespace": namespace,
+                    "labels": {
+                        "app.kubernetes.io/name": name,
+                        "app.kubernetes.io/managed-by": "kagenti-operator",
+                    },
+                },
+                "spec": {
+                    "syncPeriod": "30s",
+                    "targetRef": {
+                        "apiVersion": "apps/v1",
+                        "kind": "Deployment",
+                        "name": name,
+                    },
+                    "identityBinding": {
+                        "trustDomain": SPIRE_TRUST_DOMAIN,
+                    },
+                },
+            }
+            try:
+                kube.create_custom_resource(
+                    group=AGENTCARD_CRD_GROUP,
+                    version=AGENTCARD_CRD_VERSION,
+                    namespace=namespace,
+                    plural=AGENTCARD_PLURAL,
+                    body=card_body,
+                )
+                logger.info(f"Created AgentCard '{card_name}' with identity binding (trustDomain: {SPIRE_TRUST_DOMAIN})")
+            except ApiException as e:
+                if e.status == 409:
+                    logger.info(f"AgentCard '{card_name}' appeared concurrently, will patch instead")
+                else:
+                    logger.error(f"Failed to create AgentCard '{card_name}': {e}")
+                    return
+            else:
+                return
+
+        patch_body = {
+            "spec": {
+                "identityBinding": {
+                    "trustDomain": SPIRE_TRUST_DOMAIN,
+                }
+            }
+        }
+        try:
+            kube.patch_custom_resource(
+                group=AGENTCARD_CRD_GROUP,
+                version=AGENTCARD_CRD_VERSION,
+                namespace=namespace,
+                plural=AGENTCARD_PLURAL,
+                name=card_name,
+                body=patch_body,
+            )
+            logger.info(f"Patched AgentCard '{card_name}' with identity binding (trustDomain: {SPIRE_TRUST_DOMAIN})")
+        except ApiException as e:
+            logger.error(f"Failed to patch AgentCard '{card_name}' with identity binding: {e}")
+
+    loop.run_in_executor(None, _do_patch)
+
+
 def _build_deployment_manifest(
     request: "CreateAgentRequest",
     image: str,
@@ -2074,6 +2523,33 @@ def _build_deployment_manifest(
     if request.servicePorts and len(request.servicePorts) > 0:
         container_port = request.servicePorts[0].targetPort
 
+    container_spec: dict = {
+        "name": "agent",
+        "image": image,
+        "imagePullPolicy": DEFAULT_IMAGE_POLICY,
+        "resources": {
+            "limits": DEFAULT_RESOURCE_LIMITS,
+            "requests": DEFAULT_RESOURCE_REQUESTS,
+        },
+        "env": env_vars,
+        "ports": [
+            {
+                "name": "http",
+                "containerPort": container_port,
+                "protocol": "TCP",
+            },
+        ],
+        "volumeMounts": [
+            {"name": "cache", "mountPath": "/app/.cache"},
+            {"name": "marvin", "mountPath": "/.marvin"},
+            {"name": "shared-data", "mountPath": "/shared"},
+        ],
+    }
+
+    if request.startCommand:
+        import shlex
+        container_spec["command"] = shlex.split(request.startCommand)
+
     manifest = {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -2092,35 +2568,11 @@ def _build_deployment_manifest(
                 "metadata": {
                     "labels": {
                         **labels,
-                        # Pod-specific labels can be added here
                     },
                 },
                 "spec": {
                     "serviceAccountName": request.name,
-                    "containers": [
-                        {
-                            "name": "agent",
-                            "image": image,
-                            "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
-                            },
-                            "env": env_vars,
-                            "ports": [
-                                {
-                                    "name": "http",
-                                    "containerPort": container_port,
-                                    "protocol": "TCP",
-                                },
-                            ],
-                            "volumeMounts": [
-                                {"name": "cache", "mountPath": "/app/.cache"},
-                                {"name": "marvin", "mountPath": "/.marvin"},
-                                {"name": "shared-data", "mountPath": "/shared"},
-                            ],
-                        }
-                    ],
+                    "containers": [container_spec],
                     "volumes": [
                         {"name": "cache", "emptyDir": {}},
                         {"name": "marvin", "emptyDir": {}},
@@ -2418,6 +2870,10 @@ async def create_agent(
         f"createHttpRoute={request.createHttpRoute}"
     )
     try:
+        # Create signing resources BEFORE workload (must exist for pod scheduling)
+        if request.signingEnabled and request.workloadType != WORKLOAD_TYPE_JOB:
+            _create_signing_resources(kube, request.name, request.namespace, request)
+
         if request.deploymentMethod == "image":
             # Deploy from existing container image
             if not request.containerImage:
@@ -2444,6 +2900,8 @@ async def create_agent(
                     request=request,
                     image=request.containerImage,
                 )
+                if request.signingEnabled:
+                    _inject_signing_into_manifest(workload_manifest, request.name)
                 kube.create_deployment(
                     namespace=request.namespace,
                     body=workload_manifest,
@@ -2456,6 +2914,8 @@ async def create_agent(
                     request=request,
                     image=request.containerImage,
                 )
+                if request.signingEnabled:
+                    _inject_signing_into_manifest(workload_manifest, request.name)
                 kube.create_statefulset(
                     namespace=request.namespace,
                     body=workload_manifest,
@@ -2556,6 +3016,8 @@ async def create_agent(
             if request.createHttpRoute:
                 message += " HTTPRoute will be created after the build completes."
 
+        if request.signingEnabled and request.spireEnabled and request.workloadType != WORKLOAD_TYPE_JOB:
+            await _schedule_identity_binding_patch(kube, request.name, request.namespace)
         return CreateAgentResponse(
             success=True,
             name=request.name,
@@ -2801,8 +3263,9 @@ async def finalize_shipwright_build(
             # Convert stored dict format back to ServicePort objects
             final_service_ports = [ServicePort(**sp) for sp in stored_config["servicePorts"]]
 
-        # Propagate SPIRE identity setting from stored config
+        # Propagate SPIRE identity and signing settings from stored config
         final_spire_enabled = stored_config.get("spireEnabled", False)
+        final_signing_enabled = stored_config.get("signingEnabled", False)
 
         # Step 3: Create workload + Service with the built image
         # Build a CreateAgentRequest-like object for manifest builders
@@ -2820,6 +3283,7 @@ async def finalize_shipwright_build(
             createHttpRoute=final_create_route,
             authBridgeEnabled=final_auth_bridge,
             spireEnabled=final_spire_enabled,
+            signingEnabled=final_signing_enabled,
         )
 
         # Ensure a dedicated ServiceAccount exists so the webhook's
@@ -2834,6 +3298,10 @@ async def finalize_shipwright_build(
                 spire_enabled=final_spire_enabled,
             )
 
+        # Create signing resources BEFORE workload (must exist for pod scheduling)
+        if agent_request.signingEnabled and final_workload_type != WORKLOAD_TYPE_JOB:
+            _create_signing_resources(kube, name, namespace, agent_request)
+
         # Create workload based on workloadType
         if final_workload_type == WORKLOAD_TYPE_DEPLOYMENT:
             workload_manifest = _build_deployment_manifest(
@@ -2841,6 +3309,8 @@ async def finalize_shipwright_build(
                 image=container_image,
                 shipwright_build_name=name,
             )
+            if agent_request.signingEnabled:
+                _inject_signing_into_manifest(workload_manifest, name)
             # Add additional labels from Build
             workload_manifest["metadata"]["labels"].update(
                 {k: v for k, v in build_labels.items() if k.startswith("kagenti.io/")}
@@ -2859,6 +3329,8 @@ async def finalize_shipwright_build(
                 image=container_image,
                 shipwright_build_name=name,
             )
+            if agent_request.signingEnabled:
+                _inject_signing_into_manifest(workload_manifest, name)
             # Add additional labels from Build
             workload_manifest["metadata"]["labels"].update(
                 {k: v for k, v in build_labels.items() if k.startswith("kagenti.io/")}

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2973,6 +2973,12 @@ async def create_agent(
         f"createHttpRoute={request.createHttpRoute}"
     )
     try:
+        if request.signingEnabled and not settings.kagenti_feature_flag_agentcard_signing:
+            raise HTTPException(
+                status_code=400,
+                detail="AgentCard signing is not enabled. Set KAGENTI_FEATURE_FLAG_AGENTCARD_SIGNING=true to enable.",
+            )
+
         # Create signing resources BEFORE workload (must exist for pod scheduling)
         if request.signingEnabled and request.workloadType != WORKLOAD_TYPE_JOB:
             _create_signing_resources(kube, request.name, request.namespace, request)

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -60,13 +60,16 @@ class ChatResponse(BaseModel):
     is_complete: bool = True
 
 
-def _resolve_service_clusterip(name: str, namespace: str) -> Optional[str]:
+async def _resolve_service_clusterip(name: str, namespace: str) -> Optional[str]:
     """Look up a K8s service's clusterIP and port via the API server directly.
 
     Uses the in-cluster service account token and KUBERNETES_SERVICE_HOST env
     var so this works even when cluster DNS (UDP) is unreliable.
+
+    Uses httpx.AsyncClient to avoid blocking the event loop.
     """
-    import json as _json, os, ssl, urllib.request as _req
+    import os
+    import ssl
 
     host = os.environ.get("KUBERNETES_SERVICE_HOST")
     port = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
@@ -76,13 +79,14 @@ def _resolve_service_clusterip(name: str, namespace: str) -> Optional[str]:
     if not host or not os.path.exists(token_path):
         return None
     try:
-        with open(token_path) as f:
+        with open(token_path, encoding="utf-8") as f:
             token = f.read()
-        ctx = ssl.create_default_context(cafile=ca_path)
+        ssl_ctx = ssl.create_default_context(cafile=ca_path)
         url = f"https://{host}:{port}/api/v1/namespaces/{namespace}/services/{name}"
-        req = _req.Request(url, headers={"Authorization": f"Bearer {token}"})
-        resp = _req.urlopen(req, timeout=5, context=ctx)
-        svc = _json.loads(resp.read())
+        async with httpx.AsyncClient(verify=ssl_ctx, timeout=5.0) as client:
+            resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
+            resp.raise_for_status()
+            svc = resp.json()
         cluster_ip = svc.get("spec", {}).get("clusterIP")
         ports = svc.get("spec", {}).get("ports", [])
         if not cluster_ip or not ports:
@@ -94,14 +98,14 @@ def _resolve_service_clusterip(name: str, namespace: str) -> Optional[str]:
         return None
 
 
-def _get_agent_url(name: str, namespace: str) -> str:
+async def _get_agent_url(name: str, namespace: str) -> str:
     """Get the URL for an A2A agent.
 
     In-cluster: resolves the service clusterIP via the K8s API (avoids DNS),
     falling back to DNS-based URL if the lookup fails.
     """
     if settings.is_running_in_cluster:
-        resolved = _resolve_service_clusterip(name, namespace)
+        resolved = await _resolve_service_clusterip(name, namespace)
         if resolved:
             return resolved
         return f"http://{name}.{namespace}.svc.cluster.local:{DEFAULT_IN_CLUSTER_PORT}"
@@ -124,7 +128,7 @@ async def get_agent_card(
 
     The agent card describes the agent's capabilities, skills, and metadata.
     """
-    agent_url = _get_agent_url(name, namespace)
+    agent_url = await _get_agent_url(name, namespace)
     card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
 
     try:
@@ -198,7 +202,7 @@ async def send_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    agent_url = _get_agent_url(name, namespace)
+    agent_url = await _get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 
     # Build A2A message payload
@@ -543,7 +547,7 @@ async def stream_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    agent_url = _get_agent_url(name, namespace)
+    agent_url = await _get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 
     # Extract Authorization header if present

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 
 from app.core.auth import require_roles, ROLE_VIEWER, ROLE_OPERATOR
 from app.core.config import settings
-from app.utils.routes import get_agent_url
+from app.core.constants import DEFAULT_IN_CLUSTER_PORT, DEFAULT_OFF_CLUSTER_PORT
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -60,6 +60,56 @@ class ChatResponse(BaseModel):
     is_complete: bool = True
 
 
+def _resolve_service_clusterip(name: str, namespace: str) -> Optional[str]:
+    """Look up a K8s service's clusterIP and port via the API server directly.
+
+    Uses the in-cluster service account token and KUBERNETES_SERVICE_HOST env
+    var so this works even when cluster DNS (UDP) is unreliable.
+    """
+    import json as _json, os, ssl, urllib.request as _req
+
+    host = os.environ.get("KUBERNETES_SERVICE_HOST")
+    port = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+    token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+    if not host or not os.path.exists(token_path):
+        return None
+    try:
+        with open(token_path) as f:
+            token = f.read()
+        ctx = ssl.create_default_context(cafile=ca_path)
+        url = f"https://{host}:{port}/api/v1/namespaces/{namespace}/services/{name}"
+        req = _req.Request(url, headers={"Authorization": f"Bearer {token}"})
+        resp = _req.urlopen(req, timeout=5, context=ctx)
+        svc = _json.loads(resp.read())
+        cluster_ip = svc.get("spec", {}).get("clusterIP")
+        ports = svc.get("spec", {}).get("ports", [])
+        if not cluster_ip or not ports:
+            return None
+        svc_port = ports[0]["port"]
+        return f"http://{cluster_ip}:{svc_port}"
+    except Exception as exc:
+        logger.debug("K8s service lookup failed for %s/%s: %s", name, namespace, exc)
+        return None
+
+
+def _get_agent_url(name: str, namespace: str) -> str:
+    """Get the URL for an A2A agent.
+
+    In-cluster: resolves the service clusterIP via the K8s API (avoids DNS),
+    falling back to DNS-based URL if the lookup fails.
+    """
+    if settings.is_running_in_cluster:
+        resolved = _resolve_service_clusterip(name, namespace)
+        if resolved:
+            return resolved
+        return f"http://{name}.{namespace}.svc.cluster.local:{DEFAULT_IN_CLUSTER_PORT}"
+    else:
+        domain = settings.domain_name
+        return f"http://{name}.{namespace}.{domain}:{DEFAULT_OFF_CLUSTER_PORT}"
+
+
 @router.get(
     "/{namespace}/{name}/agent-card",
     response_model=AgentCardResponse,
@@ -74,7 +124,7 @@ async def get_agent_card(
 
     The agent card describes the agent's capabilities, skills, and metadata.
     """
-    agent_url = get_agent_url(name, namespace)
+    agent_url = _get_agent_url(name, namespace)
     card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
 
     try:
@@ -148,7 +198,7 @@ async def send_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    agent_url = get_agent_url(name, namespace)
+    agent_url = _get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 
     # Build A2A message payload
@@ -186,8 +236,14 @@ async def send_message(
             content = ""
             if "result" in result:
                 result_data = result["result"]
-                # Handle Task response
-                if "status" in result_data and "message" in result_data.get("status", {}):
+                # Handle Task response with artifacts (A2A SDK agents)
+                if "artifacts" in result_data:
+                    for artifact in result_data["artifacts"]:
+                        for part in artifact.get("parts", []):
+                            if isinstance(part, dict) and "text" in part:
+                                content += part["text"]
+                # Handle Task response with status.message
+                elif "status" in result_data and "message" in result_data.get("status", {}):
                     parts = result_data["status"]["message"].get("parts", [])
                     for part in parts:
                         if isinstance(part, dict) and "text" in part:
@@ -487,7 +543,7 @@ async def stream_message(
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
     """
-    agent_url = get_agent_url(name, namespace)
+    agent_url = _get_agent_url(name, namespace)
     session_id = request.session_id or uuid4().hex
 
     # Extract Authorization header if present

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -8,6 +8,7 @@ Provides endpoints for chatting with A2A agents using the Agent-to-Agent protoco
 """
 
 import logging
+import re
 from typing import Optional, List
 from uuid import uuid4
 
@@ -19,6 +20,8 @@ from pydantic import BaseModel
 from app.core.auth import require_roles, ROLE_VIEWER, ROLE_OPERATOR
 from app.core.config import settings
 from app.core.constants import DEFAULT_IN_CLUSTER_PORT, DEFAULT_OFF_CLUSTER_PORT
+
+_DNS_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -68,6 +71,10 @@ async def _resolve_service_clusterip(name: str, namespace: str) -> Optional[str]
 
     Uses httpx.AsyncClient to avoid blocking the event loop.
     """
+    if not _DNS_LABEL_RE.match(name) or not _DNS_LABEL_RE.match(namespace):
+        logger.warning("Invalid DNS label in service lookup: name=%s namespace=%s", name, namespace)
+        return None
+
     import os
     import ssl
 

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -17,6 +17,7 @@ class FeatureFlagsResponse(BaseModel):
     sandbox: bool
     integrations: bool
     triggers: bool
+    agentcardSigning: bool
 
 
 router = APIRouter(prefix="/config", tags=["config"])
@@ -33,6 +34,7 @@ async def get_feature_flags() -> FeatureFlagsResponse:
         sandbox=settings.kagenti_feature_flag_sandbox,
         integrations=settings.kagenti_feature_flag_integrations,
         triggers=settings.kagenti_feature_flag_triggers,
+        agentcardSigning=settings.kagenti_feature_flag_agentcard_signing,
     )
 
 

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -29,6 +29,7 @@ class KubernetesService:
         self._core_api: Optional[kubernetes.client.CoreV1Api] = None
         self._apps_api: Optional[kubernetes.client.AppsV1Api] = None
         self._batch_api: Optional[kubernetes.client.BatchV1Api] = None
+        self._rbac_api: Optional[kubernetes.client.RbacAuthorizationV1Api] = None
 
     def _load_config(self) -> kubernetes.client.ApiClient:
         """Load Kubernetes configuration (in-cluster or kubeconfig)."""
@@ -73,6 +74,13 @@ class KubernetesService:
         if self._batch_api is None:
             self._batch_api = kubernetes.client.BatchV1Api(self.api_client)
         return self._batch_api
+
+    @property
+    def rbac_api(self) -> kubernetes.client.RbacAuthorizationV1Api:
+        """Get RbacAuthorizationV1Api client for Roles and RoleBindings."""
+        if self._rbac_api is None:
+            self._rbac_api = kubernetes.client.RbacAuthorizationV1Api(self.api_client)
+        return self._rbac_api
 
     def is_running_in_cluster(self) -> bool:
         """Check if running inside a Kubernetes cluster."""
@@ -197,6 +205,29 @@ class KubernetesService:
             )
         except ApiException as e:
             logger.error(f"Error creating {plural} in {namespace}: {e}")
+            raise
+
+    def patch_custom_resource(
+        self,
+        group: str,
+        version: str,
+        namespace: str,
+        plural: str,
+        name: str,
+        body: dict,
+    ) -> dict:
+        """Patch a custom resource using merge-patch."""
+        try:
+            return self.custom_api.patch_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                name=name,
+                body=body,
+            )
+        except ApiException as e:
+            logger.error(f"Error patching {plural}/{name} in {namespace}: {e}")
             raise
 
     # -------------------------------------------------------------------------
@@ -372,6 +403,110 @@ class KubernetesService:
             )
         except ApiException as e:
             logger.error(f"Error deleting Service {name} in {namespace}: {e}")
+            raise
+
+    # -------------------------------------------------------------------------
+    # ConfigMap Operations
+    # -------------------------------------------------------------------------
+
+    def create_configmap(self, namespace: str, body: dict) -> dict:
+        """Create a ConfigMap in the specified namespace."""
+        try:
+            result = self.core_api.create_namespaced_config_map(
+                namespace=namespace,
+                body=body,
+            )
+            return result.to_dict()
+        except ApiException as e:
+            logger.error(f"Error creating ConfigMap in {namespace}: {e}")
+            raise
+
+    def delete_configmap(self, namespace: str, name: str) -> None:
+        """Delete a ConfigMap by name."""
+        try:
+            self.core_api.delete_namespaced_config_map(
+                name=name,
+                namespace=namespace,
+            )
+        except ApiException as e:
+            logger.error(f"Error deleting ConfigMap {name} in {namespace}: {e}")
+            raise
+
+    # -------------------------------------------------------------------------
+    # ServiceAccount Operations
+    # -------------------------------------------------------------------------
+
+    def create_service_account(self, namespace: str, body: dict) -> dict:
+        """Create a ServiceAccount in the specified namespace."""
+        try:
+            result = self.core_api.create_namespaced_service_account(
+                namespace=namespace,
+                body=body,
+            )
+            return result.to_dict()
+        except ApiException as e:
+            logger.error(f"Error creating ServiceAccount in {namespace}: {e}")
+            raise
+
+    def delete_service_account(self, namespace: str, name: str) -> None:
+        """Delete a ServiceAccount by name."""
+        try:
+            self.core_api.delete_namespaced_service_account(
+                name=name,
+                namespace=namespace,
+            )
+        except ApiException as e:
+            logger.error(f"Error deleting ServiceAccount {name} in {namespace}: {e}")
+            raise
+
+    # -------------------------------------------------------------------------
+    # RBAC Operations (Roles and RoleBindings)
+    # -------------------------------------------------------------------------
+
+    def create_role(self, namespace: str, body: dict) -> dict:
+        """Create a Role in the specified namespace."""
+        try:
+            result = self.rbac_api.create_namespaced_role(
+                namespace=namespace,
+                body=body,
+            )
+            return result.to_dict()
+        except ApiException as e:
+            logger.error(f"Error creating Role in {namespace}: {e}")
+            raise
+
+    def delete_role(self, namespace: str, name: str) -> None:
+        """Delete a Role by name."""
+        try:
+            self.rbac_api.delete_namespaced_role(
+                name=name,
+                namespace=namespace,
+            )
+        except ApiException as e:
+            logger.error(f"Error deleting Role {name} in {namespace}: {e}")
+            raise
+
+    def create_role_binding(self, namespace: str, body: dict) -> dict:
+        """Create a RoleBinding in the specified namespace."""
+        try:
+            result = self.rbac_api.create_namespaced_role_binding(
+                namespace=namespace,
+                body=body,
+            )
+            return result.to_dict()
+        except ApiException as e:
+            logger.error(f"Error creating RoleBinding in {namespace}: {e}")
+            raise
+
+    def delete_role_binding(self, namespace: str, name: str) -> None:
+        """Delete a RoleBinding by name."""
+        try:
+            self.rbac_api.delete_namespaced_role_binding(
+                name=name,
+                namespace=namespace,
+            )
+        except ApiException as e:
+            logger.error(f"Error deleting RoleBinding {name} in {namespace}: {e}")
             raise
 
     # -------------------------------------------------------------------------

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -433,7 +433,7 @@ class KubernetesService:
             raise
 
     # -------------------------------------------------------------------------
-    # ServiceAccount Operations
+    # ServiceAccount CRUD Operations
     # -------------------------------------------------------------------------
 
     def create_service_account(self, namespace: str, body: dict) -> dict:

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -227,7 +227,7 @@ class KubernetesService:
                 body=body,
             )
         except ApiException as e:
-            logger.error(f"Error patching {plural}/{name} in {namespace}: {e}")
+            logger.error("Error patching %s/%s in %s: %s", plural, name, namespace, e)
             raise
 
     # -------------------------------------------------------------------------
@@ -418,7 +418,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating ConfigMap in {namespace}: {e}")
+            logger.error("Error creating ConfigMap in %s: %s", namespace, e)
             raise
 
     def delete_configmap(self, namespace: str, name: str) -> None:
@@ -429,7 +429,7 @@ class KubernetesService:
                 namespace=namespace,
             )
         except ApiException as e:
-            logger.error(f"Error deleting ConfigMap {name} in {namespace}: {e}")
+            logger.error("Error deleting ConfigMap %s in %s: %s", name, namespace, e)
             raise
 
     # -------------------------------------------------------------------------
@@ -445,7 +445,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating ServiceAccount in {namespace}: {e}")
+            logger.error("Error creating ServiceAccount in %s: %s", namespace, e)
             raise
 
     def delete_service_account(self, namespace: str, name: str) -> None:
@@ -456,7 +456,7 @@ class KubernetesService:
                 namespace=namespace,
             )
         except ApiException as e:
-            logger.error(f"Error deleting ServiceAccount {name} in {namespace}: {e}")
+            logger.error("Error deleting ServiceAccount %s in %s: %s", name, namespace, e)
             raise
 
     # -------------------------------------------------------------------------
@@ -472,7 +472,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating Role in {namespace}: {e}")
+            logger.error("Error creating Role in %s: %s", namespace, e)
             raise
 
     def delete_role(self, namespace: str, name: str) -> None:
@@ -483,7 +483,7 @@ class KubernetesService:
                 namespace=namespace,
             )
         except ApiException as e:
-            logger.error(f"Error deleting Role {name} in {namespace}: {e}")
+            logger.error("Error deleting Role %s in %s: %s", name, namespace, e)
             raise
 
     def create_role_binding(self, namespace: str, body: dict) -> dict:
@@ -495,7 +495,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating RoleBinding in {namespace}: {e}")
+            logger.error("Error creating RoleBinding in %s: %s", namespace, e)
             raise
 
     def delete_role_binding(self, namespace: str, name: str) -> None:
@@ -506,7 +506,7 @@ class KubernetesService:
                 namespace=namespace,
             )
         except ApiException as e:
-            logger.error(f"Error deleting RoleBinding {name} in {namespace}: {e}")
+            logger.error("Error deleting RoleBinding %s in %s: %s", name, namespace, e)
             raise
 
     # -------------------------------------------------------------------------

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -41,10 +41,12 @@ USER 1001
 
 # OpenShift DNS ClusterIP default; override at deploy time for other platforms
 ENV DNS_RESOLVER="172.30.0.10"
+# Backend service FQDN; nginx resolver bypasses /etc/resolv.conf search domains
+ENV BACKEND_HOST="kagenti-backend.kagenti-system.svc.cluster.local"
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 
-CMD ["/bin/sh", "-c", "envsubst '${DNS_RESOLVER}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst '${DNS_RESOLVER} ${BACKEND_HOST}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -23,29 +23,28 @@ RUN npm run build
 # Stage 2: Serve with nginx
 FROM nginx:1.29-alpine@sha256:f46cb72c7df02710e693e863a983ac42f6a9579058a59a35f1ae36c9958e4ce0
 
-# Copy nginx configuration
-COPY ui-v2/nginx.conf /etc/nginx/conf.d/default.conf
+# Copy nginx configuration template
+COPY ui-v2/nginx.conf /etc/nginx/templates/default.conf.template
 
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Add non-root user for security
-RUN addgroup -g 1001 -S appgroup && \
-    adduser -u 1001 -S appuser -G appgroup && \
-    chown -R appuser:appgroup /usr/share/nginx/html && \
-    chown -R appuser:appgroup /var/cache/nginx && \
-    chown -R appuser:appgroup /var/log/nginx && \
+# Cap worker processes to avoid OOM on high-core nodes
+RUN sed -i 's/worker_processes\s*auto/worker_processes 4/' /etc/nginx/nginx.conf
+
+# Make directories writable for arbitrary UIDs (OpenShift restricted SCC)
+RUN chmod -R g+rwx /var/cache/nginx /var/log/nginx /usr/share/nginx/html /etc/nginx/conf.d && \
     touch /var/run/nginx.pid && \
-    chown -R appuser:appgroup /var/run/nginx.pid
+    chmod g+rw /var/run/nginx.pid
 
 USER 1001
 
-# Expose port
+# OpenShift DNS ClusterIP default; override at deploy time for other platforms
+ENV DNS_RESOLVER="172.30.0.10"
+
 EXPOSE 8080
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 
-# Run nginx
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/sh", "-c", "envsubst '${DNS_RESOLVER}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/kagenti/ui-v2/nginx.conf
+++ b/kagenti/ui-v2/nginx.conf
@@ -21,7 +21,9 @@ server {
 
     # API proxy to backend
     location /api/ {
-        proxy_pass http://kagenti-backend:8000;
+        resolver ${DNS_RESOLVER} valid=10s;
+        set $backend "http://kagenti-backend:8000";
+        proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/kagenti/ui-v2/nginx.conf
+++ b/kagenti/ui-v2/nginx.conf
@@ -22,7 +22,7 @@ server {
     # API proxy to backend
     location /api/ {
         resolver ${DNS_RESOLVER} valid=10s;
-        set $backend "http://kagenti-backend:8000";
+        set $backend "http://${BACKEND_HOST}:8000";
         proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -8,12 +8,14 @@ export interface FeatureFlags {
   sandbox: boolean;
   integrations: boolean;
   triggers: boolean;
+  agentcardSigning: boolean;
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   sandbox: false,
   integrations: false,
   triggers: false,
+  agentcardSigning: false,
 };
 
 let cachedFlags: FeatureFlags | null = null;
@@ -35,6 +37,7 @@ export function useFeatureFlags(): FeatureFlags {
           sandbox: data.sandbox === true,
           integrations: data.integrations === true,
           triggers: data.triggers === true,
+          agentcardSigning: data.agentcardSigning === true,
         };
         cachedFlags = validated;
         setFlags(validated);

--- a/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
@@ -30,6 +30,7 @@ import {
   DropdownItem,
   MenuToggle,
   MenuToggleElement,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   Table,
@@ -44,6 +45,7 @@ import {
   PlusCircleIcon,
   EllipsisVIcon,
   ExclamationTriangleIcon,
+  ShieldAltIcon,
 } from '@patternfly/react-icons';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -107,7 +109,7 @@ export const AgentCatalogPage: React.FC = () => {
     }
   };
 
-  const columns = ['Name', 'Description', 'Status', 'Labels', 'Workload', ''];
+  const columns = ['Name', 'Description', 'Status', 'Trust', 'Labels', 'Workload', ''];
 
   const renderWorkloadType = (workloadType: string | undefined) => {
     const type = workloadType || 'deployment';
@@ -119,6 +121,45 @@ export const AgentCatalogPage: React.FC = () => {
       color = 'gold';
     }
     return <Label color={color} isCompact>{label}</Label>;
+  };
+
+  const renderTrustBadges = (agent: Agent) => {
+    if (!agent.hasAgentCard) {
+      return <span style={{ color: 'var(--pf-v5-global--Color--200)' }}>N/A</span>;
+    }
+    if (agent.verified == null && agent.bound == null) {
+      return (
+        <Tooltip content="Waiting for operator to process">
+          <Label color="blue" isCompact>Pending</Label>
+        </Tooltip>
+      );
+    }
+    if (agent.verified === true && agent.bound === true) {
+      return (
+        <Tooltip content="Signature verified and identity bound">
+          <Label color="green" icon={<ShieldAltIcon />} isCompact>Trusted</Label>
+        </Tooltip>
+      );
+    }
+    return (
+      <LabelGroup>
+        {agent.verified === true && (
+          <Tooltip content="Signature verified but identity not yet bound">
+            <Label color="green" icon={<ShieldAltIcon />} isCompact>Verified</Label>
+          </Tooltip>
+        )}
+        {agent.verified === false && (
+          <Tooltip content="Signature not yet verified">
+            <Label color="red" isCompact>Unverified</Label>
+          </Tooltip>
+        )}
+        {agent.bound === false && (
+          <Tooltip content="Identity binding pending or failed">
+            <Label color="gold" isCompact>Not Bound</Label>
+          </Tooltip>
+        )}
+      </LabelGroup>
+    );
   };
 
   const renderStatusBadge = (status: string) => {
@@ -252,6 +293,7 @@ export const AgentCatalogPage: React.FC = () => {
                       {agent.description || 'No description'}
                     </Td>
                     <Td dataLabel="Status">{renderStatusBadge(agent.status)}</Td>
+                    <Td dataLabel="Trust">{renderTrustBadges(agent)}</Td>
                     <Td dataLabel="Labels">{renderLabels(agent)}</Td>
                     <Td dataLabel="Workload">{renderWorkloadType(agent.workloadType)}</Td>
                     <Td isActionCell>

--- a/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
@@ -51,11 +51,13 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { Agent } from '@/types';
 import { agentService } from '@/services/api';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
 
 export const AgentCatalogPage: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const features = useFeatureFlags();
   const [namespace, setNamespace] = useState<string>('team1');
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
@@ -109,7 +111,9 @@ export const AgentCatalogPage: React.FC = () => {
     }
   };
 
-  const columns = ['Name', 'Description', 'Status', 'Trust', 'Labels', 'Workload', ''];
+  const columns = features.agentcardSigning
+    ? ['Name', 'Description', 'Status', 'Trust', 'Labels', 'Workload', '']
+    : ['Name', 'Description', 'Status', 'Labels', 'Workload', ''];
 
   const renderWorkloadType = (workloadType: string | undefined) => {
     const type = workloadType || 'deployment';
@@ -125,7 +129,11 @@ export const AgentCatalogPage: React.FC = () => {
 
   const renderTrustBadges = (agent: Agent) => {
     if (!agent.hasAgentCard) {
-      return <span style={{ color: 'var(--pf-v5-global--Color--200)' }}>N/A</span>;
+      return (
+        <Tooltip content="AgentCard signing not enabled for this agent">
+          <Label color="grey" isCompact>Disabled</Label>
+        </Tooltip>
+      );
     }
     if (agent.verified == null && agent.bound == null) {
       return (
@@ -293,7 +301,9 @@ export const AgentCatalogPage: React.FC = () => {
                       {agent.description || 'No description'}
                     </Td>
                     <Td dataLabel="Status">{renderStatusBadge(agent.status)}</Td>
-                    <Td dataLabel="Trust">{renderTrustBadges(agent)}</Td>
+                    {features.agentcardSigning && (
+                      <Td dataLabel="Trust">{renderTrustBadges(agent)}</Td>
+                    )}
                     <Td dataLabel="Labels">{renderLabels(agent)}</Td>
                     <Td dataLabel="Workload">{renderWorkloadType(agent.workloadType)}</Td>
                     <Td isActionCell>

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -52,6 +52,7 @@ import {
   DropdownItem,
   MenuToggle,
   MenuToggleElement,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   Table,
@@ -65,21 +66,15 @@ import {
   CubesIcon,
   ExternalLinkAltIcon,
   ExclamationTriangleIcon,
+  ShieldAltIcon,
+  CheckCircleIcon,
 } from '@patternfly/react-icons';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import yaml from 'js-yaml';
 
 import { agentService, chatService, configService, shipwrightService, ShipwrightBuildInfo } from '@/services/api';
+import type { AgentCardStatus, StatusCondition } from '@/types';
 import { AgentChat } from '@/components/AgentChat';
-
-interface StatusCondition {
-  type: string;
-  status: string;
-  reason?: string;
-  message?: string;
-  lastTransitionTime?: string;
-  last_transition_time?: string; // snake_case from K8s API
-}
 
 interface AgentCardSkill {
   id: string;
@@ -104,6 +99,42 @@ interface AgentCard {
   skills?: AgentCardSkill[];
 }
 
+const SIGNING_STEPS = [
+  { key: 'svid', label: 'SVID Fetched' },
+  { key: 'signed', label: 'Card Signed' },
+  { key: 'verified', label: 'Verified' },
+  { key: 'bound', label: 'Bound' },
+];
+
+const SigningProgressIndicator: React.FC<{ status: AgentCardStatus }> = ({ status }) => {
+  const stepComplete = {
+    svid: status.synced === true,
+    signed: status.synced === true,
+    verified: status.verified === true,
+    bound: status.bound === true,
+  };
+
+  return (
+    <div className="kagenti-signing-progress">
+      {SIGNING_STEPS.map((step) => (
+        <div
+          key={step.key}
+          className={`kagenti-signing-step ${stepComplete[step.key as keyof typeof stepComplete] ? 'kagenti-signing-step--complete' : ''}`}
+        >
+          <div className="kagenti-signing-step__circle">
+            {stepComplete[step.key as keyof typeof stepComplete] ? (
+              <CheckCircleIcon style={{ fontSize: '12px' }} />
+            ) : (
+              <span>{SIGNING_STEPS.indexOf(step) + 1}</span>
+            )}
+          </div>
+          <span className="kagenti-signing-step__label">{step.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 export const AgentDetailPage: React.FC = () => {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
@@ -113,6 +144,7 @@ export const AgentDetailPage: React.FC = () => {
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = React.useState('');
   const [actionsMenuOpen, setActionsMenuOpen] = React.useState(false);
+  const [isConditionsExpanded, setIsConditionsExpanded] = React.useState(false);
 
   const deleteMutation = useMutation({
     mutationFn: () => agentService.delete(namespace!, name!),
@@ -179,12 +211,39 @@ export const AgentDetailPage: React.FC = () => {
   const agentReadyStatus = agent?.readyStatus;
   const isAgentReady = agentReadyStatus === 'Ready' || agentReadyStatus === 'Progressing';
 
-  // Fetch agent card if agent is ready
-  const { data: agentCard, isLoading: isAgentCardLoading } = useQuery<AgentCard>({
+  // Fetch agent card if agent is ready; fall back to CR status card data
+  const { data: agentCardDirect, isLoading: isAgentCardDirectLoading } = useQuery<AgentCard>({
     queryKey: ['agentCard', namespace, name],
     queryFn: () => chatService.getAgentCard(namespace!, name!),
     enabled: !!namespace && !!name && isAgentReady,
+    retry: false,
   });
+
+  const { data: agentCardStatus, isLoading: isAgentCardStatusLoading } = useQuery<AgentCardStatus | null>({
+    queryKey: ['agentCardStatus', namespace, name],
+    queryFn: () => agentService.getAgentCardStatus(namespace!, name!),
+    enabled: !!namespace && !!name,
+  });
+
+  const agentCard: AgentCard | undefined = React.useMemo(() => {
+    if (agentCardDirect) return agentCardDirect;
+    const c = agentCardStatus?.card;
+    if (!c) return undefined;
+    return {
+      name: (c.name as string) || name || '',
+      description: c.description as string | undefined,
+      version: (c.version as string) || 'unknown',
+      url: (c.url as string) || '',
+      protocolVersion: c.protocolVersion as string | undefined,
+      preferredTransport: c.preferredTransport as string | undefined,
+      capabilities: c.capabilities as { streaming?: boolean } | undefined,
+      defaultInputModes: c.defaultInputModes as string[] | undefined,
+      defaultOutputModes: c.defaultOutputModes as string[] | undefined,
+      skills: c.skills as AgentCardSkill[] | undefined,
+    };
+  }, [agentCardDirect, agentCardStatus?.card, name]);
+
+  const isAgentCardLoading = isAgentCardDirectLoading && !agentCard;
 
   // Check if an HTTPRoute/Route exists for this agent
   const { data: routeStatusData } = useQuery({
@@ -334,6 +393,20 @@ export const AgentDetailPage: React.FC = () => {
               {readyStatus || (isReady ? 'Ready' : 'Not Ready')}
             </Label>
           </SplitItem>
+          {agentCardStatus?.verified === true && (
+            <SplitItem style={{ marginLeft: 4 }}>
+              <Tooltip content="Signature cryptographically verified against the SPIRE trust bundle">
+                <Label color="green" icon={<ShieldAltIcon />}>Verified</Label>
+              </Tooltip>
+            </SplitItem>
+          )}
+          {agentCardStatus?.verified === false && (
+            <SplitItem style={{ marginLeft: 4 }}>
+              <Tooltip content="Signature verification failed. Check operator logs for details.">
+                <Label color="red">Unverified</Label>
+              </Tooltip>
+            </SplitItem>
+          )}
           <SplitItem isFilled />
           <SplitItem>
             <Flex>
@@ -508,6 +581,186 @@ export const AgentDetailPage: React.FC = () => {
                         </>
                       )}
                     </DescriptionList>
+                  </CardBody>
+                </Card>
+              </GridItem>
+
+              {/* Trust & Identity */}
+              <GridItem md={12}>
+                <Card>
+                  <CardTitle>Trust &amp; Identity</CardTitle>
+                  <CardBody>
+                    {isAgentCardStatusLoading ? (
+                      <Spinner size="md" aria-label="Loading trust status" />
+                    ) : !agentCardStatus?.found ? (
+                      <Alert variant="info" title="No AgentCard found" isInline>
+                        The operator creates AgentCards automatically for agents with discovery labels.
+                        Trust and verification status will appear here once an AgentCard is synced.
+                      </Alert>
+                    ) : (
+                      <>
+                        <SigningProgressIndicator status={agentCardStatus} />
+
+                        <Grid hasGutter>
+                          <GridItem md={6}>
+                            <Text component={TextVariants.h4} style={{ marginBottom: '8px' }}>Verification Status</Text>
+                            <DescriptionList isCompact isHorizontal>
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Card Synced</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {agentCardStatus.synced === true ? (
+                                    <Tooltip content="The operator has successfully fetched and processed the agent's signed card">
+                                      <Label color="green" isCompact>Synced</Label>
+                                    </Tooltip>
+                                  ) : agentCardStatus.synced === false ? (
+                                    <Tooltip content="Sync failed. The operator could not fetch the signed card from the ConfigMap.">
+                                      <Label color="orange" isCompact>Not Synced</Label>
+                                    </Tooltip>
+                                  ) : (
+                                    <Tooltip content="Waiting for the operator to sync the agent card">
+                                      <Label color="blue" isCompact>Pending</Label>
+                                    </Tooltip>
+                                  )}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Signature Verified</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {agentCardStatus.verified === true ? (
+                                    <Tooltip content={agentCardStatus.verificationDetails || "Signature cryptographically verified against the SPIRE trust bundle"}>
+                                      <Label color="green" icon={<ShieldAltIcon />} isCompact>Verified</Label>
+                                    </Tooltip>
+                                  ) : agentCardStatus.verified === false ? (
+                                    <Tooltip content={agentCardStatus.verificationDetails || "Signature verification failed. Check operator logs."}>
+                                      <Label color="red" isCompact>Unverified</Label>
+                                    </Tooltip>
+                                  ) : (
+                                    <Tooltip content="Waiting for the operator to verify the signature">
+                                      <Label color="blue" isCompact>Pending</Label>
+                                    </Tooltip>
+                                  )}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Identity Bound</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {agentCardStatus.bound === true ? (
+                                    <Tooltip content={agentCardStatus.bindingMessage || "SPIFFE identity matches the expected trust domain and service account"}>
+                                      <Label color="green" isCompact>Bound</Label>
+                                    </Tooltip>
+                                  ) : agentCardStatus.bound === false ? (
+                                    <Tooltip content={agentCardStatus.bindingMessage || "Identity binding failed. Check the trust domain configuration."}>
+                                      <Label color="gold" isCompact>Not Bound</Label>
+                                    </Tooltip>
+                                  ) : (
+                                    <Tooltip content="Waiting for the operator to check identity binding">
+                                      <Label color="blue" isCompact>Pending</Label>
+                                    </Tooltip>
+                                  )}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            </DescriptionList>
+                          </GridItem>
+
+                          <GridItem md={6}>
+                            <Text component={TextVariants.h4} style={{ marginBottom: '8px' }}>Identity Details</Text>
+                            <DescriptionList isCompact isHorizontal>
+                              {agentCardStatus.trustDomain && (
+                                <DescriptionListGroup>
+                                  <DescriptionListTerm>Trust Domain</DescriptionListTerm>
+                                  <DescriptionListDescription>{agentCardStatus.trustDomain}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                              )}
+                              {agentCardStatus.spiffeId && (
+                                <DescriptionListGroup>
+                                  <DescriptionListTerm>SPIFFE ID</DescriptionListTerm>
+                                  <DescriptionListDescription>
+                                    <code style={{ fontSize: '0.85em', wordBreak: 'break-all' }}>{agentCardStatus.spiffeId}</code>
+                                  </DescriptionListDescription>
+                                </DescriptionListGroup>
+                              )}
+                              {agentCardStatus.cardId && (
+                                <DescriptionListGroup>
+                                  <DescriptionListTerm>Card ID</DescriptionListTerm>
+                                  <DescriptionListDescription>
+                                    <code style={{ fontSize: '0.85em', wordBreak: 'break-all' }}>
+                                      {agentCardStatus.cardId}
+                                    </code>
+                                  </DescriptionListDescription>
+                                </DescriptionListGroup>
+                              )}
+                              {agentCardStatus.lastSyncTime && (
+                                <DescriptionListGroup>
+                                  <DescriptionListTerm>Last Sync</DescriptionListTerm>
+                                  <DescriptionListDescription>
+                                    {new Date(agentCardStatus.lastSyncTime).toLocaleString()}
+                                  </DescriptionListDescription>
+                                </DescriptionListGroup>
+                              )}
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Network Policy</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  <Label
+                                    color={
+                                      agentCardStatus.networkPolicyState === 'permissive' ? 'green'
+                                      : agentCardStatus.networkPolicyState === 'restrictive' ? 'red'
+                                      : 'grey'
+                                    }
+                                    isCompact
+                                  >
+                                    {agentCardStatus.networkPolicyState || 'none'}
+                                  </Label>
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            </DescriptionList>
+                          </GridItem>
+                        </Grid>
+
+                        {agentCardStatus.conditions && agentCardStatus.conditions.length > 0 && (
+                          <ExpandableSection
+                            toggleText={isConditionsExpanded ? 'Hide Conditions' : `Show Conditions (${agentCardStatus.conditions.length})`}
+                            isExpanded={isConditionsExpanded}
+                            onToggle={() => setIsConditionsExpanded(!isConditionsExpanded)}
+                            style={{ marginTop: '16px' }}
+                          >
+                            <Table variant="compact" aria-label="AgentCard conditions">
+                              <Thead>
+                                <Tr>
+                                  <Th>Type</Th>
+                                  <Th>Status</Th>
+                                  <Th>Reason</Th>
+                                  <Th>Message</Th>
+                                  <Th>Last Transition</Th>
+                                </Tr>
+                              </Thead>
+                              <Tbody>
+                                {[...agentCardStatus.conditions].sort((a, b) => {
+                                  const order: Record<string, number> = { Synced: 0, SignatureVerified: 1, Bound: 2, Ready: 3 };
+                                  return (order[a.type] ?? 99) - (order[b.type] ?? 99);
+                                }).map((cond, idx) => (
+                                  <Tr key={idx}>
+                                    <Td>{cond.type}</Td>
+                                    <Td>
+                                      <Label color={cond.status === 'True' ? 'green' : 'red'} isCompact>
+                                        {cond.status}
+                                      </Label>
+                                    </Td>
+                                    <Td>{cond.reason || '-'}</Td>
+                                    <Td>{cond.message || '-'}</Td>
+                                    <Td>
+                                      {cond.lastTransitionTime
+                                        ? new Date(cond.lastTransitionTime).toLocaleString()
+                                        : '-'}
+                                    </Td>
+                                  </Tr>
+                                ))}
+                              </Tbody>
+                            </Table>
+                          </ExpandableSection>
+                        )}
+
+                      </>
+                    )}
                   </CardBody>
                 </Card>
               </GridItem>

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -737,8 +737,8 @@ export const AgentDetailPage: React.FC = () => {
                                 {[...agentCardStatus.conditions].sort((a, b) => {
                                   const order: Record<string, number> = { Synced: 0, SignatureVerified: 1, Bound: 2, Ready: 3 };
                                   return (order[a.type] ?? 99) - (order[b.type] ?? 99);
-                                }).map((cond, idx) => (
-                                  <Tr key={idx}>
+                                }).map((cond) => (
+                                  <Tr key={cond.type}>
                                     <Td>{cond.type}</Td>
                                     <Td>
                                       <Label color={cond.status === 'True' ? 'green' : 'red'} isCompact>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -164,6 +164,17 @@ export const ImportAgentPage: React.FC = () => {
   const [authBridgeEnabled, setAuthBridgeEnabled] = useState(true);
   // SPIRE identity
   const [spireEnabled, setSpireEnabled] = useState(false);
+  // AgentCard signing
+  const [signingEnabled, setSigningEnabled] = useState(false);
+  // Feedback when signing auto-enables SPIRE
+  const [spireAutoEnabled, setSpireAutoEnabled] = useState(false);
+
+  React.useEffect(() => {
+    if (spireAutoEnabled) {
+      const timer = setTimeout(() => setSpireAutoEnabled(false), 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [spireAutoEnabled]);
 
   // Validation state
   const [validated, setValidated] = useState<Record<string, 'success' | 'error' | 'default'>>({});
@@ -453,6 +464,7 @@ export const ImportAgentPage: React.FC = () => {
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,
+        signingEnabled,
         // Shipwright build configuration (always enabled)
         shipwrightConfig,
       });
@@ -479,6 +491,7 @@ export const ImportAgentPage: React.FC = () => {
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,
+        signingEnabled,
       });
     }
   };
@@ -969,26 +982,72 @@ export const ImportAgentPage: React.FC = () => {
                 />
               </FormGroup>
 
-              {/* AuthBridge Sidecar Injection */}
-              <FormGroup fieldId="authBridgeEnabled">
-                <Checkbox
-                  id="authBridgeEnabled"
-                  label="Enable AuthBridge sidecar injection"
-                  isChecked={authBridgeEnabled}
-                  onChange={(_e, checked) => setAuthBridgeEnabled(checked)}
-                  description="When enabled, the webhook injects AuthBridge sidecars (envoy-proxy, go-processor, client-registration) into the agent pod for token exchange."
-              />
-              </FormGroup>
+              <Divider style={{ margin: '24px 0' }} />
 
-              {/* SPIRE Identity */}
-              <FormGroup fieldId="spireEnabled">
-                <Checkbox
-                  id="spireEnabled"
-                  label="Enable SPIRE identity (spiffe-helper sidecar)"
-                  isChecked={spireEnabled}
-                  onChange={(_e, checked) => setSpireEnabled(checked)}
-                />
-              </FormGroup>
+              <Title headingLevel="h3" size="md" style={{ marginBottom: '16px' }}>
+                Security &amp; Identity
+              </Title>
+
+              <Card isFlat style={{ marginTop: '8px' }}>
+                <CardBody>
+                  <FormGroup fieldId="authBridgeEnabled">
+                    <Checkbox
+                      id="authBridgeEnabled"
+                      label="Enable AuthBridge sidecar injection"
+                      isChecked={authBridgeEnabled}
+                      onChange={(_e, checked) => setAuthBridgeEnabled(checked)}
+                      description="Injects AuthBridge sidecars (envoy-proxy, go-processor, client-registration) into the agent pod for token exchange."
+                    />
+                  </FormGroup>
+
+                  <FormGroup fieldId="spireEnabled" style={{ marginTop: '12px' }}>
+                    <Checkbox
+                      id="spireEnabled"
+                      label="Enable SPIRE identity (spiffe-helper sidecar)"
+                      isChecked={spireEnabled}
+                      onChange={(_e, checked) => {
+                        setSpireEnabled(checked);
+                        if (!checked) setSigningEnabled(false);
+                      }}
+                      description="Mounts a SPIRE CSI volume and requests an X.509-SVID for the agent's service account."
+                    />
+                  </FormGroup>
+
+                  <FormGroup fieldId="signingEnabled" style={{ marginTop: '4px', marginLeft: '24px' }}>
+                    <Checkbox
+                      id="signingEnabled"
+                      label="Enable AgentCard signing"
+                      isChecked={signingEnabled}
+                      onChange={(_e, checked) => {
+                        setSigningEnabled(checked);
+                        if (checked && !spireEnabled) {
+                          setSpireEnabled(true);
+                          setSpireAutoEnabled(true);
+                        }
+                      }}
+                      description="Signs the agent card with SPIRE X.509-SVID at startup. Requires SPIRE and a ClusterSPIFFEID."
+                    />
+                  </FormGroup>
+
+                  {spireAutoEnabled && (
+                    <Alert
+                      variant="info"
+                      title="SPIRE identity has been automatically enabled (required for signing)."
+                      isInline
+                      isPlain
+                      style={{ marginTop: '8px', marginLeft: '24px' }}
+                    />
+                  )}
+
+                  {signingEnabled && (
+                    <Alert variant="info" title="SPIRE Prerequisites" isInline style={{ marginTop: '12px' }}>
+                      AgentCard signing requires: (1) SPIRE installed on the cluster, (2) a
+                      ClusterSPIFFEID matching kagenti.io/type=agent pods, and (3) the target
+                      namespace labeled with agentcard=true.
+                    </Alert>
+                  )}
+                </CardBody>
+              </Card>
 
               {/* Pod Configuration */}
               <ExpandableSection

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -37,6 +37,7 @@ import { TrashIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
 import { useMutation } from '@tanstack/react-query';
 
 import { agentService, ShipwrightBuildConfig } from '@/services/api';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
 import { EnvImportModal } from '@/components/EnvImportModal';
 import { BuildStrategySelector } from '@/components/BuildStrategySelector';
@@ -99,6 +100,7 @@ interface ServicePort {
 
 export const ImportAgentPage: React.FC = () => {
   const navigate = useNavigate();
+  const features = useFeatureFlags();
 
   // Deployment method
   const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
@@ -1013,38 +1015,49 @@ export const ImportAgentPage: React.FC = () => {
                     />
                   </FormGroup>
 
-                  <FormGroup fieldId="signingEnabled" style={{ marginTop: '4px', marginLeft: '24px' }}>
-                    <Checkbox
-                      id="signingEnabled"
-                      label="Enable AgentCard signing"
-                      isChecked={signingEnabled}
-                      onChange={(_e, checked) => {
-                        setSigningEnabled(checked);
-                        if (checked && !spireEnabled) {
-                          setSpireEnabled(true);
-                          setSpireAutoEnabled(true);
-                        }
-                      }}
-                      description="Signs the agent card with SPIRE X.509-SVID at startup. Requires SPIRE and a ClusterSPIFFEID."
-                    />
-                  </FormGroup>
+                  {/* TODO: Allow pasting custom AgentCard JSON (see PR #1038 review) */}
+                  {features.agentcardSigning && (
+                    <>
+                      <FormGroup fieldId="signingEnabled" style={{ marginTop: '4px', marginLeft: '24px' }}>
+                        <Checkbox
+                          id="signingEnabled"
+                          label="Enable AgentCard signing"
+                          isChecked={signingEnabled}
+                          onChange={(_e, checked) => {
+                            setSigningEnabled(checked);
+                            if (checked && !spireEnabled) {
+                              setSpireEnabled(true);
+                              setSpireAutoEnabled(true);
+                            }
+                          }}
+                          description="Signs the agent card with SPIRE X.509-SVID at startup. Requires SPIRE and a ClusterSPIFFEID."
+                        />
+                      </FormGroup>
 
-                  {spireAutoEnabled && (
-                    <Alert
-                      variant="info"
-                      title="SPIRE identity has been automatically enabled (required for signing)."
-                      isInline
-                      isPlain
-                      style={{ marginTop: '8px', marginLeft: '24px' }}
-                    />
-                  )}
+                      {spireAutoEnabled && (
+                        <Alert
+                          variant="info"
+                          title="SPIRE identity has been automatically enabled (required for signing)."
+                          isInline
+                          isPlain
+                          style={{ marginTop: '8px', marginLeft: '24px' }}
+                        />
+                      )}
 
-                  {signingEnabled && (
-                    <Alert variant="info" title="SPIRE Prerequisites" isInline style={{ marginTop: '12px' }}>
-                      AgentCard signing requires: (1) SPIRE installed on the cluster, (2) a
-                      ClusterSPIFFEID matching kagenti.io/type=agent pods, and (3) the target
-                      namespace labeled with agentcard=true.
-                    </Alert>
+                      {signingEnabled && (
+                        <>
+                          <Alert variant="warning" title="Experimental Feature" isInline style={{ marginTop: '12px' }}>
+                            This serves a static agent card that will <strong>overwrite</strong> the card
+                            the agent would normally serve. Intended for testing only.
+                          </Alert>
+                          <Alert variant="info" title="SPIRE Prerequisites" isInline style={{ marginTop: '8px' }}>
+                            AgentCard signing requires: (1) SPIRE installed on the cluster, (2) a
+                            ClusterSPIFFEID matching kagenti.io/type=agent pods, and (3) the target
+                            namespace labeled with agentcard=true.
+                          </Alert>
+                        </>
+                      )}
+                    </>
                   )}
                 </CardBody>
               </Card>

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -8,6 +8,7 @@
 import type {
   Agent,
   AgentDetail,
+  AgentCardStatus,
   Tool,
   ToolDetail,
   ApiListResponse,
@@ -224,12 +225,25 @@ export const agentService = {
     authBridgeEnabled?: boolean;
     // SPIRE identity
     spireEnabled?: boolean;
+    // AgentCard signing
+    signingEnabled?: boolean;
     shipwrightConfig?: ShipwrightBuildConfig;
   }): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
     return apiFetch('/agents', {
       method: 'POST',
       body: JSON.stringify(data),
     });
+  },
+
+  async getAgentCardStatus(namespace: string, name: string): Promise<AgentCardStatus | null> {
+    try {
+      return await apiFetch<AgentCardStatus>(
+        `/agents/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/agentcard`
+      );
+    } catch (error) {
+      console.warn('Failed to fetch AgentCard status:', error);
+      return null;
+    }
   },
 
   async parseEnvFile(content: string): Promise<{

--- a/kagenti/ui-v2/src/styles/global.css
+++ b/kagenti/ui-v2/src/styles/global.css
@@ -971,6 +971,74 @@ code {
   color: #151515 !important;
 }
 
+/* Ensure label icons align vertically with text */
+.pf-v5-c-label__icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* AgentCard signing progress indicator */
+.kagenti-signing-progress {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: 16px;
+  padding: 12px 0;
+}
+
+.kagenti-signing-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  position: relative;
+}
+
+.kagenti-signing-step__circle {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  margin-bottom: 6px;
+  border: 2px solid var(--pf-v5-global--Color--200);
+  background-color: var(--pf-v5-global--BackgroundColor--100);
+  color: var(--pf-v5-global--Color--200);
+}
+
+.kagenti-signing-step--complete .kagenti-signing-step__circle {
+  background-color: #3e8635;
+  border-color: #3e8635;
+  color: #ffffff;
+}
+
+.kagenti-signing-step__label {
+  font-size: 11px;
+  color: var(--pf-v5-global--Color--200);
+  text-align: center;
+}
+
+.kagenti-signing-step--complete .kagenti-signing-step__label {
+  color: var(--pf-v5-global--Color--100);
+  font-weight: 500;
+}
+
+.kagenti-signing-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 12px;
+  left: calc(50% + 16px);
+  width: calc(100% - 32px);
+  height: 2px;
+  background-color: var(--pf-v5-global--Color--200);
+}
+
+.kagenti-signing-step--complete:not(:last-child)::after {
+  background-color: #3e8635;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .kagenti-chat-message {

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -24,6 +24,37 @@ export interface Agent {
   labels: AgentLabels;
   workloadType?: WorkloadType;
   createdAt?: string;
+  hasAgentCard?: boolean;
+  verified?: boolean;
+  bound?: boolean;
+}
+
+export interface StatusCondition {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+  last_transition_time?: string;
+}
+
+export interface AgentCardStatus {
+  found: boolean;
+  verified?: boolean;
+  bound?: boolean;
+  synced?: boolean;
+  spiffeId?: string;
+  expectedSpiffeId?: string;
+  trustDomain?: string;
+  signatureKeyId?: string;
+  lastSyncTime?: string;
+  cardId?: string;
+  networkPolicyState?: 'permissive' | 'restrictive' | 'none';
+  conditions?: StatusCondition[];
+  card?: Record<string, unknown>;
+  bindingReason?: string;
+  bindingMessage?: string;
+  verificationDetails?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Integrates AgentCard SPIRE signing and verification into the Kagenti UI, enabling end-to-end agent deployment with cryptographic identity from the browser.

### Backend
- Add configurable AgentCard signing settings (signer image, timeout, resource limits, trust domain) via env var overrides
- Add `signingEnabled` flag to agent creation; on deploy, create signing resources (SA, ConfigMap, Role, RoleBinding) and inject the `sign-agentcard` init container
- Add `/agentcard` status endpoint and enrich agent list with verification status (verified, bound)
- Clean up all signing resources on agent deletion with 404 tolerance
- Fix in-cluster chat fallback to use correct port (8000), add K8s API direct service lookup, handle A2A SDK artifact response format
- Add K8s service methods for ConfigMaps, ServiceAccounts, Roles, RoleBindings, and custom resource patching

### UI
- Add Trust column to agent catalog with Trusted, Pending, Unverified, and Not Bound badges
- Add Trust & Identity card to agent detail page with signing progress indicator, verification status, identity details, and expandable conditions table
- Add AgentCard signing checkbox to import page with SPIRE auto-enable and prerequisites alert

### Helm chart
- Add `SPIRE_TRUST_DOMAIN` and `AGENTCARD_SIGNER_IMAGE` env vars to backend container
- Expand ClusterRole with permissions for agentcards, configmaps, serviceaccounts, roles, and rolebindings needed for signing lifecycle
- Add `spire.trustDomain` and `agentcard.signerImage` to values.yaml

### Infrastructure
- Make nginx DNS resolver configurable via `DNS_RESOLVER` env var with envsubst at startup
- Adjust Dockerfile permissions for OpenShift arbitrary UIDs

## Related issue(s)

- #783 (Integrate AgentCard signing and verification into the Kagenti UI)
- kagenti/kagenti-operator#234 (Publish agentcard-signer image to GHCR via CI)
- kagenti/kagenti-operator#224 (Per-agent egress scoping for verified agent NetworkPolicies)

## (Optional) Testing Instructions

Verified end-to-end on OpenShift (OVN-Kubernetes + Istio Ambient Mesh):

1. Deploy currency-agent via UI with "Enable AgentCard signing" checked
2. Confirm agent reaches Trusted status (synced, signature verified, identity bound) on the agent catalog and detail pages
3. Confirm chat works (agent responds to currency exchange queries)
4. Delete agent via UI and confirm all signing resources are cleaned up

All changes are backward-compatible. Signing is opt-in via the `signingEnabled` flag (defaults to false).

## Reference UI Images

<img width="1900" height="1018" alt="kagenti-ui-5" src="https://github.com/user-attachments/assets/a5fcf810-4d60-4b92-ae0c-f3882a6e1b0f" />

<img width="1918" height="1044" alt="kagnti-ui-4" src="https://github.com/user-attachments/assets/9959f876-cde2-4c71-9835-73a9aeec41b0" />

<img width="1915" height="1037" alt="kagenti-ui" src="https://github.com/user-attachments/assets/6d145e7d-faaa-484f-b186-ff716d115e65" />

<img width="1915" height="1047" alt="kagenti-ui-3" src="https://github.com/user-attachments/assets/e1f1dec4-911c-4677-8778-6600a5e31dab" />