### PR TITLE
fix: resolve actual Service port in tool MCP endpoints

### DIFF
--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -82,7 +82,12 @@ from app.services.shipwright import (
     get_output_image_from_buildrun,
     resolve_clone_secret,
 )
-from app.utils.routes import create_route_for_agent_or_tool, lookup_service_port, route_exists
+from app.utils.routes import (
+    create_route_for_agent_or_tool,
+    lookup_service_port,
+    route_exists,
+    sanitize_log,
+)
 from app.routers.agents import (
     _ensure_authbridge_configmaps,
     _ensure_authproxy_routes,
@@ -2072,7 +2077,7 @@ async def connect_to_tool(
     tool_url = _get_tool_url(name, namespace, kube)
     mcp_endpoint = f"{tool_url}/mcp"
 
-    logger.info("Connecting to MCP server at %s", mcp_endpoint)
+    logger.info("Connecting to MCP server at %s", sanitize_log(mcp_endpoint))
 
     exit_stack = AsyncExitStack()
     try:
@@ -2086,7 +2091,7 @@ async def connect_to_tool(
             session: ClientSession = await session_context.__aenter__()
             await session.initialize()
 
-            logger.info(f"MCP session initialized for tool '{name}'")
+            logger.info("MCP session initialized for tool %s", sanitize_log(name))
 
             # List available tools
             response = await session.list_tools()
@@ -2102,7 +2107,7 @@ async def connect_to_tool(
                             ),
                         )
                     )
-                logger.info(f"Listed {len(tools)} tools from MCP server '{name}'")
+                logger.info("Listed %d tools from MCP server %s", len(tools), sanitize_log(name))
 
             return MCPToolsResponse(tools=tools)
 
@@ -2164,12 +2169,16 @@ async def invoke_tool(
             session: ClientSession = await session_context.__aenter__()
             await session.initialize()
 
-            logger.info(f"MCP session initialized for tool invocation on '{name}'")
+            logger.info("MCP session initialized for tool invocation on %s", sanitize_log(name))
 
             # Call the tool using the MCP client library
             result = await session.call_tool(request.tool_name, request.arguments)
 
-            logger.info(f"Tool '{request.tool_name}' invoked successfully on '{name}'")
+            logger.info(
+                "Tool %s invoked successfully on %s",
+                sanitize_log(request.tool_name),
+                sanitize_log(name),
+            )
 
             # Convert the result to a serializable format
             result_data = {}

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -82,7 +82,7 @@ from app.services.shipwright import (
     get_output_image_from_buildrun,
     resolve_clone_secret,
 )
-from app.utils.routes import create_route_for_agent_or_tool, route_exists
+from app.utils.routes import create_route_for_agent_or_tool, lookup_service_port, route_exists
 from app.routers.agents import (
     _ensure_authbridge_configmaps,
     _ensure_authproxy_routes,
@@ -2027,40 +2027,30 @@ async def finalize_tool_shipwright_build(
         raise HTTPException(status_code=e.status, detail=str(e.reason))
 
 
-def _get_tool_url(name: str, namespace: str, port: int = DEFAULT_IN_CLUSTER_PORT) -> str:
+def _get_tool_url(name: str, namespace: str, kube: KubernetesService) -> str:
     """Get the URL for an MCP tool server.
+
+    Looks up the K8s Service to find the actual port instead of assuming
+    the default.  Falls back to DEFAULT_IN_CLUSTER_PORT when the Service
+    is missing or has no ports.
 
     Service naming convention:
     - Service name: {name}-mcp
-    - Port: configurable, defaults to 8000
 
     Returns different URL formats based on deployment context:
     - In-cluster: http://{name}-mcp.{namespace}.svc.cluster.local:{port}
     - Off-cluster (local dev): http://{name}.{domain}:8080 (via HTTPRoute)
     """
+    service_name = _get_tool_service_name(name)
+    port = lookup_service_port(service_name, namespace, kube, DEFAULT_IN_CLUSTER_PORT)
+
     if settings.is_running_in_cluster:
-        # In-cluster: use service DNS with new naming convention
-        service_name = _get_tool_service_name(name)
         return f"http://{service_name}.{namespace}.svc.cluster.local:{port}"
     else:
-        # Off-cluster: use external domain (e.g., localtest.me) via HTTPRoute
+        # Off-cluster: HTTPRoute handles mapping to the Service port;
+        # the URL only needs the gateway listener port (8080).
         domain = settings.domain_name
         return f"http://{name}.{domain}:8080"
-
-
-def _get_tool_service_port(kube: KubernetesService, name: str, namespace: str) -> int:
-    """Look up the actual service port for a tool from K8s.
-
-    Falls back to DEFAULT_IN_CLUSTER_PORT if the service cannot be found.
-    """
-    try:
-        service = kube.get_service(namespace, _get_tool_service_name(name))
-        ports = service.get("spec", {}).get("ports", [])
-        if ports:
-            return ports[0].get("port", DEFAULT_IN_CLUSTER_PORT)
-    except ApiException:
-        pass
-    return DEFAULT_IN_CLUSTER_PORT
 
 
 @router.post(
@@ -2079,11 +2069,10 @@ async def connect_to_tool(
     This endpoint connects to the MCP server and retrieves the list of
     available tools using the MCP client library.
     """
-    service_port = _get_tool_service_port(kube, name, namespace)
-    tool_url = _get_tool_url(name, namespace, port=service_port)
+    tool_url = _get_tool_url(name, namespace, kube)
     mcp_endpoint = f"{tool_url}/mcp"
 
-    logger.info(f"Connecting to MCP server at {mcp_endpoint}")
+    logger.info("Connecting to MCP server at %s", mcp_endpoint)
 
     exit_stack = AsyncExitStack()
     try:
@@ -2160,8 +2149,7 @@ async def invoke_tool(
     This endpoint calls a specific tool on the MCP server with
     the provided arguments and returns the result.
     """
-    service_port = _get_tool_service_port(kube, name, namespace)
-    tool_url = _get_tool_url(name, namespace, port=service_port)
+    tool_url = _get_tool_url(name, namespace, kube)
     mcp_endpoint = f"{tool_url}/mcp"
 
     exit_stack = AsyncExitStack()

--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -16,6 +16,11 @@ from app.core.constants import DEFAULT_OFF_CLUSTER_PORT
 logger = logging.getLogger(__name__)
 
 
+def sanitize_log(value: str) -> str:
+    """Strip newlines and control characters to prevent log injection (CWE-117)."""
+    return value.replace("\n", "").replace("\r", "").replace("\x00", "")
+
+
 def detect_platform(kube: KubernetesService) -> str:
     """
     Detect if running on OpenShift or regular Kubernetes.
@@ -284,8 +289,8 @@ def lookup_service_port(
     except ApiException:
         logger.warning(
             "Could not look up Service %s in %s, using default port",
-            service_name,
-            namespace,
+            sanitize_log(service_name),
+            sanitize_log(namespace),
         )
     return default_port
 

--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -281,9 +281,11 @@ def lookup_service_port(
         ports = service.get("spec", {}).get("ports", [])
         if ports:
             return ports[0].get("port", default_port)
-    except Exception:
+    except ApiException:
         logger.warning(
-            f"Could not look up Service {service_name} in {namespace}, using default port"
+            "Could not look up Service %s in %s, using default port",
+            service_name,
+            namespace,
         )
     return default_port
 

--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -269,6 +269,25 @@ def create_route_for_agent_or_tool(
         create_httproute(kube, name, namespace, service_name, service_port)
 
 
+def lookup_service_port(
+    service_name: str,
+    namespace: str,
+    kube: KubernetesService,
+    default_port: int,
+) -> int:
+    """Look up the first port of a K8s Service, falling back to *default_port*."""
+    try:
+        service = kube.get_service(namespace=namespace, name=service_name)
+        ports = service.get("spec", {}).get("ports", [])
+        if ports:
+            return ports[0].get("port", default_port)
+    except Exception:
+        logger.warning(
+            f"Could not look up Service {service_name} in {namespace}, using default port"
+        )
+    return default_port
+
+
 def get_agent_url(name: str, namespace: str, port: int = DEFAULT_OFF_CLUSTER_PORT) -> str:
     """Get the URL for an A2A agent.
 

--- a/kagenti/backend/tests/test_tool_url.py
+++ b/kagenti/backend/tests/test_tool_url.py
@@ -1,0 +1,87 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Unit tests for lookup_service_port() used by tool URL resolution.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client import ApiException
+
+from app.utils.routes import lookup_service_port
+
+
+@pytest.fixture
+def kubernetes_service():
+    """Create a KubernetesService instance with mocked APIs."""
+    with (
+        patch("app.services.kubernetes.kubernetes.config.load_incluster_config"),
+        patch("app.services.kubernetes.kubernetes.config.load_kube_config"),
+        patch("app.services.kubernetes.kubernetes.client.ApiClient"),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        from app.services.kubernetes import KubernetesService
+
+        service = KubernetesService()
+        service._apps_api = MagicMock()
+        service._core_api = MagicMock()
+        service._batch_api = MagicMock()
+        return service
+
+
+class TestLookupServicePort:
+    """Test cases for lookup_service_port()."""
+
+    def test_returns_actual_port(self, kubernetes_service):
+        """Service with a non-default port returns that port."""
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {
+            "spec": {"ports": [{"port": 9090, "targetPort": 9090}]},
+        }
+        kubernetes_service._core_api.read_namespaced_service.return_value = mock_result
+
+        port = lookup_service_port("my-tool-mcp", "team1", kubernetes_service, 8000)
+        assert port == 9090
+        kubernetes_service._core_api.read_namespaced_service.assert_called_once_with(
+            name="my-tool-mcp", namespace="team1"
+        )
+
+    def test_returns_default_when_port_matches(self, kubernetes_service):
+        """Service with the default port returns the default port."""
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {
+            "spec": {"ports": [{"port": 8000, "targetPort": 8000}]},
+        }
+        kubernetes_service._core_api.read_namespaced_service.return_value = mock_result
+
+        port = lookup_service_port("my-tool-mcp", "team1", kubernetes_service, 8000)
+        assert port == 8000
+
+    def test_service_not_found_returns_default(self, kubernetes_service):
+        """Missing Service returns the default port."""
+        kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+
+        port = lookup_service_port("my-tool-mcp", "team1", kubernetes_service, 8000)
+        assert port == 8000
+
+    def test_service_no_ports_returns_default(self, kubernetes_service):
+        """Service with empty ports list returns the default port."""
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"spec": {"ports": []}}
+        kubernetes_service._core_api.read_namespaced_service.return_value = mock_result
+
+        port = lookup_service_port("my-tool-mcp", "team1", kubernetes_service, 8000)
+        assert port == 8000
+
+    def test_different_default_port(self, kubernetes_service):
+        """Default port parameter is respected when Service is missing."""
+        kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+
+        port = lookup_service_port("my-agent", "team1", kubernetes_service, 8080)
+        assert port == 8080


### PR DESCRIPTION
## Summary

- Add `lookup_service_port()` utility in `routes.py` — generic K8s Service port lookup with fallback
- Update `_get_tool_url()` to use it instead of hardcoding `DEFAULT_IN_CLUSTER_PORT` (8000)
- Inject `KubernetesService` into `connect_to_tool` and `invoke_tool` endpoints
- Add unit tests for `lookup_service_port()` (5 cases)

## Problem

`_get_tool_url()` hardcodes port 8000 for in-cluster MCP tool URLs. When a tool's Service uses a non-default port, the backend connects on the wrong port and MCP connect/invoke requests fail.

This is the tools-side companion to PR #1224 (which fixed the same issue in chat endpoints).

## Test plan

- [x] Unit tests: `lookup_service_port()` with mocked KubernetesService (5 cases)
- [ ] Deploy tool with `port: 9090, targetPort: 8000`, verify MCP connect uses 9090
- [ ] Deploy tool with default ports, verify no behavior change

Ref: #1150