### PR TITLE
ci: add tui-admin placeholder job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,35 @@ jobs:
       - name: Build
         run: go build ./...
 
+  tui-admin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: kagenti/tui-admin
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5
+        with:
+          go-version-file: kagenti/tui-admin/go.mod
+          cache-dependency-path: kagenti/tui-admin/go.sum
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run tests
+        # Placeholder: will run real tests once kagenti/tui-admin exists on main
+        run: echo "tui-admin tests will run after rebase"
+
+      - name: Build
+        # Placeholder: will build once kagenti/tui-admin exists on main
+        run: echo "tui-admin build will run after rebase"
+
   chart-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

Add a `tui-admin` CI job placeholder to `ci.yaml`. This job will run
Go vet/test/build for the `kagenti-admin` CLI once it lands on main
via PR #1035.

Currently uses echo placeholders so CI passes before the code exists
on main. PR #1035 will rebase onto this and replace the echos with
real commands.

## Why a separate PR?

CI workflows run from the base branch (main). Adding the job in the
same PR as the code means the job definition doesn't exist when CI
runs. By merging this first, the job exists on main and will run
when #1035 rebases.

Relates-to: #1037 #1035

## Test plan

- [x] CI job passes with placeholder echo commands
- [ ] After #1035 rebases: real go test/build runs

Generated with [Claude Code](https://claude.com/claude-code)