### PR TITLE
fix: Emit authproxy-routes as YAML list for AuthProxy

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -1923,11 +1923,12 @@ def _ensure_authproxy_routes(
     """Create or update the authproxy-routes ConfigMap with outbound token exchange rules."""
     import yaml as _yaml
 
-    routes_data = {"routes": [r.model_dump() for r in routes]}
+    # AuthProxy go-processor expects a YAML list at file root (static.go), not {"routes": [...]}.
+    routes_list = [r.model_dump() for r in routes]
     kube.upsert_configmap(
         namespace=namespace,
         name="authproxy-routes",
-        data={"routes.yaml": _yaml.dump(routes_data, default_flow_style=False)},
+        data={"routes.yaml": _yaml.dump(routes_list, default_flow_style=False)},
     )
     logger.info(
         "Upserted authproxy-routes ConfigMap in namespace '%s' with %d route(s)",


### PR DESCRIPTION
## Summary

Fixes #1195.

The API was writing `authproxy-routes` `routes.yaml` as a map:

```yaml
routes:
- host: ...
```

AuthBridge **go-processor** (`internal/resolver/static.go`) unmarshals the file into a **top-level slice** (`[]yamlRoute`), so parsing failed with `cannot unmarshal !!map into []resolver.yamlRoute`. The external processor never listened on 9090, Envoy returned 500 for traffic through the sidecar, and the UI showed **Agent card not available** when loading `/.well-known/agent-card.json` via the Service.

## Change

`_ensure_authproxy_routes` now dumps a YAML **list** of route objects (same fields as before via `model_dump()`).

## Notes

- Existing clusters: patch `authproxy-routes` to list form and restart the agent Deployment, or trigger a reconcile that re-upserts the ConfigMap after deploying this backend.
- Tools reuse `_ensure_authproxy_routes` from `agents.py`, so both agents and tools benefit.