### PR TITLE
fix(ci): move chart packaging to separate job after image builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,27 +115,51 @@ jobs:
           tags: ${{ steps.meta_retry.outputs.tags || steps.meta.outputs.tags }}
           labels: ${{ steps.meta_retry.outputs.labels || steps.meta.outputs.labels }}
 
+  package-charts:
+    # Package and push Helm charts once, after all images are built.
+    # This avoids the previous issue where chart packaging ran inside the
+    # build matrix (6 times concurrently) and could race on helm push.
+    needs: build-and-push
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Package and push kagenti chart
-        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         run: |
           chartVersion=$(echo ${{ github.ref_name }} | cut -c 2-)
           chartPackageName="kagenti-${chartVersion}.tgz"
-          cd ${{ env.CHARTS_PATH }}//kagenti
+          cd ${{ env.CHARTS_PATH }}/kagenti
           echo "Fetching Helm chart dependencies..."
           helm dependency update
-          yq e ".ui.tag = \"${{ github.ref_name }}\"" -i values.yaml
+          TAG="${{ github.ref_name }}"
+          yq e ".ui.frontend.tag = \"${TAG}\"" -i values.yaml
+          yq e ".ui.backend.tag = \"${TAG}\"" -i values.yaml
+          yq e ".uiOAuthSecret.tag = \"${TAG}\"" -i values.yaml
+          yq e ".agentOAuthSecret.tag = \"${TAG}\"" -i values.yaml
+          yq e ".apiOAuthSecret.tag = \"${TAG}\"" -i values.yaml
           helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
           helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}
 
       - name: Package and push kagenti-deps chart
-        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         run: |
           chartVersion=$(echo ${{ github.ref_name }} | cut -c 2-)
           chartPackageName="kagenti-deps-${chartVersion}.tgz"
-          cd ${{ env.CHARTS_PATH }}//kagenti-deps
+          cd ${{ env.CHARTS_PATH }}/kagenti-deps
           echo "Fetching Helm chart dependencies..."
           helm dependency update
-          yq e ".ui.tag = \"${{ github.ref_name }}\"" -i values.yaml
           helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
           helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}
-


### PR DESCRIPTION
## Summary
- Move Helm chart packaging from inside the build matrix into a dedicated `package-charts` job with `needs: build-and-push`
- Fix dead `yq` path (`.ui.tag`) with correct rewrites for all 5 CI-built images
- Remove dead `yq` rewrite from kagenti-deps chart step
- Fix double-slash typo in `CHARTS_PATH` paths

## Problem

The chart packaging steps were defined as steps inside the `build-and-push` matrix job (6 images). On a `v*` tag push, all 6 matrix runners concurrently:
1. Run `helm dependency update` — 6 concurrent downloads of the same sub-charts
2. Run `helm package` — produce identical `.tgz` artifacts
3. Run `helm push` — race to push the same chart to the OCI registry

This meant **12 redundant chart pushes** (6 runners x 2 charts), wasted CI minutes, and potential race conditions. Worse, charts could be published before all images finished building — a user could `helm install` and hit `ImagePullBackOff`.

## Solution

```yaml
jobs:
  build-and-push:        # matrix job: builds 6 images in parallel
    strategy:
      matrix: ...

  package-charts:        # NEW: runs once after ALL images are ready
    needs: build-and-push
    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
    steps:
      - Package and push kagenti chart    # runs exactly once
      - Package and push kagenti-deps chart  # runs exactly once
```

This also incorporates the image tag pinning fix from #1048 (correct `yq` paths for `.ui.frontend.tag`, `.ui.backend.tag`, `.uiOAuthSecret.tag`, `.agentOAuthSecret.tag`, `.apiOAuthSecret.tag`).

Supersedes #1048.

## Test plan
- [ ] Push a test `v*` tag and verify the workflow graph shows `package-charts` running after `build-and-push` completes
- [ ] Verify charts are pushed exactly once (check OCI registry)
- [ ] Inspect published chart: `helm show values oci://ghcr.io/kagenti/kagenti/kagenti --version <ver> | grep 'tag:'` — all CI-built images should show the version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)