### PR TITLE
chore: remove unused postgres Dockerfile and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,16 +96,6 @@ updates:
         update-types: [minor, patch]
 
   - package-ecosystem: docker
-    directory: /.github/dockerfiles/postgres
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-
-  - package-ecosystem: docker
     directory: /.github/dockerfiles/python12
     schedule:
       interval: weekly

--- a/.github/dockerfiles/postgres/Dockerfile
+++ b/.github/dockerfiles/postgres/Dockerfile
@@ -1,7 +1,0 @@
-FROM postgres:18.3@sha256:69e8582b781cb44fa4557b98ed586fe68361e320d9b12f9707494335634f4f3d
-RUN mkdir temp
-RUN groupadd non-root-postgres-group
-RUN useradd non-root-postgres-user --group non-root-postgres-group
-RUN chown -R non-root-postgres-user:non-root-postgres-group /temp
-RUN chmod 777 /temp
-USER non-root-postgres

--- a/.github/workflows/build-dependency-images.yml
+++ b/.github/workflows/build-dependency-images.yml
@@ -24,9 +24,6 @@ jobs:
     strategy:
       matrix:
         image_config:
-          - name: postgres
-            path: ./.github/dockerfiles/postgres
-            tag: '17.6'
           - name: python
             path: ./.github/dockerfiles/python12
             tag: '3.12-slim'


### PR DESCRIPTION
## Summary

- Remove `.github/dockerfiles/postgres/Dockerfile` — dead code, not referenced anywhere in the codebase
- Remove the postgres entry from `.github/dependabot.yml` to stop generating no-op Dependabot PRs
- Remove the postgres entry from the `build-dependency-images.yml` workflow matrix

All Helm charts use upstream postgres images (`mirror.gcr.io/postgres`, `quay.io/fedora/postgresql-*`, `quay.io/sclorg/postgresql-*`), not `ghcr.io/kagenti/postgres`. The workflow was also manual-only (`workflow_dispatch`) and had a version mismatch (matrix tagged `17.6`, Dockerfile pinned `18.3`).

Closes #1081 (Dependabot PR closed as not needed).

## Test plan

- [ ] CI passes (no functional changes — only removing unused files)
- [ ] Verify `build-dependency-images.yml` still builds the python image correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)