### PR TITLE
fix: remove duplicate keycloak-js ignore in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,10 +48,6 @@ updates:
       # which is unavailable over plain HTTP. Block until all environments use HTTPS.
       - dependency-name: "keycloak-js"
         update-types: [version-update:semver-major]
-      # keycloak-js 26.x requires Web Crypto API (crypto.randomUUID, crypto.subtle)
-      # which is unavailable over plain HTTP. Block until all environments use HTTPS.
-      - dependency-name: "keycloak-js"
-        update-types: [version-update:semver-major]
       # PatternFly packages must be upgraded together (PF5→PF6).
       # Block major version bumps to prevent partial upgrades.
       - dependency-name: "@patternfly/*"


### PR DESCRIPTION
## Summary

Remove duplicate `keycloak-js` ignore entry that causes Dependabot config validation to fail on **all PRs**.

Error:
```
The property '#/updates/3/ignore/1/update-types' includes a duplicate.
Ignores must have a unique combination of 'dependency-name' and 'update-types'
```

1 file, 4 lines deleted.