### PR TITLE
fix(chart): use latest tag for ui and backend images on main

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -61,7 +61,7 @@ ui:
   # Frontend (UI v2) configuration
   frontend:
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.5.0-alpha.11
+    tag: latest
     resources:
       limits:
         cpu: 100m
@@ -75,7 +75,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.5.0-alpha.11
+    tag: latest
     resources:
       limits:
         cpu: 250m


### PR DESCRIPTION
## Summary
- Change `ui.frontend.tag` and `ui.backend.tag` from `v0.5.0-alpha.11` to `latest` in `charts/kagenti/values.yaml`

## Context

CI rebuilds `:latest` for ui-v2 and backend on every push to main, but `values.yaml` was pinned to `v0.5.0-alpha.11`. This means developers deploying from main get a stale image instead of the newest build.

The oauth-secret images already use `tag: latest` correctly. This PR makes ui/backend consistent.

Released charts are unaffected — the CI chart-packaging step (fixed in #1048) rewrites all CI-built image tags to the release version when publishing from a `v*` tag.

## Test plan
- [ ] Deploy from main to Kind cluster — ui-v2 and backend should pull `:latest`
- [ ] Verify no regression in released chart behavior (tags rewritten by CI on `v*` push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)