### PR TITLE
fix(ci): bump Go to 1.24 for hcp CLI build in HyperShift E2E

### DIFF
--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: false  # No go.sum at repo root; hcp CLI builds in /tmp
 
       - name: Build hcp CLI from source
@@ -273,7 +273,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: false  # No go.sum at repo root; hcp CLI builds in /tmp
 
       - name: Build hcp CLI from source


### PR DESCRIPTION
## Summary

HyperShift source now requires Go 1.24+. The `hcp` CLI build from source fails with Go 1.23.

This is a one-line change (`go-version: '1.23'` → `'1.24'`) in both jobs of `e2e-hypershift.yaml`.

Must merge to main because the workflow uses `pull_request_target` which reads the workflow file from the base branch, not the PR branch.

## Test plan

- [ ] HyperShift E2E passes after merge (trigger `/run-e2e` on PR #1095)

🤖 Generated with [Claude Code](https://claude.com/claude-code)