### PR TITLE
fix(auth): extend Keycloak session lifetimes for long-running clusters

### DIFF
--- a/charts/kagenti/templates/agent-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/agent-oauth-secret-job.yaml
@@ -113,6 +113,12 @@ spec:
         {{- end }}
         - name: SPIFFE_PREFIX
           value: {{ .Values.agentOAuthSecret.spiffePrefix }}
+        - name: KEYCLOAK_SSO_SESSION_IDLE
+          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionIdle | quote }}
+        - name: KEYCLOAK_SSO_SESSION_MAX
+          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionMax | quote }}
+        - name: KEYCLOAK_ACCESS_TOKEN_LIFESPAN
+          value: {{ .Values.keycloak.sessionLifetimes.accessTokenLifespan | quote }}
         # Create a test user in the configured realm for UI/MLflow login
         # Password is auto-generated and stored in kagenti-test-user secret
         - name: CREATE_KEYCLOAK_TEST_USER

--- a/charts/kagenti/templates/agent-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/agent-oauth-secret-job.yaml
@@ -114,11 +114,11 @@ spec:
         - name: SPIFFE_PREFIX
           value: {{ .Values.agentOAuthSecret.spiffePrefix }}
         - name: KEYCLOAK_SSO_SESSION_IDLE
-          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionIdle | quote }}
+          value: {{ printf "%d" (int .Values.keycloak.sessionLifetimes.ssoSessionIdle) | quote }}
         - name: KEYCLOAK_SSO_SESSION_MAX
-          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionMax | quote }}
+          value: {{ printf "%d" (int .Values.keycloak.sessionLifetimes.ssoSessionMax) | quote }}
         - name: KEYCLOAK_ACCESS_TOKEN_LIFESPAN
-          value: {{ .Values.keycloak.sessionLifetimes.accessTokenLifespan | quote }}
+          value: {{ printf "%d" (int .Values.keycloak.sessionLifetimes.accessTokenLifespan) | quote }}
         # Create a test user in the configured realm for UI/MLflow login
         # Password is auto-generated and stored in kagenti-test-user secret
         - name: CREATE_KEYCLOAK_TEST_USER

--- a/charts/kagenti/templates/ui-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/ui-oauth-secret-job.yaml
@@ -151,10 +151,10 @@ spec:
           value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         {{- end }}
         - name: KEYCLOAK_SSO_SESSION_IDLE
-          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionIdle | quote }}
+          value: {{ printf "%d" (int .Values.keycloak.sessionLifetimes.ssoSessionIdle) | quote }}
         - name: KEYCLOAK_SSO_SESSION_MAX
-          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionMax | quote }}
+          value: {{ printf "%d" (int .Values.keycloak.sessionLifetimes.ssoSessionMax) | quote }}
         - name: KEYCLOAK_ACCESS_TOKEN_LIFESPAN
-          value: {{ .Values.keycloak.sessionLifetimes.accessTokenLifespan | quote }}
+          value: {{ printf "%d" (int .Values.keycloak.sessionLifetimes.accessTokenLifespan) | quote }}
   backoffLimit: 5
 {{- end }}

--- a/charts/kagenti/templates/ui-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/ui-oauth-secret-job.yaml
@@ -150,5 +150,11 @@ spec:
         - name: SSL_CERT_FILE
           value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         {{- end }}
+        - name: KEYCLOAK_SSO_SESSION_IDLE
+          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionIdle | quote }}
+        - name: KEYCLOAK_SSO_SESSION_MAX
+          value: {{ .Values.keycloak.sessionLifetimes.ssoSessionMax | quote }}
+        - name: KEYCLOAK_ACCESS_TOKEN_LIFESPAN
+          value: {{ .Values.keycloak.sessionLifetimes.accessTokenLifespan | quote }}
   backoffLimit: 5
 {{- end }}

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -160,6 +160,20 @@ keycloak:
   publicUrl: http://keycloak.localtest.me:8080
   realm: kagenti
   autoBootstrapRealm: true
+  # Session/token lifetimes for long-running dev clusters (e.g. Kind).
+  # Keycloak defaults (30min idle, 10h max) cause "Signature has expired"
+  # errors after a few hours. These values extend lifetimes for dev use.
+  # For production, override with shorter values.
+  sessionLifetimes:
+    # SSO Session Idle timeout in seconds (default: 7 days)
+    # Keycloak default is 1800 (30 min)
+    ssoSessionIdle: 604800
+    # SSO Session Max lifespan in seconds (default: 30 days)
+    # Keycloak default is 36000 (10 hours)
+    ssoSessionMax: 2592000
+    # Access token lifespan in seconds (default: 30 min)
+    # Keycloak default is 300 (5 min)
+    accessTokenLifespan: 1800
 
 # ------------------------------------------------------------------
 #  Kagenti Webhook Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -163,7 +163,11 @@ keycloak:
   # Session/token lifetimes for long-running dev clusters (e.g. Kind).
   # Keycloak defaults (30min idle, 10h max) cause "Signature has expired"
   # errors after a few hours. These values extend lifetimes for dev use.
-  # For production, override with shorter values.
+  #
+  # ⚠️  PRODUCTION WARNING: These defaults are intentionally permissive for
+  # developer convenience. For production deployments, override with values
+  # appropriate for your security policy (e.g. 30min idle, 8h max session).
+  # Long-lived sessions increase the window for token theft/session hijacking.
   sessionLifetimes:
     # SSO Session Idle timeout in seconds (default: 7 days)
     # Keycloak default is 1800 (30 min)

--- a/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
+++ b/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
@@ -220,15 +220,35 @@ class KeycloakSetup:
         return False
 
     def create_realm(self):
+        sso_session_idle = int(get_optional_env("KEYCLOAK_SSO_SESSION_IDLE", "604800"))
+        sso_session_max = int(get_optional_env("KEYCLOAK_SSO_SESSION_MAX", "2592000"))
+        access_token_lifespan = int(
+            get_optional_env("KEYCLOAK_ACCESS_TOKEN_LIFESPAN", "1800")
+        )
+
+        realm_payload = {
+            "realm": self.realm_name,
+            "enabled": True,
+            "ssoSessionIdleTimeout": sso_session_idle,
+            "ssoSessionMaxLifespan": sso_session_max,
+            "accessTokenLifespan": access_token_lifespan,
+        }
+
         try:
-            self.keycloak_admin.create_realm(
-                payload={"realm": self.realm_name, "enabled": True}, skip_exists=False
+            self.keycloak_admin.create_realm(payload=realm_payload, skip_exists=False)
+            typer.echo(
+                f'Created realm "{self.realm_name}" with session lifetimes: '
+                f"idle={sso_session_idle}s, max={sso_session_max}s, "
+                f"access_token={access_token_lifespan}s"
             )
-            typer.echo(f'Created realm "{self.realm_name}"')
         except KeycloakPostError as e:
             # Keycloak returns 409 if the realm already exists
             if hasattr(e, "response_code") and e.response_code == 409:
-                typer.echo(f'Realm "{self.realm_name}" already exists')
+                typer.echo(
+                    f'Realm "{self.realm_name}" already exists, '
+                    f"updating session lifetimes"
+                )
+                self.keycloak_admin.update_realm(self.realm_name, realm_payload)
             else:
                 typer.echo(f'Failed to create realm "{self.realm_name}": {e}')
         except Exception as e:

--- a/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
+++ b/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
@@ -22,6 +22,8 @@ from kubernetes.client.rest import ApiException
 
 from keycloak import KeycloakAdmin, KeycloakPostError
 
+from kagenti.auth.shared_utils import get_session_lifetime_payload
+
 # Import common utilities
 from common import (
     get_optional_env as _get_optional_env,
@@ -220,35 +222,34 @@ class KeycloakSetup:
         return False
 
     def create_realm(self):
-        sso_session_idle = int(get_optional_env("KEYCLOAK_SSO_SESSION_IDLE", "604800"))
-        sso_session_max = int(get_optional_env("KEYCLOAK_SSO_SESSION_MAX", "2592000"))
-        access_token_lifespan = int(
-            get_optional_env("KEYCLOAK_ACCESS_TOKEN_LIFESPAN", "1800")
-        )
-
+        session_lifetimes = get_session_lifetime_payload()
         realm_payload = {
             "realm": self.realm_name,
             "enabled": True,
-            "ssoSessionIdleTimeout": sso_session_idle,
-            "ssoSessionMaxLifespan": sso_session_max,
-            "accessTokenLifespan": access_token_lifespan,
+            **session_lifetimes,
         }
 
         try:
             self.keycloak_admin.create_realm(payload=realm_payload, skip_exists=False)
             typer.echo(
                 f'Created realm "{self.realm_name}" with session lifetimes: '
-                f"idle={sso_session_idle}s, max={sso_session_max}s, "
-                f"access_token={access_token_lifespan}s"
+                f"{session_lifetimes}"
             )
         except KeycloakPostError as e:
-            # Keycloak returns 409 if the realm already exists
+            # Keycloak returns 409 if the realm already exists — update it
+            # instead. The update is idempotent so concurrent job pods are safe.
             if hasattr(e, "response_code") and e.response_code == 409:
                 typer.echo(
                     f'Realm "{self.realm_name}" already exists, '
                     f"updating session lifetimes"
                 )
-                self.keycloak_admin.update_realm(self.realm_name, realm_payload)
+                try:
+                    self.keycloak_admin.update_realm(self.realm_name, realm_payload)
+                except Exception as update_err:
+                    typer.echo(
+                        f'Warning: failed to update realm "{self.realm_name}": '
+                        f"{update_err}. Session lifetimes may not be configured."
+                    )
             else:
                 typer.echo(f'Failed to create realm "{self.realm_name}": {e}')
         except Exception as e:

--- a/kagenti/auth/shared_utils.py
+++ b/kagenti/auth/shared_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Dict, Any
+import os
+from typing import Dict, Any, Optional
 
 from keycloak import KeycloakAdmin, KeycloakPostError
 
@@ -15,6 +16,23 @@ class KeycloakOperationError(Exception):
     """Raised when Keycloak operations fail."""
 
     pass
+
+
+def get_session_lifetime_payload() -> Dict[str, int]:
+    """Return Keycloak realm session lifetime settings from environment.
+
+    Reads KEYCLOAK_SSO_SESSION_IDLE, KEYCLOAK_SSO_SESSION_MAX, and
+    KEYCLOAK_ACCESS_TOKEN_LIFESPAN with dev-friendly defaults.
+    """
+
+    def _env_int(key: str, default: str) -> int:
+        return int(os.environ.get(key, default))
+
+    return {
+        "ssoSessionIdleTimeout": _env_int("KEYCLOAK_SSO_SESSION_IDLE", "604800"),
+        "ssoSessionMaxLifespan": _env_int("KEYCLOAK_SSO_SESSION_MAX", "2592000"),
+        "accessTokenLifespan": _env_int("KEYCLOAK_ACCESS_TOKEN_LIFESPAN", "1800"),
+    }
 
 
 def register_client(

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -2,7 +2,8 @@ import logging
 import sys
 from typing import Dict
 from keycloak import KeycloakAdmin
-from kagenti.auth.shared_utils import register_client
+from keycloak.exceptions import KeycloakPostError
+from kagenti.auth.shared_utils import register_client, get_session_lifetime_payload
 from kubernetes import client, dynamic
 from kubernetes.client import api_client
 
@@ -271,42 +272,43 @@ def main() -> None:
             logger.info(
                 f"AUTO_BOOTSTRAP_REALM is enabled; ensuring realm '{keycloak_realm}' exists"
             )
-            # Session lifetime settings for dev/long-running clusters
-            sso_session_idle = int(
-                get_optional_env("KEYCLOAK_SSO_SESSION_IDLE", "604800")
-            )
-            sso_session_max = int(
-                get_optional_env("KEYCLOAK_SSO_SESSION_MAX", "2592000")
-            )
-            access_token_lifespan = int(
-                get_optional_env("KEYCLOAK_ACCESS_TOKEN_LIFESPAN", "1800")
-            )
-
+            session_lifetimes = get_session_lifetime_payload()
             realm_payload = {
                 "realm": keycloak_realm,
                 "enabled": True,
                 "registrationAllowed": False,
-                "ssoSessionIdleTimeout": sso_session_idle,
-                "ssoSessionMaxLifespan": sso_session_max,
-                "accessTokenLifespan": access_token_lifespan,
+                **session_lifetimes,
             }
 
             try:
-                existing_realms = keycloak_admin.get_realms()
-                if not any(r["realm"] == keycloak_realm for r in existing_realms):
-                    keycloak_admin.create_realm(payload=realm_payload)
-                    logger.info(
-                        f"Created Keycloak realm '{keycloak_realm}' with session "
-                        f"lifetimes: idle={sso_session_idle}s, "
-                        f"max={sso_session_max}s, "
-                        f"access_token={access_token_lifespan}s"
-                    )
-                else:
+                # Create-first, catch-409: avoids the TOCTOU race of
+                # get_realms → create when multiple job pods run concurrently.
+                keycloak_admin.create_realm(payload=realm_payload)
+                logger.info(
+                    f"Created Keycloak realm '{keycloak_realm}' with session "
+                    f"lifetimes: {session_lifetimes}"
+                )
+            except KeycloakPostError as e:
+                if hasattr(e, "response_code") and e.response_code == 409:
                     logger.info(
                         f"Realm '{keycloak_realm}' already exists, "
                         f"updating session lifetimes"
                     )
-                    keycloak_admin.update_realm(keycloak_realm, realm_payload)
+                    try:
+                        keycloak_admin.update_realm(keycloak_realm, realm_payload)
+                    except Exception as update_err:
+                        logger.warning(
+                            f"Failed to update realm '{keycloak_realm}': "
+                            f"{update_err}. Session lifetimes may not be configured."
+                        )
+                else:
+                    logger.error(
+                        f"Failed to bootstrap realm '{keycloak_realm}': {e}. "
+                        "Ensure the Keycloak admin has realm-management permissions, "
+                        "or set AUTO_BOOTSTRAP_REALM=false if the realm is "
+                        "pre-provisioned."
+                    )
+                    raise
             except Exception as e:
                 logger.error(
                     f"Failed to bootstrap realm '{keycloak_realm}': {e}. "

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -271,27 +271,42 @@ def main() -> None:
             logger.info(
                 f"AUTO_BOOTSTRAP_REALM is enabled; ensuring realm '{keycloak_realm}' exists"
             )
+            # Session lifetime settings for dev/long-running clusters
+            sso_session_idle = int(
+                get_optional_env("KEYCLOAK_SSO_SESSION_IDLE", "604800")
+            )
+            sso_session_max = int(
+                get_optional_env("KEYCLOAK_SSO_SESSION_MAX", "2592000")
+            )
+            access_token_lifespan = int(
+                get_optional_env("KEYCLOAK_ACCESS_TOKEN_LIFESPAN", "1800")
+            )
+
+            realm_payload = {
+                "realm": keycloak_realm,
+                "enabled": True,
+                "registrationAllowed": False,
+                "ssoSessionIdleTimeout": sso_session_idle,
+                "ssoSessionMaxLifespan": sso_session_max,
+                "accessTokenLifespan": access_token_lifespan,
+            }
+
             try:
                 existing_realms = keycloak_admin.get_realms()
                 if not any(r["realm"] == keycloak_realm for r in existing_realms):
-                    keycloak_admin.create_realm(
-                        payload={
-                            "realm": keycloak_realm,
-                            "enabled": True,
-                            "registrationAllowed": False,
-                            # Token lifespans to prevent premature expiry (issue #1009).
-                            # Keycloak defaults to 5-minute access tokens, which causes
-                            # "Signature has expired" errors when refresh timing is imperfect.
-                            "accessTokenLifespan": 3600,  # 1 hour
-                            "ssoSessionIdleTimeout": 86400,  # 24 hours
-                            "ssoSessionMaxLifespan": 604800,  # 7 days
-                        }
+                    keycloak_admin.create_realm(payload=realm_payload)
+                    logger.info(
+                        f"Created Keycloak realm '{keycloak_realm}' with session "
+                        f"lifetimes: idle={sso_session_idle}s, "
+                        f"max={sso_session_max}s, "
+                        f"access_token={access_token_lifespan}s"
                     )
-                    logger.info(f"Created Keycloak realm '{keycloak_realm}'")
                 else:
                     logger.info(
-                        f"Realm '{keycloak_realm}' already exists, skipping creation"
+                        f"Realm '{keycloak_realm}' already exists, "
+                        f"updating session lifetimes"
                     )
+                    keycloak_admin.update_realm(keycloak_realm, realm_payload)
             except Exception as e:
                 logger.error(
                     f"Failed to bootstrap realm '{keycloak_realm}': {e}. "

--- a/kagenti/tests/e2e/common/test_keycloak_session_lifetimes.py
+++ b/kagenti/tests/e2e/common/test_keycloak_session_lifetimes.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Keycloak Session Lifetime E2E Tests
+
+Verifies that the kagenti realm has extended session/token lifetimes
+configured, preventing "Signature has expired" errors on long-running
+dev clusters (fixes #1009).
+
+Usage:
+    pytest tests/e2e/common/test_keycloak_session_lifetimes.py -v
+
+Fixtures:
+    keycloak_token: Authenticates and returns Keycloak access token
+"""
+
+import os
+
+import pytest
+import requests
+
+
+class TestKeycloakSessionLifetimes:
+    """Verify Keycloak realm session lifetime settings."""
+
+    @pytest.mark.requires_features(["keycloak"])
+    def test_realm_session_lifetimes(self, keycloak_token):
+        """Verify the kagenti realm has extended session lifetimes.
+
+        Reads realm settings via the Keycloak admin API and asserts that
+        ssoSessionIdleTimeout, ssoSessionMaxLifespan, and accessTokenLifespan
+        have been set to values greater than Keycloak defaults.
+
+        Keycloak defaults:
+            ssoSessionIdleTimeout: 1800 (30 min)
+            ssoSessionMaxLifespan: 36000 (10 hours)
+            accessTokenLifespan: 300 (5 min)
+        """
+        keycloak_base_url = os.environ.get("KEYCLOAK_URL", "http://localhost:8081")
+        realm = os.environ.get("KEYCLOAK_REALM", "kagenti")
+
+        verify_ssl: bool | str = True
+        if os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower() == "false":
+            verify_ssl = False
+        elif os.environ.get("KEYCLOAK_CA_BUNDLE"):
+            verify_ssl = os.environ["KEYCLOAK_CA_BUNDLE"]
+
+        access_token = keycloak_token["access_token"]
+        realm_url = f"{keycloak_base_url}/admin/realms/{realm}"
+
+        response = requests.get(
+            realm_url,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+            verify=verify_ssl,
+        )
+        assert response.status_code == 200, (
+            f"Failed to read realm settings: {response.status_code} {response.text}"
+        )
+
+        realm_data = response.json()
+
+        # Verify SSO Session Idle > Keycloak default of 1800s
+        sso_idle = realm_data.get("ssoSessionIdleTimeout", 0)
+        assert sso_idle > 1800, (
+            f"ssoSessionIdleTimeout={sso_idle}s is not greater than "
+            f"Keycloak default (1800s). Session lifetimes may not be configured."
+        )
+
+        # Verify SSO Session Max > Keycloak default of 36000s
+        sso_max = realm_data.get("ssoSessionMaxLifespan", 0)
+        assert sso_max > 36000, (
+            f"ssoSessionMaxLifespan={sso_max}s is not greater than "
+            f"Keycloak default (36000s). Session lifetimes may not be configured."
+        )
+
+        # Verify Access Token Lifespan > Keycloak default of 300s
+        access_lifespan = realm_data.get("accessTokenLifespan", 0)
+        assert access_lifespan > 300, (
+            f"accessTokenLifespan={access_lifespan}s is not greater than "
+            f"Keycloak default (300s). Session lifetimes may not be configured."
+        )
+
+        print(f"\n✓ Realm '{realm}' session lifetimes configured correctly:")
+        print(f"  SSO Session Idle:    {sso_idle}s ({sso_idle // 86400}d)")
+        print(f"  SSO Session Max:     {sso_max}s ({sso_max // 86400}d)")
+        print(f"  Access Token:        {access_lifespan}s ({access_lifespan // 60}m)")
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/kagenti/tests/e2e/common/test_keycloak_session_lifetimes.py
+++ b/kagenti/tests/e2e/common/test_keycloak_session_lifetimes.py
@@ -18,6 +18,8 @@ import os
 import pytest
 import requests
 
+from kagenti.tests.conftest import _keycloak_ssl_verify
+
 
 class TestKeycloakSessionLifetimes:
     """Verify Keycloak realm session lifetime settings."""
@@ -37,13 +39,6 @@ class TestKeycloakSessionLifetimes:
         """
         keycloak_base_url = os.environ.get("KEYCLOAK_URL", "http://localhost:8081")
         realm = os.environ.get("KEYCLOAK_REALM", "kagenti")
-
-        verify_ssl: bool | str = True
-        if os.environ.get("KEYCLOAK_VERIFY_SSL", "true").lower() == "false":
-            verify_ssl = False
-        elif os.environ.get("KEYCLOAK_CA_BUNDLE"):
-            verify_ssl = os.environ["KEYCLOAK_CA_BUNDLE"]
-
         access_token = keycloak_token["access_token"]
         realm_url = f"{keycloak_base_url}/admin/realms/{realm}"
 
@@ -51,7 +46,7 @@ class TestKeycloakSessionLifetimes:
             realm_url,
             headers={"Authorization": f"Bearer {access_token}"},
             timeout=10,
-            verify=verify_ssl,
+            verify=_keycloak_ssl_verify(),
         )
         assert response.status_code == 200, (
             f"Failed to read realm settings: {response.status_code} {response.text}"


### PR DESCRIPTION
## Summary

- Extend Keycloak SSO session and token lifetimes to prevent "Signature has expired" errors on long-running Kind/dev clusters
- Add configurable `keycloak.sessionLifetimes` Helm values (7d idle, 30d max session, 30min access token)
- Update existing realms on reinstall (409 path) so the fix applies to clusters with a persisted Keycloak PVC
- Add E2E test verifying realm session lifetime settings

## Details

Keycloak defaults (30min idle timeout, 10h max session) cause token refresh failures after a few hours on dev clusters. The UI's `updateToken()` call fails with "Signature has expired" and can't recover without clearing the Keycloak session. Reinstalling doesn't help because the realm persists in PostgreSQL.

This fix:
1. **`agent_oauth_secret.py`** — `create_realm()` sets `ssoSessionIdleTimeout`, `ssoSessionMaxLifespan`, `accessTokenLifespan` from env vars. On 409 (realm exists), updates the realm with new lifetimes.
2. **`auth_secret.py`** — Bootstrap realm creation includes the same session lifetime settings, and updates existing realms.
3. **`values.yaml`** — New `keycloak.sessionLifetimes` section with dev-friendly defaults.
4. **Helm templates** — Both `agent-oauth-secret-job.yaml` and `ui-oauth-secret-job.yaml` pass the env vars.
5. **E2E test** — Verifies realm lifetimes exceed Keycloak defaults via admin API.

## Test plan

- [ ] Deploy to Kind cluster with `kind-full-test.sh`
- [ ] Verify realm settings via Keycloak admin API: `curl .../admin/realms/kagenti | jq '{ssoSessionIdleTimeout, ssoSessionMaxLifespan, accessTokenLifespan}'`
- [ ] Run E2E test: `pytest kagenti/tests/e2e/common/test_keycloak_session_lifetimes.py -v`
- [ ] Test upgrade path: deploy old version, then upgrade — realm should get updated lifetimes
- [ ] Verify UI stays logged in beyond 30 minutes idle

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)