### PR TITLE
feat: add OCP setup and cleanup scripts for Kagenti platform

### DIFF
--- a/scripts/ocp/cleanup-kagenti.sh
+++ b/scripts/ocp/cleanup-kagenti.sh
@@ -21,7 +21,6 @@
 
 set -euo pipefail
 
-KUBECTL="oc"
 AUTO_YES=false
 
 while [[ $# -gt 0 ]]; do
@@ -50,6 +49,30 @@ log_info()    { echo -e "${BLUE}→${NC} $1"; }
 log_success() { echo -e "${GREEN}✓${NC} $1"; }
 log_warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
 log_error()   { echo -e "${RED}✗${NC} $1"; }
+
+# Check for kubectl/oc
+if command -v oc &>/dev/null; then
+  KUBECTL=oc
+elif command -v kubectl &>/dev/null; then
+  KUBECTL=kubectl
+else
+  log_error "Neither oc nor kubectl found in PATH"
+  exit 1
+fi
+
+# Check cluster access
+if ! $KUBECTL cluster-info &>/dev/null; then
+  log_error "Cannot connect to cluster. Run 'oc login' first."
+  exit 1
+fi
+log_success "Connected to cluster"
+
+# Check python3
+if ! command -v python3 &>/dev/null; then
+  log_error "python3 not found in PATH. Install python3 >= 3.8"
+  exit 1
+fi
+log_success "python3 found: $(python3 --version)"
 
 echo ""
 echo "============================================"
@@ -105,9 +128,9 @@ _force_delete_ns() {
     return 0
   fi
   log_warn "  $ns stuck — stripping finalizers..."
-  $KUBECTL get namespace "$ns" -o json 2>/dev/null | \
-    jq '.spec.finalizers = []' | \
-    $KUBECTL replace --raw "/api/v1/namespaces/$ns/finalize" -f - 2>/dev/null || true
+  $KUBECTL get namespace "$ns" -o json 2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); d['spec']['finalizers']=[]; json.dump(d,sys.stdout)" \
+    | $KUBECTL replace --raw "/api/v1/namespaces/$ns/finalize" -f - >/dev/null 2>&1 || true
   sleep 3
   if $KUBECTL get namespace "$ns" &>/dev/null; then
     log_error "  $ns still exists — may need manual cleanup"

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -147,6 +147,13 @@ if ! command -v helm &>/dev/null; then
 fi
 log_success "helm found: $(helm version --short)"
 
+# Check python3
+if ! command -v python3 &>/dev/null; then
+  log_error "python3 not found in PATH. Install python3 >= 3.8"
+  exit 1
+fi
+log_success "python3 found: $(python3 --version)"
+
 # Resolve kagenti repo: local path, GitHub URL, or auto-clone from main
 _clone_kagenti() {
   local url="$1" dest="$2"
@@ -249,7 +256,7 @@ _ensure_user_workload_monitoring() {
   local merged
   merged="enableUserWorkload: true"$'\n'"$existing"
   $KUBECTL patch configmap cluster-monitoring-config -n openshift-monitoring \
-    --type=merge -p "{\"data\":{\"config.yaml\":$(echo "$merged" | jq -Rs .)}}" >/dev/null
+    --type=merge -p "{\"data\":{\"config.yaml\":$(echo "$merged" | python3 -c "import sys,json; sys.stdout.write(json.dumps(sys.stdin.read()))")}}" >/dev/null
   log_success "Merged enableUserWorkload: true into cluster-monitoring-config"
 }
 _ensure_user_workload_monitoring
@@ -715,7 +722,7 @@ _verify_release() {
     rc=1
   else
     local status
-    status=$(helm status "$release" -n "$ns" -o json 2>/dev/null | jq -r '.info.status // empty')
+    status=$(helm status "$release" -n "$ns" -o json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('info',{}).get('status',''), end='')" 2>/dev/null || echo "")
     if [ "$status" != "deployed" ]; then
       log_error "$release: status is '$status' (expected 'deployed')"
       rc=1
@@ -775,13 +782,7 @@ echo ""
 echo "============================================"
 echo "  Kagenti platform is ready!  (Time elapsed:${MINS}m ${SECS}s)"
 echo ""
-echo "  Namespace registration:"
-echo "    Namespaces self-register for webhook injection via label:"
-echo "      kubectl label namespace <ns> kagenti-enabled=true"
-echo "    setup.sh --with-a2a does this automatically."
-echo ""
-echo "  Next: deploy OpenClaw with A2A:"
-echo "    cd $REPO_ROOT"
-echo "    ./scripts/setup.sh --with-a2a"
-echo "============================================"
+echo "  Before deploying agents, add your namespace to the agentNamespaces"
+echo "  list in charts/kagenti/values.yaml so the platform provisions the"
+echo "  required resources in your namespace."
 echo ""


### PR DESCRIPTION
## Summary
Adds two bash scripts under `scripts/ocp/` to manage the full lifecycle of the Kagenti stack on OpenShift/ROSA clusters. `setup-kagenti.sh` installs the complete platform (SPIRE, cert-manager, Keycloak, operator, webhook, MCP Gateway, and optionally the UI/backend), while `cleanup-kagenti.sh` tears it all down cleanly, handling stuck namespaces and CRD finalizers with parallel deletion.

This script uses Helm Charts and removes the Ansible dependencies.

## Changes
- `scripts/ocp/setup-kagenti.sh` — installs Kagenti stack on OCP; supports `--kagenti-repo`, `--realm`, `--skip-ovn-patch`, `--skip-mcp-gateway`, `--skip-ui`, and `--dry-run` flags
- `scripts/ocp/cleanup-kagenti.sh` — uninstalls all Helm releases and namespaces in parallel.
- Tested on OCP 4.19+ (ROSA)

## Test Plan
- [x] Run `setup-kagenti.sh` against an OCP 4.19+ cluster and verify all components deploy successfully
- [x] Run `cleanup-kagenti.sh` and verify namespaces and Helm releases are fully removed