### PR TITLE
fix: Delete external route when deleting an MCP tool in UI

### DIFF
--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -769,6 +769,7 @@ async def delete_tool(
     2. Shipwright Build (if any)
     3. Deployment or StatefulSet
     4. Service
+    5. HTTPRoute or OpenShift Route (whichever exists)
     """
     deleted_resources = []
 
@@ -836,6 +837,34 @@ async def delete_tool(
     except ApiException as e:
         if e.status != 404:
             logger.warning(f"Failed to delete Service '{service_name}': {e}")
+
+    # Delete the HTTPRoute (if exists)
+    try:
+        kube.delete_custom_resource(
+            group="gateway.networking.k8s.io",
+            version="v1",
+            namespace=namespace,
+            plural="httproutes",
+            name=name,
+        )
+        deleted_resources.append(f"HTTPRoute/{name}")
+    except ApiException as e:
+        if e.status != 404:
+            logger.warning(f"Failed to delete HTTPRoute '{name}': {e}")
+
+    # Delete the OpenShift Route (if exists)
+    try:
+        kube.delete_custom_resource(
+            group="route.openshift.io",
+            version="v1",
+            namespace=namespace,
+            plural="routes",
+            name=name,
+        )
+        deleted_resources.append(f"Route/{name}")
+    except ApiException as e:
+        if e.status != 404:
+            logger.warning(f"Failed to delete Route '{name}': {e}")
 
     if deleted_resources:
         return DeleteResponse(


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Add logic to delete a custom resource HTTPRoute or OpenShift Route in `kagenti/backend/app/routers/tools.py` if it exists when a tool is deleted through UI, and document this in the docstring of the method.

## Context

When an MCP tool is deleted through the Kagenti UI, its HTTPRoute resource is left behind. This leads to orphaned networking resources and inconsistent cleanup of tool-related Kubernetes objects. This fix aligns with the existing implementation in `kagenti/backend/app/routers/agents.py` from PR #1180.

Fixes #1233

## Tests

Verified by:
- Creating an MCP tool and confirming HTTPRoute (or OpenShift Route) exists using `kubectl get httproute` (or `oc get route`)
- Deleting the tool through UI
- Confirming the HTTPRoute/OpenShift Route is removed (using same commands as above)
<!-- -->
- [x] The HTTPRoute is deleted when the MCP tool is deleted through UI on Kind
- [x] The OpenShift Route is deleted when the MCP tool is deleted through UI on OpenShift