### PR TITLE
fix(ui): trim whitespace in delete confirmation input

### DIFF
--- a/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
@@ -99,7 +99,7 @@ export const AgentCatalogPage: React.FC = () => {
   };
 
   const handleDeleteConfirm = () => {
-    if (agentToDelete && deleteConfirmText === agentToDelete.name) {
+    if (agentToDelete && deleteConfirmText.trim() === agentToDelete.name) {
       deleteMutation.mutate({
         namespace: agentToDelete.namespace,
         name: agentToDelete.name,
@@ -316,7 +316,7 @@ export const AgentCatalogPage: React.FC = () => {
             isLoading={deleteMutation.isPending}
             isDisabled={
               deleteMutation.isPending ||
-              deleteConfirmText !== agentToDelete?.name
+              deleteConfirmText.trim() !== agentToDelete?.name
             }
           >
             Delete

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -128,7 +128,7 @@ export const AgentDetailPage: React.FC = () => {
   };
 
   const handleDeleteConfirm = () => {
-    if (deleteConfirmText === name) {
+    if (deleteConfirmText.trim() === name) {
       deleteMutation.mutate();
     }
   };
@@ -1027,7 +1027,7 @@ export const AgentDetailPage: React.FC = () => {
             variant="danger"
             onClick={handleDeleteConfirm}
             isLoading={deleteMutation.isPending}
-            isDisabled={deleteMutation.isPending || deleteConfirmText !== name}
+            isDisabled={deleteMutation.isPending || deleteConfirmText.trim() !== name}
           >
             Delete
           </Button>,

--- a/kagenti/ui-v2/src/pages/ToolCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolCatalogPage.tsx
@@ -99,7 +99,7 @@ export const ToolCatalogPage: React.FC = () => {
   };
 
   const handleDeleteConfirm = () => {
-    if (toolToDelete && deleteConfirmText === toolToDelete.name) {
+    if (toolToDelete && deleteConfirmText.trim() === toolToDelete.name) {
       deleteMutation.mutate({
         namespace: toolToDelete.namespace,
         name: toolToDelete.name,
@@ -308,7 +308,7 @@ export const ToolCatalogPage: React.FC = () => {
             isLoading={deleteMutation.isPending}
             isDisabled={
               deleteMutation.isPending ||
-              deleteConfirmText !== toolToDelete?.name
+              deleteConfirmText.trim() !== toolToDelete?.name
             }
           >
             Delete

--- a/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
@@ -128,7 +128,7 @@ export const ToolDetailPage: React.FC = () => {
   };
 
   const handleDeleteConfirm = () => {
-    if (deleteConfirmText === name) {
+    if (deleteConfirmText.trim() === name) {
       deleteMutation.mutate();
     }
   };
@@ -1083,7 +1083,7 @@ export const ToolDetailPage: React.FC = () => {
             variant="danger"
             onClick={handleDeleteConfirm}
             isLoading={deleteMutation.isPending}
-            isDisabled={deleteMutation.isPending || deleteConfirmText !== name}
+            isDisabled={deleteMutation.isPending || deleteConfirmText.trim() !== name}
           >
             Delete
           </Button>,


### PR DESCRIPTION
## Summary

- Trims whitespace from the delete confirmation text input before comparing against the resource name
- Fixes all four delete dialogs: AgentCatalogPage, AgentDetailPage, ToolCatalogPage, ToolDetailPage
- Extra whitespace (trailing space from autocomplete/copy-paste) no longer prevents deletion

Fixes #1065

## Test plan

- [ ] Open agent catalog, click delete on an agent, type the name with a trailing space — confirm button should enable
- [ ] Same test on agent detail page delete dialog
- [ ] Same test on tool catalog and tool detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)