### PR TITLE
Fix: restore missing ui-v2 modules dropped during rebase

### DIFF
--- a/kagenti/ui-v2/src/components/index.ts
+++ b/kagenti/ui-v2/src/components/index.ts
@@ -12,4 +12,3 @@ export {
   formatDuration,
   getProgressInfo,
 } from './BuildProgressView';
-export { SkillWhisperer, type SkillItem } from './SkillWhisperer';

--- a/kagenti/ui-v2/src/types/graphCard.ts
+++ b/kagenti/ui-v2/src/types/graphCard.ts
@@ -1,0 +1,66 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+/**
+ * Types for agent graph-card topology data.
+ *
+ * A graph card describes the static structure of a LangGraph agent:
+ * its nodes, edges, and event catalog.
+ */
+
+// ---------------------------------------------------------------------------
+// Event catalog
+// ---------------------------------------------------------------------------
+
+/** The seven stable event categories used by loop event processing. */
+export type EventCategory =
+  | 'reasoning'
+  | 'execution'
+  | 'tool_output'
+  | 'decision'
+  | 'terminal'
+  | 'meta'
+  | 'interaction';
+
+/** Definition of a single event type in the catalog. */
+export interface EventTypeDef {
+  category: EventCategory;
+  description: string;
+}
+
+// ---------------------------------------------------------------------------
+// Graph topology
+// ---------------------------------------------------------------------------
+
+export interface GraphNode {
+  description: string;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  condition: string | null;
+  description?: string;
+}
+
+export interface GraphTopology {
+  description: string;
+  entry_node: string;
+  terminal_nodes: string[];
+  nodes: Record<string, GraphNode>;
+  edges: GraphEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// Agent graph card
+// ---------------------------------------------------------------------------
+
+export interface AgentGraphCard {
+  id: string;
+  description: string;
+  framework: string;
+  version: string;
+  event_catalog: Record<string, EventTypeDef>;
+  common_event_fields: Record<string, unknown>;
+  topology: GraphTopology;
+}


### PR DESCRIPTION
## Summary

- Add `kagenti/ui-v2/src/types/graphCard.ts` — defines `AgentGraphCard`, `EventTypeDef`, `EventCategory`, and `GraphTopology` types used by `api.ts` and `loopBuilder.ts`
- Remove dangling `SkillWhisperer` re-export from `components/index.ts` — the component file doesn't exist

## Context

PR #986 lost these files during a rebase (commit message mentions "restore utils and styles dropped during rebase" but missed these two). This broke `npm run build` / `tsc` with:

```
TS2307: Cannot find module './SkillWhisperer'
TS2307: Cannot find module '@/types/graphCard'
```

The Build-Publish workflow has been failing on main since Apr 1, blocking container image builds for v0.6.0-alpha.3.

## Test plan

- [x] `npx tsc --noEmit` passes locally with zero errors
- [ ] CI Build-Publish succeeds after merge

## Urgency

Blocks v0.6.0-alpha.3 container images. The tag is already created but images can't be built until this lands.