### PR TITLE
fix: migrate from old MaaS to LiteMaaS for LLM endpoints

### DIFF
--- a/deployments/sandbox/agents/legion/deployment.yaml
+++ b/deployments/sandbox/agents/legion/deployment.yaml
@@ -38,11 +38,14 @@ spec:
         - name: PYTHONPATH
           value: /app
         - name: LLM_MODEL
-          value: llama-4-scout-17b-16e-w4a16
+          value: llama-scout-17b
         - name: LLM_API_BASE
-          value: https://llama-4-scout-17b-16e-w4a16-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1
+          value: https://litellm-prod.apps.maas.redhatworkshops.io/v1
         - name: LLM_API_KEY
-          value: 51cd949ed51d30df4c8a18e30c2da773
+          valueFrom:
+            secretKeyRef:
+              name: openai-secret
+              key: apikey
         - name: OPENAI_API_KEY
           valueFrom:
             secretKeyRef:

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -49,7 +49,7 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "https://llama-4-scout-17b-16e-w4a16-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1"
+          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
         - name: OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
@@ -61,7 +61,7 @@ spec:
               name: openai-secret
               key: apikey
         - name: LLM_MODEL
-          value: "llama-4-scout-17b-16e-w4a16"
+          value: "llama-scout-17b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:


### PR DESCRIPTION
## Summary

Old MaaS (`maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com`) was shut down on 2026-04-03. All LLM endpoints return 503. This migrates to LiteMaaS (`litellm-prod.apps.maas.redhatworkshops.io`).

- Weather agent OCP deployment: updated `LLM_API_BASE` and `LLM_MODEL`
- Sandbox legion deployment: updated endpoint, model, and replaced hardcoded API key with `secretKeyRef`
- Model name: `llama-4-scout-17b-16e-w4a16` → `llama-scout-17b`

## GitHub Secret Update Required

After merging, update the GitHub Actions secret:
```
gh secret set OPENAI_API_KEY --repo kagenti/kagenti
```
(paste the LiteMaaS API key from `.env.maas`)

## Test plan

- [x] `curl /v1/models` returns `llama-scout-17b` ✓
- [x] Chat completion works with new endpoint ✓
- [ ] E2E HyperShift tests pass with new endpoint