### PR TITLE
feat(api): auto-create AuthBridge SCC RoleBinding on OpenShift

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
+import kubernetes.client
 from kubernetes.client import ApiException
 from pydantic import BaseModel, Field, field_validator
 
@@ -85,7 +86,7 @@ from app.models.responses import (
     DeleteResponse,
 )
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
-from app.utils.routes import create_route_for_agent_or_tool, route_exists
+from app.utils.routes import create_route_for_agent_or_tool, detect_platform, route_exists
 from app.models.shipwright import (
     ResourceType,
     ShipwrightBuildConfig,
@@ -1936,6 +1937,57 @@ def _ensure_authproxy_routes(
     )
 
 
+def _ensure_authbridge_scc_rolebinding(
+    kube: KubernetesService,
+    namespace: str,
+) -> None:
+    """On OpenShift, ensure the AuthBridge SCC RoleBinding exists.
+
+    AuthBridge sidecars need NET_ADMIN/NET_RAW capabilities, RunAsAny UIDs,
+    and CSI volumes that OpenShift's default restricted-v2 SCC blocks.
+    The Helm chart creates the ``kagenti-authbridge`` SCC and its ClusterRole;
+    this function creates the per-namespace RoleBinding that grants it to all
+    service accounts in the namespace.
+
+    On non-OpenShift clusters this is a no-op.  If the ClusterRole doesn't
+    exist (SCC not installed), a warning is logged and the function returns
+    without error — the agent will still be created, but pods may fail with
+    SCC errors until the SCC is installed.
+    """
+    if detect_platform(kube) != "openshift":
+        return
+
+    cluster_role_name = "system:openshift:scc:kagenti-authbridge"
+
+    # Verify the ClusterRole exists (implies the SCC was installed)
+    try:
+        kube.rbac_api.read_cluster_role(name=cluster_role_name)
+    except ApiException as e:
+        if e.status == 404:
+            logger.warning(
+                "ClusterRole '%s' not found. "
+                "The kagenti-authbridge SCC may not be installed. "
+                "Agent pods may fail with SCC errors. "
+                "Install via: helm upgrade kagenti charts/kagenti --set openshift=true",
+                cluster_role_name,
+            )
+            return
+        raise
+
+    kube.ensure_rolebinding(
+        namespace=namespace,
+        name="agent-authbridge-scc",
+        cluster_role_name=cluster_role_name,
+        subjects=[
+            kubernetes.client.V1Subject(
+                kind="Group",
+                api_group="rbac.authorization.k8s.io",
+                name=f"system:serviceaccounts:{namespace}",
+            ),
+        ],
+    )
+
+
 def _build_agent_shipwright_build_manifest(
     request: CreateAgentRequest, clone_secret_name: Optional[str] = None
 ) -> dict:
@@ -2615,6 +2667,10 @@ async def create_agent(
                         data=extra_config,
                     )
 
+            # On OpenShift, ensure the AuthBridge SCC RoleBinding exists
+            if request.authBridgeEnabled:
+                _ensure_authbridge_scc_rolebinding(kube=kube, namespace=request.namespace)
+
             # Create workload based on workloadType
             if request.workloadType == WORKLOAD_TYPE_DEPLOYMENT:
                 workload_manifest = _build_deployment_manifest(
@@ -3080,6 +3136,10 @@ async def finalize_shipwright_build(
                     namespace=namespace,
                     routes=final_outbound_routes,
                 )
+
+        # On OpenShift, ensure the AuthBridge SCC RoleBinding exists
+        if final_auth_bridge:
+            _ensure_authbridge_scc_rolebinding(kube=kube, namespace=namespace)
 
         # Create workload based on workloadType
         if final_workload_type == WORKLOAD_TYPE_DEPLOYMENT:

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -29,6 +29,7 @@ class KubernetesService:
         self._core_api: Optional[kubernetes.client.CoreV1Api] = None
         self._apps_api: Optional[kubernetes.client.AppsV1Api] = None
         self._batch_api: Optional[kubernetes.client.BatchV1Api] = None
+        self._rbac_api: Optional[kubernetes.client.RbacAuthorizationV1Api] = None
 
     def _load_config(self) -> kubernetes.client.ApiClient:
         """Load Kubernetes configuration (in-cluster or kubeconfig)."""
@@ -73,6 +74,13 @@ class KubernetesService:
         if self._batch_api is None:
             self._batch_api = kubernetes.client.BatchV1Api(self.api_client)
         return self._batch_api
+
+    @property
+    def rbac_api(self) -> kubernetes.client.RbacAuthorizationV1Api:
+        """Get RbacAuthorizationV1Api client for Roles and RoleBindings."""
+        if self._rbac_api is None:
+            self._rbac_api = kubernetes.client.RbacAuthorizationV1Api(self.api_client)
+        return self._rbac_api
 
     def is_running_in_cluster(self) -> bool:
         """Check if running inside a Kubernetes cluster."""
@@ -286,6 +294,48 @@ class KubernetesService:
                 logger.info("Created new ConfigMap")
             else:
                 logger.error("Error upserting ConfigMap")
+                raise
+
+    # -------------------------------------------------------------------------
+    # RoleBinding Operations
+    # -------------------------------------------------------------------------
+
+    def ensure_rolebinding(
+        self,
+        namespace: str,
+        name: str,
+        cluster_role_name: str,
+        subjects: list,
+        labels: Optional[dict] = None,
+    ) -> None:
+        """Create a RoleBinding if it does not already exist."""
+        # Sanitize for logging (CWE-117 / CodeQL Log Injection).
+        # Kubernetes names are already constrained to [a-z0-9-.] but CodeQL
+        # cannot verify that statically.
+        safe_name = name.replace("\n", "").replace("\r", "")
+        safe_ns = namespace.replace("\n", "").replace("\r", "")
+        try:
+            self.rbac_api.read_namespaced_role_binding(name=name, namespace=namespace)
+            logger.debug("RoleBinding '%s' already exists in %s", safe_name, safe_ns)
+        except ApiException as e:
+            if e.status == 404:
+                rb = kubernetes.client.V1RoleBinding(
+                    metadata=kubernetes.client.V1ObjectMeta(
+                        name=name,
+                        namespace=namespace,
+                        labels=labels or {"kagenti.io/managed-by": "kagenti-api"},
+                    ),
+                    role_ref=kubernetes.client.V1RoleRef(
+                        api_group="rbac.authorization.k8s.io",
+                        kind="ClusterRole",
+                        name=cluster_role_name,
+                    ),
+                    subjects=subjects,
+                )
+                self.rbac_api.create_namespaced_role_binding(namespace=namespace, body=rb)
+                logger.info("Created RoleBinding '%s' in %s", safe_name, safe_ns)
+            else:
+                logger.error("Error checking RoleBinding '%s' in %s: %s", safe_name, safe_ns, e)
                 raise
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

On OpenShift, AuthBridge sidecars need capabilities (`NET_ADMIN`, `NET_RAW`), `RunAsAny` UIDs (0, 1337, 1000), and CSI volumes that the default `restricted-v2` SCC blocks. The Helm chart creates the `kagenti-authbridge` SCC (cluster-scoped) and a ClusterRole for it, but agents deployed to **new namespaces** via the API were missing the per-namespace RoleBinding, causing pods to fail with SCC errors.

### What this PR does

- **Detects OpenShift** using the existing `detect_platform()` function (checks for `route.openshift.io` API)
- **Creates the `agent-authbridge-scc` RoleBinding** in the target namespace, granting the `system:openshift:scc:kagenti-authbridge` ClusterRole to all service accounts in the namespace (matches the Helm chart's `agent-namespaces.yaml`)
- **Gracefully handles missing SCC**: if the ClusterRole doesn't exist (SCC not installed via Helm), logs a warning and proceeds — agent is created but pods will fail until the SCC is installed
- **No-op on non-OpenShift clusters**: `detect_platform()` returns `"kubernetes"` and the function returns immediately

### Changes

| File | Change |
|------|--------|
| `app/services/kubernetes.py` | Added `rbac_api` property and `ensure_rolebinding()` method |
| `app/routers/agents.py` | Added `_ensure_authbridge_scc_rolebinding()` helper, called from both `create_agent` and `finalize_shipwright_build` when `authBridgeEnabled` is true |

### Prerequisites

The `kagenti-authbridge` SCC and its ClusterRole must be installed first (via Helm with `openshift=true`). This PR only creates the per-namespace RoleBinding — it does not create the cluster-scoped SCC itself, which requires cluster-admin privileges typically granted during platform installation.

Fixes #1062

## Test plan

- [ ] On OpenShift: deploy agent with `authBridgeEnabled: true` to a new namespace — verify `agent-authbridge-scc` RoleBinding is created
- [ ] Verify pods start without SCC errors
- [ ] On OpenShift without the SCC installed — verify warning is logged, agent is created, pods fail with descriptive SCC error
- [ ] On Kind/vanilla K8s — verify no RoleBinding is created (no-op)
- [ ] Deploy second agent to same namespace — verify RoleBinding is not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)