### PR TITLE
fix: bump all sidecar images to v0.4.0-alpha.10

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -170,10 +170,10 @@ keycloak:
 kagenti-webhook-chart:
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.9
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.9
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.11.0
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.4.0-alpha.9
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.10
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.10
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.4.0-alpha.10
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.4.0-alpha.10
 
 # ------------------------------------------------------------------
 #  Kagenti Operator Configuration


### PR DESCRIPTION
## Summary

- Bump all AuthBridge sidecar container images from `v0.4.0-alpha.9` to `v0.4.0-alpha.10`
- Fix `spiffeHelper` image which was incorrectly set to the upstream version (`v0.11.0`) instead of the kagenti-extensions build version

| Image | Before | After |
|-------|--------|-------|
| envoyProxy | v0.4.0-alpha.9 | v0.4.0-alpha.10 |
| proxyInit | v0.4.0-alpha.9 | v0.4.0-alpha.10 |
| spiffeHelper | v0.11.0 | v0.4.0-alpha.10 |
| clientRegistration | v0.4.0-alpha.9 | v0.4.0-alpha.10 |

## Test plan

- [ ] CI passes (Helm lint, YAML lint)
- [ ] Verify images exist at `ghcr.io/kagenti/kagenti-extensions/*:v0.4.0-alpha.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)