### PR TITLE
feat(ui): add OpenShift internal registry option

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -62,6 +62,7 @@ const FRAMEWORKS = [
 
 const REGISTRY_OPTIONS = [
   { value: 'local', label: 'Local Registry (In-Cluster)', url: 'registry.cr-system.svc.cluster.local:5000' },
+  { value: 'openshift', label: 'OpenShift Internal Registry', url: 'image-registry.openshift-image-registry.svc:5000' },
   { value: 'quay', label: 'Quay.io', url: 'quay.io' },
   { value: 'dockerhub', label: 'Docker Hub', url: 'docker.io' },
   { value: 'github', label: 'GitHub Container Registry', url: 'ghcr.io' },


### PR DESCRIPTION
## Summary

- Adds "OpenShift Internal Registry" (`image-registry.openshift-image-registry.svc:5000`) to the container registry dropdown on the Import Agent page
- Positioned after "Local Registry" since both are in-cluster options

### Push secret handling

When selected, the existing `registryType !== 'local'` logic applies:

- **Registry Namespace** field appears — user enters the target namespace (e.g., `zt-test`), producing the full URL `image-registry.openshift-image-registry.svc:5000/zt-test`
- **Registry Secret** field appears with default name `openshift-registry-secret` — user should pre-create this secret in the target namespace with push credentials for the internal registry:
  ```bash
  oc create secret docker-registry openshift-registry-secret \
    --docker-server=image-registry.openshift-image-registry.svc:5000 \
    --docker-username=serviceaccount \
    --docker-password=$(oc create token builder -n $NAMESPACE) \
    -n $NAMESPACE
  ```
- **"Authentication Required" alert** is displayed reminding the user to ensure the secret exists

Fixes #1059

## Test plan

- [ ] Open Import Agent page, select "Build from Source"
- [ ] Verify "OpenShift Internal Registry" appears in the registry dropdown
- [ ] Select it — registry namespace and secret fields should appear
- [ ] Default secret name should be `openshift-registry-secret`
- [ ] Submit with a valid namespace — verify the API receives `registryUrl: image-registry.openshift-image-registry.svc:5000/<namespace>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)