### PR TITLE
fix: use DNS_PING for Keycloak JGroups cluster discovery

### DIFF
--- a/charts/kagenti-deps/templates/keycloak-k8s.yaml
+++ b/charts/kagenti-deps/templates/keycloak-k8s.yaml
@@ -233,13 +233,17 @@ extraEnvVars with the same name override these defaults.
 - name: KC_HEALTH_ENABLED
   value: "true"
 - name: KC_CACHE
-  value: "ispn"
+  value: {{ .Values.keycloak.cache | default "local" | quote }}
+{{- if eq (.Values.keycloak.cache | default "local") "ispn" }}
 - name: POD_IP
   valueFrom:
     fieldRef:
       fieldPath: status.podIP
+- name: KC_CACHE_STACK
+  value: "kubernetes"
 - name: JAVA_OPTS_APPEND
-  value: "-Djgroups.bind.address=$(POD_IP)"
+  value: "-Djgroups.bind.address=$(POD_IP) -Djgroups.dns.query=keycloak-discovery.{{ .Values.keycloak.namespace }}.svc.cluster.local"
+{{- end }}
 {{- if .Values.keycloak.database.enabled }}
 - name: KC_DB_URL_DATABASE
   value: "keycloak"


### PR DESCRIPTION
## Summary

- Set `KC_CACHE_STACK=kubernetes` to use DNS_PING instead of JDBC_PING for JGroups cluster discovery
- Configure `jgroups.dns.query` to use the existing `keycloak-discovery` headless Service
- Eliminates `duplicate key violates unique constraint "constraint_jgroups_ping"` errors on pod restarts

## Root cause

JDBC_PING stores cluster membership in a PostgreSQL table (`jgroups_ping`). When Keycloak pods restart (Helm upgrade, CI redeploy), stale entries from the old pod remain. The new pod tries to insert with the same node name → constraint violation → Keycloak crashes → all E2E tests fail.

DNS_PING uses Kubernetes DNS (headless Service) for member discovery — no DB table, no stale entries, works for both single and multi-replica.

## Test plan

- [ ] Kind Deploy & Test passes without Keycloak constraint errors
- [ ] Keycloak health endpoint responds after deploy
- [ ] Agent E2E tests pass (Keycloak auth works)