### PR TITLE
fix: gate ztunnel ServiceMonitor behind kiali.enabled condition

### DIFF
--- a/charts/kagenti-deps/templates/istio-servicemonitor.yaml
+++ b/charts/kagenti-deps/templates/istio-servicemonitor.yaml
@@ -14,6 +14,7 @@ spec:
   - name: ztunnel-stats
     port: 15020
     targetPort: 15020
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.components.kiali.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -34,4 +35,5 @@ spec:
   - port: ztunnel-stats
     interval: 10s
     path: /metrics
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

→ Installing kagenti-deps...
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: resource mapping not found for name: "ztunnel-servicemonitor" namespace: "istio-ztunnel" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"


The ztunnel `ServiceMonitor` was rendered unconditionally whenever the Prometheus Operator CRD was present. Its `release: prometheus` label is a Prometheus Operator auto-discovery convention used exclusively by the Prometheus → Kiali observability stack. Since neither Kiali nor Prometheus is deployed in a default Kagenti setup, the `ServiceMonitor` was dead weight. This change gates it behind the existing `kiali.enabled` Helm value so it is only created when the full observability stack is present.

## Changes

- Wrap the `ServiceMonitor` block in `{{- if and ... .Values.components.kiali.enabled }}` — ensures the resource is only created when Kiali (and its Prometheus dependency) is actually enabled.

## Test Plan

- [x] Render with `kiali.enabled=false` (default): confirm no `ServiceMonitor` is produced
- [x] Render with `kiali.enabled=true` and the `monitoring.coreos.com/v1` CRD present: confirm the `ServiceMonitor` is rendered with `release: prometheus`
- [x] Deploy to Kind with default values and verify no stray `ServiceMonitor` resources appear in the `istio-ztunnel` namespace