### PR TITLE
fix: pass KEYCLOAK_PUBLIC_URL to UI for browser redirects

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -123,6 +123,8 @@ spec:
               value: "{{ .Values.featureFlags.triggers }}"
             - name: KEYCLOAK_URL
               value: {{ .Values.keycloak.url | quote }}
+            - name: KEYCLOAK_PUBLIC_URL
+              value: {{ .Values.keycloak.publicUrl | quote }}
             # Dashboard URLs from ConfigMap (populated by ui-routes-job)
             - name: TRACES_DASHBOARD_URL
               valueFrom:

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -97,24 +97,25 @@ class Settings(BaseSettings):
 
     # Legacy direct config (fallback if AUTH_ENDPOINT not provided)
     keycloak_url: str = ""
+    # Browser-facing Keycloak URL (from keycloak.publicUrl Helm value)
+    keycloak_public_url: str = ""
     keycloak_realm: str = "kagenti"
     keycloak_client_id: str = "kagenti-ui"
 
     @property
     def effective_keycloak_url(self) -> str:
         """
-        Extract Keycloak base URL from AUTH_ENDPOINT or use direct config.
+        External (browser-facing) Keycloak URL for frontend auth redirects.
 
-        This returns the external (browser-facing) URL, used for frontend
-        auth config and redirect flows.
+        Priority: AUTH_ENDPOINT (from oauth secret) > KEYCLOAK_PUBLIC_URL
+        (from Helm) > KEYCLOAK_URL (internal, last resort) > constructed default.
         """
         if self.auth_endpoint:
-            # Parse AUTH_ENDPOINT to extract base URL
-            # Pattern: {base_url}/realms/{realm}/protocol/openid-connect/auth
             match = re.match(r"(https?://[^/]+)/realms/", self.auth_endpoint)
             if match:
                 return match.group(1)
-        # Fallback to direct config or default
+        if self.keycloak_public_url:
+            return self.keycloak_public_url
         if self.keycloak_url:
             return self.keycloak_url
         return f"http://keycloak.{self.domain_name}:8080"

--- a/kagenti/backend/tests/test_keycloak_url_config.py
+++ b/kagenti/backend/tests/test_keycloak_url_config.py
@@ -1,0 +1,90 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for effective_keycloak_url priority chain.
+
+Priority: AUTH_ENDPOINT > KEYCLOAK_PUBLIC_URL > KEYCLOAK_URL > constructed default.
+Fixes: https://github.com/kagenti/kagenti/issues/1154
+"""
+
+import pytest
+from app.core.config import Settings
+
+
+@pytest.fixture
+def make_settings(monkeypatch):
+    """Create Settings with specific env vars, clearing defaults."""
+
+    def _make(**env_vars):
+        monkeypatch.delenv("AUTH_ENDPOINT", raising=False)
+        monkeypatch.delenv("KEYCLOAK_PUBLIC_URL", raising=False)
+        monkeypatch.delenv("KEYCLOAK_URL", raising=False)
+        monkeypatch.delenv("DOMAIN_NAME", raising=False)
+        for k, v in env_vars.items():
+            monkeypatch.setenv(k, v)
+        return Settings()
+
+    return _make
+
+
+class TestEffectiveKeycloakUrl:
+    """effective_keycloak_url must prefer browser-reachable URLs."""
+
+    def test_auth_endpoint_wins(self, make_settings):
+        s = make_settings(
+            AUTH_ENDPOINT="https://kc.example.com/realms/kagenti/protocol/openid-connect/auth",
+            KEYCLOAK_PUBLIC_URL="https://public.example.com",
+            KEYCLOAK_URL="http://keycloak-service.keycloak:8080",
+        )
+        assert s.effective_keycloak_url == "https://kc.example.com"
+
+    def test_public_url_when_no_auth_endpoint(self, make_settings):
+        s = make_settings(
+            KEYCLOAK_PUBLIC_URL="https://public.example.com",
+            KEYCLOAK_URL="http://keycloak-service.keycloak:8080",
+        )
+        assert s.effective_keycloak_url == "https://public.example.com"
+
+    def test_keycloak_url_as_last_resort(self, make_settings):
+        s = make_settings(
+            KEYCLOAK_URL="http://keycloak-service.keycloak:8080",
+        )
+        assert s.effective_keycloak_url == "http://keycloak-service.keycloak:8080"
+
+    def test_constructed_default(self, make_settings):
+        s = make_settings(DOMAIN_NAME="apps.cluster.example.com")
+        assert s.effective_keycloak_url == "http://keycloak.apps.cluster.example.com:8080"
+
+    def test_public_url_not_used_when_auth_endpoint_set(self, make_settings):
+        s = make_settings(
+            AUTH_ENDPOINT="https://route.example.com/realms/test/protocol/openid-connect/auth",
+            KEYCLOAK_PUBLIC_URL="https://different.example.com",
+        )
+        assert s.effective_keycloak_url == "https://route.example.com"
+
+    def test_malformed_auth_endpoint_falls_through(self, make_settings):
+        s = make_settings(
+            AUTH_ENDPOINT="not-a-url",
+            KEYCLOAK_PUBLIC_URL="https://public.example.com",
+        )
+        assert s.effective_keycloak_url == "https://public.example.com"
+
+
+class TestKeycloakInternalUrl:
+    """keycloak_internal_url should use internal URL in-cluster."""
+
+    def test_in_cluster_uses_keycloak_url(self, make_settings, monkeypatch):
+        s = make_settings(
+            KEYCLOAK_URL="http://keycloak-service.keycloak:8080",
+            KEYCLOAK_PUBLIC_URL="https://public.example.com",
+        )
+        monkeypatch.setattr(type(s), "is_running_in_cluster", property(lambda self: True))
+        assert s.keycloak_internal_url == "http://keycloak-service.keycloak:8080"
+
+    def test_off_cluster_uses_effective(self, make_settings, monkeypatch):
+        s = make_settings(
+            KEYCLOAK_URL="http://keycloak-service.keycloak:8080",
+            KEYCLOAK_PUBLIC_URL="https://public.example.com",
+        )
+        monkeypatch.setattr(type(s), "is_running_in_cluster", property(lambda self: False))
+        assert s.keycloak_internal_url == "https://public.example.com"


### PR DESCRIPTION
## Summary
- Pass `keycloak.publicUrl` Helm value as `KEYCLOAK_PUBLIC_URL` env var to the UI deployment
- Add `keycloak_public_url` config field to the backend with priority: `AUTH_ENDPOINT` > `KEYCLOAK_PUBLIC_URL` > `KEYCLOAK_URL` > default
- Add 8 unit tests covering the full priority chain and edge cases

Closes #1154

## Root Cause

On OpenShift, the browser-facing Keycloak URL depends entirely on `AUTH_ENDPOINT` from the `kagenti-ui-oauth-secret`. If the oauth-secret-job hasn't completed when the UI pod starts (init container exits 0 after 4-minute timeout), the backend falls back to `KEYCLOAK_URL` — the **internal** K8s service URL (`http://keycloak-service.keycloak:8080`) — which the browser cannot reach.

The Helm value `keycloak.publicUrl` was already correctly set by `setup-kagenti.sh` (route discovery at line 665), but was never passed to the UI deployment.

## Test plan
- [x] 8 unit tests for `effective_keycloak_url` priority chain
- [x] Regression: existing `test_dashboard_config.py` passes
- [x] Pre-commit hooks pass
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)