### PR TITLE
docs: add Weather Agent demo link to README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ From the UI you can:
 - Test agents interactively
 - Monitor traces and network traffic
 
+To learn how to deploy agents and MCP tools, follow the **[Weather Agent Demo](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md)** — the recommended getting-started tutorial that walks you through deploying an agent and tool via the UI and chatting with it end-to-end. For more demos, see the [full demo list](./docs/demos/README.md).
+
 ## Documentation
 
 | Topic | Link |


### PR DESCRIPTION
## Summary
- After the Quick Start UI access instructions, there was no guidance on what to try next
- Added a link to the [Weather Agent Demo](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md) as the recommended getting-started tutorial
- Also links to the full demo list for users who want more

## Test plan
- [ ] Verify the link renders correctly in the GitHub README preview
- [ ] Confirm the Weather Agent Demo URL resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)