### PR TITLE
docs: Add Varsha Prasad Narsing as core maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,7 @@ For general questions, feedback, or to reach the maintainer team:
 * **Morgan Foster** (@usize)
 * **Ladislav Smola** (@Ladas)
 * **Gloire Rubambiza** (@rubambiza)
+* **Varsha Prasad Narsing** (@varshaprasad96)
 
 ## Module-Specific Maintainers
 


### PR DESCRIPTION
## Summary

- Add **Varsha Prasad Narsing** ([@varshaprasad96](https://github.com/varshaprasad96)) from Red Hat to the Core Maintainers list in `MAINTAINERS.md`

Varsha is a maintainer of Kubebuilder, Kustomize, and the Operator Framework.

## Test plan

- [x] Verify `MAINTAINERS.md` renders correctly on GitHub