### PR TITLE
fix: Auto-detect Podman masquerading as Docker and override container_engine

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/00_preflight.yaml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/00_preflight.yaml
@@ -36,6 +36,26 @@
     - docker_info.rc | default(1) != 0
     - docker_podman_compat_info.rc | default(1) == 0
 
+- name: Preflight - Podman-as-Docker override
+  block:
+    - name: Preflight - Override container_engine when Podman masquerades as Docker
+      set_fact:
+        container_engine: podman
+
+    - name: Preflight - Warn about Podman-as-Docker override
+      debug:
+        msg: >-
+          Detected 'docker' is actually Podman (docker info failed but Podman format succeeded).
+          Overriding container_engine to 'podman' to use sequential image pulls and avoid
+          SSH connection failures. To silence this warning, set container_engine: podman
+          in your values file.
+  when:
+    - create_kind_cluster | default(false)
+    - not (enable_openshift | default(false))
+    - container_engine | default('docker') == 'docker'
+    - docker_podman_compat_info is defined
+    - docker_podman_compat_info.rc | default(1) == 0
+
 - name: Preflight - Get container runtime info (Podman)
   command: podman info --format "{{ '{{' }}.Host.MemTotal{{ '}}' }},{{ '{{' }}.Host.CPUs{{ '}}' }}"
   register: podman_info


### PR DESCRIPTION
## Summary
- When `docker` is aliased to `podman` (common on macOS with Podman Desktop), the installer uses the concurrent image pull path which causes SSH connection failures through the Podman VM
- The preflight check already detects Podman-as-Docker for resource parsing but does not override the `container_engine` variable, so the image preload task still takes the Docker concurrent-pull code path
- Adds two new preflight tasks that override `container_engine` to `podman` and emit a warning when this condition is detected, ensuring sequential image pulls are used

## Test plan
- [ ] Install with `docker` aliased to `podman` and `container_engine: docker` (default) — verify the override kicks in and images are pulled sequentially
- [ ] Install with native Docker — verify no change in behavior (override is skipped)
- [ ] Install with `container_engine: podman` explicitly set — verify no double-override or warnings