### PR TITLE
fix: Add cert-manager images to Kind preload list

### DIFF
--- a/deployments/ansible/kind/preload-images.txt
+++ b/deployments/ansible/kind/preload-images.txt
@@ -1,6 +1,6 @@
 # Images pre-pulled on the host and loaded into Kind for faster startup.
 # Keep versions in sync with:
-#   - deployments/ansible/default_values.yaml       (istio, shipwright)
+#   - deployments/ansible/default_values.yaml       (istio, shipwright, cert-manager)
 #   - charts/kagenti/values.yaml                    (ui-v2, backend, kagenti-operator)
 #   - charts/kagenti-deps/templates/                (phoenix, otel-collector, keycloak)
 #   - deployments/ansible/roles/.../04_install_shipwright.yaml (buildah)
@@ -14,6 +14,9 @@ docker.io/nginxinc/nginx-unprivileged:1.29.1-alpine
 docker.io/prom/prometheus:v3.5.0
 otel/opentelemetry-collector-contrib:0.122.1
 quay.io/containers/buildah:v1.37.5
+quay.io/jetstack/cert-manager-cainjector:v1.17.2
+quay.io/jetstack/cert-manager-controller:v1.17.2
+quay.io/jetstack/cert-manager-webhook:v1.17.2
 quay.io/keycloak/keycloak:26.3.3
 ghcr.io/shipwright-io/build/shipwright-build-controller:v0.14.0
 ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.14.0


### PR DESCRIPTION
## Summary
- cert-manager images (`quay.io/jetstack/cert-manager-{controller,cainjector,webhook}:v1.17.2`) were missing from `preload-images.txt`
- Without pre-loading, these images must be pulled at runtime inside the Kind node through the container VM network, which is slow and causes the 120s cert-manager webhook readiness timeout to expire
- Adds all three cert-manager v1.17.2 images to the preload list so they are pre-pulled on the host and loaded into Kind before the install begins

## Test plan
- [ ] Run `run-install.sh --env dev --preload` and verify cert-manager images appear in the preload pull output
- [ ] Verify cert-manager pods start within the 120s timeout after Kind cluster creation
- [ ] Verify the cert-manager version in `preload-images.txt` matches `certManager.version` in `default_values.yaml`