### PR TITLE
fix: Delete HTTPRoute when deleting an A2A agent in UI

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -813,6 +813,7 @@ async def delete_agent(
     This deletes:
     - Deployment, StatefulSet, or Job (whichever exists)
     - Service
+    - HTTPRoute (if exists)
     - Shipwright Build CR (if exists)
     - Shipwright BuildRun CRs (if exist)
     - Legacy: Agent CR (if exists, for backward compatibility)
@@ -859,6 +860,23 @@ async def delete_agent(
             pass
         else:
             logger.warning(f"Failed to delete Service '{name}': {e.reason}")
+
+    # Delete the HTTPRoute (if exists)
+    try:
+        kube.delete_custom_resource(
+            group="gateway.networking.k8s.io",
+            version="v1",
+            namespace=namespace,
+            plural="httproutes",
+            name=name,
+        )
+        messages.append(f"HTTPRoute '{name}' deleted")
+    except ApiException as e:
+        if e.status == 404:
+            # HTTPRoute doesn't exist, that's fine
+            pass
+        else:
+            logger.warning(f"Failed to delete HTTPRoute '{name}': {e.reason}")
 
     # Delete the AgentRuntime CR (if exists)
     try:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

- Add logic to delete a custom resource HTTPRoute in `kagenti/backend/app/routers/agents.py` if it exists when agent is deleted through UI, and document this in the docstring of the method.

## Context

When an A2A agent is deleted through the Kagenti UI, its HTTPRoute resource is left behind. This leads to orphaned networking resources and inconsistent cleanup of agent-related Kubernetes objects.

Fixes #829 

## Tests

Verified by:
- Creating an A2A agent and confirming HTTPRoute exists (`oc get httproute`)
- Deleting the agent via UI
- Confirming the HTTPRoute is removed

- [x] The HTTPRoute is deleted when the A2A agent is deleted through UI on Kind
- [x] The HTTPRoute is deleted when the A2A agent is deleted through UI on OpenShift
