### PR TITLE
Bug fix: Use correct location for 30-build-dep-image.sh

### DIFF
--- a/.github/scripts/common/31-build-deps-from-refs.sh
+++ b/.github/scripts/common/31-build-deps-from-refs.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/env-detect.sh"
 source "$SCRIPT_DIR/../lib/logging.sh"
-# Note that we must set SCRIPT_DIR again *after* running the above scripts,
-# as they override SCRIPT_DIR.
+# Note that we set SCRIPT_DIR again *after* running the above scripts,
+# as env-detect.sh overrides SCRIPT_DIR.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # No hardcoded defaults — chart deps are up-to-date (webhook v0.4.0-alpha.9).


### PR DESCRIPTION
## Summary

Resolves #1139 by recalculating the directory path after it is corrupted by a `source`d script.

## (Optional) Testing Instructions

- Create a Kind cluster
- Do `./.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy`
- Verify the above does not print ".github/scripts/lib/30-build-dep-image.sh: No such file or directory"