### PR TITLE
fix(helm): Allow kagenti-backend to mutate ConfigMaps for AuthBridge finalize

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -361,9 +361,11 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
+  # ConfigMaps: list/get for reads; create/update/patch for AuthBridge finalize
+  # (authbridge-config, envoy-config, spiffe-helper-config, authproxy-routes merge)
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]


### PR DESCRIPTION
## Change
Extend the `kagenti-backend` ClusterRole ConfigMap verbs from `get`, `list` to also include `create`, `update`, and `patch` so finalize can:
- Upsert AuthBridge ConfigMaps (`authbridge-config`, `envoy-config`, `spiffe-helper-config`)
- Merge outbound token-exchange routes into `authproxy-routes`

## Why
Without these verbs, finalize returns **403** and Shipwright builds complete without creating the agent/tool Deployment (reconciliation and UI auto-finalize both hit the same path).

## Checklist
- [x] `helm lint charts/kagenti`

Fixes kagenti/kagenti#1191