### PR TITLE
chore(chart): bump operator to 0.2.0-alpha.22, webhook to 0.4.0-alpha.9

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-alpha.21
+  version: 0.2.0-alpha.22
 - name: kagenti-webhook-chart
   repository: oci://ghcr.io/kagenti/kagenti-extensions
-  version: 0.4.0-alpha.8
-digest: sha256:66cc54b5ba694f86a66af68dbc658c75f4e55d60073e95981a58b7fde42865aa
-generated: "2026-03-15T10:52:35.566834-04:00"
+  version: 0.4.0-alpha.9
+digest: sha256:ffe04d4208ac7b09bcdd2ae08c5b8d7bdc565300a939d498eddc33b130af225c
+generated: "2026-03-18T15:07:58.940613-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,10 +7,10 @@ appVersion: "0.1.2"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-alpha.21
+  version: 0.2.0-alpha.22
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 - name: kagenti-webhook-chart
-  version: 0.4.0-alpha.8
+  version: 0.4.0-alpha.9
   repository: oci://ghcr.io/kagenti/kagenti-extensions
   condition: components.platformWebhook.enabled

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -160,9 +160,9 @@ keycloak:
 kagenti-webhook-chart:
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.8
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.8
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.4.0-alpha.8
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.9
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.9
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.4.0-alpha.9
 
 # ------------------------------------------------------------------
 #  Kagenti Operator Configuration
@@ -171,7 +171,7 @@ kagenti-operator-chart:
   controllerManager:
     container:
       image:
-        tag: 0.2.0-alpha.21
+        tag: 0.2.0-alpha.22
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
## Summary
- Bump `kagenti-operator-chart` dependency: `0.2.0-alpha.21` → `0.2.0-alpha.22`
- Bump `kagenti-webhook-chart` dependency: `0.4.0-alpha.8` → `0.4.0-alpha.9`
- Update pinned sidecar images to match webhook chart version (`v0.4.0-alpha.9`)
- Update operator controller image tag to match chart version (`0.2.0-alpha.22`)
- Regenerate `Chart.lock`

## Context

Both dependency repos were tagged with new alphas today but `Chart.yaml` and `values.yaml` still referenced the previous versions. This aligns the platform chart with the latest sub-chart releases before cutting the next kagenti alpha.

## Files changed
- `charts/kagenti/Chart.yaml` — dependency versions
- `charts/kagenti/Chart.lock` — regenerated lock file
- `charts/kagenti/values.yaml` — operator tag + webhook sidecar image tags

## Test plan
- [ ] `helm dependency update charts/kagenti/` succeeds
- [ ] Deploy to Kind cluster and verify operator and webhook pods use the new images

🤖 Generated with [Claude Code](https://claude.com/claude-code)