### PR TITLE
feat: support AGENT_EXAMPLES_BRANCH override for weather tool builds

### DIFF
--- a/.github/scripts/kagenti-operator/71-build-weather-tool.sh
+++ b/.github/scripts/kagenti-operator/71-build-weather-tool.sh
@@ -63,9 +63,16 @@ else
     kubectl delete builds.shipwright.io weather-tool -n team1 --ignore-not-found 2>/dev/null || true
     sleep 2
 
-    # Apply build manifest
+    # Apply build manifest (override branch via AGENT_EXAMPLES_BRANCH env var)
     log_info "Creating Shipwright Build..."
-    kubectl apply -f "$REPO_ROOT/kagenti/examples/tools/weather_tool_shipwright_build.yaml"
+    AGENT_EXAMPLES_BRANCH="${AGENT_EXAMPLES_BRANCH:-main}"
+    if [ "$AGENT_EXAMPLES_BRANCH" != "main" ]; then
+        log_info "Using agent-examples branch: $AGENT_EXAMPLES_BRANCH"
+        sed "s|revision: main|revision: $AGENT_EXAMPLES_BRANCH|" \
+            "$REPO_ROOT/kagenti/examples/tools/weather_tool_shipwright_build.yaml" | kubectl apply -f -
+    else
+        kubectl apply -f "$REPO_ROOT/kagenti/examples/tools/weather_tool_shipwright_build.yaml"
+    fi
 
     # Wait for Shipwright Build to be registered
     run_with_timeout 60 'until kubectl get builds.shipwright.io weather-tool -n team1 &> /dev/null; do sleep 2; done' || {


### PR DESCRIPTION
## Summary

- Add `AGENT_EXAMPLES_BRANCH` env var to `71-build-weather-tool.sh`
- When set to a non-main branch, the Shipwright Build uses that branch for the weather tool source
- Enables testing agent-examples PRs (e.g., kagenti/agent-examples#222 - weather tool retry fix) from kagenti CI

## Usage

```bash
# In CI workflow or local test:
AGENT_EXAMPLES_BRANCH=fix/weather-tool-resilience .github/scripts/kagenti-operator/71-build-weather-tool.sh
```

## Context

The weather MCP tool has no retry logic for external API calls. kagenti/agent-examples#222 adds retry with exponential backoff. This PR allows testing that fix from kagenti's E2E CI before the agent-examples PR merges.