### PR TITLE
fix(ui): Repair Outbound Routing Rules expand and Add Route on import pages

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidEnvVarName, isValidContainerImage, isValidImageTag } from '../utils/validation';
+import { newRouteRowId } from '../utils/routeRowId';
 import {
   PageSection,
   Title,
@@ -179,7 +180,11 @@ export const ImportAgentPage: React.FC = () => {
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
-  const addRoute = () => setOutboundRoutes([...outboundRoutes, { id: crypto.randomUUID(), host: '', target_audience: '', token_scopes: 'openid' }]);
+  const addRoute = () =>
+    setOutboundRoutes((prev) => [
+      ...prev,
+      { id: newRouteRowId(), host: '', target_audience: '', token_scopes: 'openid' },
+    ]);
   const removeRoute = (i: number) => setOutboundRoutes(outboundRoutes.filter((_, idx) => idx !== i));
   const updateRoute = (i: number, field: string, value: string) => {
     const updated = [...outboundRoutes];
@@ -192,6 +197,7 @@ export const ImportAgentPage: React.FC = () => {
   const [inboundPortsExclude, setInboundPortsExclude] = useState('');
   // AuthBridge config overrides
   const [defaultOutboundPolicy, setDefaultOutboundPolicy] = useState('passthrough');
+  const [showOutboundRouting, setShowOutboundRouting] = useState(false);
 
   // Validation state
   const [validated, setValidated] = useState<Record<string, 'success' | 'error' | 'default'>>({});
@@ -1071,7 +1077,8 @@ export const ImportAgentPage: React.FC = () => {
               {authBridgeEnabled && (
               <ExpandableSection
                 toggleText={`Outbound Routing Rules (${outboundRoutes.length} route${outboundRoutes.length !== 1 ? 's' : ''})`}
-                isExpanded={outboundRoutes.length > 0}
+                isExpanded={showOutboundRouting}
+                onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
               >
                 <Text component="p" style={{ marginBottom: '8px' }}>
                   Configure token exchange rules for outbound HTTP requests. Each route matches a service host and specifies the target audience and OAuth scopes for the exchanged token.

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -267,8 +267,10 @@ export const ImportToolPage: React.FC = () => {
     const [, org, repo] = githubMatch;
     const branch = gitBranch || 'main';
     const path = gitPath.replace(/^\/+|\/+$/g, '');
+    // GitHub Tool AuthBridge demo uses Keycloak/JWKS env + secret refs (not LLM keys).
+    const envFile = path === 'mcp/github_tool' ? '.env.authbridge' : '.env.openai';
 
-    return `https://raw.githubusercontent.com/${org}/${repo}/refs/heads/${branch}/${path}/.env.openai`;
+    return `https://raw.githubusercontent.com/${org}/${repo}/refs/heads/${branch}/${path}/${envFile}`;
   };
 
   // Environment variable handlers

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidEnvVarName, isValidContainerImage, isValidImageTag } from '../utils/validation';
+import { newRouteRowId } from '../utils/routeRowId';
 import {
   PageSection,
   Title,
@@ -157,7 +158,11 @@ export const ImportToolPage: React.FC = () => {
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
-  const addRoute = () => setOutboundRoutes([...outboundRoutes, { id: crypto.randomUUID(), host: '', target_audience: '', token_scopes: 'openid' }]);
+  const addRoute = () =>
+    setOutboundRoutes((prev) => [
+      ...prev,
+      { id: newRouteRowId(), host: '', target_audience: '', token_scopes: 'openid' },
+    ]);
   const removeRoute = (i: number) => setOutboundRoutes(outboundRoutes.filter((_, idx) => idx !== i));
   const updateRoute = (i: number, field: string, value: string) => {
     const updated = [...outboundRoutes];
@@ -170,6 +175,7 @@ export const ImportToolPage: React.FC = () => {
   const [inboundPortsExclude, setInboundPortsExclude] = useState('');
   // AuthBridge config overrides
   const [defaultOutboundPolicy, setDefaultOutboundPolicy] = useState('passthrough');
+  const [showOutboundRouting, setShowOutboundRouting] = useState(false);
 
   // Validation state
   const [validated, setValidated] = useState<Record<string, 'success' | 'error' | 'default'>>({});
@@ -1023,7 +1029,8 @@ export const ImportToolPage: React.FC = () => {
               {authBridgeEnabled && (
               <ExpandableSection
                 toggleText={`Outbound Routing Rules (${outboundRoutes.length} route${outboundRoutes.length !== 1 ? 's' : ''})`}
-                isExpanded={outboundRoutes.length > 0}
+                isExpanded={showOutboundRouting}
+                onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
               >
                 <Text component="p" style={{ marginBottom: '8px' }}>
                   Configure token exchange rules for outbound HTTP requests. Each route matches a service host and specifies the target audience and OAuth scopes for the exchanged token.

--- a/kagenti/ui-v2/src/utils/routeRowId.ts
+++ b/kagenti/ui-v2/src/utils/routeRowId.ts
@@ -1,0 +1,21 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+/**
+ * Unique id for outbound route row keys (React `key` prop).
+ *
+ * Avoid calling `crypto.randomUUID()` directly: on http:// hosts such as
+ * kagenti-ui.localtest.me it may be missing or throw; some browsers expose
+ * `crypto` without `randomUUID`.
+ */
+export function newRouteRowId(): string {
+  try {
+    const c = globalThis.crypto;
+    if (c != null && typeof c.randomUUID === 'function') {
+      return c.randomUUID();
+    }
+  } catch {
+    /* Secure-context or implementation errors */
+  }
+  return `r-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
+}


### PR DESCRIPTION
## What
- Control **Outbound Routing Rules** `ExpandableSection` with `showOutboundRouting` state and `onToggle`, matching other sections (Pod Configuration, Environment Variables). Previously `isExpanded={outboundRoutes.length > 0}` with no toggle kept the panel closed when empty, so **Add Route** was unreachable.
- Add `newRouteRowId()` in `utils/routeRowId.ts` with try/catch and fallback IDs when `crypto.randomUUID` is missing or throws (e.g. HTTP `localtest.me` installs). `addRoute` uses functional `setOutboundRoutes` for correct updates.
- On **Import Tool**, when the source path is `mcp/github_tool`, the default URL for **Import from File/URL** now uses [`.env.authbridge`](https://raw.githubusercontent.com/kagenti/agent-examples/refs/heads/main/mcp/github_tool/.env.authbridge) (Keycloak/JWKS + secret refs for the AuthBridge demo) instead of `.env.openai`.

## Files
- `kagenti/ui-v2/src/pages/ImportAgentPage.tsx`
- `kagenti/ui-v2/src/pages/ImportToolPage.tsx`
- `kagenti/ui-v2/src/utils/routeRowId.ts` (new)

Fixes kagenti/kagenti#1188