### PR TITLE
fix(ui): Always send tool servicePorts on import

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -463,7 +463,9 @@ export const ImportToolPage: React.FC = () => {
         imageTag,
         shipwrightConfig,
         envVars: envVars.filter((ev) => ev.name && (ev.value !== undefined || ev.valueFrom)),
-        servicePorts: showPodConfig ? servicePorts : undefined,
+        // Always send ports so Shipwright finalize uses them (matches Import Agent behavior).
+        // Previously omitted when Pod Configuration stayed collapsed → backend defaulted to 8000.
+        servicePorts,
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,
@@ -492,7 +494,7 @@ export const ImportToolPage: React.FC = () => {
           : undefined,
         envVars: envVars.filter((ev) => ev.name && (ev.value !== undefined || ev.valueFrom)),
         imagePullSecret: imagePullSecret || undefined,
-        servicePorts: showPodConfig ? servicePorts : undefined,
+        servicePorts,
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,


### PR DESCRIPTION
## Problem

`ImportToolPage` only sent `servicePorts` when **Pod Configuration** was expanded (`showPodConfig`). The form still defaulted ports to 9090 in React state, but if the user submitted with the section collapsed, the API received `servicePorts: undefined`. The Shipwright Build annotation then omitted ports, and `finalize-shipwright-build` used `DEFAULT_IN_CLUSTER_PORT` (8000)—breaking MCP tools that listen on 9090 (e.g. GitHub tool demo).

## Change

Always include `servicePorts` in both **source** and **image** create-tool payloads, matching `ImportAgentPage` behavior.

## Notes

- Existing tools already deployed with wrong Service ports still need a one-time patch or redeploy.
- `showPodConfig` remains only for expand/collapse UX.