### PR TITLE
feat(api): create card-unsigned ConfigMap for agent card signing

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2004,6 +2004,40 @@ def _ensure_authbridge_scc_rolebinding(
     )
 
 
+def _ensure_card_unsigned_configmap(
+    kube: KubernetesService,
+    name: str,
+    namespace: str,
+    service_port: int = DEFAULT_IN_CLUSTER_PORT,
+) -> None:
+    """Create the <agent>-card-unsigned ConfigMap if it does not exist.
+
+    The Kagenti operator webhook checks for this ConfigMap when a
+    Deployment is admitted.  If it exists, the webhook injects a
+    ``sign-agentcard`` init container that signs the agent card with
+    the workload's SPIRE SVID.  The ConfigMap must therefore be
+    created **before** the Deployment.
+    """
+    agent_url = f"http://{name}.{namespace}.svc.cluster.local:{service_port}"
+    agent_card = json.dumps(
+        {
+            "name": name,
+            "url": agent_url,
+            "version": "1.0.0",
+            "capabilities": {},
+            "defaultInputModes": ["application/json"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": [],
+        },
+        indent=2,
+    )
+    kube.ensure_configmap(
+        namespace=namespace,
+        name=f"{name}-card-unsigned",
+        data={"agent.json": agent_card},
+    )
+
+
 def _build_agent_shipwright_build_manifest(
     request: CreateAgentRequest, clone_secret_name: Optional[str] = None
 ) -> dict:
@@ -2687,6 +2721,21 @@ async def create_agent(
             if request.authBridgeEnabled:
                 _ensure_authbridge_scc_rolebinding(kube=kube, namespace=request.namespace)
 
+            # Create card-unsigned ConfigMap so the webhook injects
+            # the sign-agentcard init container at Deployment admission.
+            if request.spireEnabled:
+                service_port = (
+                    request.servicePorts[0].port
+                    if request.servicePorts
+                    else DEFAULT_IN_CLUSTER_PORT
+                )
+                _ensure_card_unsigned_configmap(
+                    kube=kube,
+                    name=request.name,
+                    namespace=request.namespace,
+                    service_port=service_port,
+                )
+
             # Create workload based on workloadType
             if request.workloadType == WORKLOAD_TYPE_DEPLOYMENT:
                 workload_manifest = _build_deployment_manifest(
@@ -3156,6 +3205,19 @@ async def finalize_shipwright_build(
         # On OpenShift, ensure the AuthBridge SCC RoleBinding exists
         if final_auth_bridge:
             _ensure_authbridge_scc_rolebinding(kube=kube, namespace=namespace)
+
+        # Create card-unsigned ConfigMap so the webhook injects
+        # the sign-agentcard init container at Deployment admission.
+        if final_spire_enabled:
+            service_port = (
+                final_service_ports[0].port if final_service_ports else DEFAULT_IN_CLUSTER_PORT
+            )
+            _ensure_card_unsigned_configmap(
+                kube=kube,
+                name=name,
+                namespace=namespace,
+                service_port=service_port,
+            )
 
         # Create workload based on workloadType
         if final_workload_type == WORKLOAD_TYPE_DEPLOYMENT:


### PR DESCRIPTION
## Summary

- When `spireEnabled: true`, the API now creates the `<agent-name>-card-unsigned` ConfigMap **before** creating the Deployment
- The Kagenti operator webhook checks for this ConfigMap at pod admission time — if it exists, the webhook injects a `sign-agentcard` init container that signs the agent card with the workload's SPIRE SVID
- Without this ConfigMap, agents deployed via the API were never signed (`Verified: false`, `Bound: false`)
- The ConfigMap contains a minimal A2A agent card (`name`, `url`, `version`, empty `skills`) — the agent's live `/.well-known/agent-card.json` provides the full card at runtime
- Uses create-if-not-exists semantics so pre-created or customized cards are preserved
- Also adds `ensure_configmap` to `KubernetesService` (mirrors the existing `ensure_service_account` pattern)

### Changes

| File | Change |
|------|--------|
| `app/services/kubernetes.py` | Added `ensure_configmap()` method |
| `app/routers/agents.py` | Added `_ensure_card_unsigned_configmap()` helper, called from both `create_agent` and `finalize_shipwright_build` when `spireEnabled` is true |

### Ordering constraint

The ConfigMap **must** be created before the Deployment because the webhook makes its injection decision at admission time. The code creates it after `ensure_service_account` but before `create_deployment`.

Fixes #1061

## Test plan

- [ ] Deploy agent via API with `spireEnabled: true` — verify `<agent>-card-unsigned` ConfigMap is created
- [ ] Verify the webhook injects `sign-agentcard` init container into the pod
- [ ] Verify agent shows `Verified: true` in the Kagenti UI
- [ ] Deploy with `spireEnabled: false` — verify no card-unsigned ConfigMap is created
- [ ] Pre-create a custom card-unsigned ConfigMap, deploy agent — verify custom content is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)