### PR TITLE
fix(ci): pin correct image tags in Helm chart on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,7 +123,12 @@ jobs:
           cd ${{ env.CHARTS_PATH }}//kagenti
           echo "Fetching Helm chart dependencies..."
           helm dependency update
-          yq e ".ui.tag = \"${{ github.ref_name }}\"" -i values.yaml
+          TAG="${{ github.ref_name }}"
+          yq e ".ui.frontend.tag = \"${TAG}\"" -i values.yaml
+          yq e ".ui.backend.tag = \"${TAG}\"" -i values.yaml
+          yq e ".uiOAuthSecret.tag = \"${TAG}\"" -i values.yaml
+          yq e ".agentOAuthSecret.tag = \"${TAG}\"" -i values.yaml
+          yq e ".apiOAuthSecret.tag = \"${TAG}\"" -i values.yaml
           helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
           helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}
 
@@ -135,7 +140,6 @@ jobs:
           cd ${{ env.CHARTS_PATH }}//kagenti-deps
           echo "Fetching Helm chart dependencies..."
           helm dependency update
-          yq e ".ui.tag = \"${{ github.ref_name }}\"" -i values.yaml
           helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
           helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}
 


### PR DESCRIPTION
## Summary
- Replace dead `yq e ".ui.tag = ..."` path in the chart-packaging step with correct rewrites for all 5 CI-built images: `.ui.frontend.tag`, `.ui.backend.tag`, `.uiOAuthSecret.tag`, `.agentOAuthSecret.tag`, `.apiOAuthSecret.tag`
- Remove identical dead `yq` rewrite from kagenti-deps chart step (no CI-built images to pin)

## Context

The existing `yq` rewrite targeted `.ui.tag`, but no Helm template reads that path — they use `.ui.frontend.tag`, `.ui.backend.tag`, and the `*OAuthSecret.tag` paths. This meant released charts shipped with `:latest` for oauth-secret images and stale alpha tags for ui/backend instead of the release version.

### Images intentionally NOT rewritten

| Image | Reason |
|-------|--------|
| `mlflowOAuthSecret` | Points to `quay.io/ladas/` (external), not built by this CI. Has a TODO to migrate |
| `phoenixOAuthSecret` | Not in CI build matrix — no image is built for it |
| `kagenti-operator-chart` | Built by kagenti-operator repo, pinned manually |
| webhook sidecar images | Built by kagenti-extensions repo, pinned manually |

## Verification

After merge, inspect a published chart from a `v*` tag:
```bash
helm show values oci://ghcr.io/kagenti/kagenti/kagenti --version <new-version> | grep 'tag:'
```
All CI-built images should show the version tag, not `latest` or stale alphas.

## Test plan
- [ ] Verify `yq` paths match `values.yaml` structure (`.ui.frontend.tag` at line 64, `.ui.backend.tag` at line 78, etc.)
- [ ] Verify Helm templates consume these paths (`ui.yaml`, `*-oauth-secret-job.yaml`)
- [ ] On next alpha tag, inspect the published chart to confirm tags are pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)