### PR TITLE
🐛 Allow MLFlow to accept traffic on any port under Kagenti

### DIFF
--- a/charts/kagenti-deps/templates/mlflow.yaml
+++ b/charts/kagenti-deps/templates/mlflow.yaml
@@ -154,7 +154,8 @@ spec:
             ALLOWED_HOSTS="$ROUTE_HOST,$ALLOWED_HOSTS"
           fi
           {{- else }}
-          ALLOWED_HOSTS="mlflow.{{ .Values.domain | default "localtest.me" }}:*,mlflow.{{ .Values.domain | default "localtest.me" }},mlflow,mlflow:*,mlflow.{{ .Release.Namespace }},mlflow.{{ .Release.Namespace }}:5000,mlflow.{{ .Release.Namespace }}.svc.cluster.local,mlflow.{{ .Release.Namespace }}.svc.cluster.local:5000,localhost,localhost:*,127.0.0.1,127.0.0.1:*"
+          ALLOWED_HOSTS="mlflow.{{ .Values.domain | default "localtest.me" }}:*,mlflow:*,mlflow.{{ .Release.Namespace }}:5000,mlflow.{{ .Release.Namespace }}.svc.cluster.local:5000,localhost:*,127.0.0.1:*"
+          ALLOWED_HOSTS="$ALLOWED_HOSTS,mlflow.{{ .Values.domain | default "localtest.me" }},mlflow,mlflow.{{ .Release.Namespace }},mlflow.{{ .Release.Namespace }}.svc.cluster.local,localhost,127.0.0.1"
           {{- end }}
           {{- if .Values.mlflow.auth.enabled }}
           # Set MLflow config via environment variables (used by mlflow_oidc_auth.app)


### PR DESCRIPTION
## Summary

Resolves #1101 by allowing MLFlow to serve its UI on any port when installed on _kind_.

When Kagenti is installed on _kind_, extraPortMappings are created so that http://*.localtest.me:8080/ routes to the various Kagenti components.  However, MLFlow was configured to only allow port 80, which does not work with Kind.

This relaxes MLFlow's rules to allow it to accept traffic on most ports.  This seemed better than supporting only :80 and :8080.  This may also help with port-forward.

## (Optional) Testing Instructions

Follow the instructions in #1101 and verify that you may visit or _curl_ http://mlflow.localtest.me:8080/ after installing using this PR.

Do `oc -n kagenti-system port-forward deployment/mlflow 6000:5000` and verify you can `curl localhost:6000`

Fixes #

#1101