### PR TITLE
Fix: (charts) align SPIRE operand CRs with OCP 4.19 ZTWIM CRD schemas

### DIFF
--- a/charts/kagenti-deps/templates/spire-operand.yaml
+++ b/charts/kagenti-deps/templates/spire-operand.yaml
@@ -6,7 +6,9 @@
   (SpireServer, SpireAgent, SpiffeCSIDriver, SpireOIDCDiscoveryProvider) can be configured.
 
   This CR defines the cluster-wide SPIRE configuration including trust domain and cluster name.
-  The individual operands reference this configuration.
+  The individual operands inherit trustDomain and clusterName from this parent CR —
+  those fields must NOT be set on the child operands (SpireServer, SpireAgent, etc.)
+  as their CRDs do not include them on OCP 4.19.
 */}}
 apiVersion: operator.openshift.io/v1alpha1
 kind: ZeroTrustWorkloadIdentityManager
@@ -51,14 +53,14 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  trustDomain: {{ .Values.spire.trustDomain }}
-  clusterName: agent-platform
+  # trustDomain and clusterName are inherited from the ZeroTrustWorkloadIdentityManager CR
   caSubject:
     commonName: {{ .Values.spire.trustDomain }}
     country: "US"
     organization: "RH"
   persistence:
-    type: pvc
+    # type: pvc was removed — the OCP 4.19 ZTWIM CRD does not include this field;
+    # the operator defaults to pvc when omitted.
     size: "5Gi"
     accessMode: ReadWriteOnce
   datastore:
@@ -80,8 +82,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  trustDomain: {{ .Values.spire.trustDomain }}
-  clusterName: agent-platform
+  # trustDomain and clusterName are inherited from the ZeroTrustWorkloadIdentityManager CR
   nodeAttestor:
     k8sPSATEnabled: "true"
   workloadAttestors:
@@ -100,7 +101,8 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  trustDomain: {{ .Values.spire.trustDomain }}
-  agentSocketName: 'spire-agent.sock'
+  # trustDomain is inherited from the ZeroTrustWorkloadIdentityManager CR
+  # OCP 4.19 ZTWIM CRD replaced agentSocketName with csiDriverName
+  csiDriverName: csi.spiffe.io
   jwtIssuer: "https://oidc-discovery-provider.{{.Values.spire.trustDomain}}"
 {{- end }}


### PR DESCRIPTION
## Summary

Takes over #782 (by @sallyom), rebased onto current main with review comments addressed.

On OpenShift 4.19, the ZTWIM operator CRDs have a different field layout than what the chart was generating. Without this fix, `helm install kagenti-deps` fails on a fresh OCP 4.19 cluster with:

```
failed to create typed patch object: .spec.clusterName: field not declared in schema
```

### Changes

- Remove `trustDomain` and `clusterName` from child operands (SpireServer, SpireAgent, SpireOIDCDiscoveryProvider) — inherited from the parent ZeroTrustWorkloadIdentityManager CR
- Remove `persistence.type: pvc` from SpireServer — field not in OCP 4.19 CRD; operator defaults to pvc when omitted
- Replace `agentSocketName` with `csiDriverName` on SpireOIDCDiscoveryProvider — field renamed in OCP 4.19 CRD

### Review comments addressed (from #782)

- **Commit 2 (Keycloak keys in environments ConfigMap) dropped** — superseded by `authbridge-config` ConfigMap and `keycloak-admin-secret` Secret already on main, which address the hardcoded credentials concern
- Added inline comments explaining `persistence.type` removal and `csiDriverName` change

Tested on OCP 4.19.24 (original author).

## Related issue(s)

Closes #781
Supersedes #782

## Test plan

- [ ] `helm template` renders without errors
- [ ] Deploy kagenti-deps on OCP 4.19 — SPIRE operands create successfully
- [ ] SPIRE agent and server come up healthy