### PR TITLE
docs(ui): Document combined AuthBridge webhook mode

### DIFF
--- a/docs/authbridge-combined-sidecar.md
+++ b/docs/authbridge-combined-sidecar.md
@@ -1,0 +1,27 @@
+# Combined AuthBridge sidecar (single `authbridge` container)
+
+The [kagenti-extensions](https://github.com/kagenti/kagenti-extensions) admission webhook can inject AuthBridge in two shapes:
+
+| Mode | Long-running containers | Init |
+|------|-------------------------|------|
+| **Legacy (default)** | `envoy-proxy`, `spiffe-helper`, `kagenti-client-registration` | `proxy-init` |
+| **Combined** | Single `authbridge` (Envoy + go-processor + optional spiffe-helper + client-registration processes) | `proxy-init` |
+
+Combined mode reduces per-pod overhead and is implemented in [kagenti-extensions#254](https://github.com/kagenti/kagenti-extensions/pull/254).
+
+## Who turns it on?
+
+**Cluster operators** enable combined mode on the **webhook**, not application developers from the Kagenti import UI.
+
+The webhook reads `featureGates.combinedSidecar` from its feature-gate configuration (Helm values on the `kagenti-webhook` chart, or the ConfigMap the webhook loads—see the [kagenti-webhook chart](https://github.com/kagenti/kagenti-extensions/tree/main/charts/kagenti-webhook) and [webhook README](https://github.com/kagenti/kagenti-extensions/tree/main/kagenti-webhook)).
+
+- Default: `combinedSidecar: false` (legacy three sidecars).
+- Set to `true`: new pods for injected agents/tools get one `authbridge` container (plus `proxy-init` when Envoy injection applies).
+
+## Relationship to import labels
+
+Workload labels the Kagenti UI sets (for example `kagenti.io/envoy-proxy-inject`, `kagenti.io/spiffe-helper-inject`, `kagenti.io/client-registration-inject`) still apply in combined mode: the webhook passes them as environment flags (`SPIRE_ENABLED`, `CLIENT_REGISTRATION_ENABLED`) into the single container, as described in PR #254.
+
+## Kagenti UI
+
+The import flows do **not** toggle combined mode. After enabling it on the webhook, expect fewer containers in `kubectl get pods` without changing UI settings. The Import Agent and Import Tool pages link to this document for context.

--- a/docs/install.md
+++ b/docs/install.md
@@ -350,7 +350,7 @@ kubectl get secret keycloak-initial-admin -n keycloak \
 
 ## Keycloak Admin Credentials for Agent Namespaces
 
-The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge) client-registration sidecar needs Keycloak admin credentials to automatically register agents as OAuth2 clients. These credentials are stored in a Kubernetes Secret called `keycloak-admin-secret` in each agent namespace.
+The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge) stack (separate sidecars or a single [combined `authbridge` container](authbridge-combined-sidecar.md)) needs Keycloak admin credentials for automatic OAuth2 client registration. These credentials are stored in a Kubernetes Secret called `keycloak-admin-secret` in each agent namespace.
 
 ### Automatic Provisioning
 

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1031,9 +1031,32 @@ export const ImportAgentPage: React.FC = () => {
                       setClientRegistrationInject(true);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge sidecars (envoy-proxy, go-processor, spiffe-helper, client-registration) into the agent pod for inbound JWT validation, outbound token exchange, and automatic Keycloak client registration."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation, outbound token exchange, and Keycloak client registration. With the default webhook settings this is three sidecars (envoy-proxy, spiffe-helper, client-registration) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
               />
               </FormGroup>
+
+              {authBridgeEnabled && (
+                <Alert
+                  variant="info"
+                  isInline
+                  title="Combined AuthBridge container"
+                  style={{ marginBottom: '16px' }}
+                >
+                  <Text component="p">
+                    There is no toggle here for the single-container mode. When{' '}
+                    <code>featureGates.combinedSidecar</code> is <code>true</code> on the admission
+                    webhook, injected pods get one <code>authbridge</code> container (see{' '}
+                    <a
+                      href="https://github.com/kagenti/kagenti/blob/main/docs/authbridge-combined-sidecar.md"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Combined AuthBridge sidecar
+                    </a>
+                    ). Advanced injection checkboxes still apply as flags inside that container.
+                  </Text>
+                </Alert>
+              )}
 
               {/* SPIRE Identity */}
               <FormGroup fieldId="spireEnabled">

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -985,9 +985,32 @@ export const ImportToolPage: React.FC = () => {
                       setClientRegistrationInject(true);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge sidecars (envoy-proxy, go-processor, spiffe-helper, client-registration) into the tool pod for inbound JWT validation, outbound token exchange, and automatic Keycloak client registration."
-              />
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation, outbound token exchange, and Keycloak client registration. Default webhook settings use three sidecars plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                />
               </FormGroup>
+
+              {authBridgeEnabled && (
+                <Alert
+                  variant="info"
+                  isInline
+                  title="Combined AuthBridge container"
+                  style={{ marginBottom: '16px' }}
+                >
+                  <Text component="p">
+                    Combined mode is configured on the admission webhook (
+                    <code>featureGates.combinedSidecar</code>), not on this page. See{' '}
+                    <a
+                      href="https://github.com/kagenti/kagenti/blob/main/docs/authbridge-combined-sidecar.md"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Combined AuthBridge sidecar
+                    </a>{' '}
+                    for operator steps. Advanced injection checkboxes still apply as flags inside the
+                    combined container when that gate is on.
+                  </Text>
+                </Alert>
+              )}
 
               {/* SPIRE Identity */}
               <FormGroup fieldId="spireEnabled">


### PR DESCRIPTION
## Summary

Fixes #1199.

[kagenti-extensions#254](https://github.com/kagenti/kagenti-extensions/pull/254) implements optional **combined** AuthBridge (`authbridge` + `proxy-init`) behind the webhook **cluster** gate `featureGates.combinedSidecar`. The import UI cannot toggle that today; this PR documents the operator path and clarifies the dashboard.

## Changes

- **`docs/authbridge-combined-sidecar.md`** — Combined vs legacy table, operator ownership, link to extensions PR/chart, note on import labels in combined mode.
- **`docs/install.md`** — One-line pointer to the combined-sidecar doc from the Keycloak/AuthBridge credentials section.
- **Import Agent / Import Tool** — AuthBridge checkbox description mentions both layouts; **info** alert when AuthBridge is enabled with link to the doc (no non-functional toggle).

## Not in this PR

- Per-workload combined mode (would require kagenti-extensions).
- Umbrella Helm wiring for `combinedSidecar` (optional follow-up).