### PR TITLE
docs: add platform use cases and cross-link scenario docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,12 @@ Kagenti is built on existing open-source cloud-native technologies.
 ## Demos and Tutorials
 
 For a complete list of available demos and tutorials, see the [Demos Documentation](./demos/README.md).
+## Vision & Use Cases
+
+- [Use Cases](./user-stories.md) — Platform-wide scenarios organized by persona: deployment, governance, observability, identity, developer experience, and more.
+- [Use Case Types](./use-case-types.md) — Taxonomy of agent operational models the platform supports (read-only insight, synchronous task, async task, monitoring, event-driven).
+- [Personas and Roles](../PERSONAS_AND_ROLES.md) — The people who use and operate Kagenti.
+
 ## Core Concepts
 
 Through this incubation project, we have identified several core components: 

--- a/docs/use-case-types.md
+++ b/docs/use-case-types.md
@@ -9,6 +9,10 @@ Kagenti supports deploying and orchestrating multiple categories of AI‑driven 
 
 Kagenti’s system and security architecture is designed to accommodate the requirements and constraints of each use‑case type.
 
+For platform-wide scenarios organized by persona (deployment, governance,
+observability, identity, developer experience, etc.), see
+[Use Cases](./user-stories.md).
+
 ## 1. Knowledge & Analysis Insight Service​
 
 A read‑only system that retrieves, synthesizes, and analyzes organizational content to deliver evidence‑backed, cited insights without taking external actions. ​

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -4,6 +4,10 @@ Scenarios that define the Kagenti vision across verticals. Each maps to a
 persona from [PERSONAS_AND_ROLES.md](../PERSONAS_AND_ROLES.md). Detailed
 drill-downs are linked where they exist.
 
+For the taxonomy of agent operational models these scenarios target (read-only
+insight, synchronous task, async task, monitoring, event-driven), see
+[Use Case Types](./use-case-types.md).
+
 ## Index
 
 | Area | Personas | Drill-Down |


### PR DESCRIPTION
## Summary

- Add `docs/user-stories.md` — platform-wide use cases organized by persona covering deployment & access control, platform governance, identity & trust, observability, agent lifecycle, agent discovery, multi-tenancy, developer experience, and inbox pattern. Links to Ladas's agentic runtime use cases in PR #1005 as a drill-down.
- Cross-link `docs/use-case-types.md` (agent operational model taxonomy) and the new use cases doc so they reference each other.
- Add a "Vision & Use Cases" section to `docs/README.md` linking both documents and the personas doc.

## Test plan

- [ ] Review use case coverage with team — especially inbox pattern and observability stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)