### PR TITLE
chore: remove pipeline sa in weather_agent_shipwright_build_ocp.yaml

### DIFF
--- a/kagenti/examples/agents/weather_agent_shipwright_build_ocp.yaml
+++ b/kagenti/examples/agents/weather_agent_shipwright_build_ocp.yaml
@@ -20,7 +20,6 @@ metadata:
         "createHttpRoute": false
       }
 spec:
-  serviceAccount: pipeline
   source:
     type: Git
     git:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
The spec.serviceAccount field was part of the Shipwright v1alpha1 API and was removed when the API graduated to v1beta1. Clusters running Builds for Red Hat OpenShift Operator v1.6.2 use the v1beta1 schema with strict field validation, so applying a manifest containing this field causes a hard failure:
```
Error from server (BadRequest): Build in version "v1beta1" cannot be handled as a Build:
strict decoding error: unknown field "spec.serviceAccount"
```
In v1beta1, service account binding is no longer configured in the Build spec itself — it is handled at the namespace level via a RoleBinding to the pipeline service account. The field in the OCP manifest is therefore both invalid and redundant.
## Related issue(s)

## (Optional) Testing Instructions
Apply weather_agent_shipwright_build_ocp.yaml on an OpenShift Cluster and expect no warnings/configuration errors
Fixes #
