### PR TITLE
fix(auth): unify Keycloak realm to kagenti across charts and jobs

### DIFF
--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -85,7 +85,7 @@ keycloak:
   # Internal Keycloak URL for OAuth secret jobs
   url: http://keycloak-service.keycloak:8080
   publicUrl: http://keycloak.localtest.me:8080
-  realm: demo
+  realm: kagenti
   httpRoute:
     annotations: {}
     parentRefs:

--- a/charts/kagenti/templates/agent-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/agent-oauth-secret-job.yaml
@@ -101,7 +101,7 @@ spec:
           value: {{ .Values.keycloak.adminPasswordKey | quote }}
         - name: KEYCLOAK_BASE_URL
           value: {{ .Values.keycloak.url | quote }}
-        - name: KEYCLOAK_DEMO_REALM
+        - name: KEYCLOAK_REALM
           value: {{ .Values.keycloak.realm | quote }}
         - name: KAGENTI_KEYCLOAK_CLIENT_NAME
           value: {{ .Values.agentOAuthSecret.clientName | quote }}

--- a/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
+++ b/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
@@ -103,16 +103,16 @@ def parse_bool(value: Optional[str]) -> bool:
 def get_keycloak_env_config() -> Tuple[str, str, Optional[str], str]:
     """Read common Keycloak environment configuration values.
 
-    Returns a tuple: (base_url, demo_realm_name, ssl_cert_file, spiffe_prefix)
+    Returns a tuple: (base_url, realm_name, ssl_cert_file, spiffe_prefix)
     """
     base_url = get_optional_env(
         "KEYCLOAK_BASE_URL", f"http://keycloak.{DEFAULT_DOMAIN_NAME}:8080"
     )
-    demo_realm_name = get_optional_env("KEYCLOAK_DEMO_REALM", "demo")
+    realm_name = get_optional_env("KEYCLOAK_REALM", "kagenti")
     ssl_cert_file = get_optional_env("SSL_CERT_FILE")
     spiffe_prefix = get_optional_env("SPIFFE_PREFIX", DEFAULT_SPIFFE_PREFIX)
 
-    return base_url, demo_realm_name, ssl_cert_file, spiffe_prefix
+    return base_url, realm_name, ssl_cert_file, spiffe_prefix
 
 
 def get_keycloak_admin_credentials(
@@ -327,7 +327,7 @@ def setup_keycloak(v1_api: Optional[client.CoreV1Api] = None) -> str:
     - `KEYCLOAK_BASE_URL` (default: "http://keycloak.localtest.me:8080")
     - `KEYCLOAK_ADMIN_USERNAME` (default: "admin") - can be read from secret if not provided
     - `KEYCLOAK_ADMIN_PASSWORD` (default: "admin") - can be read from secret if not provided
-    - `KEYCLOAK_DEMO_REALM` (default: "demo")
+    - `KEYCLOAK_REALM` (default: "kagenti")
     - `KAGENTI_KEYCLOAK_CLIENT_NAME` (default: "kagenti-keycloak-client")
     - `SSL_CERT_FILE` (optional) - path to custom SSL certificate for Keycloak connection
     - `KEYCLOAK_NAMESPACE` (default: "keycloak") - namespace where Keycloak admin secret exists
@@ -339,7 +339,7 @@ def setup_keycloak(v1_api: Optional[client.CoreV1Api] = None) -> str:
     Args:
         v1_api: Optional Kubernetes CoreV1Api client for reading secrets
     """
-    base_url, demo_realm_name, ssl_cert_file, spiffe_prefix = get_keycloak_env_config()
+    base_url, realm_name, ssl_cert_file, spiffe_prefix = get_keycloak_env_config()
 
     # Compute admin credentials consistently using helper
     admin_username, admin_password = get_keycloak_admin_credentials(v1_api)
@@ -347,7 +347,7 @@ def setup_keycloak(v1_api: Optional[client.CoreV1Api] = None) -> str:
     # Configure SSL verification
     verify_ssl = configure_ssl_verification(ssl_cert_file)
 
-    setup = KeycloakSetup(base_url, admin_username, admin_password, demo_realm_name)
+    setup = KeycloakSetup(base_url, admin_username, admin_password, realm_name)
     # Pass verify parameter to KeycloakAdmin (will be used in connect method)
     setup.verify_ssl = verify_ssl if verify_ssl is not None else True
     if not setup.connect():
@@ -382,7 +382,7 @@ def setup_keycloak(v1_api: Optional[client.CoreV1Api] = None) -> str:
                 string_data={
                     "username": test_user_name,
                     "password": test_user_password,
-                    "realm": get_optional_env("KEYCLOAK_DEMO_REALM", "demo"),
+                    "realm": get_optional_env("KEYCLOAK_REALM", "kagenti"),
                 },
                 type="Opaque",
             )
@@ -441,7 +441,7 @@ def create_secrets(**kwargs):
         typer.secho(f"✗ Could not connect to Kubernetes: {e}", fg="red", err=True)
         raise typer.Exit(1)
 
-    # Setup Keycloak demo realm, user, and agent client (pass v1_api for secret reading)
+    # Setup Keycloak realm, user, and agent client (pass v1_api for secret reading)
     kagenti_keycloak_client_secret = setup_keycloak(v1_api)
 
     # Distribute client secret to agent namespaces

--- a/kagenti/auth/mlflow-oauth-secret/mlflow_experiment_init.py
+++ b/kagenti/auth/mlflow-oauth-secret/mlflow_experiment_init.py
@@ -24,7 +24,7 @@ Usage:
 Environment Variables:
     MLFLOW_TRACKING_URI: MLflow server URL (required)
     KEYCLOAK_URL: Keycloak server URL (required)
-    KEYCLOAK_REALM: Keycloak realm (default: demo)
+    KEYCLOAK_REALM: Keycloak realm (default: kagenti)
     CLIENT_ID: OAuth client ID for MLflow access
     CLIENT_SECRET: OAuth client secret
     NAMESPACES: Comma-separated list of namespaces to create experiments for
@@ -179,7 +179,7 @@ def main():
     # Get configuration from environment
     mlflow_url = os.environ.get("MLFLOW_TRACKING_URI", "http://mlflow:5000")
     keycloak_url = os.environ.get("KEYCLOAK_URL")
-    keycloak_realm = os.environ.get("KEYCLOAK_REALM", "demo")
+    keycloak_realm = os.environ.get("KEYCLOAK_REALM", "kagenti")
     client_id = os.environ.get("CLIENT_ID", "mlflow")
     client_secret = os.environ.get("CLIENT_SECRET")
     namespaces_str = os.environ.get("NAMESPACES", "team1,team2")


### PR DESCRIPTION
## Summary

- The `kagenti-deps` chart defaulted to `realm: demo` while the `kagenti` chart used `realm: kagenti`, causing the `authbridge-config` configmap to point to the wrong realm
- This caused authbridge to fetch JWKS keys from the `demo` realm while tokens were issued by the `kagenti` realm, resulting in 401 errors on all agent chat requests
- Renamed the misleading `KEYCLOAK_DEMO_REALM` env var to `KEYCLOAK_REALM` for consistency with other jobs (mlflow, ui, api)

### Changes
- `charts/kagenti-deps/values.yaml`: `realm: demo` → `realm: kagenti`
- `charts/kagenti/templates/agent-oauth-secret-job.yaml`: `KEYCLOAK_DEMO_REALM` → `KEYCLOAK_REALM`
- `kagenti/auth/agent-oauth-secret/agent_oauth_secret.py`: rename variable `demo_realm_name` → `realm_name`, update env var and default
- `kagenti/auth/mlflow-oauth-secret/mlflow_experiment_init.py`: update default from `demo` to `kagenti`

## Test plan

- [ ] Deploy to Kind cluster and verify `authbridge-config` configmap in `team1` has `KEYCLOAK_REALM: kagenti` and `ISSUER: .../realms/kagenti`
- [ ] Verify weather agent chat works end-to-end (no 401 from authbridge)
- [ ] Verify MLflow OAuth secret job creates client in `kagenti` realm
- [ ] Verify agent OAuth secret job creates realm and client correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)