### PR TITLE
Feat: Create two demo users when creating a Keycloak realm during Kagenti install

### DIFF
--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -33,7 +33,7 @@ DEFAULT_ADMIN_PASSWORD_KEY = "password"
 OAUTH_REDIRECT_PATH = "/"
 OAUTH_SCOPE = "openid profile email"
 SERVICE_ACCOUNT_CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-DEFAULT_DEMO_USERS = ("demo1", "demo2")
+DEFAULT_DEMO_USERS = ("bob", "alice")
 DEFAULT_DEMO_PASSWORDS = ("kagenti1", "kagenti2")
 DEFAULT_DEMO_PASSWORD_OVERRIDE_ENV_VARS = (
     "KEYCLOAK_DEMO1_PASSWORD",


### PR DESCRIPTION
## Summary

Resolves #1120

## Testing Instructions

Build image with

```bash
docker build --load -t ghcr.io/kagenti/kagenti/ui-oauth-secret:ecs-test -f kagenti/auth/ui-oauth-secret/Dockerfile kagenti/
```

Create a variables override file:

```bash
cat <<EOF > /tmp/custom-ui-oauth-secret-image.yaml
charts:
  kagenti:
    values:
      uiOAuthSecret:
        tag: ecs-test
        imagePullPolicy: Never
EOF
```

Recreate your Kind cluster and load the test image:

```bash
kind delete cluster --name kagenti && \
  kind create cluster --name kagenti --config deployments/ansible/kind/kind-config-registry.yaml && \
  kind load docker-image ghcr.io/kagenti/kagenti/ui-oauth-secret:ecs-test --name kagenti
```

Redeploy Kagenti:

```
deployments/ansible/run-install.sh --env dev --env-file /tmp/custom-ui-oauth-secret-image.yaml
```
