### PR TITLE
fix: Set Keycloak token lifespans and add 401 retry with token refresh

### DIFF
--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -279,6 +279,12 @@ def main() -> None:
                             "realm": keycloak_realm,
                             "enabled": True,
                             "registrationAllowed": False,
+                            # Token lifespans to prevent premature expiry (issue #1009).
+                            # Keycloak defaults to 5-minute access tokens, which causes
+                            # "Signature has expired" errors when refresh timing is imperfect.
+                            "accessTokenLifespan": 3600,  # 1 hour
+                            "ssoSessionIdleTimeout": 86400,  # 24 hours
+                            "ssoSessionMaxLifespan": 604800,  # 7 days
                         }
                     )
                     logger.info(f"Created Keycloak realm '{keycloak_realm}'")

--- a/kagenti/ui-v2/src/contexts/AuthContext.tsx
+++ b/kagenti/ui-v2/src/contexts/AuthContext.tsx
@@ -12,7 +12,7 @@ import React, {
 } from 'react';
 import Keycloak from 'keycloak-js';
 
-import { setTokenGetter } from '@/services/api';
+import { setTokenGetter, setTokenForceRefresher } from '@/services/api';
 
 import { keycloakRedirectUri } from './keycloakRedirectUri';
 
@@ -351,10 +351,33 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   }, [isEnabled]);
 
-  // Register token getter with API service
+  // Force-refresh token, bypassing cache (for 401 retry, issue #1009)
+  const forceRefreshToken = useCallback(async (): Promise<string | null> => {
+    if (!isEnabled) return null;
+
+    const keycloak = keycloakRef.current;
+    if (!keycloak || !keycloak.authenticated) return null;
+
+    try {
+      // Pass -1 to force refresh regardless of current token validity
+      await keycloak.updateToken(-1);
+      const freshToken = keycloak.token || null;
+      if (freshToken) {
+        sessionStorage.setItem('kagenti_access_token', freshToken);
+        setToken(freshToken);
+      }
+      return freshToken;
+    } catch {
+      console.error('Force token refresh failed');
+      return null;
+    }
+  }, [isEnabled]);
+
+  // Register token getter and force-refresher with API service
   useEffect(() => {
     setTokenGetter(getToken);
-  }, [getToken]);
+    setTokenForceRefresher(forceRefreshToken);
+  }, [getToken, forceRefreshToken]);
 
   const value = useMemo(
     () => ({

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -22,6 +22,9 @@ export const API_CONFIG = {
 // Token getter function - set by AuthContext
 let tokenGetter: (() => Promise<string | null>) | null = null;
 
+// Force-refresh function - set by AuthContext to bypass token cache
+let tokenForceRefresher: (() => Promise<string | null>) | null = null;
+
 /**
  * Set the token getter function. Called by AuthContext on initialization.
  */
@@ -30,7 +33,16 @@ export function setTokenGetter(getter: () => Promise<string | null>): void {
 }
 
 /**
- * Generic fetch wrapper with error handling and optional authentication
+ * Set the force-refresh function. Called by AuthContext on initialization.
+ * Used to get a fresh token on 401 responses (issue #1009).
+ */
+export function setTokenForceRefresher(refresher: () => Promise<string | null>): void {
+  tokenForceRefresher = refresher;
+}
+
+/**
+ * Generic fetch wrapper with error handling, optional authentication,
+ * and automatic token refresh on 401 responses.
  */
 async function apiFetch<T>(
   endpoint: string,
@@ -61,6 +73,36 @@ async function apiFetch<T>(
     headers,
     ...options,
   });
+
+  // On 401, try once with a force-refreshed token (issue #1009)
+  if (response.status === 401 && !skipAuth && tokenForceRefresher) {
+    try {
+      const freshToken = await tokenForceRefresher();
+      if (freshToken) {
+        const retryHeaders: HeadersInit = {
+          ...headers,
+          Authorization: `Bearer ${freshToken}`,
+        };
+        const retryResponse = await fetch(url, {
+          ...options,
+          headers: retryHeaders,
+        });
+        if (!retryResponse.ok) {
+          const errorData = await retryResponse.json().catch(() => ({}));
+          throw new Error(
+            errorData.detail || `API error: ${retryResponse.status} ${retryResponse.statusText}`
+          );
+        }
+        return retryResponse.json();
+      }
+    } catch (retryError) {
+      // If retry also fails, fall through to the original error
+      if (retryError instanceof Error && retryError.message.startsWith('API error:')) {
+        throw retryError;
+      }
+      console.warn('Token refresh retry failed:', retryError);
+    }
+  }
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));


### PR DESCRIPTION
## Summary

Fixes #1009

Keycloak realm was created with default 5-minute access token lifespan, causing frequent "Signature has expired" errors. Users reported this after just hours (sometimes days) of use, with no way to recover without clearing browser cache or restarting all deployments.

## Changes

**1. Set token lifespans on realm bootstrap** (`kagenti/auth/ui-oauth-secret/auth_secret.py`)
- `accessTokenLifespan`: 1 hour (vs 5-minute Keycloak default)
- `ssoSessionIdleTimeout`: 24 hours
- `ssoSessionMaxLifespan`: 7 days

**2. Add 401 retry with force-refreshed token** (`kagenti/ui-v2/src/services/api.ts`, `kagenti/ui-v2/src/contexts/AuthContext.tsx`)
- On 401 response, the API service calls `keycloak.updateToken(-1)` to force-refresh the token (bypassing cache)
- Retries the failed request once with the fresh token
- If retry also fails, throws the original error

## Why both fixes?

| Fix | What it prevents |
|-----|-----------------|
| Longer token lifespan | Reduces frequency of refreshes, fewer chances for expiry gaps |
| 401 retry with refresh | Catches remaining edge cases (backgrounded tabs, network blips, refresh timing gaps) |

## Test plan

- [ ] Deploy to Kind cluster with auth enabled
- [ ] Verify new realm gets 1-hour token lifespan: `kubectl exec -it deployment/keycloak -n keycloak -- curl -s http://localhost:8080/realms/kagenti | jq .accessTokenLifespan` (should return 3600)
- [ ] Verify 401 retry: temporarily set short token lifespan, let token expire, confirm API call succeeds after automatic refresh
- [ ] CI passes