### PR TITLE
fix: Correct platform detection, AuthBridge SCC Rolebinding and Route deletion

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -400,6 +400,11 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get", "create"]
+  # RoleBindings — ensure_rolebinding() creates agent-authbridge-scc so service
+  # accounts in each agent namespace can use the kagenti-authbridge SCC (OpenShift).
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["get", "create"]
   {{- if .Values.featureFlags.sandbox }}
   # PersistentVolumeClaims for agent workspace storage (sandbox)
   - apiGroups: [""]

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -1995,7 +1995,7 @@ def _ensure_authbridge_scc_rolebinding(
         name="agent-authbridge-scc",
         cluster_role_name=cluster_role_name,
         subjects=[
-            kubernetes.client.V1Subject(
+            kubernetes.client.RbacV1Subject(
                 kind="Group",
                 api_group="rbac.authorization.k8s.io",
                 name=f"system:serviceaccounts:{namespace}",

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -811,7 +811,7 @@ async def delete_agent(
     This deletes:
     - Deployment, StatefulSet, or Job (whichever exists)
     - Service
-    - HTTPRoute (if exists)
+    - HTTPRoute or OpenShift Route (whichever exists)
     - Shipwright Build CR (if exists)
     - Shipwright BuildRun CRs (if exist)
     - Legacy: Agent CR (if exists, for backward compatibility)
@@ -875,6 +875,23 @@ async def delete_agent(
             pass
         else:
             logger.warning(f"Failed to delete HTTPRoute '{name}': {e.reason}")
+
+    # Delete the OpenShift Route (if exists)
+    try:
+        kube.delete_custom_resource(
+            group="route.openshift.io",
+            version="v1",
+            namespace=namespace,
+            plural="routes",
+            name=name,
+        )
+        messages.append(f"Route '{name}' deleted")
+    except ApiException as e:
+        if e.status == 404:
+            # Route doesn't exist, that's fine
+            pass
+        else:
+            logger.warning(f"Failed to delete Route '{name}': {e.reason}")
 
     # Delete the AgentRuntime CR (if exists)
     try:

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -40,6 +40,7 @@ class KubernetesService:
         self._apps_api: Optional[kubernetes.client.AppsV1Api] = None
         self._batch_api: Optional[kubernetes.client.BatchV1Api] = None
         self._rbac_api: Optional[kubernetes.client.RbacAuthorizationV1Api] = None
+        self._apis_api: Optional[kubernetes.client.ApisApi] = None
 
     def _load_config(self) -> kubernetes.client.ApiClient:
         """Load Kubernetes configuration (in-cluster or kubeconfig)."""
@@ -92,9 +93,30 @@ class KubernetesService:
             self._rbac_api = kubernetes.client.RbacAuthorizationV1Api(self.api_client)
         return self._rbac_api
 
+    @property
+    def apis_api(self) -> kubernetes.client.ApisApi:
+        """Get ApisApi client (GET /apis/ — API group discovery)."""
+        if self._apis_api is None:
+            self._apis_api = kubernetes.client.ApisApi(self.api_client)
+        return self._apis_api
+
     def is_running_in_cluster(self) -> bool:
         """Check if running inside a Kubernetes cluster."""
         return bool(os.getenv("KUBERNETES_SERVICE_HOST"))
+
+    def api_group_exists(self, group: str) -> bool:
+        """Return True if the cluster advertises the given API group (GET /apis/)."""
+        try:
+            response = self.apis_api.get_api_versions(_request_timeout=10)
+            groups = response.groups or []
+            logger.debug(
+                "Available API groups: %s",
+                sorted(g.name for g in groups if g and g.name),
+            )
+            return any(g.name == group for g in groups if g and g.name)
+        except ApiException as e:
+            logger.warning("Error listing API groups: %s", e)
+            return False
 
     def list_namespaces(self, label_selector: Optional[str] = None) -> List[str]:
         """List namespaces with optional label selector."""

--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -29,27 +29,9 @@ def detect_platform(kube: KubernetesService) -> str:
         'openshift' if route.openshift.io API is available, 'kubernetes' otherwise
     """
     try:
-        # Try to list routes API groups
-        # OpenShift exposes route.openshift.io/v1
-        from kubernetes import client
-
-        # Create API client
-        api_instance = client.ApiClient(kube.client.api_client.configuration)
-
-        # Get available API groups
-        with api_instance as api:
-            api_response = api.call_api(
-                "/apis", "GET", response_type="object", _return_http_data_only=True
-            )
-
-        groups = api_response.get("groups", [])
-        logger.debug("Available API groups: %s", [g.get("name") for g in groups])
-
-        for group in groups:
-            if group.get("name") == "route.openshift.io":
-                logger.info("Detected OpenShift platform (route.openshift.io API found)")
-                return "openshift"
-
+        if kube.api_group_exists("route.openshift.io"):
+            logger.info("Detected OpenShift platform (route.openshift.io API found)")
+            return "openshift"
         logger.info("Detected Kubernetes platform (no route.openshift.io API)")
         return "kubernetes"
     except Exception as e:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

- Add helper method in `kagenti/backend/app/services/kubernetes.py` to check if a specified API group exists, and modify `kagenti/backend/app/utils/routes.py:detect_platform()` to use the helper method to detect if Kagenti is running on OpenShift by detecting `route.openshift.io` group.
- Use `RbacV1Subject` instead of invalid `V1Subject` when building the subject list in `agents.py:_ensure_authbridge_scc_rolebinding()`. 
- Grant kagenti-backend permission to get and create rolebindings in the UI chart (ui.yaml) so the backend can create the AuthBridge SCC RoleBinding in agent namespaces.
- Add logic to delete a custom resource OpenShift Route in `kagenti/backend/app/routers/agents.py` if it exists when agent is deleted through UI, and document this in the docstring of the method.

## Context

The platform detection method in `routes.py` always defaulted to Kubernetes since it always caught an error as it tried to access `client` attribute that didn't exist. A helper method was written to manage that from `kubernetes.py`, which is in line with how other methods in `routes.py` call helper methods in `kubernetes.py`.

This PR also fixes an issue with creating AuthBridge SCC RoleBinding in agent namespaces. The code block calling `ensure_rolebinding()` in `agents.py` now passes `RbacV1Subject` in subjects list instead of invalid `V1Subject`. Permissions were also added to allow RoleBinding resources to be created by the backend. These two bugs weren't observable previously since they only trigger when platform was detected to be OpenShift, which didn't previously happen.

Lastly, when creating an agent and enabling external access through UI, routes weren't deleted when deleting the agent. PR #1180 adds the method to delete HTTPRoute, while this PR just adds the method to delete OpenShift Route.

Fixes #1196

## Tests

- [x] Correct platform is detected when creating an agent with external access enabled through UI, observed by checking logs with `oc logs -n kagenti-system deploy/kagenti-backend --tail=200 | grep "Detected platform"`.
- [x] No errors are observed in backend logs relating to AuthBridge SCC RoleBinding.
- [x] Route is deleted when an A2A agent is deleted through UI on OpenShift, observed with `oc get route -n team1`.