### PR TITLE
fix: point Kind weather agent to LiteMaaS instead of Ollama

### DIFF
--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Create secret values file for CI
         run: bash .github/scripts/common/20-create-secrets.sh
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Run Ansible installer (dev mode with kagenti-operator)
         run: bash .github/scripts/kagenti-operator/30-run-installer.sh

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -62,6 +62,8 @@ jobs:
         run: bash .github/scripts/common/10-setup-dependencies.sh
 
       - name: Create secret values file for CI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: bash .github/scripts/common/20-create-secrets.sh
 
       - name: Run Ansible installer (dev mode with kagenti-operator)

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -50,11 +50,14 @@ spec:
         - name: MCP_URL
           value: "http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp"
         - name: LLM_API_BASE
-          value: "http://dockerhost:11434/v1"
+          value: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
         - name: LLM_API_KEY
-          value: "dummy"
+          valueFrom:
+            secretKeyRef:
+              name: openai-secret
+              key: apikey
         - name: LLM_MODEL
-          value: "qwen2.5:3b"
+          value: "llama-scout-17b"
         - name: GITHUB_SECRET_NAME
           value: "github-token-secret"
         ports:


### PR DESCRIPTION
## Summary

Switch Kind weather agent deployment from Ollama (dockerhost:11434) to LiteMaaS. The agent-examples `has_valid_api_key` check rejects dummy keys for non-localhost hosts, breaking Kind Deploy&Test on main.

Uses the same LiteMaaS endpoint as OCP + `secretKeyRef` for API key from `openai-secret`.

## Context

Main's E2E Kind is broken since the `has_valid_api_key` check was added to agent-examples.