### PR TITLE
feat: add remaining sandbox, integration, and analytics API routes

### DIFF
--- a/kagenti/backend/app/core/auth.py
+++ b/kagenti/backend/app/core/auth.py
@@ -86,7 +86,7 @@ class KeycloakJWKS:
             jwks_data = response.json()
             self._keys = {key["kid"]: key for key in jwks_data.get("keys", [])}
             self._loaded = True
-            logger.info(f"Loaded {len(self._keys)} keys from Keycloak JWKS")
+            logger.info("Loaded %d keys from Keycloak JWKS", len(self._keys))
 
     def get_key(self, kid: str) -> Optional[dict]:
         """Get a specific key by its ID."""
@@ -236,19 +236,19 @@ async def validate_token(token: str) -> TokenData:
         )
 
     except JWTError as e:
-        logger.warning(f"JWT validation error: {e}")
+        logger.warning("JWT validation error: %s", e)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Invalid token: {str(e)}",
         )
     except JWKError as e:
-        logger.warning(f"JWK error: {e}")
+        logger.warning("JWK error: %s", e)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token key error",
         )
     except (httpx.HTTPError, ConnectionError) as e:
-        logger.error(f"Failed to connect to Keycloak for token validation: {e}")
+        logger.error("Failed to connect to Keycloak for token validation: %s", e)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Authentication service unavailable",

--- a/kagenti/backend/app/main.py
+++ b/kagenti/backend/app/main.py
@@ -99,9 +99,9 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     """Application lifespan handler for startup/shutdown events."""
     logger.info("Starting Kagenti Backend API")
-    logger.info(f"Debug mode: {settings.debug}")
-    logger.info(f"Domain: {settings.domain_name}")
-    logger.info(f"ENABLE_AUTH environment variable set to: {settings.enable_auth}")
+    logger.info("Debug mode: %s", settings.debug)
+    logger.info("Domain: %s", settings.domain_name)
+    logger.info("ENABLE_AUTH environment variable set to: %s", settings.enable_auth)
 
     # Start build reconciliation loop
     reconciliation_task = None

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -356,6 +356,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/agents", tags=["agents"])
 
 
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
 def _is_deployment_ready(resource_data: dict) -> str:
     """Check if a Kubernetes Deployment is ready based on status.
 
@@ -677,7 +683,7 @@ async def list_agents(
             except ApiException as e:
                 # CRD not installed or not accessible - that's fine, just skip
                 if e.status not in (404, 403):
-                    logger.warning(f"Failed to list legacy Agent CRDs: {e.reason}")
+                    logger.warning("Failed to list legacy Agent CRDs: %s", e.reason)
 
         return AgentListResponse(items=agents)
 
@@ -741,7 +747,9 @@ async def get_agent(
             service = kube.get_service(namespace=namespace, name=name)
         except ApiException as e:
             if e.status != 404:
-                logger.warning(f"Failed to get Service for agent '{name}': {e.reason}")
+                logger.warning(
+                    "Failed to get Service for agent '%s': %s", _safe_log(name), e.reason
+                )
 
     # Build response with workload info and optional Service info
     metadata = workload.get("metadata", {})
@@ -827,9 +835,9 @@ async def delete_agent(
         messages.append(f"Deployment '{name}' deleted")
     except ApiException as e:
         if e.status == 404:
-            logger.debug(f"Deployment '{name}' not found (may be other workload type)")
+            logger.debug("Deployment '%s' not found (may be other workload type)", _safe_log(name))
         else:
-            logger.warning(f"Failed to delete Deployment '{name}': {e.reason}")
+            logger.warning("Failed to delete Deployment '%s': %s", _safe_log(name), e.reason)
 
     # Delete the StatefulSet (if exists)
     try:
@@ -837,9 +845,9 @@ async def delete_agent(
         messages.append(f"StatefulSet '{name}' deleted")
     except ApiException as e:
         if e.status == 404:
-            logger.debug(f"StatefulSet '{name}' not found")
+            logger.debug("StatefulSet '%s' not found", _safe_log(name))
         else:
-            logger.warning(f"Failed to delete StatefulSet '{name}': {e.reason}")
+            logger.warning("Failed to delete StatefulSet '%s': %s", _safe_log(name), e.reason)
 
     # Delete the Job (if exists)
     try:
@@ -847,9 +855,9 @@ async def delete_agent(
         messages.append(f"Job '{name}' deleted")
     except ApiException as e:
         if e.status == 404:
-            logger.debug(f"Job '{name}' not found")
+            logger.debug("Job '%s' not found", _safe_log(name))
         else:
-            logger.warning(f"Failed to delete Job '{name}': {e.reason}")
+            logger.warning("Failed to delete Job '%s': %s", _safe_log(name), e.reason)
 
     # Delete the Service
     try:
@@ -860,7 +868,7 @@ async def delete_agent(
             # Service doesn't exist, that's fine
             pass
         else:
-            logger.warning(f"Failed to delete Service '{name}': {e.reason}")
+            logger.warning("Failed to delete Service '%s': %s", _safe_log(name), e.reason)
 
     # Delete the HTTPRoute (if exists)
     try:
@@ -877,7 +885,7 @@ async def delete_agent(
             # HTTPRoute doesn't exist, that's fine
             pass
         else:
-            logger.warning(f"Failed to delete HTTPRoute '{name}': {e.reason}")
+            logger.warning("Failed to delete HTTPRoute '%s': %s", _safe_log(name), e.reason)
 
     # Delete the AgentRuntime CR (if exists)
     try:
@@ -910,7 +918,7 @@ async def delete_agent(
             # Agent CR doesn't exist, that's expected for new deployments
             pass
         else:
-            logger.warning(f"Failed to delete Agent CR '{name}': {e.reason}")
+            logger.warning("Failed to delete Agent CR '%s': %s", _safe_log(name), e.reason)
 
     # Delete Shipwright BuildRuns associated with the build
     try:
@@ -935,10 +943,14 @@ async def delete_agent(
                     messages.append(f"BuildRun '{buildrun_name}' deleted")
                 except ApiException as e:
                     if e.status != 404:
-                        logger.warning(f"Failed to delete BuildRun '{buildrun_name}': {e.reason}")
+                        logger.warning(
+                            "Failed to delete BuildRun '%s': %s",
+                            _safe_log(buildrun_name),
+                            e.reason,
+                        )
     except ApiException as e:
         if e.status != 404:
-            logger.warning(f"Failed to list BuildRuns for '{name}': {e.reason}")
+            logger.warning("Failed to list BuildRuns for '%s': %s", _safe_log(name), e.reason)
 
     # Delete the Shipwright Build CR if it exists
     try:
@@ -955,7 +967,7 @@ async def delete_agent(
             # Shipwright Build doesn't exist, that's fine (might be image-based or Tekton deployment)
             pass
         else:
-            logger.warning(f"Failed to delete Shipwright Build '{name}': {e.reason}")
+            logger.warning("Failed to delete Shipwright Build '%s': %s", _safe_log(name), e.reason)
 
     return DeleteResponse(success=True, message="; ".join(messages))
 
@@ -1076,7 +1088,11 @@ async def migrate_agent(
     unless the existing Deployment was created by kagenti-operator (in which
     case we just need to clean up the Agent CRD).
     """
-    logger.info(f"Starting migration of Agent CRD '{name}' in namespace '{namespace}'")
+    logger.info(
+        "Starting migration of Agent CRD '%s' in namespace '%s'",
+        _safe_log(name),
+        _safe_log(namespace),
+    )
 
     deployment_created = False
     service_created = False
@@ -1123,7 +1139,7 @@ async def migrate_agent(
     try:
         kube.get_service(namespace=namespace, name=name)
         service_exists = True
-        logger.info(f"Service '{name}' already exists")
+        logger.info("Service '%s' already exists", _safe_log(name))
     except ApiException as e:
         if e.status != 404:
             raise HTTPException(status_code=e.status, detail=str(e.reason))
@@ -1146,9 +1162,9 @@ async def migrate_agent(
                     }
                 }
                 kube.patch_deployment(namespace=namespace, name=name, body=patch)
-                logger.info(f"Patched Deployment '{name}' with migration annotations")
+                logger.info("Patched Deployment '%s' with migration annotations", _safe_log(name))
             except ApiException as e:
-                logger.warning(f"Failed to patch Deployment '{name}': {e.reason}")
+                logger.warning("Failed to patch Deployment '%s': %s", _safe_log(name), e.reason)
         else:
             raise HTTPException(
                 status_code=409,
@@ -1162,7 +1178,7 @@ async def migrate_agent(
         try:
             kube.create_deployment(namespace=namespace, body=deployment_manifest)
             deployment_created = True
-            logger.info(f"Created Deployment '{name}' from Agent CRD")
+            logger.info("Created Deployment '%s' from Agent CRD", _safe_log(name))
         except ApiException as e:
             raise HTTPException(
                 status_code=e.status,
@@ -1175,7 +1191,7 @@ async def migrate_agent(
         try:
             kube.create_service(namespace=namespace, body=service_manifest)
             service_created = True
-            logger.info(f"Created Service '{name}' from Agent CRD")
+            logger.info("Created Service '%s' from Agent CRD", _safe_log(name))
         except ApiException as e:
             # If Deployment was created, try to clean up
             if deployment_created:
@@ -1203,10 +1219,10 @@ async def migrate_agent(
                 name=name,
             )
             agent_crd_deleted = True
-            logger.info(f"Deleted Agent CRD '{name}'")
+            logger.info("Deleted Agent CRD '%s'", _safe_log(name))
         except ApiException as e:
             if e.status != 404:
-                logger.warning(f"Failed to delete Agent CRD '{name}': {e.reason}")
+                logger.warning("Failed to delete Agent CRD '%s': %s", _safe_log(name), e.reason)
 
     # Build response message
     messages = []
@@ -1533,7 +1549,7 @@ async def list_build_strategies(
         return ClusterBuildStrategiesResponse(strategies=strategy_list)
 
     except ApiException as e:
-        logger.error(f"Failed to list ClusterBuildStrategies: {e}")
+        logger.error("Failed to list ClusterBuildStrategies: %s", e)
         raise HTTPException(
             status_code=e.status,
             detail=f"Failed to list build strategies: {e.reason}",
@@ -1869,7 +1885,7 @@ async def get_shipwright_build_info(
         except ApiException as e:
             # BuildRun not found is OK, just means no build has been triggered
             if e.status != 404:
-                logger.warning(f"Failed to get BuildRun for build '{name}': {e}")
+                logger.warning("Failed to get BuildRun for build '%s': %s", _safe_log(name), e)
 
         return response
 
@@ -1931,7 +1947,7 @@ def _ensure_authbridge_configmaps(
         data={"helper.conf": DEFAULT_SPIFFE_HELPER_CONF},
     )
 
-    logger.info(f"Ensured AuthBridge ConfigMaps in namespace '{namespace}'")
+    logger.info("Ensured AuthBridge ConfigMaps in namespace '%s'", _safe_log(namespace))
 
 
 def _ensure_authproxy_routes(
@@ -2724,7 +2740,11 @@ async def create_agent(
                     namespace=request.namespace,
                     body=workload_manifest,
                 )
-                logger.info(f"Created Job '{request.name}' in namespace '{request.namespace}'")
+                logger.info(
+                    "Created Job '%s' in namespace '%s'",
+                    _safe_log(request.name),
+                    _safe_log(request.namespace),
+                )
 
             # Create Service (not needed for Jobs)
             if request.workloadType != WORKLOAD_TYPE_JOB:
@@ -2733,7 +2753,11 @@ async def create_agent(
                     namespace=request.namespace,
                     body=service_manifest,
                 )
-                logger.info(f"Created Service '{request.name}' in namespace '{request.namespace}'")
+                logger.info(
+                    "Created Service '%s' in namespace '%s'",
+                    _safe_log(request.name),
+                    _safe_log(request.namespace),
+                )
 
             # Create AgentRuntime CR so the webhook injects sidecars on pod rollout
             if request.workloadType != WORKLOAD_TYPE_JOB:
@@ -2835,7 +2859,7 @@ async def create_agent(
                 status_code=404,
                 detail="Agent CRD not found. Is the kagenti-operator installed?",
             )
-        logger.error(f"Failed to create agent: {e}")
+        logger.error("Failed to create agent: %s", e)
         raise HTTPException(status_code=e.status, detail=str(e.reason))
 
 
@@ -2885,7 +2909,11 @@ async def finalize_shipwright_build(
     Agent configuration can be provided in the request body, or it will be read from
     the Build's kagenti.io/agent-config annotation (stored during build creation).
     """
-    logger.info(f"Finalizing Shipwright build '{name}' in namespace '{namespace}'")
+    logger.info(
+        "Finalizing Shipwright build '%s' in namespace '%s'",
+        _safe_log(name),
+        _safe_log(namespace),
+    )
 
     try:
         # Step 1: Get the latest BuildRun status to get the output image
@@ -2948,7 +2976,7 @@ async def finalize_shipwright_build(
             try:
                 stored_config = json.loads(agent_config_json)
             except json.JSONDecodeError as e:
-                logger.warning(f"Failed to parse agent config from Build annotation: {e}")
+                logger.warning("Failed to parse agent config from Build annotation: %s", e)
 
         # Determine expected workload type from stored config
         expected_workload_type = stored_config.get("workloadType", WORKLOAD_TYPE_DEPLOYMENT)
@@ -3224,7 +3252,9 @@ async def finalize_shipwright_build(
                 {k: v for k, v in build_labels.items() if k.startswith("kagenti.io/")}
             )
             kube.create_service(namespace=namespace, body=service_manifest)
-            logger.info(f"Created Service '{name}' in namespace '{namespace}'")
+            logger.info(
+                "Created Service '%s' in namespace '%s'", _safe_log(name), _safe_log(namespace)
+            )
 
         # Create AgentRuntime CR so the webhook injects sidecars on pod rollout
         # Only for agents — tools don't need sidecar injection
@@ -3268,7 +3298,7 @@ async def finalize_shipwright_build(
                 status_code=409,
                 detail=f"Agent '{name}' already exists in namespace '{namespace}'",
             )
-        logger.error(f"Failed to finalize build: {e}")
+        logger.error("Failed to finalize build: %s", e)
         raise HTTPException(status_code=e.status, detail=str(e.reason))
 
 
@@ -3409,12 +3439,12 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
     import ssl
     from pathlib import Path
 
-    logger.info(f"Fetching .env file from URL: {request.url}")
+    logger.info("Fetching .env file from URL: %s", _safe_log(request.url))
 
     # Log SSL/Certificate configuration
-    logger.info(f"SSL_CERT_FILE env: {os.environ.get('SSL_CERT_FILE', 'NOT SET')}")
-    logger.info(f"REQUESTS_CA_BUNDLE env: {os.environ.get('REQUESTS_CA_BUNDLE', 'NOT SET')}")
-    logger.info(f"Default SSL context: {ssl.get_default_verify_paths()}")
+    logger.info("SSL_CERT_FILE env: %s", os.environ.get("SSL_CERT_FILE", "NOT SET"))
+    logger.info("REQUESTS_CA_BUNDLE env: %s", os.environ.get("REQUESTS_CA_BUNDLE", "NOT SET"))
+    logger.info("Default SSL context: %s", ssl.get_default_verify_paths())
 
     # Check if cert files exist
     cert_paths = [
@@ -3426,7 +3456,7 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
         exists = (
             Path(cert_path).exists() if cert_path.endswith(".crt") else Path(cert_path).is_dir()
         )
-        logger.info(f"Certificate path {cert_path}: {'EXISTS' if exists else 'NOT FOUND'}")
+        logger.info("Certificate path %s: %s", cert_path, "EXISTS" if exists else "NOT FOUND")
 
     # Security validation - only allow http/https
     parsed_url = urlparse(request.url)
@@ -3440,19 +3470,19 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
     # Prevent SSRF attacks - block private IPs
     try:
         ip = socket.gethostbyname(parsed_url.hostname)
-        logger.debug(f"Resolved {parsed_url.hostname} to {ip}")
+        logger.debug("Resolved %s to %s", _safe_log(parsed_url.hostname), ip)
         if is_ip_blocked(ip):
-            logger.warning(f"Blocked private IP address: {ip}")
+            logger.warning("Blocked private IP address: %s", ip)
             raise HTTPException(
                 status_code=400, detail="Private IP addresses are not allowed for security reasons"
             )
     except socket.gaierror as e:
         # Domain can't be resolved - log but let httpx handle it
-        logger.warning(f"Could not resolve hostname {parsed_url.hostname}: {e}")
+        logger.warning("Could not resolve hostname %s: %s", _safe_log(parsed_url.hostname), e)
     except HTTPException:
         raise
     except Exception as e:
-        logger.warning(f"Error checking IP for {parsed_url.hostname}: {e}")
+        logger.warning("Error checking IP for %s: %s", _safe_log(parsed_url.hostname), e)
 
     # Fetch content with timeout
     try:
@@ -3467,7 +3497,7 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
                     ca_bundle_path = fallback
                     break
 
-        logger.info(f"Using CA bundle: {ca_bundle_path}")
+        logger.info("Using CA bundle: %s", ca_bundle_path)
 
         # Create SSL context with system certificates
         ssl_context = ssl.create_default_context(cafile=ca_bundle_path)
@@ -3475,11 +3505,11 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
         async with httpx.AsyncClient(
             timeout=10.0, follow_redirects=True, verify=ssl_context
         ) as client:
-            logger.debug(f"Making HTTP request to {request.url}")
+            logger.debug("Making HTTP request to %s", _safe_log(request.url))
             response = await client.get(request.url)
             response.raise_for_status()
 
-            logger.info(f"Successfully fetched URL, content length: {len(response.text)} bytes")
+            logger.info("Successfully fetched URL, content length: %d bytes", len(response.text))
 
             # Validate content isn't too large (max 1MB)
             content = response.text
@@ -3488,17 +3518,19 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
 
             return FetchEnvUrlResponse(content=content, url=request.url)
     except httpx.TimeoutException as e:
-        logger.error(f"Timeout fetching URL {request.url}: {e}")
+        logger.error("Timeout fetching URL %s: %s", _safe_log(request.url), e)
         raise HTTPException(status_code=504, detail="Request timeout while fetching URL")
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error fetching URL {request.url}: {e.response.status_code}")
+        logger.error(
+            "HTTP error fetching URL %s: %s", _safe_log(request.url), e.response.status_code
+        )
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"Failed to fetch URL: {e.response.status_code} {e.response.reason_phrase}",
         )
     except httpx.HTTPError as e:
-        logger.error(f"HTTP error fetching URL {request.url}: {str(e)}")
+        logger.error("HTTP error fetching URL %s: %s", _safe_log(request.url), e)
         raise HTTPException(status_code=502, detail=f"Failed to fetch URL: {str(e)}")
     except Exception as e:
-        logger.error(f"Unexpected error fetching URL {request.url}: {str(e)}")
+        logger.error("Unexpected error fetching URL %s: %s", _safe_log(request.url), e)
         raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -8,6 +8,7 @@ Provides endpoints for chatting with A2A agents using the Agent-to-Agent protoco
 """
 
 import logging
+import re
 from typing import Optional, List
 from uuid import uuid4
 
@@ -22,6 +23,26 @@ from app.utils.routes import get_agent_url
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
+
+# Cluster-local URL pattern for SSRF prevention (CWE-918)
+_CLUSTER_LOCAL_URL_RE = re.compile(
+    r"^http://[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+    r"\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.svc\.cluster\.local:\d+$"
+)
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
+def _validate_agent_url(agent_url: str) -> str:
+    """Validate that agent_url is a cluster-local service URL (SSRF prevention)."""
+    if not _CLUSTER_LOCAL_URL_RE.match(agent_url):
+        raise ValueError("Invalid agent URL: must be a cluster-local service URL")
+    return agent_url
+
 
 # A2A protocol constants
 A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json"
@@ -77,6 +98,8 @@ async def get_agent_card(
     All agents are reached via their cluster-internal URL through AuthBridge.
     """
     agent_url = get_agent_url(name, namespace)
+    if settings.is_running_in_cluster:
+        _validate_agent_url(agent_url)
     card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
 
     try:
@@ -111,19 +134,19 @@ async def get_agent_card(
             )
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error fetching agent card: {e}")
+        logger.error("HTTP error fetching agent card: %s", e)
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"Failed to fetch agent card: {e.response.text}",
         )
     except httpx.RequestError as e:
-        logger.error(f"Request error fetching agent card: {e}")
+        logger.error("Request error fetching agent card: %s", e)
         raise HTTPException(
             status_code=503,
             detail=f"Failed to connect to agent at {agent_url}",
         )
     except Exception as e:
-        logger.error(f"Unexpected error fetching agent card: {e}")
+        logger.error("Unexpected error fetching agent card: %s", e)
         raise HTTPException(
             status_code=500,
             detail=f"Error fetching agent card: {str(e)}",
@@ -152,6 +175,8 @@ async def send_message(
     authenticated requests.
     """
     agent_url = get_agent_url(name, namespace)
+    if settings.is_running_in_cluster:
+        _validate_agent_url(agent_url)
     session_id = request.session_id or uuid4().hex
 
     # Build A2A message payload
@@ -215,19 +240,19 @@ async def send_message(
             )
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error sending message: {e}")
+        logger.error("HTTP error sending message: %s", e)
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"Agent returned error: {e.response.text}",
         )
     except httpx.RequestError as e:
-        logger.error(f"Request error sending message: {e}")
+        logger.error("Request error sending message: %s", e)
         raise HTTPException(
             status_code=503,
             detail=f"Failed to connect to agent at {agent_url}",
         )
     except Exception as e:
-        logger.error(f"Unexpected error sending message: {e}")
+        logger.error("Unexpected error sending message: %s", e)
         raise HTTPException(
             status_code=500,
             detail=f"Error sending message: {str(e)}",
@@ -303,8 +328,12 @@ async def _stream_a2a_response(
         },
     }
 
-    logger.info(f"Starting A2A stream to {agent_url} with session_id={session_id}")
-    logger.debug(f"Message payload: {json.dumps(message_payload, indent=2)}")
+    logger.info(
+        "Starting A2A stream to %s with session_id=%s",
+        _safe_log(agent_url),
+        _safe_log(session_id),
+    )
+    logger.debug("Message payload: %s", json.dumps(message_payload, indent=2))
 
     # Prepare headers with optional Authorization
     headers = {
@@ -451,7 +480,7 @@ async def _stream_a2a_response(
                                         if content:
                                             payload["content"] = content
 
-                                logger.info(f"Yielding task event: state={state}")
+                                logger.info("Yielding task event: state=%s", state)
                                 yield f"data: {json.dumps(payload)}\n\n"
 
                             # Direct message (A2AMessage)
@@ -472,22 +501,26 @@ async def _stream_a2a_response(
                                     payload["content"] = content
 
                                 logger.info(
-                                    f"Yielding direct message event: messageId={message_id}"
+                                    "Yielding direct message event: messageId=%s", message_id
                                 )
                                 yield f"data: {json.dumps(payload)}\n\n"
 
                             else:
                                 logger.warning(
-                                    f"Unknown result structure: keys={list(result.keys())}"
+                                    "Unknown result structure: keys=%s", list(result.keys())
                                 )
 
                         except json.JSONDecodeError as e:
-                            logger.warning(f"Failed to parse SSE data: {data[:200]}, error: {e}")
+                            logger.warning(
+                                "Failed to parse SSE data: %s, error: %s",
+                                _safe_log(data[:200]),
+                                e,
+                            )
                             continue
 
     except httpx.HTTPStatusError as e:
         error_msg = f"Agent error: {e.response.status_code}"
-        logger.error(f"{error_msg}: {e.response.text[:500]}")
+        logger.error("%s: %s", error_msg, _safe_log(e.response.text[:500]))
         yield f"data: {json.dumps({'error': error_msg, 'session_id': session_id})}\n\n"
     except httpx.RequestError as e:
         error_msg = f"Connection error: {str(e)}"
@@ -517,6 +550,8 @@ async def stream_message(
     authenticated requests.
     """
     agent_url = get_agent_url(name, namespace)
+    if settings.is_running_in_cluster:
+        _validate_agent_url(agent_url)
     session_id = request.session_id or uuid4().hex
 
     # Extract Authorization header if present

--- a/kagenti/backend/app/routers/events.py
+++ b/kagenti/backend/app/routers/events.py
@@ -1,0 +1,272 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Paginated event retrieval API endpoints.
+
+Provides read access to per-event records stored in the events table.
+Events are persisted during SSE streaming (one row per loop event) and
+retrieved here for paginated history loading.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.core.auth import (
+    get_required_user,
+    require_roles,
+    TokenData,
+    ROLE_VIEWER,
+)
+from app.services.session_db import get_session_pool
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/sandbox", tags=["events"])
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class EventRecord(BaseModel):
+    """Single persisted event."""
+
+    id: int
+    context_id: str
+    task_id: str
+    event_index: int
+    event_type: str
+    event_category: Optional[str] = None
+    langgraph_node: Optional[str] = None
+    payload: Dict[str, Any]
+    created_at: Optional[str] = None
+
+
+class PaginatedEvents(BaseModel):
+    """Paginated list of events."""
+
+    events: List[EventRecord]
+    has_more: bool
+    next_index: int
+
+
+class TaskEventSummary(BaseModel):
+    """Summary of a task for paginated task listing."""
+
+    task_id: str
+    user_message: str
+    status: str
+    step_count: int
+    created_at: Optional[str] = None
+    agent_name: str
+
+
+class PaginatedTasks(BaseModel):
+    """Paginated list of task summaries."""
+
+    tasks: List[TaskEventSummary]
+    has_more: bool
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_json_field(value: Any) -> Any:
+    """Parse a JSON field that may be a string or already a dict/list."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{namespace}/events",
+    response_model=PaginatedEvents,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_events(
+    namespace: str,
+    context_id: str = Query(..., description="Session context ID"),
+    task_id: Optional[str] = Query(default=None, description="Filter by task ID"),
+    from_index: int = Query(default=0, ge=0, description="Start from event_index"),
+    limit: int = Query(default=100, ge=1, le=2000, description="Max events to return"),
+    user: TokenData = Depends(get_required_user),
+):
+    """Get paginated events for a session/task.
+
+    Returns events ordered by event_index ascending, starting from from_index.
+    """
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        if task_id:
+            rows = await conn.fetch(
+                "SELECT id, context_id, task_id, event_index, event_type,"
+                "       event_category, langgraph_node, payload, created_at"
+                " FROM events"
+                " WHERE context_id = $1 AND task_id = $2 AND event_index >= $3"
+                " ORDER BY event_index ASC"
+                " LIMIT $4",
+                context_id,
+                task_id,
+                from_index,
+                limit + 1,  # fetch one extra to detect has_more
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT id, context_id, task_id, event_index, event_type,"
+                "       event_category, langgraph_node, payload, created_at"
+                " FROM events"
+                " WHERE context_id = $1 AND event_index >= $2"
+                " ORDER BY event_index ASC"
+                " LIMIT $3",
+                context_id,
+                from_index,
+                limit + 1,
+            )
+
+    has_more = len(rows) > limit
+    result_rows = rows[:limit]
+
+    events = []
+    for r in result_rows:
+        payload = r["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        events.append(
+            EventRecord(
+                id=r["id"],
+                context_id=r["context_id"],
+                task_id=r["task_id"],
+                event_index=r["event_index"],
+                event_type=r["event_type"],
+                event_category=r["event_category"],
+                langgraph_node=r["langgraph_node"],
+                payload=payload,
+                created_at=str(r["created_at"]) if r["created_at"] else None,
+            )
+        )
+
+    next_index = result_rows[-1]["event_index"] + 1 if result_rows else from_index
+
+    return PaginatedEvents(events=events, has_more=has_more, next_index=next_index)
+
+
+@router.get(
+    "/{namespace}/tasks/paginated",
+    response_model=PaginatedTasks,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_paginated_tasks(
+    namespace: str,
+    context_id: str = Query(..., description="Session context ID"),
+    limit: int = Query(default=5, ge=1, le=50, description="Max tasks to return"),
+    before_id: Optional[str] = Query(
+        default=None, description="Return tasks created before this task_id"
+    ),
+    user: TokenData = Depends(get_required_user),
+):
+    """Get paginated task summaries for a session.
+
+    Returns tasks ordered by creation time descending (newest first).
+    Each task includes the user message, status, step count, and agent name.
+    """
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        # Build query based on whether before_id is provided
+        if before_id:
+            # Get the created_at of the before_id task for cursor pagination
+            before_row = await conn.fetchrow(
+                "SELECT id FROM tasks WHERE id = $1 AND context_id = $2",
+                before_id,
+                context_id,
+            )
+            if not before_row:
+                raise HTTPException(404, f"Task {before_id} not found")
+
+            rows = await conn.fetch(
+                "SELECT id, context_id, status, metadata, history"
+                " FROM tasks"
+                " WHERE context_id = $1 AND id < $2"
+                " ORDER BY id DESC"
+                " LIMIT $3",
+                context_id,
+                before_id,
+                limit + 1,
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT id, context_id, status, metadata, history"
+                " FROM tasks"
+                " WHERE context_id = $1"
+                " ORDER BY id DESC"
+                " LIMIT $2",
+                context_id,
+                limit + 1,
+            )
+
+        has_more = len(rows) > limit
+        result_rows = rows[:limit]
+
+        tasks = []
+        for r in result_rows:
+            meta = _parse_json_field(r["metadata"]) or {}
+            status = _parse_json_field(r["status"]) or {}
+            history = _parse_json_field(r["history"]) or []
+
+            # Extract user message from history
+            user_message = ""
+            for h in history:
+                if isinstance(h, dict) and h.get("role") == "user":
+                    parts = h.get("parts", [])
+                    for p in parts:
+                        if isinstance(p, dict) and p.get("text"):
+                            user_message = p["text"]
+                            break
+                    if user_message:
+                        break
+            if not user_message:
+                user_message = meta.get("title", "")
+
+            # Count events (steps) from events table or loop_events in metadata
+            loop_events = meta.get("loop_events", [])
+            step_count = len(loop_events)
+
+            # If events table has data, use that count instead
+            try:
+                evt_count = await conn.fetchval(
+                    "SELECT COUNT(*) FROM events WHERE task_id = $1",
+                    r["id"],
+                )
+                if evt_count and evt_count > 0:
+                    step_count = evt_count
+            except Exception:
+                pass  # events table may not exist yet
+
+            tasks.append(
+                TaskEventSummary(
+                    task_id=r["id"],
+                    user_message=user_message[:200],
+                    status=status.get("state", "unknown"),
+                    step_count=step_count,
+                    created_at=None,  # tasks table doesn't have created_at column
+                    agent_name=meta.get("agent_name", ""),
+                )
+            )
+
+    return PaginatedTasks(tasks=tasks, has_more=has_more)

--- a/kagenti/backend/app/routers/integrations.py
+++ b/kagenti/backend/app/routers/integrations.py
@@ -1,0 +1,625 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Integration API endpoints.
+
+Manages Integration custom resources that connect repositories
+to agents via webhooks, cron schedules, and alert triggers.
+"""
+
+import base64
+import hashlib
+import hmac
+import json as json_module
+import logging
+import re
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel
+
+from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+
+logger = logging.getLogger(__name__)
+
+_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+# Cluster-local URL pattern for SSRF prevention (CWE-918)
+_CLUSTER_LOCAL_URL_RE = re.compile(
+    r"^http://[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+    r"\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.svc\.cluster\.local:\d+$"
+)
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
+router = APIRouter(prefix="/integrations", tags=["integrations"])
+
+# CRD constants
+CRD_GROUP = "kagenti.io"
+CRD_VERSION = "v1alpha1"
+CRD_PLURAL = "integrations"
+
+
+# Request/Response models
+class IntegrationAgentRef(BaseModel):
+    """Reference to an agent associated with an integration."""
+
+    name: str
+    namespace: str
+
+
+class IntegrationWebhook(BaseModel):
+    """Webhook trigger configuration for an integration."""
+
+    name: str
+    events: list[str]
+    filters: Optional[dict] = None
+
+
+class IntegrationSchedule(BaseModel):
+    """Cron schedule trigger configuration for an integration."""
+
+    name: str
+    cron: str
+    skill: str
+    agent: str
+    enabled: bool = True
+
+
+class IntegrationAlert(BaseModel):
+    """Alert trigger configuration for an integration."""
+
+    name: str
+    source: str  # prometheus | pagerduty
+    matchLabels: dict[str, str]  # noqa: N815
+    agent: str
+
+
+class RepositorySpec(BaseModel):
+    """Repository connection specification."""
+
+    url: str
+    provider: str = "github"
+    branch: str = "main"
+    credentialsSecret: Optional[str] = None  # noqa: N815
+
+
+class CreateIntegrationRequest(BaseModel):
+    """Request body for creating an Integration resource."""
+
+    name: str
+    namespace: str
+    repository: RepositorySpec
+    agents: list[IntegrationAgentRef]
+    webhooks: list[IntegrationWebhook] = []
+    schedules: list[IntegrationSchedule] = []
+    alerts: list[IntegrationAlert] = []
+
+
+class IntegrationSummary(BaseModel):
+    """Summary representation of an Integration resource."""
+
+    name: str
+    namespace: str
+    repository: dict
+    agents: list[dict]
+    webhooks: list[dict]
+    schedules: list[dict]
+    alerts: list[dict]
+    status: str
+    webhookUrl: Optional[str] = None  # noqa: N815
+    lastWebhookEvent: Optional[str] = None  # noqa: N815
+    lastScheduleRun: Optional[str] = None  # noqa: N815
+    createdAt: Optional[str] = None  # noqa: N815
+
+
+class IntegrationListResponse(BaseModel):
+    """Response containing a list of Integration summaries."""
+
+    items: list[IntegrationSummary]
+
+
+def _crd_to_summary(obj: dict) -> IntegrationSummary:
+    """Convert a K8s Integration CRD object to an IntegrationSummary."""
+    metadata = obj.get("metadata", {})
+    spec = obj.get("spec", {})
+    obj_status = obj.get("status", {})
+
+    # Determine status from conditions
+    conditions = obj_status.get("conditions", [])
+    integration_status = "Pending"
+    for cond in conditions:
+        if cond.get("type") == "Connected" and cond.get("status") == "True":
+            integration_status = "Connected"
+            break
+        if cond.get("type") == "Error":
+            integration_status = "Error"
+            break
+
+    return IntegrationSummary(
+        name=metadata.get("name", ""),
+        namespace=metadata.get("namespace", ""),
+        repository=spec.get("repository", {}),
+        agents=list(spec.get("agents", [])),
+        webhooks=spec.get("webhooks", []),
+        schedules=spec.get("schedules", []),
+        alerts=spec.get("alerts", []),
+        status=integration_status,
+        webhookUrl=obj_status.get("webhookUrl"),
+        lastWebhookEvent=obj_status.get("lastWebhookEvent"),
+        lastScheduleRun=obj_status.get("lastScheduleRun"),
+        createdAt=metadata.get("creationTimestamp"),
+    )
+
+
+@router.get(
+    "",
+    response_model=IntegrationListResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def list_integrations(
+    namespace: str = Query(..., description="Namespace to list integrations from"),
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> IntegrationListResponse:
+    """List Integration resources in a namespace."""
+    try:
+        result = kube.custom_api.list_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=namespace,
+            plural=CRD_PLURAL,
+        )
+        items = [_crd_to_summary(obj) for obj in result.get("items", [])]
+        return IntegrationListResponse(items=items)
+    except Exception as e:
+        logger.error("Failed to list integrations in %s: %s", _safe_log(namespace), e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list integrations",
+        )
+
+
+@router.get(
+    "/{namespace}/{name}",
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_integration(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Get a specific Integration resource."""
+    try:
+        obj = kube.custom_api.get_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=namespace,
+            plural=CRD_PLURAL,
+            name=name,
+        )
+        summary = _crd_to_summary(obj)
+        # Add conditions for detail view
+        obj_status = obj.get("status", {})
+        return {
+            **summary.model_dump(),
+            "conditions": obj_status.get("conditions", []),
+        }
+    except Exception as e:
+        if "NotFound" in str(e) or "404" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Integration {namespace}/{name} not found",
+            )
+        logger.error(
+            "Failed to get integration %s/%s: %s", _safe_log(namespace), _safe_log(name), e
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to get integration",
+        )
+
+
+@router.post(
+    "",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def create_integration(
+    request: CreateIntegrationRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Create a new Integration resource."""
+    body = {
+        "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
+        "kind": "Integration",
+        "metadata": {
+            "name": request.name,
+            "namespace": request.namespace,
+            "labels": {
+                "kagenti.io/provider": request.repository.provider,
+            },
+        },
+        "spec": {
+            "repository": request.repository.model_dump(exclude_none=True),
+            "agents": [a.model_dump() for a in request.agents],
+            "webhooks": [w.model_dump(exclude_none=True) for w in request.webhooks],
+            "schedules": [s.model_dump() for s in request.schedules],
+            "alerts": [a.model_dump() for a in request.alerts],
+        },
+    }
+
+    try:
+        kube.custom_api.create_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=request.namespace,
+            plural=CRD_PLURAL,
+            body=body,
+        )
+        return {
+            "success": True,
+            "name": request.name,
+            "namespace": request.namespace,
+            "message": f"Integration {request.name} created",
+        }
+    except Exception as e:
+        if "AlreadyExists" in str(e) or "409" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Integration {request.name} already exists in {request.namespace}",
+            )
+        logger.error("Failed to create integration: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create integration",
+        )
+
+
+@router.put(
+    "/{namespace}/{name}",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def update_integration(
+    namespace: str,
+    name: str,
+    request: dict,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Update an existing Integration resource (partial spec update)."""
+    try:
+        obj = kube.custom_api.get_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=namespace,
+            plural=CRD_PLURAL,
+            name=name,
+        )
+
+        spec = obj.get("spec", {})
+        for key in ["agents", "webhooks", "schedules", "alerts"]:
+            if key in request:
+                spec[key] = request[key]
+        obj["spec"] = spec
+
+        kube.custom_api.replace_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=namespace,
+            plural=CRD_PLURAL,
+            name=name,
+            body=obj,
+        )
+        return {"success": True, "message": f"Integration {name} updated"}
+    except Exception as e:
+        if "NotFound" in str(e) or "404" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Integration {namespace}/{name} not found",
+            )
+        logger.error(
+            "Failed to update integration %s/%s: %s", _safe_log(namespace), _safe_log(name), e
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update integration",
+        )
+
+
+@router.delete(
+    "/{namespace}/{name}",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def delete_integration(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Delete an Integration resource."""
+    try:
+        kube.custom_api.delete_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=namespace,
+            plural=CRD_PLURAL,
+            name=name,
+        )
+        return {"success": True, "message": f"Integration {name} deleted"}
+    except Exception as e:
+        if "NotFound" in str(e) or "404" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Integration {namespace}/{name} not found",
+            )
+        logger.error(
+            "Failed to delete integration %s/%s: %s", _safe_log(namespace), _safe_log(name), e
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete integration",
+        )
+
+
+@router.post(
+    "/{namespace}/{name}/test",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def test_integration_connection(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Test connectivity to the integration's repository."""
+    try:
+        obj = kube.custom_api.get_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=namespace,
+            plural=CRD_PLURAL,
+            name=name,
+        )
+        repo_url = obj.get("spec", {}).get("repository", {}).get("url", "")
+        if not repo_url.startswith("https://"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Repository URL must use HTTPS",
+            )
+        async with httpx.AsyncClient() as client:
+            response = await client.head(repo_url, timeout=10.0, follow_redirects=True)
+            if response.status_code < 400:
+                return {"success": True, "message": f"Repository {repo_url} is reachable"}
+            return {
+                "success": False,
+                "message": f"Repository returned status {response.status_code}",
+            }
+    except httpx.HTTPError as e:
+        logger.warning(
+            "Connection test failed for %s/%s: %s", _safe_log(namespace), _safe_log(name), e
+        )
+        return {"success": False, "message": "Connection failed"}
+    except Exception as e:
+        logger.error("Test failed for %s/%s: %s", _safe_log(namespace), _safe_log(name), e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Integration connection test failed",
+        )
+
+
+@router.post(
+    "/{namespace}/{name}/webhook",
+)
+async def receive_webhook(
+    namespace: str,
+    name: str,
+    request: Request,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """
+    Receive a webhook event from GitHub/GitLab.
+
+    This endpoint is public (no auth required) — it validates the webhook
+    signature using the secret stored in the Integration CRD.
+    """
+    body = await request.body()
+
+    # Get the Integration CRD
+    try:
+        obj = kube.custom_api.get_namespaced_custom_object(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=namespace,
+            plural=CRD_PLURAL,
+            name=name,
+        )
+    except Exception as e:
+        if "NotFound" in str(e) or "404" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Integration {namespace}/{name} not found",
+            )
+        raise
+
+    spec = obj.get("spec", {})
+    repo = spec.get("repository", {})
+    agents = spec.get("agents", [])
+    webhooks = spec.get("webhooks", [])
+
+    # Validate webhook signature if configured
+    webhook_secret = None
+    for wh in webhooks:
+        if wh.get("secret"):
+            webhook_secret = wh["secret"]
+            break
+
+    if webhook_secret:
+        # Look up the secret value from K8s
+        try:
+            secret_obj = kube.core_api.read_namespaced_secret(
+                name=webhook_secret, namespace=namespace
+            )
+            secret_value = base64.b64decode(secret_obj.data.get("webhook-secret", "")).decode()
+
+            # Validate HMAC signature
+            signature = request.headers.get("X-Hub-Signature-256", "")
+            if signature:
+                expected = (
+                    "sha256=" + hmac.new(secret_value.encode(), body, hashlib.sha256).hexdigest()
+                )
+                if not hmac.compare_digest(signature, expected):
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="Invalid webhook signature",
+                    )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning("Could not validate webhook signature: %s", e)
+
+    # Parse the event
+    try:
+        payload = json_module.loads(body)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid JSON payload",
+        )
+
+    event_type = request.headers.get("X-GitHub-Event", "unknown")
+    delivery_id = request.headers.get("X-GitHub-Delivery", "")
+
+    # Build event summary for the agent
+    event_summary = _summarize_github_event(event_type, payload)
+
+    # Log the event
+    logger.info(
+        "Webhook received: integration=%s/%s event=%s delivery=%s agents=%d",
+        _safe_log(namespace),
+        _safe_log(name),
+        _safe_log(event_type),
+        _safe_log(delivery_id),
+        len(agents),
+    )
+
+    # Forward to assigned agents via A2A
+    results = []
+    for agent_ref in agents:
+        agent_name = agent_ref.get("name", "")
+        agent_ns = agent_ref.get("namespace", namespace)
+
+        # Build A2A message
+        a2a_payload = {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": event_summary}],
+            },
+            "metadata": {
+                "session_type": "trigger",
+                "trigger_source": "webhook",
+                "trigger_event": f"{event_type}",
+                "trigger_repo": repo.get("url", ""),
+                "trigger_delivery_id": delivery_id,
+                "integration_name": name,
+                "integration_namespace": namespace,
+            },
+        }
+
+        # Send to agent's A2A endpoint — validate inputs to prevent SSRF (CWE-918)
+        if not _K8S_NAME_RE.match(agent_name) or not _K8S_NAME_RE.match(agent_ns):
+            logger.warning(
+                "Skipping agent with invalid name/namespace: %s/%s",
+                _safe_log(agent_ns),
+                _safe_log(agent_name),
+            )
+            continue
+        agent_url = f"http://{agent_name}.{agent_ns}.svc.cluster.local:8000"
+        if not _CLUSTER_LOCAL_URL_RE.match(agent_url):
+            logger.warning("Skipping agent with invalid URL: %s", _safe_log(agent_url))
+            continue
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{agent_url}/ap/v1/agent/tasks/send",
+                    json=a2a_payload,
+                    timeout=30.0,
+                )
+                results.append(
+                    {
+                        "agent": f"{agent_ns}/{agent_name}",
+                        "status": resp.status_code,
+                        "success": resp.status_code < 400,
+                    }
+                )
+        except Exception as e:
+            logger.error("Failed to forward webhook to %s: %s", _safe_log(agent_name), e)
+            results.append(
+                {
+                    "agent": f"{agent_ns}/{agent_name}",
+                    "status": 0,
+                    "success": False,
+                    "error": "Failed to deliver webhook to agent",
+                }
+            )
+
+    return {
+        "received": True,
+        "event": event_type,
+        "delivery_id": delivery_id,
+        "agents_notified": len(results),
+        "results": results,
+    }
+
+
+def _summarize_github_event(event_type: str, payload: dict) -> str:
+    """Create a human-readable summary of a GitHub webhook event."""
+    repo_name = payload.get("repository", {}).get("full_name", "unknown")
+    sender = payload.get("sender", {}).get("login", "unknown")
+
+    if event_type == "pull_request":
+        pr = payload.get("pull_request", {})
+        action = payload.get("action", "")
+        return (
+            f"GitHub PR #{pr.get('number', '?')} {action} in {repo_name}\n"
+            f"Title: {pr.get('title', '')}\n"
+            f"Author: {sender}\n"
+            f"Branch: {pr.get('head', {}).get('ref', '')} "
+            f"\u2192 {pr.get('base', {}).get('ref', '')}\n"
+            f"URL: {pr.get('html_url', '')}\n"
+            f"\n{pr.get('body', '')[:500]}"
+        )
+    elif event_type == "issue_comment":
+        comment = payload.get("comment", {})
+        issue = payload.get("issue", {})
+        return (
+            f"GitHub comment on #{issue.get('number', '?')} in {repo_name}\n"
+            f"By: {sender}\n"
+            f"Issue: {issue.get('title', '')}\n"
+            f"Comment: {comment.get('body', '')[:500]}"
+        )
+    elif event_type == "push":
+        commits = payload.get("commits", [])
+        ref = payload.get("ref", "")
+        return (
+            f"GitHub push to {ref} in {repo_name}\n"
+            f"By: {sender}\n"
+            f"Commits: {len(commits)}\n"
+            + "\n".join(f"  - {c.get('message', '').split(chr(10))[0]}" for c in commits[:5])
+        )
+    elif event_type == "check_suite":
+        suite = payload.get("check_suite", {})
+        return (
+            f"GitHub check suite {payload.get('action', '')} in {repo_name}\n"
+            f"Status: {suite.get('status', '')} / {suite.get('conclusion', '')}\n"
+            f"Branch: {suite.get('head_branch', '')}"
+        )
+    else:
+        return (
+            f"GitHub {event_type} event in {repo_name}\n"
+            f"By: {sender}\n"
+            f"Action: {payload.get('action', 'N/A')}"
+        )

--- a/kagenti/backend/app/routers/llm_keys.py
+++ b/kagenti/backend/app/routers/llm_keys.py
@@ -1,0 +1,479 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+LLM virtual key management API.
+
+Manages LiteLLM teams (per namespace) and virtual keys (per agent)
+through the LiteLLM admin API. The backend holds the master key and
+proxies admin operations.
+
+Key hierarchy:
+  Master Key (kagenti-system) → Team (namespace) → Agent Key (per-agent)
+"""
+
+import logging
+import os
+import re
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.core.auth import require_roles, ROLE_ADMIN, ROLE_VIEWER
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+
+logger = logging.getLogger(__name__)
+
+_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
+router = APIRouter(prefix="/llm", tags=["llm-keys"])
+
+LITELLM_BASE_URL = os.getenv("LITELLM_BASE_URL", "http://litellm-proxy.kagenti-system.svc:4000")
+LITELLM_MASTER_KEY = os.getenv("LITELLM_MASTER_KEY", "")
+
+
+def _master_headers() -> dict[str, str]:
+    if not LITELLM_MASTER_KEY:
+        raise HTTPException(
+            status_code=503,
+            detail="LiteLLM master key not configured (LITELLM_MASTER_KEY env var)",
+        )
+    return {
+        "Authorization": f"Bearer {LITELLM_MASTER_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class TeamCreateRequest(BaseModel):
+    namespace: str
+    max_budget: float = 500.0
+    budget_duration: str = "30d"
+    models: Optional[list[str]] = None
+
+
+class TeamResponse(BaseModel):
+    team_id: str
+    namespace: str
+    max_budget: float = 0.0
+    budget_used: float = 0.0
+    models: list[str] = []
+
+
+class KeyCreateRequest(BaseModel):
+    namespace: str
+    agent_name: str
+    max_budget: float = 100.0
+    budget_duration: str = "30d"
+    models: Optional[list[str]] = None
+
+
+class KeyResponse(BaseModel):
+    key_alias: str
+    secret_name: str
+    namespace: str
+
+
+class KeyInfo(BaseModel):
+    key_alias: str
+    agent_name: str
+    max_budget: float = 0.0
+    budget_used: float = 0.0
+    models: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _litellm_request(
+    method: str, path: str, json: dict | None = None, *, allow_conflict: bool = False
+) -> dict:
+    """Make an authenticated request to LiteLLM admin API."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.request(
+            method,
+            f"{LITELLM_BASE_URL}{path}",
+            headers=_master_headers(),
+            json=json,
+        )
+        if resp.status_code >= 400:
+            if allow_conflict and resp.status_code == 400 and "already exists" in resp.text:
+                logger.info("LiteLLM %s %s: resource already exists (idempotent)", method, path)
+                return {"_already_exists": True}
+            logger.warning(
+                "LiteLLM %s %s returned %s: %s",
+                method,
+                path,
+                resp.status_code,
+                resp.text[:300],
+            )
+            raise HTTPException(
+                status_code=resp.status_code,
+                detail=f"LiteLLM error: {resp.text[:300]}",
+            )
+        return resp.json()
+
+
+def _extract_keys(data: dict | list) -> list[dict]:
+    """Extract key list from litellm /key/list response.
+
+    LiteLLM returns {"keys": [...], "total_count": ...} — NOT {"data": [...]}.
+    """
+    if isinstance(data, list):
+        return [k for k in data if isinstance(k, dict)]
+    raw = data.get("keys", data.get("data", []))
+    return [k for k in raw if isinstance(k, dict)]
+
+
+async def _get_team_id(namespace: str) -> str | None:
+    """Look up litellm team_id for a namespace by alias."""
+    try:
+        data = await _litellm_request("GET", "/team/list")
+        teams = data if isinstance(data, list) else data.get("data", data.get("teams", []))
+        for team in teams:
+            if team.get("team_alias") == namespace:
+                return team.get("team_id")
+    except HTTPException:
+        pass
+    return None
+
+
+async def _ensure_team(
+    namespace: str, max_budget: float = 500.0, budget_duration: str = "30d"
+) -> str:
+    """Get or create a litellm team for a namespace. Returns team_id."""
+    existing = await _get_team_id(namespace)
+    if existing:
+        return existing
+
+    data = await _litellm_request(
+        "POST",
+        "/team/new",
+        json={
+            "team_alias": namespace,
+            "max_budget": max_budget,
+            "budget_duration": budget_duration,
+        },
+    )
+    team_id = data.get("team_id", "")
+    if not team_id:
+        raise HTTPException(status_code=500, detail="LiteLLM did not return team_id")
+    logger.info(
+        "Created litellm team %s for namespace %s", _safe_log(team_id), _safe_log(namespace)
+    )
+    return team_id
+
+
+async def _create_virtual_key(
+    team_id: str,
+    key_alias: str,
+    namespace: str,
+    max_budget: float = 100.0,
+    budget_duration: str = "30d",
+    models: list[str] | None = None,
+) -> str:
+    """Generate a litellm virtual key under a team. Returns the key token."""
+    body: dict = {
+        "team_id": team_id,
+        "key_alias": key_alias,
+        "max_budget": max_budget,
+        "budget_duration": budget_duration,
+        "metadata": {"namespace": namespace, "agent": key_alias},
+    }
+    if models:
+        body["models"] = models
+
+    data = await _litellm_request("POST", "/key/generate", json=body, allow_conflict=True)
+    if data.get("_already_exists"):
+        return ""  # Key exists — caller should handle empty return
+    key = data.get("token") or data.get("key", "")
+    if not key:
+        raise HTTPException(status_code=500, detail="LiteLLM did not return a key")
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Team endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/teams",
+    response_model=TeamResponse,
+    dependencies=[Depends(require_roles(ROLE_ADMIN))],
+)
+async def create_team(
+    req: TeamCreateRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Create a litellm team for a namespace and store a default virtual key."""
+    team_id = await _ensure_team(req.namespace, req.max_budget, req.budget_duration)
+
+    # Create default namespace key (idempotent — may already exist)
+    key = await _create_virtual_key(
+        team_id=team_id,
+        key_alias=f"{req.namespace}-default",
+        namespace=req.namespace,
+        max_budget=req.max_budget,
+        budget_duration=req.budget_duration,
+        models=req.models,
+    )
+
+    # Store in k8s secret (only if new key was created)
+    if key:
+        kube.create_secret(
+            namespace=req.namespace,
+            name="litellm-virtual-keys",
+            string_data={"api-key": key},
+            labels={
+                "app.kubernetes.io/managed-by": "kagenti",
+                "kagenti.io/litellm-team-id": team_id,
+            },
+        )
+    logger.info(
+        "Created team %s + default key for namespace %s",
+        _safe_log(team_id),
+        _safe_log(req.namespace),
+    )
+
+    return TeamResponse(
+        team_id=team_id,
+        namespace=req.namespace,
+        max_budget=req.max_budget,
+    )
+
+
+@router.get(
+    "/teams",
+    response_model=list[TeamResponse],
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def list_teams():
+    """List all litellm teams."""
+    try:
+        data = await _litellm_request("GET", "/team/list")
+    except HTTPException as exc:
+        if exc.status_code == 503:
+            return []
+        raise
+
+    teams_raw = data if isinstance(data, list) else data.get("data", data.get("teams", []))
+    return [
+        TeamResponse(
+            team_id=t.get("team_id", ""),
+            namespace=t.get("team_alias", ""),
+            max_budget=t.get("max_budget") or 0.0,
+            budget_used=t.get("spend") or 0.0,
+            models=t.get("models") or [],
+        )
+        for t in teams_raw
+    ]
+
+
+@router.get(
+    "/teams/{namespace}",
+    response_model=TeamResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_team(namespace: str):
+    """Get team details for a namespace."""
+    team_id = await _get_team_id(namespace)
+    if not team_id:
+        raise HTTPException(status_code=404, detail=f"No team for namespace {namespace}")
+
+    data = await _litellm_request("GET", "/team/list")
+    teams_raw = data if isinstance(data, list) else data.get("data", data.get("teams", []))
+    for t in teams_raw:
+        if t.get("team_id") == team_id:
+            return TeamResponse(
+                team_id=team_id,
+                namespace=namespace,
+                max_budget=t.get("max_budget") or 0.0,
+                budget_used=t.get("spend") or 0.0,
+                models=t.get("models") or [],
+            )
+    raise HTTPException(status_code=404, detail=f"Team {team_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# Key endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/keys",
+    response_model=KeyResponse,
+    dependencies=[Depends(require_roles(ROLE_ADMIN))],
+)
+async def create_agent_key(
+    req: KeyCreateRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Create a per-agent virtual key under the namespace's team."""
+    team_id = await _ensure_team(req.namespace)
+
+    key = await _create_virtual_key(
+        team_id=team_id,
+        key_alias=req.agent_name,
+        namespace=req.namespace,
+        max_budget=req.max_budget,
+        budget_duration=req.budget_duration,
+        models=req.models,
+    )
+
+    secret_name = f"{req.agent_name}-llm-key"
+    if key:
+        kube.create_secret(
+            namespace=req.namespace,
+            name=secret_name,
+            string_data={"apikey": key},
+            labels={
+                "app.kubernetes.io/managed-by": "kagenti",
+                "kagenti.io/agent": req.agent_name,
+                "kagenti.io/litellm-team-id": team_id,
+            },
+        )
+        logger.info(
+            "Created agent key for agent %s in namespace %s",
+            _safe_log(req.agent_name),
+            _safe_log(req.namespace),
+        )
+    else:
+        logger.info("Agent key for %s already exists (idempotent)", _safe_log(req.agent_name))
+
+    return KeyResponse(
+        key_alias=req.agent_name,
+        secret_name=secret_name,
+        namespace=req.namespace,
+    )
+
+
+@router.get(
+    "/keys",
+    response_model=list[KeyInfo],
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def list_keys(namespace: str | None = None):
+    """List virtual keys, optionally filtered by namespace."""
+    try:
+        data = await _litellm_request("GET", "/key/list")
+    except HTTPException as exc:
+        if exc.status_code == 503:
+            return []
+        raise
+
+    keys_raw = _extract_keys(data)
+    result = []
+    for k in keys_raw:
+        meta = k.get("metadata") or {}
+        ns = meta.get("namespace", "")
+        if namespace and ns != namespace:
+            continue
+        result.append(
+            KeyInfo(
+                key_alias=k.get("key_alias") or k.get("key_name", ""),
+                agent_name=meta.get("agent", k.get("key_alias", "")),
+                max_budget=k.get("max_budget") or 0.0,
+                budget_used=k.get("spend") or 0.0,
+                models=k.get("models") or [],
+            )
+        )
+    return result
+
+
+@router.delete(
+    "/keys/{namespace}/{agent_name}",
+    dependencies=[Depends(require_roles(ROLE_ADMIN))],
+)
+async def delete_agent_key(
+    namespace: str,
+    agent_name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Revoke an agent's virtual key and delete the k8s secret."""
+    # Find the key by alias
+    try:
+        data = await _litellm_request("GET", "/key/list")
+        keys_raw = _extract_keys(data)
+        for k in keys_raw:
+            if k.get("key_alias") == agent_name:
+                token = k.get("token", k.get("key", ""))
+                if token:
+                    await _litellm_request("POST", "/key/delete", json={"keys": [token]})
+                    logger.info("Revoked litellm key for %s", _safe_log(agent_name))
+                break
+    except HTTPException:
+        logger.warning(
+            "Could not revoke litellm key for %s (litellm may be down)", _safe_log(agent_name)
+        )
+
+    # Delete k8s secret
+    secret_name = f"{agent_name}-llm-key"
+    try:
+        kube.core_api.delete_namespaced_secret(secret_name, namespace)
+        logger.info(
+            "Deleted LLM key secret for agent %s in namespace %s",
+            _safe_log(agent_name),
+            _safe_log(namespace),
+        )
+    except Exception:
+        logger.warning(
+            "Could not delete LLM key secret for agent %s in namespace %s",
+            _safe_log(agent_name),
+            _safe_log(namespace),
+        )
+
+    return {"status": "deleted", "agent_name": agent_name, "namespace": namespace}
+
+
+# ---------------------------------------------------------------------------
+# Agent model access endpoint (for chat model selector)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/agent-models/{namespace}/{agent_name}",
+    response_model=list[dict],
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_agent_models(namespace: str, agent_name: str):
+    """Get models accessible by a specific agent's virtual key.
+
+    If the agent has a scoped key with model restrictions, returns only
+    those models. Otherwise falls back to all models available on litellm.
+    """
+    # Try to find agent-specific key with model restrictions
+    try:
+        data = await _litellm_request("GET", "/key/list")
+        keys_raw = _extract_keys(data)
+        for k in keys_raw:
+            if k.get("key_alias") == agent_name:
+                agent_models = k.get("models") or []
+                if agent_models:
+                    return [{"id": m} for m in agent_models]
+                break
+    except HTTPException:
+        pass
+
+    # Fallback: return all models from litellm
+    try:
+        data = await _litellm_request("GET", "/models")
+        raw = data.get("data", [])
+        return [{"id": item["id"]} for item in raw if isinstance(item, dict) and "id" in item]
+    except HTTPException:
+        return []

--- a/kagenti/backend/app/routers/models.py
+++ b/kagenti/backend/app/routers/models.py
@@ -1,0 +1,86 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Available LLM models endpoint.
+
+Proxies the LiteLLM /models list and caches for 5 minutes.
+"""
+
+import logging
+import os
+import time
+from typing import Any, Dict, List
+
+import httpx
+from fastapi import APIRouter, Depends
+
+from app.core.auth import require_roles, ROLE_VIEWER
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+# ---------------------------------------------------------------------------
+# Configuration (same env vars as token_usage.py)
+# ---------------------------------------------------------------------------
+
+LITELLM_BASE_URL = os.getenv("LITELLM_BASE_URL", "http://litellm-proxy.kagenti-system.svc:4000")
+LITELLM_API_KEY = os.getenv("LITELLM_API_KEY", "")
+
+# ---------------------------------------------------------------------------
+# In-memory cache (5 minutes)
+# ---------------------------------------------------------------------------
+
+_cache: Dict[str, Any] = {"models": [], "expires_at": 0.0}
+CACHE_TTL_SECONDS = 300
+
+
+async def _fetch_models() -> List[Dict[str, str]]:
+    """Fetch model list from LiteLLM /models, with 5-minute cache."""
+    now = time.monotonic()
+    if _cache["models"] and now < _cache["expires_at"]:
+        return _cache["models"]
+
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if LITELLM_API_KEY:
+        headers["Authorization"] = f"Bearer {LITELLM_API_KEY}"
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(f"{LITELLM_BASE_URL}/models", headers=headers)
+            response.raise_for_status()
+            payload = response.json()
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "LiteLLM /models returned %s: %s",
+            exc.response.status_code,
+            exc.response.text[:200],
+        )
+        return _cache["models"]  # return stale cache on error
+    except httpx.RequestError as exc:
+        logger.warning("LiteLLM /models request failed: %s", exc)
+        return _cache["models"]
+
+    # LiteLLM returns OpenAI-compatible {"data": [{"id": "model-name", ...}]}
+    raw = payload.get("data", [])
+    models = [{"id": item["id"]} for item in raw if isinstance(item, dict) and "id" in item]
+
+    _cache["models"] = models
+    _cache["expires_at"] = now + CACHE_TTL_SECONDS
+    return models
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "",
+    response_model=List[Dict[str, str]],
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def list_models():
+    """Return available LLM models from LiteLLM."""
+    return await _fetch_models()

--- a/kagenti/backend/app/routers/sandbox.py
+++ b/kagenti/backend/app/routers/sandbox.py
@@ -1,0 +1,4060 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Sandbox sessions API endpoints.
+
+Provides read-only access to sandbox agent sessions stored in per-namespace
+PostgreSQL databases. Session data is managed by the A2A SDK's DatabaseTaskStore
+(table: 'tasks') — the backend only reads from it for UI purposes.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+from typing import Any, AsyncGenerator, Dict, List, Optional
+from uuid import uuid4
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, field_validator
+
+from app.core.auth import (
+    get_required_user,
+    require_roles,
+    TokenData,
+    ROLE_ADMIN,
+    ROLE_OPERATOR,
+    ROLE_VIEWER,
+)
+from app.services.session_db import get_session_pool
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/sandbox", tags=["sandbox"])
+
+# Kubernetes name validation: lowercase alphanumeric + dashes, max 63 chars
+_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+# Cluster-local URL pattern for SSRF prevention (CWE-918)
+_CLUSTER_LOCAL_URL_RE = re.compile(
+    r"^http://[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+    r"\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.svc\.cluster\.local:\d+$"
+)
+
+
+def _validate_agent_url(agent_url: str) -> str:
+    """Validate that agent_url is a cluster-local service URL (SSRF prevention)."""
+    if not _CLUSTER_LOCAL_URL_RE.match(agent_url):
+        raise ValueError("Invalid agent URL: must be a cluster-local service URL")
+    return agent_url
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
+# Legacy event types filtered out during loop-event processing
+_LEGACY_EVENT_TYPES = frozenset({"plan", "plan_step", "reflection", "llm_response"})
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class TaskSummary(BaseModel):
+    """Lightweight task/session representation for list views."""
+
+    id: str
+    context_id: str
+    kind: str
+    status: Dict[str, Any]
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class TaskDetail(TaskSummary):
+    """Full task with artifacts and history."""
+
+    artifacts: Optional[List[Dict[str, Any]]] = None
+    history: Optional[List[Dict[str, Any]]] = None
+
+
+class TaskListResponse(BaseModel):
+    """Paginated list of tasks/sessions."""
+
+    items: List[TaskSummary]
+    total: int
+    limit: int
+    offset: int
+
+
+class HistoryPage(BaseModel):
+    """Paginated slice of session history messages."""
+
+    messages: List[Dict[str, Any]]
+    total: int
+    has_more: bool
+    loop_events: Optional[List[Dict[str, Any]]] = None
+    task_state: Optional[str] = None
+    last_updated: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_json_field(value: Any) -> Any:
+    """Parse a JSON field that may be a string or already a dict/list."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def _row_to_summary(row: dict) -> TaskSummary:
+    """Convert an asyncpg Record (as dict) to a TaskSummary."""
+    data = dict(row)
+    data["status"] = _parse_json_field(data.get("status"))
+    data["metadata"] = _parse_json_field(data.get("metadata"))
+
+    # Fix stale "working" status for sessions that completed but the
+    # A2A SDK didn't update (e.g. client disconnect during streaming).
+    status = data.get("status") or {}
+    meta = data.get("metadata") or {}
+    if isinstance(status, dict) and status.get("state") == "working":
+        loop_events = meta.get("loop_events", []) if isinstance(meta, dict) else []
+        has_reporter = any(
+            e.get("type") == "reporter_output" for e in loop_events if isinstance(e, dict)
+        )
+        if has_reporter:
+            status["state"] = "completed"
+
+    return TaskSummary(**data)
+
+
+def _row_to_detail(row: dict) -> TaskDetail:
+    """Convert an asyncpg Record (as dict) to a TaskDetail."""
+    data = dict(row)
+    data["status"] = _parse_json_field(data.get("status"))
+    data["metadata"] = _parse_json_field(data.get("metadata"))
+    data["artifacts"] = _parse_json_field(data.get("artifacts"))
+    data["history"] = _parse_json_field(data.get("history"))
+    return TaskDetail(**data)
+
+
+def _check_session_ownership(meta: Optional[Dict[str, Any]], user: TokenData, action: str) -> None:
+    """Raise 403 if user is not the session owner (unless admin)."""
+    if user.has_role(ROLE_ADMIN):
+        return
+    owner = (meta or {}).get("owner")
+    if owner and owner != user.username:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Cannot {action}: session owned by '{owner}'",
+        )
+
+
+class VisibilityRequest(BaseModel):
+    visibility: str  # "private" or "namespace"
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — reading from A2A SDK's 'tasks' table
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{namespace}/sessions",
+    response_model=TaskListResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def list_sessions(
+    namespace: str,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    search: Optional[str] = Query(default=None, description="Search by context_id"),
+    agent_name: Optional[str] = Query(default=None, description="Filter by agent name"),
+    user: TokenData = Depends(get_required_user),
+):
+    """List sessions (tasks) with pagination and optional search.
+
+    Queries the sessions table first (fast indexed lookup), then JOINs
+    with the tasks table for latest status/kind.  Falls back to the
+    legacy tasks-only CTE when the sessions table is empty (first run
+    or pre-migration).
+
+    Visibility is role-based:
+    - Admin: all sessions across all namespaces.
+    - Operator: own sessions + sessions with visibility='namespace'.
+    - Viewer: only own sessions.
+    """
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        # Check if sessions table has data for this namespace
+        sessions_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM sessions WHERE namespace = $1", namespace
+        )
+
+        if sessions_count > 0:
+            # --- Primary path: query sessions table ---
+            items, total = await _list_sessions_from_sessions_table(
+                conn, namespace, user, limit, offset, search, agent_name
+            )
+        else:
+            # --- Fallback: legacy tasks-only path (backward compat) ---
+            items, total = await _list_sessions_from_tasks_table(
+                conn, namespace, user, limit, offset, search, agent_name
+            )
+
+    return TaskListResponse(items=items, total=total, limit=limit, offset=offset)
+
+
+async def _list_sessions_from_sessions_table(
+    conn,
+    namespace: str,
+    user: TokenData,
+    limit: int,
+    offset: int,
+    search: Optional[str],
+    agent_name: Optional[str],
+) -> tuple:
+    """Query sessions table with LATERAL join to tasks for status."""
+    is_admin = user.has_role(ROLE_ADMIN)
+
+    conditions: List[str] = ["s.namespace = $1"]
+    args: List[Any] = [namespace]
+    idx = 2
+
+    if search:
+        conditions.append(f"s.context_id ILIKE ${idx}")
+        args.append(f"%{search}%")
+        idx += 1
+
+    if agent_name:
+        conditions.append(f"s.agent_name = ${idx}")
+        args.append(agent_name)
+        idx += 1
+
+    # Role-based visibility filtering
+    if not is_admin:
+        conditions.append(f"(s.owner = ${idx} OR s.visibility != 'private' OR s.owner = '')")
+        args.append(user.username)
+        idx += 1
+
+    where = "WHERE " + " AND ".join(conditions)
+
+    total = await conn.fetchval(
+        f"SELECT COUNT(*) FROM sessions s {where}",
+        *args,
+    )
+
+    rows = await conn.fetch(
+        f"SELECT s.context_id, s.agent_name, s.title, s.owner, s.visibility,"
+        f"       s.namespace, s.model_override, s.budget_max_tokens,"
+        f"       s.created_at, s.updated_at, s.last_message_at,"
+        f"       t.status, t.kind"
+        f" FROM sessions s"
+        f" LEFT JOIN LATERAL ("
+        f"   SELECT status, kind FROM tasks"
+        f"   WHERE context_id = s.context_id"
+        f"   ORDER BY id DESC LIMIT 1"
+        f" ) t ON true"
+        f" {where}"
+        f" ORDER BY s.updated_at DESC"
+        f" LIMIT ${idx} OFFSET ${idx + 1}",
+        *args,
+        limit,
+        offset,
+    )
+
+    items = []
+    for r in rows:
+        status = _parse_json_field(r["status"]) if r["status"] else {"state": "unknown"}
+        metadata = {
+            "title": r["title"] or "",
+            "owner": r["owner"] or "",
+            "visibility": r["visibility"] or "private",
+            "agent_name": r["agent_name"] or "",
+        }
+        items.append(
+            TaskSummary(
+                id=r["context_id"],
+                context_id=r["context_id"],
+                kind=r["kind"] or "",
+                status=status,
+                metadata=metadata,
+            )
+        )
+
+    return items, total
+
+
+async def _list_sessions_from_tasks_table(
+    conn,
+    namespace: str,
+    user: TokenData,
+    limit: int,
+    offset: int,
+    search: Optional[str],
+    agent_name: Optional[str],
+) -> tuple:
+    """Legacy fallback: query tasks table directly when sessions table is empty."""
+    conditions: List[str] = []
+    args: List[Any] = []
+    idx = 1
+
+    if search:
+        conditions.append(f"context_id ILIKE ${idx}")
+        args.append(f"%{search}%")
+        idx += 1
+
+    if agent_name:
+        conditions.append(f"metadata::json->>'agent_name' = ${idx}")
+        args.append(agent_name)
+        idx += 1
+
+    # Role-based visibility filtering
+    if not user.has_role(ROLE_ADMIN):
+        if user.has_role(ROLE_OPERATOR):
+            conditions.append(
+                f"(metadata::json->>'owner' = ${idx}"
+                f" OR metadata::json->>'visibility' = 'namespace'"
+                f" OR metadata::json->>'owner' IS NULL)"
+            )
+            args.append(user.username)
+            idx += 1
+        else:
+            conditions.append(
+                f"(metadata::json->>'owner' = ${idx} OR metadata::json->>'owner' IS NULL)"
+            )
+            args.append(user.username)
+            idx += 1
+
+    where = ""
+    if conditions:
+        where = "WHERE " + " AND ".join(conditions)
+
+    dedup_cte = (
+        "WITH latest AS ("
+        "  SELECT DISTINCT ON (context_id) id, context_id, kind, status, metadata"
+        "  FROM tasks ORDER BY context_id, id DESC"
+        ")"
+    )
+
+    total = await conn.fetchval(f"{dedup_cte} SELECT COUNT(*) FROM latest {where}", *args)
+
+    rows = await conn.fetch(
+        f"{dedup_cte} SELECT id, context_id, kind, status, metadata"
+        f" FROM latest {where}"
+        f" ORDER BY COALESCE((status::json->>'timestamp')::text, id::text) DESC"
+        f" LIMIT ${idx} OFFSET ${idx + 1}",
+        *args,
+        limit,
+        offset,
+    )
+
+    items = [_row_to_summary(r) for r in rows]
+    return items, total
+
+
+@router.get(
+    "/{namespace}/sessions/{context_id}",
+    response_model=TaskDetail,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_session(namespace: str, context_id: str):
+    """Get a task/session by context_id with full history and artifacts.
+
+    If multiple tasks share the same context_id (e.g. retries), returns
+    the latest one (highest id).
+    """
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        # Pick the record with the longest history (most complete conversation)
+        row = await conn.fetchrow(
+            "SELECT * FROM tasks WHERE context_id = $1"
+            " ORDER BY COALESCE(json_array_length(history::json), 0) DESC, id DESC"
+            " LIMIT 1",
+            context_id,
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+    return _row_to_detail(row)
+
+
+class SessionChainEntry(BaseModel):
+    """One node in a session lineage chain."""
+
+    context_id: str
+    type: str  # "root", "child", "passover"
+    status: Optional[str] = None
+    parent: Optional[str] = None
+    passover_from: Optional[str] = None
+    title: Optional[str] = None
+
+
+class SessionChainResponse(BaseModel):
+    """Full session lineage: root + ordered chain of children/passovers."""
+
+    root: str
+    chain: List[SessionChainEntry]
+
+
+@router.get(
+    "/{namespace}/sessions/{context_id}/chain",
+    response_model=SessionChainResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_session_chain(namespace: str, context_id: str):
+    """Return the full lineage chain for a session.
+
+    Walks parent_context_id upward to find the root, then collects all
+    children (via parent_context_id) and passovers (via passover_from/to).
+    Returns an ordered list starting from the root.
+    """
+    _validate_namespace(namespace)
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        # Fetch all sessions with their metadata (deduplicated by context_id)
+        rows = await conn.fetch(
+            "SELECT DISTINCT ON (context_id) context_id, status, metadata"
+            " FROM tasks ORDER BY context_id, id DESC"
+        )
+
+    # Build lookup maps
+    meta_map: Dict[str, Dict] = {}
+    for r in rows:
+        meta = _parse_json_field(r["metadata"]) or {}
+        status = _parse_json_field(r["status"]) or {}
+        meta_map[r["context_id"]] = {
+            "meta": meta if isinstance(meta, dict) else {},
+            "status": status if isinstance(status, dict) else {},
+        }
+
+    if context_id not in meta_map:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Walk upward to find root
+    root_id = context_id
+    visited = {root_id}
+    while True:
+        entry = meta_map.get(root_id, {})
+        parent = entry.get("meta", {}).get("parent_context_id")
+        pf = entry.get("meta", {}).get("passover_from")
+        ancestor = parent or pf
+        if not ancestor or ancestor in visited or ancestor not in meta_map:
+            break
+        visited.add(ancestor)
+        root_id = ancestor
+
+    # Collect chain: BFS from root following children + passovers
+    chain: List[SessionChainEntry] = []
+    queue = [root_id]
+    seen = set()
+
+    while queue:
+        cid = queue.pop(0)
+        if cid in seen:
+            continue
+        seen.add(cid)
+
+        entry = meta_map.get(cid, {})
+        meta = entry.get("meta", {})
+        status = entry.get("status", {})
+        state = status.get("state") if isinstance(status, dict) else None
+
+        # Determine type
+        if cid == root_id:
+            node_type = "root"
+        elif meta.get("parent_context_id"):
+            node_type = "child"
+        elif meta.get("passover_from"):
+            node_type = "passover"
+        else:
+            node_type = "related"
+
+        chain.append(
+            SessionChainEntry(
+                context_id=cid,
+                type=node_type,
+                status=state,
+                parent=meta.get("parent_context_id"),
+                passover_from=meta.get("passover_from"),
+                title=meta.get("title"),
+            )
+        )
+
+        # Find children and passovers pointing FROM this node
+        for other_cid, other in meta_map.items():
+            om = other.get("meta", {})
+            if om.get("parent_context_id") == cid and other_cid not in seen:
+                queue.append(other_cid)
+            if om.get("passover_from") == cid and other_cid not in seen:
+                queue.append(other_cid)
+
+    return SessionChainResponse(root=root_id, chain=chain)
+
+
+@router.get(
+    "/{namespace}/sessions/{context_id}/history",
+    response_model=HistoryPage,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_session_history(
+    namespace: str,
+    context_id: str,
+    limit: int = Query(default=30, ge=1, le=200),
+    before: Optional[int] = Query(
+        default=None,
+        description="Return messages before this index (for reverse pagination). "
+        "Omit to get the most recent messages.",
+    ),
+    skip_events: bool = Query(
+        default=False,
+        description="Skip loop_events extraction (for lightweight polling).",
+    ),
+    events_since: Optional[int] = Query(
+        default=None,
+        description="Only return loop_events after this count (incremental polling).",
+    ),
+):
+    """Return a paginated slice of session history.
+
+    Messages are ordered oldest-first in the DB. We serve them in reverse
+    (newest-first) so the client can implement reverse infinite scroll:
+    load the latest page, then fetch progressively older pages on scroll-up.
+
+    Intermediate graph-event dumps (``assistant: {...}``, ``tools: {...}``)
+    are filtered out server-side so the client receives only meaningful
+    user/agent messages.
+    """
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        # Aggregate history + artifacts across ALL task records for this context_id.
+        # The A2A SDK creates a new immutable task per message exchange, so a
+        # multi-turn session has N task records. Each record's history contains
+        # the messages for that specific exchange. We merge them chronologically.
+        rows = await conn.fetch(
+            "SELECT id, history, artifacts, metadata, status FROM tasks WHERE context_id = $1"
+            " ORDER BY COALESCE((status::json->>'timestamp')::text, '') ASC",
+            context_id,
+        )
+        if not rows:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+    # Extract task_state and last_updated from the most recent task row.
+    # The A2A SDK stores state transitions in the status JSON column.
+    _last_status = _parse_json_field(rows[-1].get("status")) or {}
+    _task_state = (
+        _last_status.get("state")
+        if isinstance(_last_status.get("state"), str)
+        else (
+            _last_status.get("state", {}).get("state")
+            if isinstance(_last_status.get("state"), dict)
+            else None
+        )
+    )
+    _last_updated = _last_status.get("timestamp")
+
+    # Merge history from all task records (ordered by task creation time)
+    raw_history: list = []
+
+    # Collect artifacts from all tasks (each task may have a final answer)
+    all_artifact_texts: List[str] = []
+
+    # Extract persisted loop events from ALL task rows.
+    # Skip entirely when skip_events=True (lightweight polling for messages only).
+    persisted_loop_events: Optional[List[Dict[str, Any]]] = None
+    all_loop_events: List[Dict[str, Any]] = []
+    seen_event_json: set = set()
+    total_raw_count = 0
+    _skip_event_extraction = skip_events
+    for row in rows:
+        meta = _parse_json_field(row.get("metadata"))
+        if not _skip_event_extraction and isinstance(meta, dict) and meta.get("loop_events"):
+            for evt in meta["loop_events"]:
+                total_raw_count += 1
+                # Dedup by full JSON to handle exact duplicates from old metadata merge
+                evt_json = json.dumps(evt, sort_keys=True)
+                if evt_json not in seen_event_json:
+                    seen_event_json.add(evt_json)
+                    all_loop_events.append(evt)
+    for row in rows:
+        task_history = _parse_json_field(row["history"]) or []
+
+        # If this task has no persisted loop_events but its history contains
+        # JSON lines with loop_id (agent messages from a cut-short stream),
+        # extract them so the UI can show an incomplete loop card.
+        row_meta = _parse_json_field(row.get("metadata"))
+        has_persisted = isinstance(row_meta, dict) and bool(row_meta.get("loop_events"))
+        if not _skip_event_extraction and not has_persisted:
+            # Extract events server-side via SQL to avoid loading full history
+            # into Python memory (can be 500KB+). Query uses jsonb functions
+            # to parse event JSON lines from agent message parts.
+            task_id = row.get("id") or (row["id"] if "id" in row.keys() else None)
+            if task_id:
+                try:
+                    extract_pool = await get_session_pool(namespace)
+                    async with extract_pool.acquire() as extract_conn:
+                        db_events = await extract_conn.fetch(
+                            """
+                            SELECT DISTINCT ON (evt_json)
+                                line::jsonb AS evt,
+                                line AS evt_json
+                            FROM tasks,
+                                jsonb_array_elements(history::jsonb) AS msg,
+                                jsonb_array_elements(msg->'parts') AS part,
+                                unnest(string_to_array(part->>'text', E'\\n')) AS line
+                            WHERE tasks.id = $1
+                                AND msg->>'role' = 'agent'
+                                AND part->>'text' IS NOT NULL
+                                AND line ~ '^\\s*\\{.*"loop_id"'
+                                AND line::jsonb->>'type' IS NOT NULL
+                                AND line::jsonb->>'type' NOT IN ('plan', 'plan_step', 'reflection', 'llm_response')
+                            """,
+                            task_id,
+                        )
+                        for db_evt in db_events:
+                            evt = json.loads(db_evt["evt_json"])
+                            evt_json = json.dumps(evt, sort_keys=True)
+                            if evt_json not in seen_event_json:
+                                seen_event_json.add(evt_json)
+                                all_loop_events.append(evt)
+                except Exception as e:
+                    logger.warning(
+                        "SQL event extraction failed for task %s: %s — falling back to Python",
+                        task_id,
+                        e,
+                    )
+                    # Fallback: Python extraction (loads full history)
+                    for msg in task_history:
+                        if msg.get("role") != "agent":
+                            continue
+                        for part in msg.get("parts") or []:
+                            text = part.get("text", "") if isinstance(part, dict) else ""
+                            for line in text.split("\n"):
+                                line = line.strip()
+                                if not line:
+                                    continue
+                                try:
+                                    parsed = json.loads(line)
+                                    if isinstance(parsed, dict) and "loop_id" in parsed:
+                                        evt_type = parsed.get("type", "")
+                                        if evt_type not in _LEGACY_EVENT_TYPES:
+                                            evt_json = json.dumps(parsed, sort_keys=True)
+                                            if evt_json not in seen_event_json:
+                                                seen_event_json.add(evt_json)
+                                                all_loop_events.append(parsed)
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+
+        for msg in task_history:
+            raw_history.append(msg)
+
+        # Accumulate artifacts from ALL task records
+        task_artifacts = _parse_json_field(row.get("artifacts")) or []
+        if isinstance(task_artifacts, list):
+            for art in task_artifacts:
+                if not isinstance(art, dict):
+                    continue
+                for part in art.get("parts") or []:
+                    if isinstance(part, dict) and part.get("text"):
+                        all_artifact_texts.append(part["text"])
+
+    # Set persisted_loop_events AFTER both extraction passes (metadata + history text)
+    # Apply events_since filter — only return new events the client hasn't seen
+    if events_since is not None and len(all_loop_events) > events_since:
+        all_loop_events = all_loop_events[events_since:]
+    elif events_since is not None and len(all_loop_events) <= events_since:
+        all_loop_events = []  # Client already has everything
+
+    if all_loop_events:
+        persisted_loop_events = all_loop_events
+        logger.info(
+            "HISTORY session=%s tasks=%d total_events=%d unique=%d types=%s",
+            _safe_log(context_id),
+            len(rows),
+            total_raw_count,
+            len(all_loop_events),
+            [e.get("type") for e in all_loop_events[:10]],
+        )
+        # Write-back: if events were extracted from history text but not in
+        # metadata, persist them so future loads don't need re-extraction.
+        if total_raw_count == 0 and len(all_loop_events) > 0 and rows:
+
+            async def _writeback():
+                try:
+                    wb_pool = await get_session_pool(namespace)
+                    async with wb_pool.acquire() as conn:
+                        task_id = rows[-1]["id"]
+                        row = await conn.fetchrow(
+                            "SELECT metadata FROM tasks WHERE id = $1", task_id
+                        )
+                        if row:
+                            meta = _parse_json_field(row["metadata"]) or {}
+                            meta["loop_events"] = all_loop_events
+                            await conn.execute(
+                                "UPDATE tasks SET metadata = $1::jsonb WHERE id = $2",
+                                json.dumps(meta),
+                                task_id,
+                            )
+                            logger.info(
+                                "HISTORY write-back: saved %d events to metadata for session %s",
+                                len(all_loop_events),
+                                _safe_log(context_id),
+                            )
+                except Exception as e:
+                    logger.warning(
+                        "HISTORY write-back failed for session %s: %s", _safe_log(context_id), e
+                    )
+
+            asyncio.create_task(_writeback())
+
+    # Parse graph event dumps into structured tool call data.
+    # Raw history contains: user messages + graph events like:
+    #   "assistant: {'messages': [AIMessage(content='...', tool_calls=[...])]}"
+    #   "tools: {'messages': [ToolMessage(content='output', name='shell')]}"
+    # We parse these into a richer conversation view.
+    def _parse_graph_event(text: str) -> Optional[Dict[str, Any]]:
+        """Parse a graph event — JSON first, improved regex for old format."""
+        stripped = text.strip()
+
+        # New format: structured JSON
+        try:
+            data = json.loads(stripped)
+            if isinstance(data, dict) and "type" in data:
+                return data
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Old format: Python repr — improved regex for robustness
+        if stripped.startswith("assistant:"):
+            # Try to extract tool calls (may be truncated)
+            if "tool_calls=" in stripped or ("'name':" in stripped and "'args':" in stripped):
+                calls = re.findall(r"'name':\s*'([^']+)'.*?'args':\s*(\{[^}]*\}?)", stripped)
+                if calls:
+                    return {
+                        "type": "tool_call",
+                        "tools": [{"name": c[0], "args": c[1]} for c in calls],
+                    }
+            # Extract content — try single quotes then double quotes
+            for pattern in [
+                r"content='((?:[^'\\]|\\.){1,2000})'",
+                r'content="((?:[^"\\]|\\.){1,2000})"',
+                r"content='([^']{1,500})",  # truncated (no closing quote)
+            ]:
+                match = re.search(pattern, stripped)
+                if match and match.group(1).strip():
+                    return {"type": "llm_response", "content": match.group(1)[:2000]}
+
+        elif stripped.startswith("tools:"):
+            # Extract tool result — try single then double quotes
+            for pattern in [
+                r"content='((?:[^'\\]|\\.)*?)'\s*,\s*name='([^']*)'",
+                r'content="((?:[^"\\]|\\.)*?)"\s*,\s*name=\'([^\']*)\'',
+                r"content='((?:[^'\\]|\\.)*?)'\s*,\s*name=\"([^\"]*)\"",
+                r'content="((?:[^"\\]|\\.)*?)"\s*,\s*name="([^"]*)"',
+            ]:
+                match = re.search(pattern, stripped)
+                if match:
+                    output = match.group(1)[:2000].replace("\\n", "\n")
+                    return {
+                        "type": "tool_result",
+                        "name": match.group(2),
+                        "output": output,
+                    }
+
+        return None
+
+    filtered: List[Dict[str, Any]] = []
+    for msg in raw_history:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "user":
+            # Propagate username from A2A message metadata to top level
+            username = (msg.get("metadata") or {}).get("username")
+            entry: Dict[str, Any] = {
+                "role": "user",
+                "parts": msg.get("parts", []),
+            }
+            if username:
+                entry["username"] = username
+            filtered.append(entry)
+            continue
+
+        # Try to parse graph event dumps
+        text = "".join(
+            p.get("text", "")
+            for p in (msg.get("parts") or [])
+            if isinstance(p, dict) and p.get("text")
+        )
+        if not text:
+            continue
+
+        # Text may contain multiple JSON events on separate lines
+        # (agent emits "\n".join(serializer.serialize(...) for ...))
+        for line in text.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parsed = _parse_graph_event(line)
+            if parsed:
+                filtered.append(
+                    {
+                        "role": "agent",
+                        "parts": [{"kind": "data", **parsed}],
+                    }
+                )
+
+    # Append final responses from artifacts, but deduplicate against
+    # llm_response entries already parsed from graph events.  Without this
+    # guard the same final answer appears twice: once from the graph event
+    # dump (kind=data, type=llm_response) and once from the artifact.
+    seen_llm_texts: set = set()
+    for msg in filtered:
+        parts = msg.get("parts") or []
+        for p in parts:
+            if not isinstance(p, dict):
+                continue
+            if p.get("kind") == "data" and p.get("type") == "llm_response":
+                content = (p.get("content") or "").strip()
+                if content:
+                    # Store a normalised prefix for fuzzy dedup
+                    seen_llm_texts.add(content[:200])
+
+    for art_text in all_artifact_texts:
+        normalised = art_text.strip()[:200]
+        if normalised and normalised in seen_llm_texts:
+            continue  # already present as an llm_response
+        filtered.append(
+            {
+                "role": "agent",
+                "parts": [{"kind": "text", "text": art_text}],
+            }
+        )
+
+    total = len(filtered)
+
+    # Reverse pagination: slice from the end
+    if before is not None:
+        end_idx = max(before, 0)
+    else:
+        end_idx = total
+    start_idx = max(end_idx - limit, 0)
+
+    page = filtered[start_idx:end_idx]
+    has_more = start_idx > 0
+
+    # Add index to each message so the client can request the next page
+    for i, msg in enumerate(page):
+        msg["_index"] = start_idx + i
+
+    return HistoryPage(
+        messages=page,
+        total=total,
+        has_more=has_more,
+        loop_events=persisted_loop_events,
+        task_state=_task_state,
+        last_updated=_last_updated,
+    )
+
+
+@router.delete(
+    "/{namespace}/sessions/{context_id}",
+    status_code=204,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def delete_session(
+    namespace: str,
+    context_id: str,
+    user: TokenData = Depends(get_required_user),
+):
+    """Delete a task/session by context_id. Only owner or admin can delete."""
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT metadata FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1",
+            context_id,
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        meta = _parse_json_field(row["metadata"])
+        _check_session_ownership(meta, user, "delete")
+
+        await conn.execute("DELETE FROM tasks WHERE context_id = $1", context_id)
+
+    return None
+
+
+class RenameRequest(BaseModel):
+    title: str
+
+
+@router.put(
+    "/{namespace}/sessions/{context_id}/rename",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def rename_session(
+    namespace: str,
+    context_id: str,
+    request: RenameRequest,
+    user: TokenData = Depends(get_required_user),
+):
+    """Set or clear a custom session title.
+
+    Pass an empty title to revert to the auto-generated default (first message).
+    """
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT metadata, history FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1",
+            context_id,
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        meta = _parse_json_field(row["metadata"]) or {}
+        _check_session_ownership(meta, user, "rename")
+
+        if request.title.strip():
+            meta["title"] = request.title.strip()[:120]
+        else:
+            # Revert to default: first user message
+            history = _parse_json_field(row["history"]) or []
+            first_msg = next(
+                (
+                    m
+                    for m in history
+                    if m.get("role") == "user" and m.get("parts") and m["parts"][0].get("text")
+                ),
+                None,
+            )
+            if first_msg:
+                meta["title"] = first_msg["parts"][0]["text"][:80].replace("\n", " ")
+            else:
+                meta.pop("title", None)
+
+        await conn.execute(
+            "UPDATE tasks SET metadata = $1::json WHERE context_id = $2",
+            json.dumps(meta),
+            context_id,
+        )
+
+    return {"title": meta.get("title", "")}
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/kill",
+    response_model=TaskDetail,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def kill_session(
+    namespace: str,
+    context_id: str,
+    user: TokenData = Depends(get_required_user),
+):
+    """Mark a task as canceled by updating its status JSON. Only owner or admin."""
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT * FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1", context_id
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        meta = _parse_json_field(row["metadata"])
+        _check_session_ownership(meta, user, "kill")
+
+        # Update the status JSON to set state to 'canceled'
+        status = _parse_json_field(row["status"])
+        if isinstance(status, dict):
+            state = status.get("state", {})
+            if isinstance(state, dict):
+                state["state"] = "canceled"
+            else:
+                status["state"] = "canceled"
+        else:
+            status = {"state": "canceled"}
+
+        await conn.execute(
+            "UPDATE tasks SET status = $1::json WHERE context_id = $2",
+            json.dumps(status),
+            context_id,
+        )
+
+        # Re-fetch updated row
+        row = await conn.fetchrow(
+            "SELECT * FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1", context_id
+        )
+
+    return _row_to_detail(row)
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/approve",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def approve_session(
+    namespace: str,
+    context_id: str,
+    user: TokenData = Depends(get_required_user),
+):
+    """Approve a pending HITL request — resumes the agent graph via A2A.
+
+    No ownership check: any ROLE_OPERATOR can approve any session's HITL request.
+    This is intentional — HITL approval is a team-level action, not owner-only.
+    """
+    _validate_namespace(namespace)
+    logger.info(
+        "User %s approved HITL request for session %s in namespace %s",
+        _safe_log(user.username),
+        _safe_log(context_id),
+        _safe_log(namespace),
+    )
+    return await _resume_agent_graph(namespace, context_id, user, approved=True)
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/deny",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def deny_session(
+    namespace: str,
+    context_id: str,
+    user: TokenData = Depends(get_required_user),
+):
+    """Deny a pending HITL request — resumes the agent graph with denial.
+
+    No ownership check: same rationale as approve — team-level action.
+    """
+    _validate_namespace(namespace)
+    logger.info(
+        "User %s denied HITL request for session %s in namespace %s",
+        _safe_log(user.username),
+        _safe_log(context_id),
+        _safe_log(namespace),
+    )
+    return await _resume_agent_graph(namespace, context_id, user, approved=False)
+
+
+async def _resume_agent_graph(
+    namespace: str,
+    context_id: str,
+    user: TokenData,
+    approved: bool,
+) -> dict:
+    """Resume an agent's LangGraph graph by sending an A2A message.
+
+    When an agent enters INPUT_REQUIRED state, it pauses and waits for
+    the next user message on the same contextId.  Sending a message/send
+    with the approval/denial text resumes the graph via LangGraph's
+    Command(resume=...) pattern handled inside the agent.
+    """
+    # 1. Look up agent_name from session metadata
+    pool = await get_session_pool(namespace)
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT metadata FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1",
+            context_id,
+        )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    meta = _parse_json_field(row["metadata"]) or {}
+    agent_name = meta.get("agent_name")
+    if not agent_name:
+        raise HTTPException(
+            status_code=400,
+            detail="Session has no agent_name in metadata — cannot determine target agent",
+        )
+    # Defense-in-depth: agent_name comes from DB, not user input, but validate
+    # against K8s naming rules to prevent SSRF if metadata is ever corrupted.
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, f"Invalid agent_name in session metadata: {agent_name}")
+
+    # 2. Build the A2A message to resume the graph
+    decision = "approved" if approved else "denied"
+    agent_url = _validate_agent_url(f"http://{agent_name}.{namespace}.svc.cluster.local:8000")
+    a2a_msg = {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "id": uuid4().hex,
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": decision}],
+                "messageId": uuid4().hex,
+                "contextId": context_id,
+                "metadata": {
+                    "username": user.username,
+                    "hitl_decision": decision,
+                },
+            }
+        },
+    }
+
+    # 3. POST to the agent — this resumes the LangGraph graph
+    try:
+        async with httpx.AsyncClient(timeout=180.0) as client:
+            resp = await client.post(f"{agent_url}/", json=a2a_msg)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as e:
+        logger.error("Failed to resume agent %s: %s", _safe_log(agent_name), e)
+        raise HTTPException(502, f"Failed to resume agent: {e}")
+
+    if "error" in data:
+        raise HTTPException(502, f"A2A error: {data['error']}")
+
+    result = data.get("result", {})
+    return {
+        "status": decision,
+        "context_id": context_id,
+        "agent_name": agent_name,
+        "task_status": result.get("status", {}),
+    }
+
+
+@router.put(
+    "/{namespace}/sessions/{context_id}/visibility",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def set_session_visibility(
+    namespace: str,
+    context_id: str,
+    request: VisibilityRequest,
+    user: TokenData = Depends(get_required_user),
+):
+    """Toggle session visibility between 'private' and 'namespace'.
+
+    Only the session owner or admin can change visibility.
+    """
+    if request.visibility not in ("private", "namespace"):
+        raise HTTPException(400, "visibility must be 'private' or 'namespace'")
+
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT metadata FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1",
+            context_id,
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        meta = _parse_json_field(row["metadata"]) or {}
+        _check_session_ownership(meta, user, "change visibility")
+
+        meta["visibility"] = request.visibility
+        await conn.execute(
+            "UPDATE tasks SET metadata = $1::json WHERE context_id = $2",
+            json.dumps(meta),
+            context_id,
+        )
+
+        # Keep sessions table in sync
+        await conn.execute(
+            "UPDATE sessions SET visibility = $1, updated_at = NOW() WHERE context_id = $2",
+            request.visibility,
+            context_id,
+        )
+
+    return {"visibility": request.visibility}
+
+
+# ---------------------------------------------------------------------------
+# TTL cleanup — mark stale submitted tasks as failed
+# ---------------------------------------------------------------------------
+
+
+class CleanupResponse(BaseModel):
+    """Result of a stale-session cleanup run."""
+
+    cleaned: int
+
+
+@router.post("/{namespace}/cleanup", response_model=CleanupResponse)
+async def cleanup_stale_sessions(
+    namespace: str,
+    ttl_minutes: int = Query(default=5, ge=1, description="Age threshold in minutes"),
+):
+    """Mark stale *submitted* tasks as failed.
+
+    Scans the ``tasks`` table for rows whose status JSON contains a state of
+    ``submitted`` and whose status timestamp is older than *ttl_minutes*
+    minutes ago (or has no timestamp at all).  Each matching task is updated
+    to state ``failed`` with the message ``"Agent timeout"``.
+    """
+    pool = await get_session_pool(namespace)
+
+    async with pool.acquire() as conn:
+        # Fetch all tasks that are still in "submitted" state.
+        rows = await conn.fetch(
+            "SELECT id, context_id, status FROM tasks WHERE status::text ILIKE '%submitted%'"
+        )
+
+        if not rows:
+            return CleanupResponse(cleaned=0)
+
+        from datetime import datetime, timedelta, timezone
+
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=ttl_minutes)
+        cleaned = 0
+
+        for row in rows:
+            status = _parse_json_field(row["status"])
+            if not isinstance(status, dict):
+                continue
+
+            # Determine the current state — handle both flat and nested shapes.
+            state_value = status.get("state", {})
+            current_state = (
+                state_value.get("state") if isinstance(state_value, dict) else state_value
+            )
+            if current_state != "submitted":
+                continue
+
+            # Check timestamp: if present, skip tasks that are still fresh.
+            ts_str = status.get("timestamp")
+            if ts_str:
+                try:
+                    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                    if ts > cutoff:
+                        continue  # still within TTL
+                except (ValueError, TypeError):
+                    pass  # unparseable timestamp — treat as stale
+
+            # Mark as failed.
+            if isinstance(state_value, dict):
+                state_value["state"] = "failed"
+            else:
+                status["state"] = "failed"
+            status["message"] = {
+                "role": "agent",
+                "parts": [{"kind": "text", "text": "Agent timeout"}],
+            }
+
+            await conn.execute(
+                "UPDATE tasks SET status = $1::json WHERE id = $2",
+                json.dumps(status),
+                row["id"],
+            )
+            cleaned += 1
+            logger.info(
+                "Cleanup: marked task %s (context_id=%s) as failed (agent timeout)",
+                row["id"],
+                _safe_log(row["context_id"]),
+            )
+
+    return CleanupResponse(cleaned=cleaned)
+
+
+# ---------------------------------------------------------------------------
+# Sandbox agent visibility — list agent deployments with session counts
+# ---------------------------------------------------------------------------
+
+
+class SandboxAgentInfo(BaseModel):
+    """Summary of a sandbox agent deployment."""
+
+    name: str
+    namespace: str
+    status: str  # "ready", "pending", "error"
+    replicas: str  # "1/1"
+    session_count: int
+    active_sessions: int
+    image: str
+    created: Optional[str] = None
+
+
+def _get_apps_api():
+    """Return an AppsV1Api client, or None if K8s is unavailable."""
+    try:
+        import kubernetes.client
+        import kubernetes.config
+        from kubernetes.config import ConfigException
+
+        try:
+            if os.getenv("KUBERNETES_SERVICE_HOST"):
+                kubernetes.config.load_incluster_config()
+            else:
+                kubernetes.config.load_kube_config()
+        except ConfigException:
+            return None
+        return kubernetes.client.AppsV1Api()
+    except ImportError:
+        return None
+
+
+def _get_core_api():
+    """Return a CoreV1Api client, or None if K8s is unavailable."""
+    try:
+        import kubernetes.client
+        import kubernetes.config
+        from kubernetes.config import ConfigException
+
+        try:
+            if os.getenv("KUBERNETES_SERVICE_HOST"):
+                kubernetes.config.load_incluster_config()
+            else:
+                kubernetes.config.load_kube_config()
+        except ConfigException:
+            return None
+        return kubernetes.client.CoreV1Api()
+    except ImportError:
+        return None
+
+
+def _get_custom_objects_api():
+    """Return a CustomObjectsApi client, or None if K8s is unavailable."""
+    try:
+        import kubernetes.client
+        import kubernetes.config
+        from kubernetes.config import ConfigException
+
+        try:
+            if os.getenv("KUBERNETES_SERVICE_HOST"):
+                kubernetes.config.load_incluster_config()
+            else:
+                kubernetes.config.load_kube_config()
+        except ConfigException:
+            return None
+        return kubernetes.client.CustomObjectsApi()
+    except ImportError:
+        return None
+
+
+def _parse_cpu(value: str) -> float:
+    """Parse a Kubernetes CPU value (e.g. '100m', '1', '0.5') to millicores."""
+    if not value:
+        return 0.0
+    value = value.strip()
+    if value.endswith("n"):
+        return float(value[:-1]) / 1_000_000
+    if value.endswith("m"):
+        return float(value[:-1])
+    return float(value) * 1000
+
+
+def _parse_memory(value: str) -> int:
+    """Parse a Kubernetes memory value (e.g. '128Mi', '1Gi', '1024Ki') to bytes."""
+    if not value:
+        return 0
+    value = value.strip()
+    suffixes = {
+        "Ki": 1024,
+        "Mi": 1024**2,
+        "Gi": 1024**3,
+        "Ti": 1024**4,
+        "k": 1000,
+        "M": 1000**2,
+        "G": 1000**3,
+        "T": 1000**4,
+    }
+    for suffix, multiplier in suffixes.items():
+        if value.endswith(suffix):
+            return int(float(value[: -len(suffix)]) * multiplier)
+    # plain bytes
+    try:
+        return int(value)
+    except ValueError:
+        return 0
+
+
+@router.get("/{namespace}/agents", response_model=List[SandboxAgentInfo])
+async def list_sandbox_agents(namespace: str):
+    """List sandbox agent deployments in the namespace with session counts."""
+    apps_api = _get_apps_api()
+    if apps_api is None:
+        return []
+
+    try:
+        deployments = apps_api.list_namespaced_deployment(
+            namespace=namespace,
+            label_selector="kagenti.io/type=agent",
+        )
+    except Exception as exc:
+        logger.warning("Failed to list deployments in %s: %s", _safe_log(namespace), exc)
+        return []
+
+    # Query session counts from DB (best effort)
+    session_counts: Dict[str, int] = {}
+    active_counts: Dict[str, int] = {}
+    try:
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            # Total sessions per agent_name
+            rows = await conn.fetch(
+                "SELECT COALESCE(metadata::json->>'agent_name', 'sandbox-legion') AS agent,"
+                " COUNT(*) AS cnt"
+                " FROM tasks GROUP BY agent"
+            )
+            for row in rows:
+                session_counts[row["agent"]] = row["cnt"]
+
+            # Active sessions (working or submitted)
+            rows = await conn.fetch(
+                "SELECT COALESCE(metadata::json->>'agent_name', 'sandbox-legion') AS agent,"
+                " COUNT(*) AS cnt"
+                " FROM tasks"
+                " WHERE status::text ILIKE '%working%' OR status::text ILIKE '%submitted%'"
+                " GROUP BY agent"
+            )
+            for row in rows:
+                active_counts[row["agent"]] = row["cnt"]
+    except Exception as exc:
+        logger.debug("Could not query session counts for %s: %s", _safe_log(namespace), exc)
+
+    result: List[SandboxAgentInfo] = []
+    for dep in deployments.items:
+        name = dep.metadata.name
+        ready = dep.status.ready_replicas or 0
+        desired = dep.spec.replicas or 1
+
+        if ready >= desired:
+            status = "ready"
+        elif ready > 0:
+            status = "pending"
+        else:
+            # Check if there are unavailable replicas with error conditions
+            if dep.status.conditions:
+                has_error = any(
+                    c.type == "Available" and c.status == "False" for c in dep.status.conditions
+                )
+                status = "error" if has_error else "pending"
+            else:
+                status = "pending"
+
+        # Extract container image from the first container
+        image = ""
+        if dep.spec.template.spec.containers:
+            image = dep.spec.template.spec.containers[0].image or ""
+
+        created = None
+        if dep.metadata.creation_timestamp:
+            created = dep.metadata.creation_timestamp.isoformat()
+
+        result.append(
+            SandboxAgentInfo(
+                name=name,
+                namespace=namespace,
+                status=status,
+                replicas=f"{ready}/{desired}",
+                session_count=session_counts.get(name, 0),
+                active_sessions=active_counts.get(name, 0),
+                image=image,
+                created=created,
+            )
+        )
+
+    return result
+
+
+@router.get("/{namespace}/agent-card/{agent_name}")
+async def get_sandbox_agent_card(namespace: str, agent_name: str):
+    """Proxy the A2A agent card from a sandbox agent pod (port 8000)."""
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, "Invalid agent name")
+    if not _K8S_NAME_RE.match(namespace):
+        raise HTTPException(400, "Invalid namespace")
+
+    agent_url = _validate_agent_url(f"http://{agent_name}.{namespace}.svc.cluster.local:8000")
+    card_url = f"{agent_url}/.well-known/agent-card.json"
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(card_url)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(e.response.status_code, f"Agent returned {e.response.status_code}")
+    except httpx.RequestError as e:
+        logger.warning("Failed to fetch agent card from %s: %s", _safe_log(card_url), e)
+        raise HTTPException(503, f"Cannot reach agent {agent_name}")
+
+
+@router.get("/{namespace}/agents/{agent_name}/pod-status")
+async def get_agent_pod_status(namespace: str, agent_name: str):
+    """Return pod status, events, and resources for all pods related to an agent deployment.
+
+    Checks three deployments: the agent itself, its egress proxy, and the
+    shared llm-budget-proxy.
+    """
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, "Invalid agent name")
+    if not _K8S_NAME_RE.match(namespace):
+        raise HTTPException(400, "Invalid namespace")
+
+    apps_api = _get_apps_api()
+    core_api = _get_core_api()
+    if apps_api is None or core_api is None:
+        raise HTTPException(503, "Kubernetes API unavailable")
+
+    from kubernetes.client import ApiException
+
+    component_deployments = [
+        ("agent", agent_name),
+        ("egress-proxy", f"{agent_name}-egress-proxy"),
+        ("llm-budget-proxy", "llm-budget-proxy"),
+    ]
+
+    pods_result: List[Dict[str, Any]] = []
+
+    for component, deploy_name in component_deployments:
+        # --- Fetch the Deployment -------------------------------------------
+        try:
+            deployment = apps_api.read_namespaced_deployment(name=deploy_name, namespace=namespace)
+        except ApiException as e:
+            if e.status == 404:
+                continue  # deployment doesn't exist, skip
+            logger.warning(
+                "Error reading deployment %s/%s: %s",
+                _safe_log(namespace),
+                _safe_log(deploy_name),
+                _safe_log(e),
+            )
+            continue
+
+        replicas = deployment.spec.replicas or 1
+        ready_replicas = deployment.status.ready_replicas or 0
+
+        # --- Find pods for this deployment ----------------------------------
+        match_labels = deployment.spec.selector.match_labels or {}
+        label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
+
+        try:
+            pod_list = core_api.list_namespaced_pod(
+                namespace=namespace, label_selector=label_selector
+            )
+        except ApiException as e:
+            logger.warning(
+                "Error listing pods for %s/%s: %s",
+                _safe_log(namespace),
+                _safe_log(deploy_name),
+                _safe_log(e),
+            )
+            pods_result.append(
+                {
+                    "component": component,
+                    "deployment": deploy_name,
+                    "replicas": replicas,
+                    "ready_replicas": ready_replicas,
+                    "pod_name": None,
+                    "status": "Unknown",
+                    "restarts": 0,
+                    "last_restart_reason": None,
+                    "resources": {
+                        "requests": {"cpu": "", "memory": ""},
+                        "limits": {"cpu": "", "memory": ""},
+                    },
+                    "events": [],
+                }
+            )
+            continue
+
+        if not pod_list.items:
+            pods_result.append(
+                {
+                    "component": component,
+                    "deployment": deploy_name,
+                    "replicas": replicas,
+                    "ready_replicas": ready_replicas,
+                    "pod_name": None,
+                    "status": "No pods",
+                    "restarts": 0,
+                    "last_restart_reason": None,
+                    "resources": {
+                        "requests": {"cpu": "", "memory": ""},
+                        "limits": {"cpu": "", "memory": ""},
+                    },
+                    "events": [],
+                }
+            )
+            continue
+
+        for pod in pod_list.items:
+            pod_name = pod.metadata.name
+
+            # --- Container status -------------------------------------------
+            status = "Unknown"
+            restarts = 0
+            last_restart_reason = None
+
+            container_statuses = pod.status.container_statuses or []
+            if container_statuses:
+                cs = container_statuses[0]
+                restarts = cs.restart_count or 0
+
+                if cs.state:
+                    if cs.state.running:
+                        status = "Running"
+                    elif cs.state.waiting:
+                        status = cs.state.waiting.reason or "Waiting"
+                    elif cs.state.terminated:
+                        status = cs.state.terminated.reason or "Terminated"
+
+                if cs.last_state and cs.last_state.terminated:
+                    last_restart_reason = cs.last_state.terminated.reason
+            elif pod.status.phase:
+                status = pod.status.phase
+
+            # --- Resources from pod spec ------------------------------------
+            resources: Dict[str, Dict[str, str]] = {
+                "requests": {"cpu": "", "memory": ""},
+                "limits": {"cpu": "", "memory": ""},
+            }
+            containers = pod.spec.containers or []
+            if containers:
+                res = containers[0].resources
+                if res:
+                    if res.requests:
+                        resources["requests"] = {
+                            "cpu": res.requests.get("cpu", ""),
+                            "memory": res.requests.get("memory", ""),
+                        }
+                    if res.limits:
+                        resources["limits"] = {
+                            "cpu": res.limits.get("cpu", ""),
+                            "memory": res.limits.get("memory", ""),
+                        }
+
+            # --- Events for this pod ----------------------------------------
+            events: List[Dict[str, Any]] = []
+            try:
+                event_list = core_api.list_namespaced_event(
+                    namespace=namespace,
+                    field_selector=f"involvedObject.name={pod_name}",
+                )
+                for evt in event_list.items:
+                    timestamp = None
+                    if evt.last_timestamp:
+                        timestamp = evt.last_timestamp.isoformat()
+                    elif evt.event_time:
+                        timestamp = evt.event_time.isoformat()
+                    events.append(
+                        {
+                            "type": evt.type or "",
+                            "reason": evt.reason or "",
+                            "message": evt.message or "",
+                            "timestamp": timestamp or "",
+                            "count": evt.count or 1,
+                        }
+                    )
+            except ApiException as e:
+                logger.warning(
+                    "Error listing events for pod %s/%s: %s", _safe_log(namespace), pod_name, e
+                )
+
+            pods_result.append(
+                {
+                    "component": component,
+                    "deployment": deploy_name,
+                    "replicas": replicas,
+                    "ready_replicas": ready_replicas,
+                    "pod_name": pod_name,
+                    "status": status,
+                    "restarts": restarts,
+                    "last_restart_reason": last_restart_reason,
+                    "resources": resources,
+                    "events": events,
+                }
+            )
+
+    return {"pods": pods_result}
+
+
+@router.get("/{namespace}/pods/{agent_name}/metrics")
+async def get_pod_metrics(namespace: str, agent_name: str):
+    """Return CPU/memory usage from metrics-server for pods related to an agent.
+
+    Uses the metrics.k8s.io/v1beta1 API (requires metrics-server installed).
+    Returns current usage alongside limits from the pod spec so the UI can
+    render percentage-based progress bars.
+    """
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, "Invalid agent name")
+    if not _K8S_NAME_RE.match(namespace):
+        raise HTTPException(400, "Invalid namespace")
+
+    apps_api = _get_apps_api()
+    core_api = _get_core_api()
+    custom_api = _get_custom_objects_api()
+    if apps_api is None or core_api is None:
+        raise HTTPException(503, "Kubernetes API unavailable")
+
+    from kubernetes.client import ApiException
+
+    component_deployments = [
+        ("agent", agent_name),
+        ("egress-proxy", f"{agent_name}-egress-proxy"),
+        ("llm-budget-proxy", "llm-budget-proxy"),
+    ]
+
+    metrics_result: List[Dict[str, Any]] = []
+
+    for component, deploy_name in component_deployments:
+        # --- Fetch the Deployment to find its pods ---------------------------
+        try:
+            deployment = apps_api.read_namespaced_deployment(name=deploy_name, namespace=namespace)
+        except ApiException as e:
+            if e.status == 404:
+                continue
+            logger.warning(
+                "Error reading deployment %s/%s: %s",
+                _safe_log(namespace),
+                _safe_log(deploy_name),
+                _safe_log(e),
+            )
+            continue
+
+        match_labels = deployment.spec.selector.match_labels or {}
+        label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
+
+        try:
+            pod_list = core_api.list_namespaced_pod(
+                namespace=namespace, label_selector=label_selector
+            )
+        except ApiException:
+            continue
+
+        for pod in pod_list.items or []:
+            pod_name = pod.metadata.name
+
+            # --- Resource limits from pod spec --------------------------------
+            containers_spec = pod.spec.containers or []
+            limits_cpu = ""
+            limits_memory = ""
+            if containers_spec:
+                res = containers_spec[0].resources
+                if res and res.limits:
+                    limits_cpu = res.limits.get("cpu", "")
+                    limits_memory = res.limits.get("memory", "")
+
+            # --- Current usage from metrics-server ----------------------------
+            container_metrics: List[Dict[str, Any]] = []
+            if custom_api is not None:
+                try:
+                    pod_metrics = custom_api.get_namespaced_custom_object(
+                        group="metrics.k8s.io",
+                        version="v1beta1",
+                        namespace=namespace,
+                        plural="pods",
+                        name=pod_name,
+                    )
+                    for cm in pod_metrics.get("containers", []):
+                        usage = cm.get("usage", {})
+                        usage_cpu_raw = usage.get("cpu", "0")
+                        usage_mem_raw = usage.get("memory", "0")
+                        usage_cpu_mc = _parse_cpu(usage_cpu_raw)
+                        usage_mem_bytes = _parse_memory(usage_mem_raw)
+                        limit_cpu_mc = _parse_cpu(limits_cpu)
+                        limit_mem_bytes = _parse_memory(limits_memory)
+
+                        container_metrics.append(
+                            {
+                                "name": cm.get("name", ""),
+                                "cpu_usage_mc": round(usage_cpu_mc, 1),
+                                "cpu_limit_mc": round(limit_cpu_mc, 1),
+                                "cpu_usage_raw": usage_cpu_raw,
+                                "memory_usage_bytes": usage_mem_bytes,
+                                "memory_limit_bytes": limit_mem_bytes,
+                                "memory_usage_raw": usage_mem_raw,
+                            }
+                        )
+                except ApiException as e:
+                    if e.status != 404:
+                        logger.warning(
+                            "Error fetching metrics for pod %s/%s: %s",
+                            _safe_log(namespace),
+                            pod_name,
+                            e,
+                        )
+                    # metrics-server may not have data yet; return empty list
+                except Exception as e:
+                    logger.warning("Unexpected error fetching pod metrics: %s", e)
+
+            metrics_result.append(
+                {
+                    "component": component,
+                    "pod_name": pod_name,
+                    "limits_cpu": limits_cpu,
+                    "limits_memory": limits_memory,
+                    "containers": container_metrics,
+                }
+            )
+
+    return {"pods": metrics_result}
+
+
+@router.get("/{namespace}/pods/{agent_name}/events")
+async def get_pod_events(namespace: str, agent_name: str):
+    """Return events for all pods related to an agent deployment.
+
+    Collects events from the Kubernetes Events API for each pod owned by the
+    agent's deployments. Results are sorted by timestamp descending.
+    """
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, "Invalid agent name")
+    if not _K8S_NAME_RE.match(namespace):
+        raise HTTPException(400, "Invalid namespace")
+
+    apps_api = _get_apps_api()
+    core_api = _get_core_api()
+    if apps_api is None or core_api is None:
+        raise HTTPException(503, "Kubernetes API unavailable")
+
+    from kubernetes.client import ApiException
+
+    component_deployments = [
+        ("agent", agent_name),
+        ("egress-proxy", f"{agent_name}-egress-proxy"),
+        ("llm-budget-proxy", "llm-budget-proxy"),
+    ]
+
+    all_events: List[Dict[str, Any]] = []
+
+    for component, deploy_name in component_deployments:
+        try:
+            deployment = apps_api.read_namespaced_deployment(name=deploy_name, namespace=namespace)
+        except ApiException as e:
+            if e.status == 404:
+                continue
+            logger.warning(
+                "Error reading deployment %s/%s: %s",
+                _safe_log(namespace),
+                _safe_log(deploy_name),
+                _safe_log(e),
+            )
+            continue
+
+        match_labels = deployment.spec.selector.match_labels or {}
+        label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
+
+        try:
+            pod_list = core_api.list_namespaced_pod(
+                namespace=namespace, label_selector=label_selector
+            )
+        except ApiException:
+            continue
+
+        for pod in pod_list.items or []:
+            pod_name = pod.metadata.name
+            try:
+                event_list = core_api.list_namespaced_event(
+                    namespace=namespace,
+                    field_selector=f"involvedObject.name={pod_name}",
+                )
+                for evt in event_list.items:
+                    timestamp = None
+                    if evt.last_timestamp:
+                        timestamp = evt.last_timestamp.isoformat()
+                    elif evt.event_time:
+                        timestamp = evt.event_time.isoformat()
+
+                    all_events.append(
+                        {
+                            "pod_name": pod_name,
+                            "component": component,
+                            "type": evt.type or "",
+                            "reason": evt.reason or "",
+                            "message": evt.message or "",
+                            "timestamp": timestamp or "",
+                            "count": evt.count or 1,
+                        }
+                    )
+            except ApiException as e:
+                logger.warning(
+                    "Error listing events for pod %s/%s: %s",
+                    _safe_log(namespace),
+                    pod_name,
+                    e,
+                )
+
+    # Sort by timestamp descending (most recent first)
+    all_events.sort(key=lambda e: e["timestamp"], reverse=True)
+
+    return {"events": all_events}
+
+
+# ---------------------------------------------------------------------------
+# Chat proxy — forwards A2A messages to sandbox agents on port 8000
+# ---------------------------------------------------------------------------
+
+
+class SandboxChatRequest(BaseModel):
+    message: str
+    session_id: Optional[str] = None
+    agent_name: str = "sandbox-legion"
+    skill: Optional[str] = None
+
+    @field_validator("agent_name")
+    @classmethod
+    def validate_agent_name(cls, v: str) -> str:
+        if not _K8S_NAME_RE.match(v):
+            raise ValueError("Invalid agent name — must be a valid Kubernetes name")
+        return v
+
+
+def _validate_namespace(namespace: str) -> str:
+    """Validate namespace matches Kubernetes naming rules (prevent SSRF)."""
+    if not _K8S_NAME_RE.match(namespace):
+        raise HTTPException(400, "Invalid namespace name")
+    return namespace
+
+
+async def _resolve_agent_name(
+    namespace: str,
+    session_id: str | None,
+    request_agent: str,
+) -> str:
+    """Resolve the authoritative agent name for a request.
+
+    Agent Name Resolution Architecture
+    -----------------------------------
+    1. ``_resolve_agent_name()`` is the **single source of truth** for
+       determining which agent owns a session.
+    2. For **new sessions** (no ``session_id``): uses ``request_agent``
+       supplied by the frontend.
+    3. For **existing sessions**: reads ``agent_name`` from the DB
+       metadata, which is authoritative.  The frontend's
+       ``selectedAgent`` state is unreliable due to race conditions.
+    4. ``_set_owner_metadata()`` (streaming path) and ``chat_send()``
+       (non-streaming path) both call this function and **always
+       overwrite** the metadata ``agent_name`` with the resolved value
+       so every task record stays consistent.
+    5. ``list_sessions()`` merges ``agent_name`` across task records for
+       the sidebar, ensuring the correct name appears even when some
+       records lack metadata.
+    """
+    if not session_id:
+        return request_agent or "sandbox-legion"
+
+    try:
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            # Check sessions table first (fast, indexed lookup)
+            srow = await conn.fetchrow(
+                "SELECT agent_name FROM sessions WHERE context_id = $1",
+                session_id,
+            )
+            if srow and srow["agent_name"]:
+                if srow["agent_name"] != request_agent:
+                    logger.info(
+                        "Resolved agent from sessions table: %s (request had %s) for session %s",
+                        _safe_log(srow["agent_name"]),
+                        _safe_log(request_agent),
+                        _safe_log(session_id[:12]),
+                    )
+                return srow["agent_name"]
+
+            # Fall back to tasks metadata (backward compat)
+            row = await conn.fetchrow(
+                "SELECT metadata FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1",
+                session_id,
+            )
+            if row and row["metadata"]:
+                meta = _parse_json_field(row["metadata"]) or {}
+                bound_agent = meta.get("agent_name")
+                if bound_agent:
+                    if bound_agent != request_agent:
+                        logger.info(
+                            "Resolved agent from DB: %s (request had %s) for session %s",
+                            _safe_log(bound_agent),
+                            _safe_log(request_agent),
+                            _safe_log(session_id[:12]),
+                        )
+                    return bound_agent
+    except Exception as e:
+        logger.warning("Failed to resolve agent from DB: %s", e)
+
+    # Never return empty — fall back to default agent
+    return request_agent or "sandbox-legion"
+
+
+@router.post(
+    "/{namespace}/chat",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def chat_send(
+    namespace: str,
+    request: SandboxChatRequest,
+    user: TokenData = Depends(get_required_user),
+):
+    """Send a message to a sandbox agent via A2A JSON-RPC (non-streaming).
+
+    Proxies the message to the agent's in-cluster service on port 8000.
+    Returns the complete response (no SSE streaming).
+    """
+    _validate_namespace(namespace)
+    context_id = request.session_id or uuid4().hex[:36]
+
+    # Resolve agent name: for existing sessions, use DB-bound agent
+    agent_name = await _resolve_agent_name(namespace, request.session_id, request.agent_name)
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, "Invalid resolved agent name")
+    agent_url = _validate_agent_url(f"http://{agent_name}.{namespace}.svc.cluster.local:8000")
+
+    metadata: dict = {"username": user.username}
+    if request.skill:
+        metadata["skill"] = request.skill
+
+    a2a_msg = {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "id": uuid4().hex,
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": request.message}],
+                "messageId": uuid4().hex,
+                "contextId": context_id,
+                "metadata": metadata,
+            }
+        },
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=180.0) as client:
+            resp = await client.post(f"{agent_url}/", json=a2a_msg)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as e:
+        logger.error("Agent error: %s", e)
+        raise HTTPException(502, "Agent communication error")
+
+    result = data.get("result", {})
+    if "error" in data:
+        raise HTTPException(502, f"A2A error: {data['error']}")
+
+    # Extract text from artifacts — only the final human-readable content
+    text = ""
+    artifacts = result.get("artifacts", [])
+    if artifacts:
+        for artifact in artifacts:
+            for part in artifact.get("parts", []):
+                if "text" in part:
+                    text += part["text"]
+
+    # Guard: if the agent serialized a list of content blocks (e.g. from a
+    # tool-calling model), extract only the text portions.
+    if text.startswith("[{") and "'type': 'text'" in text and len(text) < 100_000:
+        try:
+            import ast
+
+            blocks = ast.literal_eval(text)
+            if isinstance(blocks, list):
+                text = "\n".join(
+                    b.get("text", "")
+                    for b in blocks
+                    if isinstance(b, dict) and b.get("type") == "text"
+                )
+        except (ValueError, SyntaxError):
+            pass  # keep original text
+
+    # Auto-set session title from first message (truncated to 80 chars).
+    # Merge metadata across ALL task rows so agent-written fields
+    # (e.g. llm_request_ids) and backend fields (owner, title, agent_name)
+    # coexist on every row.
+    final_context_id = result.get("contextId", context_id)
+    try:
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT metadata FROM tasks WHERE context_id = $1",
+                final_context_id,
+            )
+            if rows:
+                merged: dict = {}
+                for row in rows:
+                    m = _parse_json_field(row["metadata"]) or {}
+                    merged.update({k: v for k, v in m.items() if v is not None})
+                changed = False
+                if not merged.get("title"):
+                    merged["title"] = request.message[:80].replace("\n", " ")
+                    changed = True
+                if not merged.get("owner"):
+                    merged["owner"] = user.username
+                    merged["visibility"] = "private"
+                    changed = True
+                resolved = await _resolve_agent_name(
+                    namespace, final_context_id, request.agent_name
+                )
+                if resolved and merged.get("agent_name") != resolved:
+                    merged["agent_name"] = resolved
+                    changed = True
+                if changed:
+                    await conn.execute(
+                        "UPDATE tasks SET metadata = $1::json WHERE context_id = $2",
+                        json.dumps(merged),
+                        final_context_id,
+                    )
+
+                # Upsert into sessions table (authoritative session metadata)
+                await conn.execute(
+                    "INSERT INTO sessions (context_id, agent_name, namespace, title, owner, updated_at, last_message_at)"
+                    " VALUES ($1, $2, $3, $4, $5, NOW(), NOW())"
+                    " ON CONFLICT (context_id) DO UPDATE SET"
+                    "   title = COALESCE(NULLIF(sessions.title, ''), EXCLUDED.title),"
+                    "   agent_name = COALESCE(NULLIF(sessions.agent_name, ''), EXCLUDED.agent_name),"
+                    "   owner = COALESCE(NULLIF(sessions.owner, ''), EXCLUDED.owner),"
+                    "   last_message_at = NOW(),"
+                    "   updated_at = NOW()",
+                    final_context_id,
+                    merged.get("agent_name", ""),
+                    namespace,
+                    merged.get("title", ""),
+                    merged.get("owner", ""),
+                )
+    except Exception:
+        pass  # non-critical
+
+    return {
+        "content": text,
+        "context_id": final_context_id,
+        "task_id": result.get("id"),
+        "status": result.get("status", {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming endpoint
+# ---------------------------------------------------------------------------
+
+
+def _extract_text_from_parts(parts: list) -> str:
+    """Extract text content from A2A message parts."""
+    content = ""
+    for part in parts:
+        if isinstance(part, dict):
+            if "text" in part:
+                content += part["text"]
+            elif part.get("kind") == "text":
+                content += part.get("text", "")
+            elif "data" in part:
+                data = part["data"]
+                if isinstance(data, dict):
+                    if "content_type" in data and "content" in data:
+                        content_type = data.get("content_type", "")
+                        content_value = data.get("content", "")
+                        if content_type == "application/json" and content_value:
+                            try:
+                                json_data = json.loads(content_value)
+                                formatted = json.dumps(json_data, indent=2)
+                                content += f"\n```json\n{formatted}\n```\n"
+                            except json.JSONDecodeError:
+                                content += f"\n{content_value}\n"
+                        elif not content_type.startswith("image/"):
+                            content += f"\n{content_value}\n"
+                    else:
+                        formatted = json.dumps(data, indent=2)
+                        content += f"\n```json\n{formatted}\n```\n"
+                elif isinstance(data, str):
+                    try:
+                        json_data = json.loads(data)
+                        formatted = json.dumps(json_data, indent=2)
+                        content += f"\n```json\n{formatted}\n```\n"
+                    except (json.JSONDecodeError, TypeError):
+                        content += f"\n{data}\n"
+                elif isinstance(data, (list, int, float, bool)):
+                    formatted = json.dumps(data, indent=2)
+                    content += f"\n```json\n{formatted}\n```\n"
+    return content
+
+
+# ---------------------------------------------------------------------------
+# Incremental loop-event persistence
+# ---------------------------------------------------------------------------
+_INCREMENTAL_PERSIST_THRESHOLD = 1  # persist every event — no batching, no loss on disconnect
+_INCREMENTAL_TRIGGER_TYPES = frozenset(
+    {
+        "planner_output",
+        "replanner_output",
+        "executor_step",
+        "tool_call",
+        "tool_result",
+        "micro_reasoning",
+        "reflector_decision",
+        "reporter_output",
+        "step_selector",
+        "budget_update",
+    }
+)
+
+
+async def _persist_loop_events_incremental(
+    task_id: str,
+    loop_events: list[dict],
+    namespace: str,
+) -> None:
+    """Write the current loop_events list to the task metadata (fire-and-forget).
+
+    Uses ``jsonb_set`` so only the ``loop_events`` key is touched — other
+    metadata fields are left intact.  This is safe to call concurrently with
+    the final writeback because the final writeback overwrites the same key
+    with the complete list.
+    """
+    try:
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE tasks SET metadata = jsonb_set("
+                "  COALESCE(metadata::jsonb, '{}'),"
+                "  '{loop_events}',"
+                "  $1::jsonb"
+                ") WHERE id = $2",
+                json.dumps(loop_events),
+                task_id,
+            )
+        logger.debug(
+            "Incremental persist: %d loop events for task %s",
+            len(loop_events),
+            task_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Incremental loop-event persist failed for task %s: %s",
+            task_id,
+            exc,
+        )
+
+
+def _should_persist_incrementally(
+    loop_events: list[dict],
+    last_persisted_count: int,
+    latest_event: dict,
+) -> bool:
+    """Decide whether to fire an incremental DB write."""
+    # Always persist on high-value event types
+    if latest_event.get("type") in _INCREMENTAL_TRIGGER_TYPES:
+        return True
+    # Persist every N events
+    if len(loop_events) - last_persisted_count >= _INCREMENTAL_PERSIST_THRESHOLD:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Per-event persistence (events table)
+# ---------------------------------------------------------------------------
+
+# Event type -> category mapping (mirrors loopBuilder.ts EVENT_CATALOG)
+_EVENT_CATEGORY_MAP: dict[str, str] = {
+    "planner_output": "reasoning",
+    "replanner_output": "reasoning",
+    "executor_step": "reasoning",
+    "thinking": "reasoning",
+    "micro_reasoning": "reasoning",
+    "tool_call": "execution",
+    "tool_result": "tool_output",
+    "reflector_decision": "decision",
+    "router": "decision",
+    "step_selector": "decision",
+    "reporter_output": "terminal",
+    "budget": "meta",
+    "budget_update": "meta",
+    "node_transition": "meta",
+    "hitl_request": "interaction",
+}
+
+
+# ---------------------------------------------------------------------------
+# Background event consumer — survives UI disconnects
+# ---------------------------------------------------------------------------
+
+# Registry of active consumers — keyed by (namespace, session_id)
+_active_consumers: dict[tuple[str, str], asyncio.Task] = {}
+
+_terminal_states = frozenset({"completed", "failed", "canceled"})
+
+
+async def _background_event_consumer(
+    agent_url: str,
+    session_id: str,
+    namespace: str,
+    task_id: str,
+    message: str,
+    owner: str | None = None,
+    agent_name: str | None = None,
+    skill: str | None = None,
+) -> None:
+    """Background task: consume agent SSE events and persist to events table.
+
+    Independent of UI connection. Survives UI disconnects.
+    Reconnects automatically if agent SSE drops (exponential backoff, max 10 retries).
+    Stops when agent reaches terminal status (completed/failed/canceled).
+
+    Uses tasks/resubscribe to open its own SSE connection to the agent,
+    running in parallel with the UI proxy generator. The consumer ensures
+    ALL events are persisted to the events table and loop_events metadata
+    blob, even if the UI disconnects mid-stream.
+    """
+    _validate_agent_url(agent_url)
+    _event_counter: int = 0
+    loop_events: list[dict] = []
+    _last_persisted_count: int = 0
+    _persist_bg_tasks: set[asyncio.Task] = set()
+    _max_reconnect = 10
+    _done_received = False
+
+    logger.info(
+        "BGConsumer: STARTED session=%s task=%s agent_url=%s",
+        _safe_log(session_id),
+        _safe_log(task_id),
+        _safe_log(agent_url),
+    )
+
+    async def _persist_event(parsed: dict) -> None:
+        """Persist a single loop event to the events table."""
+        nonlocal _event_counter
+        _event_counter += 1
+        evt_type = parsed.get("type", "")
+        t = asyncio.create_task(
+            _persist_event_row(
+                context_id=session_id,
+                task_id=task_id,
+                event_index=_event_counter,
+                event_type=evt_type,
+                event_category=_EVENT_CATEGORY_MAP.get(evt_type),
+                langgraph_node=parsed.get("langgraph_node"),
+                payload=parsed,
+                namespace=namespace,
+            )
+        )
+        _persist_bg_tasks.add(t)
+        t.add_done_callback(_persist_bg_tasks.discard)
+
+    async def _persist_loop_events_snapshot() -> None:
+        """Persist current loop_events snapshot to task metadata."""
+        nonlocal _last_persisted_count
+        if not loop_events:
+            return
+        _last_persisted_count = len(loop_events)
+        t = asyncio.create_task(
+            _persist_loop_events_incremental(
+                task_id,
+                list(loop_events),
+                namespace,
+            )
+        )
+        _persist_bg_tasks.add(t)
+        t.add_done_callback(_persist_bg_tasks.discard)
+
+    def _process_sse_line(line: str) -> str | None:
+        """Extract data payload from an SSE line. Returns None if not a data line."""
+        if line.startswith("data: "):
+            return line[6:]
+        return None
+
+    async def _process_events_from_status_message(status_message: str) -> bool:
+        """Parse loop events from a status message. Returns True if terminal."""
+        nonlocal _done_received
+        if not status_message:
+            return False
+
+        msg_lines = [ln.strip() for ln in status_message.split("\n") if ln.strip()]
+        for msg_line in msg_lines:
+            try:
+                parsed = json.loads(msg_line)
+                if isinstance(parsed, dict) and "loop_id" in parsed:
+                    evt_type = parsed.get("type", "")
+                    loop_events.append(parsed)
+
+                    # Persist to events table
+                    await _persist_event(parsed)
+
+                    # Incremental persist to loop_events metadata
+                    if _should_persist_incrementally(loop_events, _last_persisted_count, parsed):
+                        await _persist_loop_events_snapshot()
+
+                    logger.debug(
+                        "BGConsumer: event session=%s type=%s step=%s",
+                        _safe_log(session_id),
+                        evt_type,
+                        parsed.get("step", ""),
+                    )
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return False
+
+    async def _consume_stream(client: httpx.AsyncClient) -> bool:
+        """Open a tasks/resubscribe stream and consume events.
+
+        Returns True if [DONE] was received (terminal), False if stream
+        ended prematurely (needs reconnect).
+        """
+        nonlocal _done_received
+
+        resub_msg = {
+            "jsonrpc": "2.0",
+            "id": str(uuid4()),
+            "method": "tasks/resubscribe",
+            "params": {"id": task_id},
+        }
+
+        # First check if task is already terminal
+        try:
+            check_resp = await client.post(
+                agent_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": str(uuid4()),
+                    "method": "tasks/get",
+                    "params": {"id": task_id},
+                },
+            )
+            if check_resp.status_code == 200:
+                check_data = check_resp.json()
+                check_state = (
+                    check_data.get("result", {}).get("status", {}).get("state", "").lower()
+                )
+                if check_state in _terminal_states:
+                    logger.info(
+                        "BGConsumer: task already %s — extracting events from history",
+                        check_state,
+                    )
+                    # Extract any events from task history we haven't seen
+                    history = check_data.get("result", {}).get("history", [])
+                    for msg in history:
+                        for part in msg.get("parts", []):
+                            text = part.get("text", "")
+                            await _process_events_from_status_message(text)
+
+                    _done_received = True
+                    return True
+        except Exception as exc:
+            logger.debug("BGConsumer: tasks/get check failed: %s", exc)
+
+        # Open resubscribe stream
+        async with client.stream(
+            "POST",
+            agent_url,
+            json=resub_msg,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "text/event-stream",
+            },
+        ) as response:
+            if response.status_code != 200:
+                logger.warning(
+                    "BGConsumer: resubscribe returned %d for session=%s",
+                    response.status_code,
+                    _safe_log(session_id),
+                )
+                return False
+
+            logger.info(
+                "BGConsumer: connected to agent stream session=%s task=%s",
+                _safe_log(session_id),
+                task_id,
+            )
+            line_iter = response.aiter_lines().__aiter__()
+
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        line_iter.__anext__(),
+                        timeout=30,  # longer timeout than UI — we're patient
+                    )
+                except asyncio.TimeoutError:
+                    continue  # just keep waiting
+                except StopAsyncIteration:
+                    logger.info(
+                        "BGConsumer: stream exhausted for session=%s",
+                        _safe_log(session_id),
+                    )
+                    return False  # stream ended without [DONE]
+
+                if not line:
+                    continue
+
+                data = _process_sse_line(line)
+                if data is None:
+                    continue
+
+                if data == "[DONE]":
+                    logger.info(
+                        "BGConsumer: [DONE] received for session=%s (%d events)",
+                        _safe_log(session_id),
+                        len(loop_events),
+                    )
+                    _done_received = True
+                    return True
+
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+
+                if "result" not in chunk:
+                    continue
+
+                result = chunk["result"]
+
+                # Process status messages containing loop events
+                if "status" in result:
+                    status = result["status"]
+                    if "message" in status and status["message"]:
+                        parts = status["message"].get("parts", [])
+                        status_message = _extract_text_from_parts(parts)
+                        await _process_events_from_status_message(status_message)
+
+        return False  # should not reach here
+
+    try:
+        # Small delay to let the initial message/stream POST establish
+        # the agent task before we try to resubscribe
+        await asyncio.sleep(1.0)
+
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=30.0, read=None, write=30.0, pool=None)
+        ) as client:
+            delay = 2.0
+            for attempt in range(1, _max_reconnect + 1):
+                try:
+                    done = await _consume_stream(client)
+                    if done:
+                        break
+                except (
+                    httpx.RequestError,
+                    httpx.ReadError,
+                    httpx.RemoteProtocolError,
+                ) as exc:
+                    logger.warning(
+                        "BGConsumer: connection error attempt %d/%d session=%s: %s",
+                        attempt,
+                        _max_reconnect,
+                        _safe_log(session_id),
+                        exc,
+                    )
+
+                if attempt < _max_reconnect:
+                    logger.info(
+                        "BGConsumer: reconnecting in %.1fs (attempt %d/%d) session=%s",
+                        delay,
+                        attempt,
+                        _max_reconnect,
+                        _safe_log(session_id),
+                    )
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 60.0)
+                else:
+                    logger.warning(
+                        "BGConsumer: max reconnects reached for session=%s",
+                        _safe_log(session_id),
+                    )
+
+    except asyncio.CancelledError:
+        logger.info("BGConsumer: cancelled for session=%s", _safe_log(session_id))
+        raise
+    except Exception:
+        logger.warning(
+            "BGConsumer: unexpected error for session=%s",
+            _safe_log(session_id),
+            exc_info=True,
+        )
+    finally:
+        # Wait for any in-flight persist tasks
+        if _persist_bg_tasks:
+            logger.info(
+                "BGConsumer: waiting for %d persist tasks session=%s",
+                len(_persist_bg_tasks),
+                _safe_log(session_id),
+            )
+            await asyncio.gather(*_persist_bg_tasks, return_exceptions=True)
+
+        # Final persist of loop_events to task metadata
+        if loop_events and namespace:
+            try:
+                pool = await get_session_pool(namespace)
+                async with pool.acquire() as conn:
+                    row = await conn.fetchrow("SELECT metadata FROM tasks WHERE id = $1", task_id)
+                    if row:
+                        meta = _parse_json_field(row["metadata"]) or {}
+                        existing = meta.get("loop_events", [])
+                        # Only overwrite if we have more events
+                        if len(loop_events) >= len(existing):
+                            meta["loop_events"] = loop_events
+                            await conn.execute(
+                                "UPDATE tasks SET metadata = $1::json WHERE id = $2",
+                                json.dumps(meta),
+                                task_id,
+                            )
+                            logger.info(
+                                "BGConsumer: final persist %d events for session=%s",
+                                len(loop_events),
+                                _safe_log(session_id),
+                            )
+            except Exception as exc:
+                logger.warning(
+                    "BGConsumer: final persist failed session=%s: %s",
+                    _safe_log(session_id),
+                    exc,
+                )
+
+        # Update session status if we know the terminal state
+        if _done_received and namespace:
+            try:
+                pool = await get_session_pool(namespace)
+                async with pool.acquire() as conn:
+                    # Get final task status from agent
+                    has_reporter = any(e.get("type") == "reporter_output" for e in loop_events)
+                    terminal_status = "completed" if has_reporter else "working"
+
+                    # Update sessions table
+                    await conn.execute(
+                        "UPDATE sessions SET updated_at = NOW() WHERE context_id = $1",
+                        session_id,
+                    )
+                    logger.info(
+                        "BGConsumer: session status updated session=%s status=%s",
+                        _safe_log(session_id),
+                        terminal_status,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "BGConsumer: session status update failed session=%s: %s",
+                    _safe_log(session_id),
+                    exc,
+                )
+
+        logger.info(
+            "BGConsumer: FINISHED session=%s events=%d done=%s",
+            _safe_log(session_id),
+            len(loop_events),
+            _done_received,
+        )
+
+
+def _spawn_background_consumer(
+    agent_url: str,
+    session_id: str,
+    namespace: str,
+    task_id: str,
+    message: str,
+    owner: str | None = None,
+    agent_name: str | None = None,
+    skill: str | None = None,
+) -> asyncio.Task | None:
+    """Spawn a background event consumer for a session if one isn't already running.
+
+    Returns the Task if spawned, None if a consumer already exists.
+    """
+    key = (namespace, session_id)
+    existing = _active_consumers.get(key)
+    if existing is not None and not existing.done():
+        logger.info(
+            "BGConsumer: already active for session=%s — skipping spawn",
+            _safe_log(session_id),
+        )
+        return None
+
+    task = asyncio.create_task(
+        _background_event_consumer(
+            agent_url=agent_url,
+            session_id=session_id,
+            namespace=namespace,
+            task_id=task_id,
+            message=message,
+            owner=owner,
+            agent_name=agent_name,
+            skill=skill,
+        ),
+        name=f"bg-consumer-{session_id[:12]}",
+    )
+    _active_consumers[key] = task
+
+    def _cleanup(t: asyncio.Task) -> None:
+        _active_consumers.pop(key, None)
+        if t.cancelled():
+            logger.info("BGConsumer: task cancelled for session=%s", _safe_log(session_id))
+        elif t.exception():
+            logger.warning(
+                "BGConsumer: task failed for session=%s: %s",
+                _safe_log(session_id),
+                t.exception(),
+            )
+        else:
+            logger.info("BGConsumer: task completed for session=%s", _safe_log(session_id))
+
+    task.add_done_callback(_cleanup)
+
+    logger.info(
+        "BGConsumer: spawned for session=%s task=%s",
+        _safe_log(session_id),
+        task_id,
+    )
+    return task
+
+
+async def _persist_event_row(
+    context_id: str,
+    task_id: str,
+    event_index: int,
+    event_type: str,
+    event_category: Optional[str],
+    langgraph_node: Optional[str],
+    payload: dict,
+    namespace: str,
+) -> None:
+    """Persist a single event to the events table (fire-and-forget).
+
+    Uses INSERT ... ON CONFLICT DO NOTHING so duplicate events from
+    retries or resubscribe are silently skipped.
+    """
+    try:
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO events (context_id, task_id, event_index,"
+                "  event_type, event_category, langgraph_node, payload)"
+                " VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)"
+                " ON CONFLICT (context_id, task_id, event_index) DO NOTHING",
+                context_id,
+                task_id,
+                event_index,
+                event_type,
+                event_category,
+                langgraph_node,
+                json.dumps(payload),
+            )
+    except Exception as exc:
+        logger.debug(
+            "Event persist failed (ctx=%s idx=%d): %s", _safe_log(context_id), event_index, exc
+        )
+
+
+async def _stream_sandbox_response(
+    agent_url: str,
+    message: str,
+    session_id: str,
+    owner: Optional[str] = None,
+    namespace: Optional[str] = None,
+    agent_name: Optional[str] = None,
+    skill: Optional[str] = None,
+) -> AsyncGenerator[str, None]:
+    """Async generator that proxies A2A SSE events from the agent."""
+    _validate_agent_url(agent_url)
+    owner_set = False
+    loop_events_persisted = False  # Guard against double-write of loop events
+    session_has_loops = False  # Session-level flag: once loop_id seen, suppress flat events
+    loop_events: list[dict] = []  # Accumulated loop events for persistence
+    _event_counter: int = 0  # Monotonic counter for per-event persistence
+    stream_task_id: Optional[str] = None  # DB id of the task row created by THIS stream
+    _last_persisted_count: int = 0  # count at last incremental persist
+    # Hold strong references to fire-and-forget persist tasks so the event loop
+    # doesn't garbage-collect them before completion (Python asyncio only keeps
+    # weak refs to tasks).
+    _persist_bg_tasks: set[asyncio.Task] = set()
+
+    async def _set_owner_metadata():
+        """Set owner on THIS stream's task row only.
+
+        Reads only the current task row's metadata (identified by
+        ``stream_task_id``) and writes backend-managed fields (owner,
+        title, agent_name) to that single row. Does NOT merge metadata
+        across task rows — each task keeps its own metadata to prevent
+        cross-pollination of loop_events and other per-turn data.
+
+        Called on every SSE event batch (not just the first) to handle
+        task rows created after the initial call. Retries on transient
+        DB errors.
+        """
+        nonlocal stream_task_id
+        logger.info(
+            "_set_owner_metadata: agent_name=%s, owner=%s, namespace=%s, session=%s, task_id=%s",
+            _safe_log(agent_name),
+            _safe_log(owner),
+            _safe_log(namespace),
+            _safe_log(session_id),
+            _safe_log(stream_task_id),
+        )
+        if not namespace:
+            logger.warning(
+                "_set_owner_metadata skipped: namespace is empty for session %s",
+                _safe_log(session_id),
+            )
+            return
+        for attempt in range(3):
+            try:
+                pool = await get_session_pool(namespace)
+                async with pool.acquire() as conn:
+                    # Use stream_task_id captured from A2A event — no fallback
+                    if stream_task_id is None:
+                        if attempt < 2:
+                            await asyncio.sleep(0.5 * (attempt + 1))
+                            continue
+                        logger.warning(
+                            "_set_owner_metadata: stream_task_id still None after retries for session %s",
+                            _safe_log(session_id),
+                        )
+                        return
+
+                    row = await conn.fetchrow(
+                        "SELECT metadata FROM tasks WHERE id = $1",
+                        stream_task_id,
+                    )
+                    if row is None:
+                        if attempt < 2:
+                            await asyncio.sleep(0.5 * (attempt + 1))
+                            continue
+                        return
+                    meta = _parse_json_field(row["metadata"]) or {}
+
+                    # Set/overwrite backend-managed fields on this row only
+                    if owner and not meta.get("owner"):
+                        meta["owner"] = owner
+                        meta["visibility"] = "private"
+                    if not meta.get("title"):
+                        meta["title"] = message[:80].replace("\n", " ")
+                    if agent_name:
+                        meta["agent_name"] = agent_name
+                    else:
+                        logger.warning(
+                            "_set_owner_metadata called with empty agent_name for session %s",
+                            _safe_log(session_id),
+                        )
+                    # Update only THIS task row
+                    result = await conn.execute(
+                        "UPDATE tasks SET metadata = $1::json WHERE id = $2",
+                        json.dumps(meta),
+                        stream_task_id,
+                    )
+                    affected = int(str(result).split()[-1]) if result else 0
+                    if affected == 0:
+                        logger.warning(
+                            "Metadata update matched 0 rows for task %s session %s",
+                            _safe_log(stream_task_id),
+                            _safe_log(session_id),
+                        )
+
+                    # Upsert into sessions table (authoritative session metadata)
+                    title = meta.get("title", "")
+                    await conn.execute(
+                        "INSERT INTO sessions (context_id, agent_name, namespace, title, owner, updated_at, last_message_at)"
+                        " VALUES ($1, $2, $3, $4, $5, NOW(), NOW())"
+                        " ON CONFLICT (context_id) DO UPDATE SET"
+                        "   title = COALESCE(NULLIF(sessions.title, ''), EXCLUDED.title),"
+                        "   agent_name = COALESCE(NULLIF(sessions.agent_name, ''), EXCLUDED.agent_name),"
+                        "   owner = COALESCE(NULLIF(sessions.owner, ''), EXCLUDED.owner),"
+                        "   last_message_at = NOW(),"
+                        "   updated_at = NOW()",
+                        session_id,
+                        agent_name or "",
+                        namespace or "",
+                        title or "",
+                        owner or "",
+                    )
+                break  # Success
+            except Exception:
+                logger.warning(
+                    "Failed to set owner on session %s (attempt %d/3)",
+                    _safe_log(session_id),
+                    attempt + 1,
+                    exc_info=True,
+                )
+                if attempt < 2:
+                    await asyncio.sleep(0.5 * (attempt + 1))
+
+    metadata: dict = {"username": owner}
+    if skill:
+        metadata["skill"] = skill
+
+    a2a_msg = {
+        "jsonrpc": "2.0",
+        "id": str(uuid4()),
+        "method": "message/stream",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": message}],
+                "messageId": uuid4().hex,
+                "contextId": session_id,
+                "metadata": metadata,
+            },
+        },
+    }
+
+    logger.info(
+        "Starting sandbox SSE stream to %s (session=%s)",
+        _safe_log(agent_url),
+        _safe_log(session_id),
+    )
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    }
+
+    # SSE keepalive interval (seconds). Prevents nginx proxy_read_timeout
+    # (default 300s) from killing long-running agent connections.
+    _keepalive_interval = 15
+
+    _max_resubscribe = 5  # Max reconnection attempts via tasks/resubscribe
+    _done_received = False
+
+    try:
+        # No global read timeout — agent sessions can run 10+ minutes.
+        # Per-line timeout via asyncio.wait_for(_keepalive_interval) handles
+        # keepalive pings. Connection closes when agent stops streaming.
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=30.0, read=None, write=30.0, pool=None)
+        ) as client:
+            # --- Initial stream: message/stream ---
+            async with client.stream(
+                "POST",
+                agent_url,
+                json=a2a_msg,
+                headers=headers,
+            ) as response:
+                response.raise_for_status()
+                logger.info("Connected to agent, status=%d", response.status_code)
+
+                line_count = 0
+                line_iter = response.aiter_lines().__aiter__()
+                stream_exhausted = False
+
+                while not stream_exhausted:
+                    try:
+                        line = await asyncio.wait_for(
+                            line_iter.__anext__(),
+                            timeout=_keepalive_interval,
+                        )
+                    except asyncio.TimeoutError:
+                        yield f"data: {json.dumps({'ping': True})}\n\n"
+                        continue
+                    except StopAsyncIteration:
+                        logger.info(
+                            "SSE stream exhausted for session=%s after %d lines",
+                            _safe_log(session_id),
+                            line_count,
+                        )
+                        stream_exhausted = True
+                        break
+
+                    if not line:
+                        continue
+                    line_count += 1
+                    # Log all SSE lines for pipeline debugging
+                    logger.info("Agent SSE [%d]: %s", line_count, _safe_log(line[:300]))
+
+                    if line.startswith("data: "):
+                        data = line[6:]
+
+                        if data == "[DONE]":
+                            _done_received = True
+                            logger.info("Received [DONE] from agent")
+                            # Fan out done signal to sidecar manager so
+                            # the looper detects stream completion
+                            try:
+                                from app.services.sidecar_manager import get_sidecar_manager
+
+                                get_sidecar_manager().fan_out_event(
+                                    session_id,
+                                    {"done": True, "session_id": session_id},
+                                )
+                            except Exception:
+                                pass  # best-effort
+
+                            await _set_owner_metadata()
+                            # Persist accumulated loop events to THIS task row only
+                            if loop_events and namespace and not loop_events_persisted:
+                                try:
+                                    pool = await get_session_pool(namespace)
+                                    async with pool.acquire() as conn:
+                                        # Use stream_task_id to target this stream's row
+                                        task_db_id = stream_task_id
+                                        if task_db_id is None:
+                                            task_db_id = await conn.fetchval(
+                                                "SELECT id FROM tasks WHERE context_id = $1"
+                                                " ORDER BY id DESC LIMIT 1",
+                                                session_id,
+                                            )
+                                        if task_db_id is not None:
+                                            row = await conn.fetchrow(
+                                                "SELECT metadata FROM tasks WHERE id = $1",
+                                                task_db_id,
+                                            )
+                                            if row:
+                                                meta = (
+                                                    json.loads(row["metadata"])
+                                                    if row["metadata"]
+                                                    else {}
+                                                )
+                                                meta["loop_events"] = loop_events
+                                                await conn.execute(
+                                                    "UPDATE tasks SET metadata = $1::json WHERE id = $2",
+                                                    json.dumps(meta),
+                                                    task_db_id,
+                                                )
+                                    loop_events_persisted = True
+                                except Exception as e:
+                                    logger.warning(
+                                        "Failed to persist loop events for %s: %s",
+                                        _safe_log(session_id),
+                                        e,
+                                    )
+                            yield f"data: {json.dumps({'done': True, 'session_id': session_id})}\n\n"
+                            break
+
+                        try:
+                            chunk = json.loads(data)
+                        except json.JSONDecodeError as e:
+                            logger.warning(
+                                "Failed to parse SSE data: %s, error: %s",
+                                _safe_log(data[:200]),
+                                e,
+                            )
+                            continue
+
+                        # Fan out event to sidecar manager
+                        try:
+                            from app.services.sidecar_manager import get_sidecar_manager
+
+                            get_sidecar_manager().fan_out_event(session_id, chunk)
+                        except Exception:
+                            pass  # Sidecar fan-out is best-effort
+
+                        if "result" not in chunk:
+                            continue
+
+                        result = chunk["result"]
+
+                        # Capture stream_task_id from ANY A2A event as early as possible.
+                        # TaskStatusUpdateEvent has "taskId", initial Task has "id".
+                        if stream_task_id is None:
+                            a2a_task_id = (
+                                result.get("taskId") or result.get("task_id") or result.get("id")
+                            )
+                            if a2a_task_id and a2a_task_id != chunk.get("id"):
+                                # Exclude JSON-RPC request id (chunk["id"])
+                                stream_task_id = a2a_task_id
+                                logger.info(
+                                    "Captured stream_task_id=%s for session %s (kind=%s)",
+                                    _safe_log(stream_task_id),
+                                    _safe_log(session_id),
+                                    result.get("kind", "?"),
+                                )
+                                # Flush any events buffered before task_id was known
+                                if loop_events and namespace:
+                                    _last_persisted_count = len(loop_events)
+                                    _t = asyncio.create_task(
+                                        _persist_loop_events_incremental(
+                                            stream_task_id,
+                                            list(loop_events),
+                                            namespace,
+                                        )
+                                    )
+                                    _persist_bg_tasks.add(_t)
+                                    _t.add_done_callback(_persist_bg_tasks.discard)
+
+                                # Spawn background consumer — ensures event
+                                # persistence survives UI disconnects. The
+                                # consumer uses tasks/resubscribe to open its
+                                # own independent SSE connection.
+                                if namespace:
+                                    _spawn_background_consumer(
+                                        agent_url=agent_url,
+                                        session_id=session_id,
+                                        namespace=namespace,
+                                        task_id=stream_task_id,
+                                        message=message,
+                                        owner=owner,
+                                        agent_name=agent_name,
+                                        skill=skill,
+                                    )
+
+                        payload: dict = {"session_id": session_id}
+                        if owner:
+                            payload["username"] = owner
+
+                        # Set owner after first event (task exists in DB).
+                        # Runs once per stream; the [DONE] handler runs it again
+                        # to catch task rows created mid-stream.
+                        if not owner_set:
+                            await _set_owner_metadata()
+                            owner_set = True
+
+                        # --- TaskArtifactUpdateEvent ---
+                        if "artifact" in result:
+                            # Suppress artifact events in loop mode
+                            # (loop cards handle all content display)
+                            if session_has_loops:
+                                continue
+
+                            artifact = result["artifact"]
+                            parts = artifact.get("parts", [])
+                            content = _extract_text_from_parts(parts)
+
+                            payload["event"] = {
+                                "type": "artifact",
+                                "taskId": result.get("taskId", ""),
+                                "name": artifact.get("name"),
+                                "index": artifact.get("index"),
+                            }
+                            if content:
+                                payload["content"] = content
+
+                            yield f"data: {json.dumps(payload)}\n\n"
+
+                        # --- TaskStatusUpdateEvent ---
+                        elif "status" in result and "taskId" in result:
+                            status = result["status"]
+                            is_final = result.get("final", False)
+                            state = status.get("state", "UNKNOWN")
+
+                            status_message = ""
+                            if "message" in status and status["message"]:
+                                parts = status["message"].get("parts", [])
+                                status_message = _extract_text_from_parts(parts)
+
+                            # Detect HITL (Human-in-the-Loop) requests
+                            event_type = "status"
+                            if state == "INPUT_REQUIRED":
+                                event_type = "hitl_request"
+
+                            # Forward structured loop events (loop_id)
+                            # The agent serializer puts JSON lines in the message text.
+                            # Parse each line and forward loop_id at top level so the
+                            # UI can group events into AgentLoopCards.
+                            has_loop_events = False
+                            if status_message:
+                                msg_lines = [
+                                    line.strip()
+                                    for line in status_message.split("\n")
+                                    if line.strip()
+                                ]
+                                logger.info(
+                                    "SSE_PARSE session=%s lines=%d preview=%s",
+                                    _safe_log(session_id),
+                                    len(msg_lines),
+                                    msg_lines[0][:120] if msg_lines else "(empty)",
+                                )
+                                for msg_line in msg_lines:
+                                    try:
+                                        parsed = json.loads(msg_line)
+                                        if isinstance(parsed, dict) and "loop_id" in parsed:
+                                            evt_type = parsed.get("type", "")
+
+                                            # Forward to frontend
+                                            loop_payload = dict(payload)
+                                            loop_payload["loop_id"] = parsed["loop_id"]
+                                            loop_payload["loop_event"] = parsed
+                                            yield f"data: {json.dumps(loop_payload)}\n\n"
+
+                                            # Log forwarding
+                                            logger.info(
+                                                "LOOP_FWD session=%s loop=%s type=%s step=%s",
+                                                _safe_log(session_id),
+                                                parsed["loop_id"][:8],
+                                                evt_type,
+                                                parsed.get("step", ""),
+                                            )
+
+                                            has_loop_events = True
+                                            session_has_loops = True
+                                            loop_events.append(parsed)
+
+                                            # Per-event persistence handled by background
+                                            # consumer (_background_event_consumer) —
+                                            # removed from SSE proxy to avoid duplicate
+                                            # event_index values in the events table.
+
+                                            # -- Incremental persist --
+                                            should_persist = _should_persist_incrementally(
+                                                loop_events, _last_persisted_count, parsed
+                                            )
+                                            if stream_task_id and namespace and should_persist:
+                                                logger.info(
+                                                    "INCR_PERSIST session=%s task=%s events=%d type=%s",
+                                                    _safe_log(session_id),
+                                                    stream_task_id[:12],
+                                                    len(loop_events),
+                                                    evt_type,
+                                                )
+                                                _last_persisted_count = len(loop_events)
+                                                _t = asyncio.create_task(
+                                                    _persist_loop_events_incremental(
+                                                        stream_task_id,
+                                                        list(loop_events),  # snapshot
+                                                        namespace,
+                                                    )
+                                                )
+                                                _persist_bg_tasks.add(_t)
+                                                _t.add_done_callback(_persist_bg_tasks.discard)
+                                            elif not stream_task_id:
+                                                logger.warning(
+                                                    "INCR_PERSIST_SKIP session=%s no stream_task_id events=%d",
+                                                    _safe_log(session_id),
+                                                    len(loop_events),
+                                                )
+
+                                            continue
+                                    except (json.JSONDecodeError, TypeError):
+                                        pass
+
+                            # Skip ALL flat events once loop mode is active
+                            # (prevents duplicate flat blocks alongside AgentLoopCards)
+                            if has_loop_events or session_has_loops:
+                                continue
+
+                            # Log flat event forwarding (no loop_id detected)
+                            if status_message:
+                                logger.info(
+                                    "FLAT_FWD session=%s content_len=%d first_80=%s",
+                                    _safe_log(session_id),
+                                    len(status_message),
+                                    status_message[:80].replace("\n", "\\n"),
+                                )
+
+                            payload["event"] = {
+                                "type": event_type,
+                                "taskId": result.get("taskId", ""),
+                                "state": state,
+                                "final": is_final,
+                                "message": status_message or None,
+                            }
+
+                            if is_final or state in ("COMPLETED", "FAILED"):
+                                if status_message:
+                                    payload["content"] = status_message
+
+                            yield f"data: {json.dumps(payload)}\n\n"
+
+                        # --- Task object (initial response) ---
+                        elif "id" in result and "status" in result:
+                            task_status = result["status"]
+                            state = task_status.get("state", "UNKNOWN")
+
+                            payload["event"] = {
+                                "type": "status",
+                                "taskId": result.get("id", ""),
+                                "state": state,
+                                "final": state in ("COMPLETED", "FAILED"),
+                            }
+
+                            if state in ("COMPLETED", "FAILED"):
+                                if "message" in task_status and task_status["message"]:
+                                    parts = task_status["message"].get("parts", [])
+                                    content = _extract_text_from_parts(parts)
+                                    if content:
+                                        payload["content"] = content
+
+                            yield f"data: {json.dumps(payload)}\n\n"
+
+                        # --- Direct message (A2AMessage) ---
+                        elif "parts" in result:
+                            content = _extract_text_from_parts(result["parts"])
+                            message_id = result.get("messageId", "")
+
+                            payload["event"] = {
+                                "type": "status",
+                                "taskId": message_id,
+                                "state": "WORKING",
+                                "final": False,
+                                "message": content or None,
+                            }
+                            if content:
+                                payload["content"] = content
+
+                            yield f"data: {json.dumps(payload)}\n\n"
+
+                        else:
+                            logger.warning(
+                                "Unknown result structure: keys=%s",
+                                list(result.keys()),
+                            )
+
+            # --- Resubscribe loop: reconnect if stream closed without [DONE] ---
+            if not _done_received and stream_task_id:
+                for resub_attempt in range(1, _max_resubscribe + 1):
+                    logger.info(
+                        "Resubscribe attempt %d/%d: task=%s session=%s",
+                        resub_attempt,
+                        _max_resubscribe,
+                        _safe_log(stream_task_id),
+                        _safe_log(session_id),
+                    )
+                    resub_msg = {
+                        "jsonrpc": "2.0",
+                        "id": str(uuid4()),
+                        "method": "tasks/resubscribe",
+                        "params": {"id": stream_task_id},
+                    }
+                    try:
+                        # First try a non-streaming POST to check if the task
+                        # is still running. If it's terminal, resubscribe will
+                        # fail, so we skip to recovery polling.
+                        check_resp = await client.post(
+                            agent_url,
+                            json={
+                                "jsonrpc": "2.0",
+                                "id": str(uuid4()),
+                                "method": "tasks/get",
+                                "params": {"id": stream_task_id},
+                            },
+                        )
+                        if check_resp.status_code == 200:
+                            check_data = check_resp.json()
+                            check_state = (
+                                check_data.get("result", {})
+                                .get("status", {})
+                                .get("state", "")
+                                .lower()
+                            )
+                            if check_state in ("completed", "failed", "canceled"):
+                                logger.info(
+                                    "Task already %s — skipping resubscribe, using recovery",
+                                    check_state,
+                                )
+                                break
+
+                        async with client.stream(
+                            "POST",
+                            agent_url,
+                            json=resub_msg,
+                            headers=headers,
+                        ) as resub_response:
+                            if resub_response.status_code != 200:
+                                logger.info(
+                                    "Resubscribe returned %d — falling back to recovery",
+                                    resub_response.status_code,
+                                )
+                                break
+
+                            logger.info(
+                                "Resubscribed to agent stream, status=%d",
+                                resub_response.status_code,
+                            )
+                            resub_iter = resub_response.aiter_lines().__aiter__()
+                            resub_exhausted = False
+
+                            while not resub_exhausted:
+                                try:
+                                    line = await asyncio.wait_for(
+                                        resub_iter.__anext__(),
+                                        timeout=_keepalive_interval,
+                                    )
+                                except asyncio.TimeoutError:
+                                    yield f"data: {json.dumps({'ping': True})}\n\n"
+                                    continue
+                                except StopAsyncIteration:
+                                    resub_exhausted = True
+                                    break
+
+                                if not line:
+                                    continue
+                                line_count += 1
+                                logger.info(
+                                    "Agent SSE [%d] (resub): %s", line_count, _safe_log(line[:300])
+                                )
+
+                                if line.startswith("data: "):
+                                    data = line[6:]
+
+                                    if data == "[DONE]":
+                                        _done_received = True
+                                        logger.info("Received [DONE] from agent (via resubscribe)")
+                                        await _set_owner_metadata()
+                                        if loop_events and namespace and not loop_events_persisted:
+                                            try:
+                                                pool = await get_session_pool(namespace)
+                                                async with pool.acquire() as conn:
+                                                    task_db_id = stream_task_id
+                                                    if task_db_id is not None:
+                                                        row = await conn.fetchrow(
+                                                            "SELECT metadata FROM tasks WHERE id = $1",
+                                                            task_db_id,
+                                                        )
+                                                        if row:
+                                                            meta = (
+                                                                json.loads(row["metadata"])
+                                                                if row["metadata"]
+                                                                else {}
+                                                            )
+                                                            meta["loop_events"] = loop_events
+                                                            await conn.execute(
+                                                                "UPDATE tasks SET metadata = $1::json WHERE id = $2",
+                                                                json.dumps(meta),
+                                                                task_db_id,
+                                                            )
+                                                    loop_events_persisted = True
+                                            except Exception as e:
+                                                logger.warning(
+                                                    "Failed to persist loop events on resubscribe: %s",
+                                                    e,
+                                                )
+                                        yield f"data: {json.dumps({'done': True, 'session_id': session_id})}\n\n"
+                                        break
+
+                                    try:
+                                        chunk = json.loads(data)
+                                    except json.JSONDecodeError:
+                                        continue
+
+                                    if "result" not in chunk:
+                                        continue
+
+                                    result = chunk["result"]
+                                    payload: dict = {"session_id": session_id}
+                                    if owner:
+                                        payload["username"] = owner
+
+                                    # Process status updates (same logic as initial stream)
+                                    if "status" in result and "message" in result.get("status", {}):
+                                        state = result["status"].get("state", "UNKNOWN")
+                                        parts = result["status"].get("message", {}).get("parts", [])
+                                        status_message = _extract_text_from_parts(parts)
+                                        is_final = result.get("final", False)
+
+                                        has_loop_events = False
+                                        if status_message:
+                                            msg_lines = [
+                                                line.strip()
+                                                for line in status_message.split("\n")
+                                                if line.strip()
+                                            ]
+                                            for msg_line in msg_lines:
+                                                try:
+                                                    parsed = json.loads(msg_line)
+                                                    if (
+                                                        isinstance(parsed, dict)
+                                                        and "loop_id" in parsed
+                                                    ):
+                                                        evt_type = parsed.get("type", "")
+                                                        if evt_type in _LEGACY_EVENT_TYPES:
+                                                            continue
+                                                        loop_payload = dict(payload)
+                                                        loop_payload["loop_id"] = parsed["loop_id"]
+                                                        loop_payload["loop_event"] = parsed
+                                                        yield f"data: {json.dumps(loop_payload)}\n\n"
+                                                        logger.info(
+                                                            "LOOP_FWD session=%s loop=%s type=%s step=%s (resub)",
+                                                            _safe_log(session_id),
+                                                            parsed["loop_id"][:8],
+                                                            evt_type,
+                                                            parsed.get("step", ""),
+                                                        )
+                                                        has_loop_events = True
+                                                        session_has_loops = True
+                                                        loop_events.append(parsed)
+
+                                                        # -- Incremental persist (resub) --
+                                                        if (
+                                                            stream_task_id
+                                                            and namespace
+                                                            and _should_persist_incrementally(
+                                                                loop_events,
+                                                                _last_persisted_count,
+                                                                parsed,
+                                                            )
+                                                        ):
+                                                            _last_persisted_count = len(loop_events)
+                                                            _t = asyncio.create_task(
+                                                                _persist_loop_events_incremental(
+                                                                    stream_task_id,
+                                                                    list(loop_events),  # snapshot
+                                                                    namespace,
+                                                                )
+                                                            )
+                                                            _persist_bg_tasks.add(_t)
+                                                            _t.add_done_callback(
+                                                                _persist_bg_tasks.discard
+                                                            )
+
+                                                except (json.JSONDecodeError, TypeError):
+                                                    pass
+
+                                            if not has_loop_events and not session_has_loops:
+                                                payload["event"] = {
+                                                    "type": "status",
+                                                    "taskId": result.get("taskId", ""),
+                                                    "state": state,
+                                                    "final": is_final,
+                                                    "message": status_message or None,
+                                                }
+                                                yield f"data: {json.dumps(payload)}\n\n"
+
+                    except (httpx.RequestError, httpx.ReadError, httpx.RemoteProtocolError) as e:
+                        logger.warning(
+                            "Resubscribe connection error (attempt %d): %s", resub_attempt, e
+                        )
+                        await asyncio.sleep(2)
+                        continue
+                    except Exception as e:
+                        logger.warning("Resubscribe error (attempt %d): %s", resub_attempt, e)
+                        break
+
+                    if _done_received:
+                        break
+
+    except httpx.HTTPStatusError as e:
+        error_msg = f"Agent error: {e.response.status_code}"
+        logger.error("%s: %s", error_msg, _safe_log(e.response.text[:500]))
+        yield f"data: {json.dumps({'error': error_msg, 'session_id': session_id})}\n\n"
+    except (httpx.RequestError, httpx.ReadError, httpx.RemoteProtocolError) as e:
+        logger.warning("Connection error: %s — will poll for completion in finally block", str(e))
+        yield f"data: {json.dumps({'error': 'Connection error: agent unavailable', 'retry': True, 'session_id': session_id})}\n\n"
+    except Exception as e:
+        logger.error("Unexpected error: %s", str(e), exc_info=True)
+        yield f"data: {json.dumps({'error': 'Unexpected server error', 'session_id': session_id})}\n\n"
+    finally:
+        logger.info(
+            "Stream finally block for session %s: %d loop events, persisted=%s, task_id=%s",
+            _safe_log(session_id),
+            len(loop_events),
+            loop_events_persisted,
+            stream_task_id,
+        )
+        # IMPORTANT: All DB writes and recovery MUST run as background tasks.
+        # This finally block runs in an async generator that can be interrupted
+        # by GeneratorExit (a BaseException) when the client disconnects.
+        # GeneratorExit kills any `await` in progress and is NOT caught by
+        # `except Exception`. Background tasks are immune to this.
+        if namespace:
+            has_reporter = any(e.get("type") == "reporter_output" for e in loop_events)
+            logger.info(
+                "Spawning background persist+recovery: session=%s task=%s "
+                "events=%d has_reporter=%s session_has_loops=%s",
+                _safe_log(session_id),
+                stream_task_id,
+                len(loop_events),
+                has_reporter,
+                session_has_loops,
+            )
+            asyncio.create_task(
+                _persist_and_recover(
+                    namespace=namespace,
+                    session_id=session_id,
+                    task_db_id=stream_task_id,
+                    loop_events=list(loop_events),  # snapshot
+                    loop_events_already_persisted=loop_events_persisted,
+                    owner=owner,
+                    message=message,
+                    agent_name=agent_name,
+                    session_has_loops=session_has_loops,
+                    has_reporter=has_reporter,
+                    agent_url=agent_url,
+                )
+            )
+
+
+async def _persist_and_recover(
+    namespace: str,
+    session_id: str,
+    task_db_id: Optional[str],
+    loop_events: list[dict],
+    loop_events_already_persisted: bool = False,
+    owner: Optional[str] = None,
+    message: Optional[str] = None,
+    agent_name: Optional[str] = None,
+    session_has_loops: bool = False,
+    has_reporter: bool = False,
+    agent_url: str = "",
+) -> None:
+    """Background task: persist metadata + loop events, then recover if needed.
+
+    Runs as a standalone coroutine (not a generator), so it is immune to
+    GeneratorExit that would kill the finally block of the SSE generator.
+
+    Always writes metadata (owner, title, agent_name). Only writes loop_events
+    if they weren't already persisted by the inline [DONE] handler.
+    """
+    if agent_url:
+        _validate_agent_url(agent_url)
+    try:
+        if task_db_id is None:
+            logger.warning(
+                "stream_task_id is None for session %s — cannot persist metadata",
+                _safe_log(session_id),
+            )
+            return
+
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT metadata FROM tasks WHERE id = $1", task_db_id)
+            logger.info(
+                "BG persist: task %s row_found=%s loop_events=%d already_persisted=%s",
+                task_db_id[:12] if task_db_id else "?",
+                row is not None,
+                len(loop_events),
+                loop_events_already_persisted,
+            )
+            if row:
+                meta = _parse_json_field(row["metadata"]) or {}
+                logger.info(
+                    "BG persist: DB meta BEFORE update session=%s keys=%s agent=%s owner=%s",
+                    _safe_log(session_id),
+                    list(meta.keys()),
+                    meta.get("agent_name", "(none)"),
+                    meta.get("owner", "(none)"),
+                )
+                # Always set metadata fields — the inline _set_owner_metadata
+                # may have been killed by GeneratorExit before committing
+                if owner:
+                    meta["owner"] = owner
+                    meta["visibility"] = meta.get("visibility", "private")
+                if message:
+                    meta["title"] = meta.get("title") or message[:80].replace("\n", " ")
+                if agent_name:
+                    meta["agent_name"] = agent_name
+                if loop_events and not loop_events_already_persisted:
+                    meta["loop_events"] = loop_events
+                meta_json = json.dumps(meta)
+                logger.info(
+                    "BG persist: WRITING session=%s agent=%s owner=%s events=%d json_len=%d",
+                    _safe_log(session_id),
+                    _safe_log(meta.get("agent_name", "(none)")),
+                    _safe_log(meta.get("owner", "(none)")),
+                    len(meta.get("loop_events", [])),
+                    len(meta_json),
+                )
+                result = await conn.execute(
+                    "UPDATE tasks SET metadata = $1::json WHERE id = $2",
+                    meta_json,
+                    task_db_id,
+                )
+                logger.info(
+                    "BG persist: UPDATE result=%s session=%s task=%s",
+                    result,
+                    _safe_log(session_id),
+                    task_db_id,
+                )
+
+                # Upsert into sessions table (authoritative session metadata)
+                await conn.execute(
+                    "INSERT INTO sessions (context_id, agent_name, namespace, title, owner, updated_at, last_message_at)"
+                    " VALUES ($1, $2, $3, $4, $5, NOW(), NOW())"
+                    " ON CONFLICT (context_id) DO UPDATE SET"
+                    "   title = COALESCE(NULLIF(sessions.title, ''), EXCLUDED.title),"
+                    "   agent_name = COALESCE(NULLIF(sessions.agent_name, ''), EXCLUDED.agent_name),"
+                    "   owner = COALESCE(NULLIF(sessions.owner, ''), EXCLUDED.owner),"
+                    "   last_message_at = NOW(),"
+                    "   updated_at = NOW()",
+                    session_id,
+                    meta.get("agent_name", ""),
+                    namespace,
+                    meta.get("title", ""),
+                    meta.get("owner", ""),
+                )
+
+        # Recovery: if loop didn't complete, poll agent for remaining events
+        if session_has_loops and not has_reporter:
+            logger.info("BG persist: triggering recovery for session %s", _safe_log(session_id))
+            await _recover_loop_events_from_agent(
+                agent_url, _safe_log(session_id), _safe_log(namespace), task_db_id
+            )
+    except Exception:
+        logger.warning(
+            "BG persist+recover failed for session %s",
+            _safe_log(session_id),
+            exc_info=True,
+        )
+
+
+async def _recover_loop_events_from_agent(
+    agent_url: str,
+    session_id: str,
+    namespace: str,
+    task_db_id: Optional[int],
+    max_retries: int = 10,
+) -> None:
+    """Fallback: poll the agent's A2A task store until the task completes,
+    then extract loop_events from the task history.
+
+    This handles the case where nginx dropped the SSE connection (e.g.
+    proxy_read_timeout) before the agent finished, causing loop events
+    to be lost from the SSE stream. The agent's task store still has the
+    complete history.
+
+    Polls with exponential backoff (5s, 10s, 20s, ...) up to max_retries
+    attempts, waiting for the task to reach COMPLETED or FAILED state.
+    """
+    _validate_agent_url(agent_url)
+    try:
+        _terminal_states = {"completed", "failed", "canceled"}
+
+        # Use task_db_id (the A2A task ID captured from the stream) to query
+        # the agent. The agent stores tasks by their own UUID (task.id), NOT
+        # by context_id (session_id). Using session_id here was why recovery
+        # always returned "Task not found".
+        if not task_db_id:
+            logger.warning(
+                "Recovery: no A2A task ID available for session %s — cannot query agent",
+                _safe_log(session_id),
+            )
+            return
+        logger.info(
+            "Recovery: querying agent with a2a_task_id=%s (session=%s)",
+            _safe_log(task_db_id),
+            _safe_log(session_id),
+        )
+        a2a_request = {
+            "jsonrpc": "2.0",
+            "id": str(uuid4()),
+            "method": "tasks/get",
+            "params": {"id": task_db_id},
+        }
+
+        recovered_events: list[dict] = []
+        delay = 5.0  # start with 5 seconds
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            for attempt in range(1, max_retries + 1):
+                resp = await client.post(agent_url, json=a2a_request)
+                if resp.status_code != 200:
+                    logger.debug(
+                        "Recovery attempt %d/%d: tasks/get returned %d for %s",
+                        attempt,
+                        max_retries,
+                        resp.status_code,
+                        _safe_log(session_id),
+                    )
+                    break
+
+                data = resp.json()
+                result = data.get("result", {})
+                task_state = result.get("status", {}).get("state", "").lower()
+                history = result.get("history", [])
+
+                logger.info(
+                    "Recovery attempt %d/%d: session=%s state=%s history_msgs=%d",
+                    attempt,
+                    max_retries,
+                    _safe_log(session_id),
+                    task_state,
+                    len(history),
+                )
+
+                if task_state in _terminal_states:
+                    # Task finished — extract events from history
+                    for msg in history:
+                        for part in msg.get("parts", []):
+                            text = part.get("text", "")
+                            for line in text.split("\n"):
+                                line = line.strip()
+                                if not line:
+                                    continue
+                                try:
+                                    parsed = json.loads(line)
+                                    if isinstance(parsed, dict) and "loop_id" in parsed:
+                                        recovered_events.append(parsed)
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+                    break
+
+                # Task still running — wait with exponential backoff
+                if attempt < max_retries:
+                    logger.info(
+                        "Recovery: agent still processing, waiting %.0fs (attempt %d/%d)",
+                        delay,
+                        attempt,
+                        max_retries,
+                    )
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 60.0)  # cap at 60s
+
+        if not recovered_events:
+            logger.info("No loop events recovered from agent for %s", _safe_log(session_id))
+            return
+
+        logger.info(
+            "Recovered %d loop events from agent task store for session %s",
+            len(recovered_events),
+            _safe_log(session_id),
+        )
+
+        # Write recovered events to this stream's task row, replacing any
+        # partial set (e.g. just the router event persisted by the finally block)
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            if task_db_id is None:
+                task_db_id = await conn.fetchval(
+                    "SELECT id FROM tasks WHERE context_id = $1 ORDER BY id DESC LIMIT 1",
+                    session_id,
+                )
+            if task_db_id is not None:
+                row = await conn.fetchrow("SELECT metadata FROM tasks WHERE id = $1", task_db_id)
+                if row:
+                    meta = _parse_json_field(row["metadata"]) or {}
+                    existing = meta.get("loop_events", [])
+                    # MERGE: keep SSE-captured events (have prompt data)
+                    # and add only NEW events from recovery.
+                    # Dedup by (type, step, micro_step) or full JSON.
+                    existing_sigs = set()
+                    for evt in existing:
+                        sig = json.dumps(
+                            {
+                                k: evt.get(k)
+                                for k in ("type", "loop_id", "step", "micro_step", "name")
+                            },
+                            sort_keys=True,
+                        )
+                        existing_sigs.add(sig)
+
+                    merged = list(existing)
+                    added = 0
+                    for evt in recovered_events:
+                        sig = json.dumps(
+                            {
+                                k: evt.get(k)
+                                for k in ("type", "loop_id", "step", "micro_step", "name")
+                            },
+                            sort_keys=True,
+                        )
+                        if sig not in existing_sigs:
+                            merged.append(evt)
+                            existing_sigs.add(sig)
+                            added += 1
+
+                    if added > 0:
+                        meta["loop_events"] = merged
+                        await conn.execute(
+                            "UPDATE tasks SET metadata = $1::json WHERE id = $2",
+                            json.dumps(meta),
+                            task_db_id,
+                        )
+                        logger.info(
+                            "Recovery: merged %d existing + %d new events for session %s (total %d)",
+                            len(existing),
+                            added,
+                            _safe_log(session_id),
+                            len(merged),
+                        )
+    except Exception:
+        logger.warning(
+            "Recovery failed for session %s",
+            _safe_log(session_id),
+            exc_info=True,
+        )
+
+
+@router.post(
+    "/{namespace}/chat/stream",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def chat_stream(
+    namespace: str,
+    request: SandboxChatRequest,
+    user: TokenData = Depends(get_required_user),
+):
+    """Stream agent responses via Server-Sent Events (SSE).
+
+    Sends the user message to the A2A agent using ``message/stream`` and
+    proxies the resulting SSE events back to the browser in real-time,
+    so the UI can display intermediate status (thinking, tool execution)
+    as well as partial results.
+
+    The connection is kept alive for up to 5 minutes.  If the agent
+    disconnects or errors, a final error event is emitted so the client
+    can surface the failure gracefully.
+    """
+    _validate_namespace(namespace)
+    session_id = request.session_id or uuid4().hex[:36]
+
+    # Resolve agent name: for existing sessions, use the DB-bound agent
+    # (authoritative). For new sessions, trust the request.
+    agent_name = await _resolve_agent_name(namespace, request.session_id, request.agent_name)
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, "Invalid resolved agent name")
+    agent_url = _validate_agent_url(f"http://{agent_name}.{namespace}.svc.cluster.local:8000")
+
+    return StreamingResponse(
+        _stream_sandbox_response(
+            agent_url,
+            request.message,
+            session_id,
+            owner=user.username,
+            namespace=namespace,
+            agent_name=agent_name,
+            skill=request.skill,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get(
+    "/{namespace}/sessions/{session_id}/subscribe",
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def subscribe_session(
+    namespace: str,
+    session_id: str,
+    user: TokenData = Depends(get_required_user),
+):
+    """Subscribe to a running session's event stream via tasks/resubscribe.
+
+    Used when the UI opens a session that's still in 'working' state.
+    Returns an SSE stream of events from the agent without resending
+    the original message.
+    """
+    _validate_namespace(namespace)
+
+    # Look up the A2A task ID and agent name for this session
+    pool = await get_session_pool(namespace)
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT id, status::json->>'state' as state FROM tasks "
+            "WHERE context_id = $1 ORDER BY id DESC LIMIT 1",
+            session_id,
+        )
+    if not row:
+        raise HTTPException(404, "Session not found")
+
+    task_id = row["id"]
+    state = (row["state"] or "").lower()
+    logger.info("Subscribe: session=%s task=%s state=%s", _safe_log(session_id), task_id, state)
+    if state in ("completed", "failed", "canceled"):
+        # Task already finished — nothing to subscribe to
+        logger.info("Subscribe: session=%s already %s — sending done", _safe_log(session_id), state)
+        return StreamingResponse(
+            _done_stream(session_id),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    agent_name = await _resolve_agent_name(namespace, session_id, None)
+    if not _K8S_NAME_RE.match(agent_name):
+        raise HTTPException(400, "Invalid resolved agent name")
+    agent_url = _validate_agent_url(f"http://{agent_name}.{namespace}.svc.cluster.local:8000")
+
+    # Ensure a background consumer is running for this session.
+    # On UI reconnect, the consumer may have already been spawned
+    # from the initial chat_stream — _spawn_background_consumer
+    # will skip if one is already active.
+    _spawn_background_consumer(
+        agent_url=agent_url,
+        session_id=session_id,
+        namespace=namespace,
+        task_id=task_id,
+        message="",  # not needed for resubscribe
+        owner=None,
+        agent_name=agent_name,
+    )
+
+    return StreamingResponse(
+        _subscribe_stream(agent_url, task_id, session_id, namespace),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _done_stream(session_id: str):
+    """Emit a single done event for already-completed sessions."""
+    yield f"data: {json.dumps({'done': True, 'session_id': session_id})}\n\n"
+
+
+async def _subscribe_stream(
+    agent_url: str,
+    task_id: str,
+    session_id: str,
+    namespace: str,
+):
+    """Proxy A2A tasks/resubscribe events to the browser."""
+    _validate_agent_url(agent_url)
+    _keepalive_interval = 15
+    resub_msg = {
+        "jsonrpc": "2.0",
+        "id": str(uuid4()),
+        "method": "tasks/resubscribe",
+        "params": {"id": task_id},
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=300.0) as client:
+            async with client.stream(
+                "POST",
+                agent_url,
+                json=resub_msg,
+            ) as response:
+                if response.status_code != 200:
+                    logger.warning("Subscribe: resubscribe returned %d", response.status_code)
+                    yield f"data: {json.dumps({'done': True, 'session_id': session_id})}\n\n"
+                    return
+
+                logger.info(
+                    "Subscribe: connected to agent stream for session %s", _safe_log(session_id)
+                )
+                line_iter = response.aiter_lines().__aiter__()
+
+                while True:
+                    try:
+                        line = await asyncio.wait_for(
+                            line_iter.__anext__(),
+                            timeout=_keepalive_interval,
+                        )
+                    except asyncio.TimeoutError:
+                        yield f"data: {json.dumps({'ping': True})}\n\n"
+                        continue
+                    except StopAsyncIteration:
+                        break
+
+                    if not line or not line.startswith("data: "):
+                        continue
+
+                    data = line[6:]
+                    if data == "[DONE]":
+                        logger.info(
+                            "Subscribe: received [DONE] for session %s", _safe_log(session_id)
+                        )
+                        yield f"data: {json.dumps({'done': True, 'session_id': session_id})}\n\n"
+                        return
+
+                    try:
+                        chunk = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+
+                    if "result" not in chunk:
+                        continue
+
+                    result = chunk["result"]
+                    payload: dict = {"session_id": session_id}
+
+                    # Forward loop events
+                    if "status" in result and "message" in result.get("status", {}):
+                        parts = result["status"].get("message", {}).get("parts", [])
+                        status_message = _extract_text_from_parts(parts)
+                        if status_message:
+                            for msg_line in [
+                                line.strip() for line in status_message.split("\n") if line.strip()
+                            ]:
+                                try:
+                                    parsed = json.loads(msg_line)
+                                    if isinstance(parsed, dict) and "loop_id" in parsed:
+                                        evt_type = parsed.get("type", "")
+                                        if evt_type not in _LEGACY_EVENT_TYPES:
+                                            loop_payload = dict(payload)
+                                            loop_payload["loop_id"] = parsed["loop_id"]
+                                            loop_payload["loop_event"] = parsed
+                                            yield f"data: {json.dumps(loop_payload)}\n\n"
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+
+    except Exception as e:
+        logger.warning("Subscribe stream error: %s", e)
+        yield f"data: {json.dumps({'error': 'Subscribe stream error', 'session_id': session_id})}\n\n"

--- a/kagenti/backend/app/routers/sandbox_deploy.py
+++ b/kagenti/backend/app/routers/sandbox_deploy.py
@@ -1,0 +1,1257 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Sandbox agent deployment API endpoints.
+
+Provides endpoints for deploying new sandbox agents (Deployment + Service)
+via the Kubernetes Python client. Mirrors the resources created by
+76-deploy-sandbox-agents.sh but driven from the UI wizard.
+"""
+
+import logging
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from kubernetes.client import ApiException
+from pydantic import BaseModel, field_validator
+
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.utils.routes import create_route_for_agent_or_tool, detect_platform
+
+# Add deployments/sandbox to path for SandboxProfile
+# Walk up to find repo root (works at any depth, including containers)
+_this_dir = Path(__file__).resolve().parent
+_sandbox_dir = None
+for _parent in _this_dir.parents:
+    _candidate = _parent / "deployments" / "sandbox"
+    if _candidate.is_dir():
+        _sandbox_dir = _candidate
+        break
+if _sandbox_dir and str(_sandbox_dir) not in sys.path:
+    sys.path.insert(0, str(_sandbox_dir))
+
+try:
+    from sandbox_profile import SandboxProfile  # noqa: E402  # pylint: disable=wrong-import-position,wrong-import-order
+except ImportError:
+    SandboxProfile = None
+
+logger = logging.getLogger(__name__)
+
+# Cluster-aware LLM defaults — set via env vars on the backend deployment
+# or via Helm values. Route through the per-namespace LLM budget proxy
+# which enforces per-session token budgets and tracks usage.
+# The budget proxy forwards to LiteLLM after budget checks.
+DEFAULT_LLM_API_BASE = os.environ.get(
+    "SANDBOX_LLM_API_BASE",
+    "http://llm-budget-proxy.{namespace}.svc:8080/v1",
+)
+DEFAULT_LLM_MODEL = os.environ.get("SANDBOX_LLM_MODEL", "llama-4-scout")
+DEFAULT_LLM_SECRET = os.environ.get("SANDBOX_LLM_SECRET", "litellm-virtual-keys")
+DEFAULT_LLM_SECRET_KEY = os.environ.get("SANDBOX_LLM_SECRET_KEY", "api-key")
+
+router = APIRouter(prefix="/sandbox", tags=["sandbox-deploy"])
+
+# Kubernetes name validation: lowercase alphanumeric + dashes, max 63 chars
+_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+# Repo URL must be HTTPS to prevent SSRF via file://, ftp://, etc.
+_SAFE_REPO_URL = re.compile(r"^https://", re.IGNORECASE)
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class SandboxCreateRequest(BaseModel):
+    """Request body for creating a new sandbox agent deployment."""
+
+    name: str
+    repo: str
+    branch: str = "main"
+    context_dir: str = "/"
+    dockerfile: str = "Dockerfile"
+    base_agent: str = "sandbox-legion"
+    model: str = ""  # Empty = use cluster default (DEFAULT_LLM_MODEL)
+    namespace: str = "team1"
+    enable_persistence: bool = True
+    isolation_mode: str = "shared"  # shared or pod-per-session
+    workspace_size: str = "5Gi"
+    workspace_storage: str = "pvc"  # "pvc" (default, persistent) or "emptydir" (ephemeral)
+    # Composable security layers (Session F)
+    secctx: bool = True
+    landlock: bool = False
+    proxy: bool = True
+    proxy_domains: Optional[str] = None
+    # Deployment mechanism
+    managed_lifecycle: bool = False
+    ttl_hours: int = 2
+    # Legacy fields (kept for backwards compat)
+    non_root: bool = True
+    drop_caps: bool = True
+    read_only_root: bool = False
+    proxy_allowlist: str = "github.com, pypi.org"
+    # Credentials
+    github_pat: Optional[str] = None
+    github_pat_secret_name: Optional[str] = None  # Use existing K8s secret instead of raw PAT
+    llm_api_key: Optional[str] = None
+    llm_key_source: str = "existing"  # "existing" or "new"
+    llm_secret_name: str = ""  # Empty = use cluster default (DEFAULT_LLM_SECRET)
+    allowed_models: Optional[list[str]] = None  # Model restrictions for virtual key (empty = all)
+    # Per-node model overrides (empty = use model default)
+    model_planner: str = ""
+    model_executor: str = ""
+    model_reflector: str = ""
+    model_reporter: str = ""
+    model_thinking: str = ""
+    model_micro_reasoning: str = ""
+    # Skill packs (Session M)
+    skill_packs: list[str] = []  # Pack names from skill-packs.yaml (empty = defaults)
+    # LLM behavior
+    force_tool_choice: bool = True
+    text_tool_parsing: bool = True
+    debug_prompts: bool = False
+    enable_tracing: bool = True  # Enable OTel GenAI auto-instrumentation
+    # Budget controls (passed as SANDBOX_* env vars to the agent)
+    max_iterations: int = 200
+    max_tokens: int = 1_000_000
+    max_tool_calls_per_step: int = 20  # legacy alias for max_think_act_cycles
+    max_think_act_cycles: int = 20
+    thinking_iteration_budget: int = 2
+    max_parallel_tool_calls: int = 5
+    max_wall_clock_s: int = 3600  # 1 hour default
+    hitl_interval: int = 50
+    recursion_limit: int = 300
+    # Pod resource limits
+    agent_memory_limit: Optional[str] = "1Gi"
+    agent_cpu_limit: Optional[str] = "500m"
+    proxy_memory_limit: Optional[str] = "256Mi"
+    proxy_cpu_limit: Optional[str] = "200m"
+
+    @field_validator("repo")
+    @classmethod
+    def validate_repo_url(cls, v: str) -> str:
+        """Validate repo URL uses HTTPS to prevent SSRF (CWE-918)."""
+        if v and not _SAFE_REPO_URL.match(v):
+            raise ValueError("Repository URL must use HTTPS")
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate name matches Kubernetes naming rules."""
+        if v and not _K8S_NAME_RE.match(v):
+            raise ValueError(
+                "Name must be a valid Kubernetes name (lowercase alphanumeric + hyphens)"
+            )
+        return v
+
+    @field_validator("namespace")
+    @classmethod
+    def validate_namespace(cls, v: str) -> str:
+        """Validate namespace matches Kubernetes naming rules."""
+        if v and not _K8S_NAME_RE.match(v):
+            raise ValueError(
+                "Namespace must be a valid Kubernetes name (lowercase alphanumeric + hyphens)"
+            )
+        return v
+
+    @property
+    def profile(self):
+        """Build a SandboxProfile from this request's security toggles."""
+        if SandboxProfile is None:
+            return None
+        return SandboxProfile(
+            base_agent=self.base_agent,
+            secctx=self.secctx,
+            landlock=self.landlock,
+            proxy=self.proxy,
+            managed_lifecycle=self.managed_lifecycle,
+            ttl_hours=self.ttl_hours,
+            namespace=self.namespace,
+            proxy_domains=self.proxy_domains,
+        )
+
+    @property
+    def composable_name(self) -> str:
+        """Self-documenting agent name from active layers."""
+        return self.profile.name
+
+
+class SandboxCreateResponse(BaseModel):
+    """Response body after initiating a sandbox agent deployment."""
+
+    status: str  # "deploying", "ready", "failed"
+    message: str
+    agent_url: Optional[str] = None
+    composable_name: Optional[str] = None
+    security_warnings: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_squid_conf(req: SandboxCreateRequest) -> str:
+    """Build squid.conf content from the request's proxy domain list.
+
+    When domains are specified, only those are allowed.
+    When empty, all egress is denied (secure default).
+
+    Config is designed for non-root containers (OCP arbitrary UID):
+    all writable paths point to /tmp.
+    """
+    proxy_domains = req.proxy_domains or req.proxy_allowlist or ""
+    domain_lines = ""
+    for domain in proxy_domains.split(","):
+        d = domain.strip()
+        if d:
+            domain_lines += f"acl allowed_domains dstdomain .{d}\n"
+
+    base = (
+        "http_port 3128\n"
+        "pid_filename /tmp/squid.pid\n"
+        "cache_log /tmp/cache.log\n"
+        "access_log /tmp/access.log\n"
+        "coredump_dir /tmp\n"
+        "cache_dir null /tmp\n"
+        "cache deny all\n"
+        "logfile_rotate 0\n"
+        "acl localnet src 10.0.0.0/8\n"
+        "acl localnet src 172.16.0.0/12\n"
+        "acl localnet src 192.168.0.0/16\n"
+        "acl localnet src 127.0.0.0/8\n"
+        "acl SSL_ports port 443\n"
+        "acl Safe_ports port 80\n"
+        "acl Safe_ports port 443\n"
+        "acl Safe_ports port 8000-9000\n"
+        "acl CONNECT method CONNECT\n"
+        "http_access deny !Safe_ports\n"
+        "http_access deny CONNECT !SSL_ports\n"
+    )
+    if domain_lines:
+        return (
+            base
+            + domain_lines
+            + "http_access allow localnet allowed_domains\nhttp_access deny all\n"
+        )
+    return base + "http_access deny all\n"
+
+
+def _build_deployment_manifest(
+    req: SandboxCreateRequest,
+    llm_secret: Optional[str] = None,
+    github_pat_secret: Optional[str] = None,
+) -> dict:
+    """Build a Kubernetes Deployment manifest matching 76-deploy-sandbox-agents.sh.
+
+    The deployment spec mirrors sandbox_legion_deployment.yaml / sandbox_agent_deployment.yaml
+    with environment variables for the chosen variant and model.
+
+    Args:
+        req: The sandbox create request.
+        llm_secret: Name of the K8s Secret containing the LLM API key (key: "apikey").
+        github_pat_secret: Name of the K8s Secret containing the GitHub PAT (key: "token").
+                           If None, no GITHUB_TOKEN env var is injected.
+    """
+    namespace = req.namespace
+    name = req.name
+
+    # Image from internal registry (same as 76-deploy-sandbox-agents.sh)
+    image = f"image-registry.openshift-image-registry.svc:5000/{namespace}/sandbox-agent:v0.0.1"
+
+    # Resolve cluster-aware defaults
+    effective_secret = llm_secret or req.llm_secret_name or DEFAULT_LLM_SECRET
+    effective_model = req.model or DEFAULT_LLM_MODEL
+    effective_api_base = DEFAULT_LLM_API_BASE.format(namespace=namespace)
+
+    # Determine secret key name: per-agent secrets use "apikey",
+    # namespace default (litellm-virtual-keys) uses "api-key"
+    is_per_agent_secret = llm_secret and llm_secret != DEFAULT_LLM_SECRET
+    effective_secret_key = "apikey" if is_per_agent_secret else DEFAULT_LLM_SECRET_KEY
+
+    # Core env vars shared by all variants
+    env_vars = [
+        {"name": "PORT", "value": "8000"},
+        {"name": "HOST", "value": "0.0.0.0"},
+        {"name": "WORKSPACE_ROOT", "value": "/workspace"},
+        *(
+            [
+                {
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+                    "value": "http://otel-collector.kagenti-system.svc.cluster.local:8335",
+                },
+            ]
+            if req.enable_tracing
+            else []
+        ),
+        {"name": "LLM_API_BASE", "value": effective_api_base},
+        {
+            "name": "LLM_API_KEY",
+            "valueFrom": {"secretKeyRef": {"name": effective_secret, "key": effective_secret_key}},
+        },
+        {
+            "name": "OPENAI_API_KEY",
+            "valueFrom": {"secretKeyRef": {"name": effective_secret, "key": effective_secret_key}},
+        },
+        {"name": "LLM_MODEL", "value": effective_model},
+        {"name": "UV_CACHE_DIR", "value": "/app/.cache/uv"},
+    ]
+
+    # Per-node model overrides (only add if set)
+    for node_type, field in [
+        ("PLANNER", req.model_planner),
+        ("EXECUTOR", req.model_executor),
+        ("REFLECTOR", req.model_reflector),
+        ("REPORTER", req.model_reporter),
+        ("THINKING", req.model_thinking),
+        ("MICRO_REASONING", req.model_micro_reasoning),
+    ]:
+        if field:
+            env_vars.append({"name": f"LLM_MODEL_{node_type}", "value": field})
+
+    # Skill repos — pass through from backend env or derive from source repo.
+    # Skills live in the kagenti repo (.claude/skills/), not agent-examples.
+    # When deploying from a kagenti fork/branch, use that for skills too.
+    skill_repos = os.environ.get("SANDBOX_SKILL_REPOS")
+    if not skill_repos and req.repo and "kagenti" in req.repo and "agent-examples" not in req.repo:
+        # Source repo IS kagenti — use same branch for skills
+        skill_repos = f"{req.repo}@{req.branch}#.claude/skills"
+    if skill_repos:
+        env_vars.append({"name": "SKILL_REPOS", "value": skill_repos})
+
+    # Inject GitHub PAT for gh CLI and git operations.
+    # GH_TOKEN is read by the gh CLI; GITHUB_TOKEN by git credential helpers.
+    gh_secret = github_pat_secret or "github-readonly-secret"
+    for env_name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        env_vars.append(
+            {
+                "name": env_name,
+                "valueFrom": {"secretKeyRef": {"name": gh_secret, "key": "token"}},
+            }
+        )
+
+    # Persistence env vars (PostgreSQL session store + checkpointing)
+    if req.enable_persistence:
+        db_url = (
+            f"postgresql+asyncpg://kagenti:kagenti-sessions-dev"
+            f"@postgres-sessions.{namespace}:5432/sessions"
+        )
+        checkpoint_url = (
+            f"postgresql://kagenti:kagenti-sessions-dev"
+            f"@postgres-sessions.{namespace}:5432/sessions?sslmode=disable"
+        )
+        env_vars.append({"name": "TASK_STORE_DB_URL", "value": db_url})
+        env_vars.append({"name": "CHECKPOINT_DB_URL", "value": checkpoint_url})
+
+    # LLM behavior
+    env_vars.append(
+        {"name": "SANDBOX_FORCE_TOOL_CHOICE", "value": "1" if req.force_tool_choice else "0"}
+    )
+    env_vars.append(
+        {"name": "SANDBOX_TEXT_TOOL_PARSING", "value": "1" if req.text_tool_parsing else "0"}
+    )
+    env_vars.append({"name": "SANDBOX_DEBUG_PROMPTS", "value": "1" if req.debug_prompts else "0"})
+    # Budget env vars (consumed by AgentBudget dataclass in the agent)
+    env_vars.append({"name": "SANDBOX_MAX_ITERATIONS", "value": str(req.max_iterations)})
+    env_vars.append({"name": "SANDBOX_MAX_TOKENS", "value": str(req.max_tokens)})
+    env_vars.append(
+        {"name": "SANDBOX_MAX_TOOL_CALLS_PER_STEP", "value": str(req.max_tool_calls_per_step)}
+    )
+    env_vars.append(
+        {"name": "SANDBOX_MAX_THINK_ACT_CYCLES", "value": str(req.max_think_act_cycles)}
+    )
+    env_vars.append(
+        {"name": "SANDBOX_THINKING_ITERATION_BUDGET", "value": str(req.thinking_iteration_budget)}
+    )
+    env_vars.append(
+        {"name": "SANDBOX_MAX_PARALLEL_TOOL_CALLS", "value": str(req.max_parallel_tool_calls)}
+    )
+    env_vars.append({"name": "SANDBOX_MAX_WALL_CLOCK_S", "value": str(req.max_wall_clock_s)})
+    env_vars.append({"name": "SANDBOX_HITL_INTERVAL", "value": str(req.hitl_interval)})
+    env_vars.append({"name": "SANDBOX_RECURSION_LIMIT", "value": str(req.recursion_limit)})
+
+    labels = {
+        "kagenti.io/type": "agent",
+        "kagenti.io/protocol": "a2a",
+        "kagenti.io/framework": "LangGraph",
+        "kagenti.io/workload-type": "deployment",
+        "app.kubernetes.io/name": name,
+        "app.kubernetes.io/managed-by": "kagenti-ui",
+        "app.kubernetes.io/component": "agent",
+    }
+
+    # -- Container security context from wizard settings --
+    security_context: dict = {}
+    if req.non_root:
+        security_context["runAsNonRoot"] = True
+    if req.drop_caps:
+        security_context["allowPrivilegeEscalation"] = False
+        security_context["capabilities"] = {"drop": ["ALL"]}
+    security_context["seccompProfile"] = {"type": "RuntimeDefault"}
+    # readOnlyRootFilesystem only if explicitly requested AND not postgres-dependent
+    if req.read_only_root:
+        security_context["readOnlyRootFilesystem"] = True
+
+    init_containers: list[dict] = []
+
+    # Workspace volume: "pvc" for persistence, "emptydir" for ephemeral.
+    # No fallback — deploy exactly what was selected or fail.
+    workspace_pvc_name = f"{name}-workspace"
+    if req.workspace_storage == "pvc":
+        workspace_vol = {
+            "name": "workspace",
+            "persistentVolumeClaim": {"claimName": workspace_pvc_name},
+        }
+    else:
+        workspace_vol = {"name": "workspace", "emptyDir": {"sizeLimit": req.workspace_size}}
+    volumes = [workspace_vol, {"name": "cache", "emptyDir": {}}]
+
+    # -- Per-agent egress proxy (separate pod) -----------------------------
+    # Each agent gets its own egress-proxy Deployment + Service with a
+    # ConfigMap containing the domain allowlist from the wizard.
+    # The agent's HTTP_PROXY env var points to the proxy service.
+    # A namespace-wide NetworkPolicy blocks direct public egress from
+    # agent pods — only the egress-proxy pods can reach the internet.
+    # Only inject proxy env vars when proxy is enabled — otherwise the
+    # agent would try to route traffic through a non-existent proxy.
+    if req.proxy:
+        proxy_svc = f"{name}-egress-proxy"
+        proxy_url = f"http://{proxy_svc}.{namespace}.svc:3128"
+        no_proxy = "localhost,127.0.0.1,.svc,.svc.cluster.local"
+        for var_name in ("HTTP_PROXY", "http_proxy"):
+            env_vars.append({"name": var_name, "value": proxy_url})
+        for var_name in ("HTTPS_PROXY", "https_proxy"):
+            env_vars.append({"name": var_name, "value": proxy_url})
+        for var_name in ("NO_PROXY", "no_proxy"):
+            env_vars.append({"name": var_name, "value": no_proxy})
+
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": labels,
+            "annotations": {
+                # Legacy annotations (backward compat)
+                "kagenti.io/description": f"Sandbox agent ({req.base_agent}) deployed via UI wizard",
+                "kagenti.io/variant": req.base_agent,
+                "kagenti.io/isolation-mode": req.isolation_mode,
+                "kagenti.io/proxy-allowlist": req.proxy_allowlist,
+                "kagenti.io/source-repo": req.repo,
+                "kagenti.io/source-branch": req.branch,
+                # Full wizard config (cfg-* annotations)
+                "kagenti.io/cfg-name": req.name,
+                "kagenti.io/cfg-repo": req.repo,
+                "kagenti.io/cfg-branch": req.branch,
+                "kagenti.io/cfg-context-dir": req.context_dir,
+                "kagenti.io/cfg-dockerfile": req.dockerfile,
+                "kagenti.io/cfg-base-agent": req.base_agent,
+                "kagenti.io/cfg-model": req.model,
+                "kagenti.io/cfg-namespace": req.namespace,
+                "kagenti.io/cfg-enable-persistence": str(req.enable_persistence).lower(),
+                "kagenti.io/cfg-isolation-mode": req.isolation_mode,
+                "kagenti.io/cfg-workspace-size": req.workspace_size,
+                "kagenti.io/cfg-workspace-storage": req.workspace_storage,
+                "kagenti.io/cfg-secctx": str(req.secctx).lower(),
+                "kagenti.io/cfg-landlock": str(req.landlock).lower(),
+                "kagenti.io/cfg-proxy": str(req.proxy).lower(),
+                "kagenti.io/cfg-proxy-domains": req.proxy_domains or "",
+                "kagenti.io/cfg-llm-key-source": req.llm_key_source,
+                "kagenti.io/cfg-llm-secret-name": req.llm_secret_name,
+                "kagenti.io/cfg-db-source": "postgres" if req.enable_persistence else "none",
+                "kagenti.io/cfg-max-iterations": str(req.max_iterations),
+                "kagenti.io/cfg-max-tokens": str(req.max_tokens),
+                "kagenti.io/cfg-max-tool-calls-per-step": str(req.max_tool_calls_per_step),
+                "kagenti.io/cfg-max-think-act-cycles": str(req.max_think_act_cycles),
+                "kagenti.io/cfg-thinking-iteration-budget": str(req.thinking_iteration_budget),
+                "kagenti.io/cfg-max-parallel-tool-calls": str(req.max_parallel_tool_calls),
+                "kagenti.io/cfg-max-wall-clock-s": str(req.max_wall_clock_s),
+                "kagenti.io/cfg-hitl-interval": str(req.hitl_interval),
+                "kagenti.io/cfg-recursion-limit": str(req.recursion_limit),
+                "kagenti.io/cfg-agent-memory-limit": req.agent_memory_limit or "",
+                "kagenti.io/cfg-agent-cpu-limit": req.agent_cpu_limit or "",
+            },
+        },
+        "spec": {
+            "replicas": 1,
+            # Recreate strategy: old pod stops before new starts.
+            # Required for RWO PVC — can't mount on two pods simultaneously.
+            "strategy": {"type": "Recreate"},
+            "selector": {
+                "matchLabels": {
+                    "kagenti.io/type": "agent",
+                    "app.kubernetes.io/name": name,
+                },
+            },
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "kagenti.io/type": "agent",
+                        "kagenti.io/protocol": "a2a",
+                        "kagenti.io/framework": "LangGraph",
+                        "app.kubernetes.io/name": name,
+                    },
+                },
+                "spec": {
+                    # fsGroup ensures PVC volumes are group-writable by the
+                    # agent container (EBS ext4 root is owned by root:root).
+                    "securityContext": {"fsGroup": 1001},
+                    "initContainers": init_containers,
+                    "containers": [
+                        {
+                            "name": "agent",
+                            "image": image,
+                            "imagePullPolicy": "Always",
+                            "env": env_vars,
+                            "ports": [
+                                {
+                                    "containerPort": 8000,
+                                    "name": "http",
+                                    "protocol": "TCP",
+                                }
+                            ],
+                            "resources": {
+                                "requests": {"cpu": "100m", "memory": "256Mi"},
+                                "limits": {
+                                    "cpu": req.agent_cpu_limit or "500m",
+                                    "memory": req.agent_memory_limit or "1Gi",
+                                },
+                            },
+                            "securityContext": security_context,
+                            "volumeMounts": [
+                                {"name": "workspace", "mountPath": "/workspace"},
+                                {"name": "cache", "mountPath": "/app/.cache"},
+                            ],
+                        },
+                    ],
+                    "volumes": volumes,
+                },
+            },
+        },
+    }
+
+
+def _build_egress_proxy_manifests(req: SandboxCreateRequest) -> tuple[dict, dict]:
+    """Build Deployment + Service manifests for the per-agent egress proxy.
+
+    Returns (deployment, service) dicts.
+    """
+    name = f"{req.name}-egress-proxy"
+    namespace = req.namespace
+    labels = {
+        "kagenti.io/type": "egress-proxy",
+        "app.kubernetes.io/name": name,
+        "app.kubernetes.io/part-of": req.name,
+        "app.kubernetes.io/managed-by": "kagenti-ui",
+        "istio.io/dataplane-mode": "ambient",
+        "istio.io/use-waypoint": "waypoint",
+    }
+    deployment = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": name, "namespace": namespace, "labels": labels},
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": {"app.kubernetes.io/name": name}},
+            "template": {
+                "metadata": {"labels": labels},
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "squid",
+                            "image": "ubuntu/squid:latest",
+                            "command": [
+                                "squid",
+                                "--foreground",
+                                "-f",
+                                "/etc/squid/squid.conf",
+                                "-YC",
+                            ],
+                            "ports": [{"containerPort": 3128}],
+                            "resources": {
+                                "requests": {"cpu": "50m", "memory": "64Mi"},
+                                "limits": {
+                                    "cpu": req.proxy_cpu_limit or "100m",
+                                    "memory": req.proxy_memory_limit or "256Mi",
+                                },
+                            },
+                            "volumeMounts": [
+                                {
+                                    "name": "config",
+                                    "mountPath": "/etc/squid/squid.conf",
+                                    "subPath": "squid.conf",
+                                }
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "name": "config",
+                            "configMap": {"name": f"{req.name}-squid-config"},
+                        }
+                    ],
+                },
+            },
+        },
+    }
+    service = {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": name, "namespace": namespace, "labels": labels},
+        "spec": {
+            "selector": {"app.kubernetes.io/name": name},
+            "ports": [{"port": 3128, "targetPort": 3128, "protocol": "TCP"}],
+        },
+    }
+    return deployment, service
+
+
+def _build_service_manifest(req: SandboxCreateRequest) -> dict:
+    """Build a Kubernetes Service manifest matching sandbox_legion_service.yaml."""
+    name = req.name
+    namespace = req.namespace
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": {
+                "kagenti.io/type": "agent",
+                "app.kubernetes.io/name": name,
+            },
+        },
+        "spec": {
+            "selector": {
+                "kagenti.io/type": "agent",
+                "app.kubernetes.io/name": name,
+            },
+            "ports": [
+                {
+                    "port": 8000,
+                    "targetPort": 8000,
+                    "protocol": "TCP",
+                    "name": "http",
+                }
+            ],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/defaults")
+async def get_sandbox_defaults():
+    """Return the backend's default SandboxCreateRequest values as JSON.
+
+    The wizard loads these on mount instead of hardcoded INITIAL_STATE,
+    keeping the UI in sync with backend defaults and cluster-level env vars.
+    """
+    defaults = SandboxCreateRequest(name="", repo="")
+    result = defaults.model_dump()
+    # Include cluster-level defaults from env vars
+    result["default_llm_model"] = DEFAULT_LLM_MODEL
+    result["default_llm_secret"] = DEFAULT_LLM_SECRET
+    result["default_llm_secret_key"] = DEFAULT_LLM_SECRET_KEY
+    return result
+
+
+@router.post("/{namespace}/create", response_model=SandboxCreateResponse)
+async def create_sandbox(
+    namespace: str,
+    request: SandboxCreateRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SandboxCreateResponse:
+    """Deploy a new sandbox agent (Deployment + Service) into the given namespace.
+
+    Creates Kubernetes resources matching those produced by
+    76-deploy-sandbox-agents.sh. On OpenShift, also creates a Route.
+    Returns immediately with status="deploying".
+    """
+    # Override namespace from the path parameter
+    request.namespace = namespace
+
+    # --- Composable security profile (Session F) ---
+    profile = request.profile
+    composable_name = profile.name if profile else request.name
+    security_warnings = profile.warnings if profile else []
+    if security_warnings:
+        logger.warning(
+            "Security warnings for '%s': %s",
+            _safe_log(composable_name),
+            "; ".join(_safe_log(w) for w in security_warnings),
+        )
+
+    # --- Create credential Secrets when the user provides new values ---
+    managed_labels = {
+        "app.kubernetes.io/managed-by": "kagenti-ui",
+        "app.kubernetes.io/part-of": request.name,
+    }
+
+    # LLM API key secret
+    if request.llm_key_source == "new" and request.llm_api_key:
+        llm_secret = f"{request.name}-llm-secret"
+        try:
+            kube.create_secret(
+                namespace=namespace,
+                name=llm_secret,
+                string_data={"apikey": request.llm_api_key},
+                labels=managed_labels,
+            )
+            logger.info(
+                "Created LLM API key Secret for agent '%s' in namespace '%s'",
+                _safe_log(request.name),
+                _safe_log(namespace),
+            )
+        except ApiException as e:
+            logger.error("Failed to create LLM Secret: %s", e)
+            return SandboxCreateResponse(
+                status="failed",
+                message=f"Failed to create LLM API key Secret: {e.reason}",
+            )
+    else:
+        llm_secret = request.llm_secret_name
+
+    # GitHub PAT secret -- prefer existing secret reference, fall back to raw PAT
+    github_pat_secret: Optional[str] = None
+    if request.github_pat:
+        # Manual PAT entry: create a new secret from the raw value
+        github_pat_secret = f"{request.name}-github-pat"
+        try:
+            kube.create_secret(
+                namespace=namespace,
+                name=github_pat_secret,
+                string_data={"token": request.github_pat},
+                labels=managed_labels,
+            )
+            logger.info(
+                "Created GitHub PAT Secret '<redacted>' in namespace '%s'",
+                _safe_log(namespace),
+            )
+        except ApiException as e:
+            logger.error("Failed to create GitHub PAT Secret: %s", e)
+            return SandboxCreateResponse(
+                status="failed",
+                message=f"Failed to create GitHub PAT Secret: {e.reason}",
+            )
+    elif request.github_pat_secret_name:
+        # Use an existing K8s secret by name (no new secret created)
+        github_pat_secret = request.github_pat_secret_name
+        logger.info(
+            "Using existing GitHub PAT Secret '<redacted>' in namespace '%s'",
+            _safe_log(namespace),
+        )
+
+    deployment_manifest = _build_deployment_manifest(
+        request,
+        llm_secret=llm_secret,
+        github_pat_secret=github_pat_secret,
+    )
+    service_manifest = _build_service_manifest(request)
+
+    # --- Create skill-pack ConfigMaps (init container dependencies) ---
+    managed_cm_labels = {
+        "app.kubernetes.io/managed-by": "kagenti-ui",
+        "app.kubernetes.io/part-of": request.name,
+    }
+
+    # Skills are loaded by the agent at startup (git clone from sources.json).
+    # No ConfigMaps or init containers needed — the agent handles skill loading.
+    # TODO(Session N): Once base image moves to kagenti repo, bake
+    # skill_pack_loader.py into the image for verified skill loading.
+
+    # --- Create workspace PVC if selected (no fallback — fail if it can't be created) ---
+    if request.workspace_storage == "pvc":
+        workspace_pvc_name = f"{request.name}-workspace"
+        try:
+            pvc_body = {
+                "apiVersion": "v1",
+                "kind": "PersistentVolumeClaim",
+                "metadata": {
+                    "name": workspace_pvc_name,
+                    "namespace": namespace,
+                    "labels": managed_cm_labels,
+                },
+                "spec": {
+                    "accessModes": ["ReadWriteOnce"],
+                    "resources": {
+                        "requests": {"storage": request.workspace_size},
+                    },
+                },
+            }
+            kube.core_api.create_namespaced_persistent_volume_claim(
+                namespace=namespace, body=pvc_body
+            )
+            logger.info(
+                "Created workspace PVC '%s' (%s)",
+                _safe_log(workspace_pvc_name),
+                _safe_log(request.workspace_size),
+            )
+        except ApiException as e:
+            if e.status == 409:
+                logger.info("Workspace PVC '%s' already exists", _safe_log(workspace_pvc_name))
+            else:
+                logger.error("Failed to create workspace PVC: %s", e)
+                return SandboxCreateResponse(
+                    status="failed",
+                    message=f"Failed to create workspace PVC: {e.reason}",
+                )
+
+    # --- Create Squid proxy ConfigMap + egress proxy (only when proxy is enabled) ---
+    if request.proxy:
+        squid_conf = _build_squid_conf(request)
+        try:
+            kube.create_configmap(
+                namespace=namespace,
+                name=f"{request.name}-squid-config",
+                data={"squid.conf": squid_conf},
+                labels=managed_cm_labels,
+            )
+            logger.info(
+                "Created Squid ConfigMap '%s-squid-config' (domains: %s)",
+                _safe_log(request.name),
+                _safe_log(request.proxy_domains or request.proxy_allowlist or "DENY ALL"),
+            )
+        except Exception as e:
+            logger.warning("Failed to create/update Squid ConfigMap: %s", e)
+
+        # --- Create per-agent egress proxy (Deployment + Service) ---
+        proxy_deploy, proxy_svc = _build_egress_proxy_manifests(request)
+        try:
+            kube.create_deployment(namespace=namespace, body=proxy_deploy)
+            logger.info(
+                "Created egress proxy Deployment '%s-egress-proxy'", _safe_log(request.name)
+            )
+        except ApiException as e:
+            if e.status == 409:
+                # Update existing proxy with new resource limits / config
+                proxy_name = f"{request.name}-egress-proxy"
+                try:
+                    kube.patch_deployment(name=proxy_name, namespace=namespace, body=proxy_deploy)
+                    logger.info("Updated egress proxy Deployment '%s'", _safe_log(proxy_name))
+                except Exception as patch_err:
+                    logger.warning(
+                        "Failed to update egress proxy '%s': %s", _safe_log(proxy_name), patch_err
+                    )
+            else:
+                logger.warning("Failed to create egress proxy Deployment: %s", e)
+        try:
+            kube.create_service(namespace=namespace, body=proxy_svc)
+            logger.info("Created egress proxy Service '%s-egress-proxy'", _safe_log(request.name))
+        except ApiException as e:
+            if e.status == 409:
+                logger.info("Egress proxy Service already exists")
+            else:
+                logger.warning("Failed to create egress proxy Service: %s", e)
+
+    # --- Create the agent Deployment ---
+    try:
+        kube.create_deployment(namespace=namespace, body=deployment_manifest)
+        logger.info(
+            "Created Deployment '%s' in namespace '%s'",
+            _safe_log(request.name),
+            _safe_log(namespace),
+        )
+    except ApiException as e:
+        if e.status == 409:
+            # Update existing deployment with new config (redeploy/reconfigure)
+            try:
+                kube.patch_deployment(
+                    name=request.name, namespace=namespace, body=deployment_manifest
+                )
+                logger.info(
+                    "Updated Deployment '%s' in namespace '%s'",
+                    _safe_log(request.name),
+                    _safe_log(namespace),
+                )
+            except Exception as patch_err:
+                logger.warning(
+                    "Failed to update Deployment '%s': %s", _safe_log(request.name), patch_err
+                )
+        else:
+            logger.error("Failed to create Deployment: %s", e)
+            return SandboxCreateResponse(
+                status="failed",
+                message=f"Failed to create Deployment: {e.reason}",
+            )
+
+    # --- Create the Service ---
+    try:
+        kube.create_service(namespace=namespace, body=service_manifest)
+        logger.info(
+            "Created Service '%s' in namespace '%s'", _safe_log(request.name), _safe_log(namespace)
+        )
+    except ApiException as e:
+        if e.status == 409:
+            logger.warning(
+                "Service '%s' already exists in namespace '%s'",
+                _safe_log(request.name),
+                _safe_log(namespace),
+            )
+        else:
+            logger.error("Failed to create Service: %s", e)
+            return SandboxCreateResponse(
+                status="failed",
+                message=f"Failed to create Service: {e.reason}",
+            )
+
+    # --- Create Route (OpenShift) or skip (Kind/vanilla k8s) ---
+    agent_url: Optional[str] = None
+    try:
+        platform = detect_platform(kube)
+        if platform == "openshift":
+            create_route_for_agent_or_tool(
+                kube=kube,
+                name=request.name,
+                namespace=namespace,
+                service_name=request.name,
+                service_port=8000,
+            )
+            logger.info(
+                "Created Route for '%s' in namespace '%s'",
+                _safe_log(request.name),
+                _safe_log(namespace),
+            )
+        # Build the in-cluster URL regardless of platform
+        agent_url = f"http://{request.name}.{namespace}.svc.cluster.local:8000"
+    except ApiException as e:
+        # Route creation failure is non-fatal — the agent is still accessible in-cluster
+        logger.warning("Failed to create Route for '%s': %s", _safe_log(request.name), e)
+
+    return SandboxCreateResponse(
+        status="deploying",
+        message=f"Sandbox agent '{request.name}' ({composable_name}) is being deployed in namespace '{namespace}'",
+        composable_name=composable_name,
+        security_warnings=security_warnings,
+        agent_url=agent_url,
+    )
+
+
+@router.delete("/{namespace}/{name}", response_model=dict)
+async def delete_sandbox(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> dict:
+    """Delete a sandbox agent and all associated resources.
+
+    Cleans up: Deployment, Service, egress-proxy Deployment + Service,
+    workspace PVC, squid ConfigMap, and any Secrets created by the wizard.
+    """
+    deleted: list[str] = []
+    errors: list[str] = []
+
+    resources = [
+        ("Deployment", name, lambda: kube.apps_api.delete_namespaced_deployment(name, namespace)),
+        ("Service", name, lambda: kube.core_api.delete_namespaced_service(name, namespace)),
+        (
+            "Deployment",
+            f"{name}-egress-proxy",
+            lambda: kube.apps_api.delete_namespaced_deployment(f"{name}-egress-proxy", namespace),
+        ),
+        (
+            "Service",
+            f"{name}-egress-proxy",
+            lambda: kube.core_api.delete_namespaced_service(f"{name}-egress-proxy", namespace),
+        ),
+        (
+            "PVC",
+            f"{name}-workspace",
+            lambda: kube.core_api.delete_namespaced_persistent_volume_claim(
+                f"{name}-workspace", namespace
+            ),
+        ),
+        (
+            "ConfigMap",
+            f"{name}-squid-config",
+            lambda: kube.core_api.delete_namespaced_config_map(f"{name}-squid-config", namespace),
+        ),
+    ]
+
+    for kind, rname, delete_fn in resources:
+        try:
+            delete_fn()
+            deleted.append(f"{kind}/{rname}")
+            logger.info(
+                "Deleted %s '%s' from namespace '%s'",
+                _safe_log(kind),
+                _safe_log(rname),
+                _safe_log(namespace),
+            )
+        except ApiException as e:
+            if e.status == 404:
+                pass  # Already gone
+            else:
+                errors.append(f"{kind}/{rname}: {e.reason}")
+                logger.warning(
+                    "Failed to delete %s '%s': %s",
+                    _safe_log(kind),
+                    _safe_log(rname),
+                    _safe_log(e),
+                )
+
+    return {
+        "status": "deleted" if not errors else "partial",
+        "deleted": deleted,
+        "errors": errors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Config retrieval & update endpoints
+# ---------------------------------------------------------------------------
+
+# Annotation prefix -> camelCase key mapping for the GET /config endpoint
+_CFG_KEY_MAP = {
+    "cfg-name": "name",
+    "cfg-repo": "repo",
+    "cfg-branch": "branch",
+    "cfg-context-dir": "contextDir",
+    "cfg-dockerfile": "dockerfile",
+    "cfg-base-agent": "baseAgent",
+    "cfg-model": "model",
+    "cfg-namespace": "namespace",
+    "cfg-enable-persistence": "enablePersistence",
+    "cfg-isolation-mode": "isolationMode",
+    "cfg-workspace-size": "workspaceSize",
+    "cfg-workspace-storage": "workspaceStorage",
+    "cfg-secctx": "secctx",
+    "cfg-landlock": "landlock",
+    "cfg-proxy": "proxy",
+    "cfg-proxy-domains": "proxyDomains",
+    "cfg-llm-key-source": "llmKeySource",
+    "cfg-llm-secret-name": "llmSecretName",
+    "cfg-db-source": "dbSource",
+    "cfg-max-iterations": "maxIterations",
+    "cfg-max-tokens": "maxTokens",
+    "cfg-max-tool-calls-per-step": "maxToolCallsPerStep",
+    "cfg-max-think-act-cycles": "maxThinkActCycles",
+    "cfg-thinking-iteration-budget": "thinkingIterationBudget",
+    "cfg-max-parallel-tool-calls": "maxParallelToolCalls",
+    "cfg-max-wall-clock-s": "maxWallClockS",
+    "cfg-hitl-interval": "hitlInterval",
+    "cfg-recursion-limit": "recursionLimit",
+}
+
+_BOOL_KEYS = {"enablePersistence", "secctx", "landlock", "proxy"}
+_INT_KEYS = {
+    "maxIterations",
+    "maxTokens",
+    "maxToolCallsPerStep",
+    "maxWallClockS",
+    "hitlInterval",
+    "recursionLimit",
+}
+
+# Fields whose change means the container image must be rebuilt
+_BUILD_FIELDS = {"cfg-repo", "cfg-branch", "cfg-context-dir", "cfg-dockerfile", "cfg-base-agent"}
+
+
+@router.get("/{namespace}/{name}/config")
+async def get_sandbox_config(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> dict:
+    """Return the wizard configuration stored in the Deployment's annotations.
+
+    Reads ``kagenti.io/cfg-*`` annotations and returns them as a JSON object
+    with camelCase keys matching the frontend WizardState shape.
+    """
+    try:
+        deployment = kube.get_deployment(namespace=namespace, name=name)
+    except ApiException as e:
+        logger.error(
+            "Failed to read Deployment %s/%s: %s", _safe_log(namespace), _safe_log(name), e
+        )
+        return {"error": f"Deployment not found: {e.reason}"}
+
+    annotations: dict = (deployment.get("metadata") or {}).get("annotations") or {}
+
+    config: dict = {}
+    for ann_suffix, camel_key in _CFG_KEY_MAP.items():
+        ann_key = f"kagenti.io/{ann_suffix}"
+        value = annotations.get(ann_key)
+        if value is None:
+            continue
+        if camel_key in _BOOL_KEYS:
+            config[camel_key] = value.lower() == "true"
+        elif camel_key in _INT_KEYS:
+            try:
+                config[camel_key] = int(value)
+            except (ValueError, TypeError):
+                config[camel_key] = value
+        else:
+            config[camel_key] = value
+
+    return config
+
+
+@router.put("/{namespace}/{name}")
+async def update_sandbox(
+    namespace: str,
+    name: str,
+    request: SandboxCreateRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SandboxCreateResponse:
+    """Update (reconfigure) an existing sandbox agent deployment.
+
+    Compares the new request against the current annotations to detect
+    build-related changes, patches the Deployment and proxy resources,
+    and triggers a rollout restart.
+    """
+    # Override namespace from path
+    request.namespace = namespace
+    request.name = name
+
+    # 1. Read current deployment to get existing annotations
+    try:
+        current = kube.get_deployment(namespace=namespace, name=name)
+    except ApiException as e:
+        logger.error(
+            "Failed to read Deployment %s/%s: %s", _safe_log(namespace), _safe_log(name), e
+        )
+        return SandboxCreateResponse(
+            status="failed",
+            message=f"Deployment '{name}' not found in namespace '{namespace}': {e.reason}",
+        )
+
+    current_annotations: dict = (current.get("metadata") or {}).get("annotations") or {}
+
+    # 2. Detect build-related changes
+    rebuild_required = False
+    for field in _BUILD_FIELDS:
+        ann_key = f"kagenti.io/{field}"
+        old_val = current_annotations.get(ann_key, "")
+        new_val = getattr(request, field.replace("cfg-", "").replace("-", "_"), "")
+        if str(old_val) != str(new_val):
+            rebuild_required = True
+            logger.info(
+                "Build field '%s' changed: '%s' -> '%s'",
+                field,
+                _safe_log(old_val),
+                _safe_log(new_val),
+            )
+
+    # 3. Rebuild the deployment manifest (resolve GitHub PAT secret reference)
+    github_pat_secret: Optional[str] = None
+    if request.github_pat:
+        github_pat_secret = f"{request.name}-github-pat"
+        try:
+            kube.create_secret(
+                namespace=namespace,
+                name=github_pat_secret,
+                string_data={"token": request.github_pat},
+                labels={
+                    "app.kubernetes.io/managed-by": "kagenti-ui",
+                    "app.kubernetes.io/part-of": request.name,
+                },
+            )
+        except ApiException:
+            pass  # Secret may already exist; patch will update the deployment
+    elif request.github_pat_secret_name:
+        github_pat_secret = request.github_pat_secret_name
+
+    deployment_manifest = _build_deployment_manifest(request, github_pat_secret=github_pat_secret)
+
+    # 4. Add rollout restart annotation (triggers pod recreation)
+    restart_annotation = {
+        "kubectl.kubernetes.io/restartedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    deployment_manifest["spec"]["template"]["metadata"].setdefault("annotations", {})
+    deployment_manifest["spec"]["template"]["metadata"]["annotations"].update(restart_annotation)
+
+    # 5. Patch the Deployment
+    try:
+        kube.patch_deployment(namespace=namespace, name=name, body=deployment_manifest)
+        logger.info(
+            "Patched Deployment '%s' in namespace '%s'", _safe_log(name), _safe_log(namespace)
+        )
+    except ApiException as e:
+        logger.error(
+            "Failed to patch Deployment %s/%s: %s", _safe_log(namespace), _safe_log(name), e
+        )
+        return SandboxCreateResponse(
+            status="failed",
+            message=f"Failed to patch Deployment: {e.reason}",
+        )
+
+    # 6. Update Squid proxy ConfigMap if proxy settings changed
+    old_proxy_domains = current_annotations.get("kagenti.io/cfg-proxy-domains", "")
+    new_proxy_domains = request.proxy_domains or ""
+    if old_proxy_domains != new_proxy_domains:
+        squid_conf = _build_squid_conf(request)
+        managed_labels = {
+            "app.kubernetes.io/managed-by": "kagenti-ui",
+            "app.kubernetes.io/part-of": name,
+        }
+        try:
+            kube.create_configmap(
+                namespace=namespace,
+                name=f"{name}-squid-config",
+                data={"squid.conf": squid_conf},
+                labels=managed_labels,
+            )
+            logger.info(
+                "Updated Squid ConfigMap '%s-squid-config' (domains: %s)",
+                _safe_log(name),
+                _safe_log(new_proxy_domains or "DENY ALL"),
+            )
+        except Exception as e:
+            logger.warning("Failed to update Squid ConfigMap: %s", e)
+
+    # 7. Update egress proxy deployment if proxy config changed
+    if old_proxy_domains != new_proxy_domains:
+        proxy_deploy, _proxy_svc = _build_egress_proxy_manifests(request)
+        # Add restart annotation to force proxy pod recreation
+        proxy_deploy["spec"]["template"]["metadata"].setdefault("annotations", {})
+        proxy_deploy["spec"]["template"]["metadata"]["annotations"].update(restart_annotation)
+        try:
+            kube.patch_deployment(
+                namespace=namespace,
+                name=f"{name}-egress-proxy",
+                body=proxy_deploy,
+            )
+            logger.info("Patched egress proxy Deployment '%s-egress-proxy'", _safe_log(name))
+        except ApiException as e:
+            if e.status == 404:
+                logger.info("Egress proxy not found, skipping update")
+            else:
+                logger.warning("Failed to patch egress proxy: %s", e)
+
+    # 8. Build response
+    profile = request.profile
+    composable_name = profile.name if profile else name
+    security_warnings = profile.warnings if profile else []
+
+    status_msg = "updated"
+    message_parts = [f"Sandbox agent '{name}' updated in namespace '{namespace}'"]
+    if rebuild_required:
+        message_parts.append("Container image rebuild required (build fields changed)")
+
+    return SandboxCreateResponse(
+        status=status_msg,
+        message=". ".join(message_parts),
+        composable_name=composable_name,
+        security_warnings=security_warnings,
+        agent_url=f"http://{name}.{namespace}.svc.cluster.local:8000",
+    )

--- a/kagenti/backend/app/routers/sandbox_files.py
+++ b/kagenti/backend/app/routers/sandbox_files.py
@@ -1,0 +1,551 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Sandbox File Browser API — list directories and read files from sandbox agent pods.
+
+Uses Kubernetes pod exec to run commands inside running sandbox pods,
+providing a file browser experience in the UI.
+"""
+
+import logging
+import posixpath
+import re
+from typing import List, Literal, Union
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from kubernetes.client import ApiException
+from kubernetes.stream import stream as k8s_stream
+from pydantic import BaseModel
+
+from app.core.auth import ROLE_VIEWER, require_roles
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MB
+WORKSPACE_ROOT = "/workspace"
+
+# ---------------------------------------------------------------------------
+# Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class FileEntry(BaseModel):
+    """Single entry in a directory listing."""
+
+    name: str
+    path: str  # absolute path inside the pod
+    type: Literal["file", "directory"]
+    size: int  # bytes
+    modified: str  # ISO-8601 timestamp string
+    permissions: str  # e.g. "drwxr-xr-x" or "-rw-r--r--"
+
+
+class DirectoryListing(BaseModel):
+    """Response when the requested path is a directory."""
+
+    path: str
+    entries: List[FileEntry]
+
+
+class FileContent(BaseModel):
+    """Response when the requested path is a regular file."""
+
+    path: str
+    content: str
+    size: int
+    modified: str
+    type: str = "file"
+    encoding: str = "utf-8"
+
+
+class MountInfo(BaseModel):
+    """Single mount entry from ``df -h`` output."""
+
+    filesystem: str
+    size: str
+    used: str
+    available: str
+    use_percent: str
+    mount_point: str
+
+
+class PodStorageStats(BaseModel):
+    """Aggregated storage statistics for a sandbox pod."""
+
+    mounts: List[MountInfo]
+    total_mounts: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_path(path: str) -> str:
+    """
+    Validate and normalise the requested filesystem path.
+
+    Raises HTTPException(400) if the path contains traversal sequences or
+    is not an absolute path.
+    """
+    # Normalise the path (collapse //, resolve . but NOT ..)
+    normalised = posixpath.normpath(path)
+
+    # Reject any component that is ".."
+    if ".." in normalised.split("/"):
+        raise HTTPException(
+            status_code=400,
+            detail="Path traversal ('..') is not allowed.",
+        )
+
+    # Must be an absolute path
+    if not normalised.startswith("/"):
+        raise HTTPException(
+            status_code=400,
+            detail="Path must be absolute (start with '/').",
+        )
+
+    return normalised
+
+
+def _find_pod(
+    kube: KubernetesService,
+    namespace: str,
+    agent_name: str,
+) -> str:
+    """
+    Find the first Running pod for the given agent.
+
+    Pods are selected by label ``app={agent_name}``.
+
+    Returns:
+        The pod name.
+
+    Raises:
+        HTTPException(404) if no running pod is found.
+    """
+    try:
+        pods = kube.core_api.list_namespaced_pod(
+            namespace=namespace,
+            label_selector=f"app.kubernetes.io/name={agent_name}",
+        )
+    except ApiException as exc:
+        logger.error(
+            "K8s error listing pods for %s/%s: %s", _safe_log(namespace), _safe_log(agent_name), exc
+        )
+        raise HTTPException(status_code=502, detail="Failed to list pods.") from exc
+
+    for pod in pods.items:
+        if pod.status and pod.status.phase == "Running":
+            return pod.metadata.name
+
+    raise HTTPException(
+        status_code=404,
+        detail=f"No running pod found for agent '{agent_name}' in namespace '{namespace}'.",
+    )
+
+
+def _exec_in_pod(
+    kube: KubernetesService,
+    namespace: str,
+    pod_name: str,
+    command: List[str],
+) -> str:
+    """
+    Execute a command inside a pod and return the combined stdout/stderr.
+
+    Uses ``kubernetes.stream.stream()`` for websocket-based exec.
+
+    Raises:
+        HTTPException(502) on K8s API errors.
+    """
+    try:
+        result = k8s_stream(
+            kube.core_api.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            command=command,
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+        )
+        return result
+    except ApiException as exc:
+        logger.error(
+            "K8s exec error in %s/%s: %s",
+            _safe_log(namespace),
+            _safe_log(pod_name),
+            exc,
+        )
+        raise HTTPException(status_code=502, detail="Failed to exec in pod.") from exc
+
+
+def _parse_ls_output(raw: str, base_path: str) -> List[FileEntry]:
+    """
+    Parse output of ``ls -la --time-style=full-iso`` into :class:`FileEntry` objects.
+
+    Expected line format (space-separated, 9 fields minimum)::
+
+        -rw-r--r-- 1 root root  1234 2025-06-01 12:34:56.000000000 +0000 filename
+
+    Skips the ``total`` header line and the ``.`` / ``..`` entries.
+    """
+    entries: List[FileEntry] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("total"):
+            continue
+
+        parts = line.split(None, 8)
+        if len(parts) < 9:
+            continue
+
+        permissions = parts[0]
+        try:
+            size = int(parts[4])
+        except (ValueError, IndexError):
+            size = 0
+
+        # Date + time + tz -> parts[5], parts[6], parts[7]
+        modified = f"{parts[5]}T{parts[6]}{parts[7]}"  # e.g. 2025-06-01T12:34:56.000000000+0000
+
+        name = parts[8]
+        if name in (".", ".."):
+            continue
+
+        entry_type: Literal["file", "directory"] = (
+            "directory" if permissions.startswith("d") else "file"
+        )
+        entry_path = posixpath.join(base_path, name)
+
+        entries.append(
+            FileEntry(
+                name=name,
+                path=entry_path,
+                type=entry_type,
+                size=size,
+                modified=modified,
+                permissions=permissions,
+            )
+        )
+
+    return entries
+
+
+# Pseudo-filesystem types to filter out of storage stats
+_PSEUDO_FS = {"proc", "sysfs", "devtmpfs"}
+
+
+def _parse_df_output(raw: str) -> List[MountInfo]:
+    """
+    Parse output of ``df -h`` into :class:`MountInfo` objects.
+
+    Expected header::
+
+        Filesystem      Size  Used Avail Use% Mounted on
+
+    Each subsequent line has 6 whitespace-separated fields (the last field,
+    *Mounted on*, may contain spaces so we split into at most 6 parts).
+
+    Filters out pseudo-filesystems (proc, sysfs, devtmpfs) and tmpfs mounts
+    that report 0 size.
+    """
+    mounts: List[MountInfo] = []
+    lines = raw.strip().splitlines()
+
+    # Skip the header line
+    for line in lines[1:]:
+        line = line.strip()
+        if not line:
+            continue
+
+        parts = line.split(None, 5)
+        if len(parts) < 6:
+            continue
+
+        filesystem, size, used, available, use_percent, mount_point = parts
+
+        # Filter pseudo-filesystems
+        if filesystem in _PSEUDO_FS:
+            continue
+
+        # Filter tmpfs with 0 size
+        if filesystem == "tmpfs" and size == "0":
+            continue
+
+        mounts.append(
+            MountInfo(
+                filesystem=filesystem,
+                size=size,
+                used=used,
+                available=available,
+                use_percent=use_percent,
+                mount_point=mount_point,
+            )
+        )
+
+    return mounts
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+router = APIRouter(
+    prefix="/sandbox",
+    tags=["sandbox-files"],
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+
+
+@router.get(
+    "/{namespace}/files/{agent_name}",
+    response_model=Union[DirectoryListing, FileContent],
+    summary="Browse files in a sandbox agent pod",
+)
+async def get_sandbox_files(
+    namespace: str,
+    agent_name: str,
+    path: str = Query(default="/", description="Absolute path inside the pod"),
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """
+    If *path* is a directory, return a :class:`DirectoryListing`.
+    If *path* is a regular file, return its :class:`FileContent` (up to 1 MB).
+
+    Traversal via ``..`` is rejected. Path must be absolute.
+    """
+    safe_path = _sanitize_path(path)
+    pod_name = _find_pod(kube, namespace, agent_name)
+
+    # ---- Determine whether path is a file or directory ----
+    # stat --format=%F|%s|%Y -> "regular file|1234|1717200000"  or  "directory|4096|..."
+    stat_output = _exec_in_pod(
+        kube,
+        namespace,
+        pod_name,
+        ["stat", "--format=%F|%s|%Y", safe_path],
+    ).strip()
+
+    if not stat_output:
+        raise HTTPException(status_code=404, detail=f"Path not found: {safe_path}")
+
+    # stat may produce an error message (e.g. "No such file or directory")
+    if "|" not in stat_output:
+        raise HTTPException(status_code=404, detail=f"Path not found: {safe_path}")
+
+    parts = stat_output.split("|", 2)
+    file_type = parts[0].strip().lower()
+    try:
+        file_size = int(parts[1]) if len(parts) > 1 else 0
+    except ValueError:
+        file_size = 0
+
+    # ---- Directory listing ----
+    if "directory" in file_type:
+        ls_output = _exec_in_pod(
+            kube,
+            namespace,
+            pod_name,
+            ["ls", "-la", "--time-style=full-iso", safe_path],
+        )
+        entries = _parse_ls_output(ls_output, safe_path)
+        return DirectoryListing(path=safe_path, entries=entries)
+
+    # ---- Regular file ----
+    if file_size > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large ({file_size} bytes). Maximum is {MAX_FILE_SIZE} bytes.",
+        )
+
+    content = _exec_in_pod(
+        kube,
+        namespace,
+        pod_name,
+        ["cat", safe_path],
+    )
+
+    # Get modification time for the file
+    mtime_output = _exec_in_pod(
+        kube,
+        namespace,
+        pod_name,
+        ["stat", "--format=%y", safe_path],
+    ).strip()
+
+    return FileContent(
+        path=safe_path,
+        content=content,
+        size=file_size,
+        modified=mtime_output,
+    )
+
+
+@router.get(
+    "/{namespace}/files/{agent_name}/list",
+    response_model=DirectoryListing,
+    summary="List directory contents in a sandbox agent pod",
+)
+async def list_sandbox_directory(
+    namespace: str,
+    agent_name: str,
+    path: str = Query(default="/", description="Absolute path inside the pod"),
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """List directory contents. Alias for the main files endpoint when path is a directory."""
+    safe_path = _sanitize_path(path)
+    pod_name = _find_pod(kube, namespace, agent_name)
+
+    ls_output = _exec_in_pod(
+        kube,
+        namespace,
+        pod_name,
+        ["ls", "-la", "--time-style=full-iso", safe_path],
+    )
+    entries = _parse_ls_output(ls_output, safe_path)
+    return DirectoryListing(path=safe_path, entries=entries)
+
+
+@router.get(
+    "/{namespace}/files/{agent_name}/content",
+    response_model=FileContent,
+    summary="Read file content from a sandbox agent pod",
+)
+async def read_sandbox_file(
+    namespace: str,
+    agent_name: str,
+    path: str = Query(default="/", description="Absolute path inside the pod"),
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """Read file content. Alias for the main files endpoint when path is a file."""
+    safe_path = _sanitize_path(path)
+    pod_name = _find_pod(kube, namespace, agent_name)
+
+    stat_output = _exec_in_pod(
+        kube,
+        namespace,
+        pod_name,
+        ["stat", "--format=%F|%s|%Y", safe_path],
+    ).strip()
+
+    if not stat_output or "|" not in stat_output:
+        raise HTTPException(status_code=404, detail=f"Path not found: {safe_path}")
+
+    parts = stat_output.split("|", 2)
+    try:
+        file_size = int(parts[1]) if len(parts) > 1 else 0
+    except ValueError:
+        file_size = 0
+
+    if file_size > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large ({file_size} bytes). Maximum is {MAX_FILE_SIZE} bytes.",
+        )
+
+    content = _exec_in_pod(kube, namespace, pod_name, ["cat", safe_path])
+    mtime_output = _exec_in_pod(
+        kube,
+        namespace,
+        pod_name,
+        ["stat", "--format=%y", safe_path],
+    ).strip()
+
+    return FileContent(
+        path=safe_path,
+        content=content,
+        size=file_size,
+        modified=mtime_output,
+    )
+
+
+@router.get(
+    "/{namespace}/files/{agent_name}/{context_id}",
+    response_model=Union[DirectoryListing, FileContent],
+    summary="Browse files scoped to a session workspace",
+)
+async def get_context_files(
+    namespace: str,
+    agent_name: str,
+    context_id: str,
+    path: str = Query(default="/", description="Path relative to the context workspace"),
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """
+    Browse files within /workspace/{context_id}/.
+
+    Defined AFTER /list and /content routes so those match first.
+    """
+    if not re.match(r"^[a-zA-Z0-9_-]+$", context_id):
+        raise HTTPException(status_code=400, detail="Invalid context_id format")
+
+    context_root = f"/workspace/{context_id}"
+    if path == "/" or path == "":
+        full_path = context_root
+    elif path.startswith(context_root):
+        # Path is already absolute (e.g., from a TreeView click returning
+        # the full path from a previous directory listing) — use as-is.
+        full_path = _sanitize_path(path)
+    else:
+        rel = path.lstrip("/")
+        full_path = posixpath.normpath(posixpath.join(context_root, rel))
+
+    if not full_path.startswith(context_root):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Path escapes context workspace: {path}",
+        )
+
+    return await get_sandbox_files(
+        namespace=namespace,
+        agent_name=agent_name,
+        path=full_path,
+        kube=kube,
+    )
+
+
+@router.get(
+    "/{namespace}/stats/{agent_name}",
+    response_model=PodStorageStats,
+    summary="Get storage/mount statistics for a sandbox agent pod",
+)
+async def get_pod_storage_stats(
+    namespace: str,
+    agent_name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+):
+    """
+    Execute ``df -h`` inside the sandbox pod and return parsed mount
+    information, filtering out pseudo-filesystems (proc, sysfs, devtmpfs)
+    and zero-size tmpfs mounts.
+    """
+    pod_name = _find_pod(kube, namespace, agent_name)
+
+    df_output = _exec_in_pod(
+        kube,
+        namespace,
+        pod_name,
+        ["df", "-h"],
+    )
+
+    mounts = _parse_df_output(df_output)
+
+    return PodStorageStats(
+        mounts=mounts,
+        total_mounts=len(mounts),
+    )

--- a/kagenti/backend/app/routers/sandbox_trigger.py
+++ b/kagenti/backend/app/routers/sandbox_trigger.py
@@ -1,0 +1,119 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Sandbox Trigger API — create sandboxes from cron, webhook, and alert events.
+
+Creates kubernetes-sigs SandboxClaim resources via the SandboxTrigger module.
+Requires ROLE_OPERATOR for all operations (creates K8s resources).
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.core.auth import require_roles, ROLE_OPERATOR
+
+# Add deployments/sandbox to path for trigger module
+# Walk up to find repo root (works at any depth, including containers)
+_this_dir = Path(__file__).resolve().parent
+_sandbox_dir = None
+for _parent in _this_dir.parents:
+    _candidate = _parent / "deployments" / "sandbox"
+    if _candidate.is_dir():
+        _sandbox_dir = _candidate
+        break
+if _sandbox_dir and str(_sandbox_dir) not in sys.path:
+    sys.path.insert(0, str(_sandbox_dir))
+
+try:
+    from triggers import SandboxTrigger  # noqa: E402  # pylint: disable=wrong-import-position,wrong-import-order
+except ImportError:
+    SandboxTrigger = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/sandbox", tags=["sandbox-triggers"])
+
+
+class TriggerRequest(BaseModel):
+    """Request body for creating a sandbox trigger."""
+
+    type: str  # "cron", "webhook", "alert"
+    # Cron fields
+    skill: Optional[str] = None
+    schedule: Optional[str] = ""
+    # Webhook fields
+    event: Optional[str] = None
+    repo: Optional[str] = None
+    branch: Optional[str] = "main"
+    pr_number: Optional[int] = 0
+    # Alert fields
+    alert: Optional[str] = None
+    cluster: Optional[str] = ""
+    severity: Optional[str] = "warning"
+    # Common
+    namespace: Optional[str] = "team1"
+    ttl_hours: Optional[int] = 2
+
+
+class TriggerResponse(BaseModel):
+    """Response from sandbox trigger creation."""
+
+    sandbox_claim: str
+    namespace: str
+
+
+@router.post(
+    "/trigger",
+    response_model=TriggerResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def create_sandbox_trigger(request: TriggerRequest) -> TriggerResponse:
+    """Create a sandbox from a trigger event.
+
+    Requires ROLE_OPERATOR — creates SandboxClaim K8s resources.
+    """
+    if SandboxTrigger is None:
+        raise HTTPException(501, "Trigger module not available (missing deployments/sandbox)")
+    trigger = SandboxTrigger(
+        namespace=request.namespace,
+        ttl_hours=request.ttl_hours,
+    )
+
+    try:
+        if request.type == "cron":
+            if not request.skill:
+                raise HTTPException(422, "skill is required for cron triggers")
+            name = trigger.create_from_cron(
+                skill=request.skill,
+                schedule=request.schedule or "",
+            )
+        elif request.type == "webhook":
+            if not request.event or not request.repo:
+                raise HTTPException(422, "event and repo are required for webhook triggers")
+            name = trigger.create_from_webhook(
+                event_type=request.event,
+                repo=request.repo,
+                branch=request.branch or "main",
+                pr_number=request.pr_number or 0,
+            )
+        elif request.type == "alert":
+            if not request.alert:
+                raise HTTPException(422, "alert is required for alert triggers")
+            name = trigger.create_from_alert(
+                alert_name=request.alert,
+                cluster=request.cluster or "",
+                severity=request.severity or "warning",
+            )
+        else:
+            raise HTTPException(400, f"Unknown trigger type: {request.type}")
+    except RuntimeError as e:
+        logger.error("Failed to create sandbox trigger: %s", e)
+        raise HTTPException(500, str(e))
+
+    return TriggerResponse(sandbox_claim=name, namespace=trigger.namespace)

--- a/kagenti/backend/app/routers/sidecar.py
+++ b/kagenti/backend/app/routers/sidecar.py
@@ -1,0 +1,275 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Sidecar Agents API — manage sidecar lifecycle and observations.
+
+Provides REST endpoints for enabling/disabling sidecars, updating config,
+listing observations, and HITL approval/denial. Also provides an SSE
+endpoint for streaming sidecar observations in real-time.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from app.core.auth import ROLE_VIEWER, require_roles
+from app.services.sidecar_manager import (
+    SidecarManager,
+    SidecarType,
+    get_sidecar_manager,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/sandbox",
+    tags=["sidecars"],
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+
+
+# ── Request/Response Models ──────────────────────────────────────────────────
+
+
+class EnableRequest(BaseModel):
+    auto_approve: bool = False
+    config: Optional[dict] = None
+    agent_name: str = "sandbox-legion"
+
+
+class ConfigUpdateRequest(BaseModel):
+    interval_seconds: Optional[int] = None
+    counter_limit: Optional[int] = None
+    warn_threshold_pct: Optional[int] = None
+    critical_threshold_pct: Optional[int] = None
+    auto_approve: Optional[bool] = None
+
+
+class SidecarResponse(BaseModel):
+    context_id: str
+    sidecar_type: str
+    parent_context_id: str
+    enabled: bool
+    auto_approve: bool
+    config: dict
+    observation_count: int
+    pending_count: int
+
+
+class ObservationResponse(BaseModel):
+    id: str
+    sidecar_type: str
+    timestamp: float
+    message: str
+    severity: str
+    requires_approval: bool
+
+
+# ── Helper ───────────────────────────────────────────────────────────────────
+
+
+def _parse_sidecar_type(type_str: str) -> SidecarType:
+    try:
+        return SidecarType(type_str)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid sidecar type: {type_str}. "
+            f"Valid types: {[t.value for t in SidecarType]}",
+        )
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/{namespace}/sessions/{context_id}/sidecars",
+    response_model=list[SidecarResponse],
+    summary="List all sidecars for a session",
+)
+async def list_sidecars(
+    namespace: str,
+    context_id: str,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    # Restore persisted state on first access after restart
+    await manager._restore_sidecars_for_session(context_id, namespace)
+    return manager.list_sidecars(context_id)
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/sidecars/{sidecar_type}/enable",
+    response_model=SidecarResponse,
+    summary="Enable a sidecar for a session",
+)
+async def enable_sidecar(
+    namespace: str,
+    context_id: str,
+    sidecar_type: str,
+    body: Optional[EnableRequest] = None,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    st = _parse_sidecar_type(sidecar_type)
+    handle = await manager.enable(
+        parent_context_id=context_id,
+        sidecar_type=st,
+        auto_approve=body.auto_approve if body else False,
+        config=body.config if body else None,
+        namespace=namespace,
+        agent_name=body.agent_name if body else "sandbox-legion",
+    )
+    return handle.to_dict()
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/sidecars/{sidecar_type}/disable",
+    summary="Disable a sidecar",
+)
+async def disable_sidecar(
+    namespace: str,
+    context_id: str,
+    sidecar_type: str,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    st = _parse_sidecar_type(sidecar_type)
+    await manager.disable(context_id, st)
+    return {"status": "disabled", "sidecar_type": sidecar_type}
+
+
+@router.put(
+    "/{namespace}/sessions/{context_id}/sidecars/{sidecar_type}/config",
+    response_model=SidecarResponse,
+    summary="Update sidecar config (hot-reload)",
+)
+async def update_config(
+    namespace: str,
+    context_id: str,
+    sidecar_type: str,
+    body: ConfigUpdateRequest,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    st = _parse_sidecar_type(sidecar_type)
+    config = {k: v for k, v in body.model_dump().items() if v is not None}
+    try:
+        handle = await manager.update_config(context_id, st, config)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return handle.to_dict()
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/sidecars/{sidecar_type}/reset",
+    summary="Reset sidecar state (e.g., Looper counter)",
+)
+async def reset_sidecar(
+    namespace: str,
+    context_id: str,
+    sidecar_type: str,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    st = _parse_sidecar_type(sidecar_type)
+    # Restore persisted state on first access after restart
+    await manager._restore_sidecars_for_session(context_id, namespace)
+    handle = manager.get_handle(context_id, st)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="Sidecar not found")
+
+    # Reset by disabling and re-enabling with same config (fresh analyzer)
+    old_config = handle.config.copy()
+    old_auto = handle.auto_approve
+    ns = handle.namespace
+    agent = handle.agent_name
+    await manager.disable(context_id, st)
+    await manager.enable(
+        context_id,
+        st,
+        auto_approve=old_auto,
+        config=old_config,
+        namespace=ns,
+        agent_name=agent,
+    )
+
+    return {"status": "reset", "sidecar_type": sidecar_type}
+
+
+@router.get(
+    "/{namespace}/sessions/{context_id}/sidecars/{sidecar_type}/observations",
+    summary="Stream sidecar observations via SSE",
+)
+async def stream_observations(
+    namespace: str,
+    context_id: str,
+    sidecar_type: str,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    st = _parse_sidecar_type(sidecar_type)
+    # Restore persisted state on first access after restart
+    await manager._restore_sidecars_for_session(context_id, namespace)
+
+    async def event_generator():
+        last_count = 0
+        while True:
+            observations = manager.get_observations(context_id, st)
+            if len(observations) > last_count:
+                for obs in observations[last_count:]:
+                    data = json.dumps(
+                        {
+                            "id": obs.id,
+                            "sidecar_type": obs.sidecar_type,
+                            "timestamp": obs.timestamp,
+                            "message": obs.message,
+                            "severity": obs.severity,
+                            "requires_approval": obs.requires_approval,
+                        }
+                    )
+                    yield f"data: {data}\n\n"
+                last_count = len(observations)
+            await asyncio.sleep(1)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/sidecars/{sidecar_type}/approve/{msg_id}",
+    summary="Approve a pending HITL intervention",
+)
+async def approve_intervention(
+    namespace: str,
+    context_id: str,
+    sidecar_type: str,
+    msg_id: str,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    st = _parse_sidecar_type(sidecar_type)
+    result = await manager.approve_intervention(context_id, st, msg_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Intervention not found")
+    return {"status": "approved", "id": msg_id}
+
+
+@router.post(
+    "/{namespace}/sessions/{context_id}/sidecars/{sidecar_type}/deny/{msg_id}",
+    summary="Deny a pending HITL intervention",
+)
+async def deny_intervention(
+    namespace: str,
+    context_id: str,
+    sidecar_type: str,
+    msg_id: str,
+    manager: SidecarManager = Depends(get_sidecar_manager),
+):
+    st = _parse_sidecar_type(sidecar_type)
+    result = await manager.deny_intervention(context_id, st, msg_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Intervention not found")
+    return {"status": "denied", "id": msg_id}

--- a/kagenti/backend/app/routers/token_usage.py
+++ b/kagenti/backend/app/routers/token_usage.py
@@ -1,0 +1,339 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Token usage analytics endpoints.
+
+Proxies LiteLLM spend data and aggregates per-model token usage
+for individual sessions and session trees (parent + children).
+"""
+
+import json
+import logging
+import os
+import re
+from collections import defaultdict
+from typing import Any, Dict, List
+
+import httpx
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.core.auth import require_roles, ROLE_VIEWER
+from app.services.session_db import get_session_pool
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
+# Kubernetes-style name validation (RFC 1123 DNS label)
+_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+router = APIRouter(prefix="/token-usage", tags=["token-usage"])
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+LITELLM_BASE_URL = os.getenv("LITELLM_BASE_URL", "http://litellm-proxy.kagenti-system.svc:4000")
+LITELLM_API_KEY = os.getenv("LITELLM_API_KEY", "")
+LLM_BUDGET_PROXY_URL = os.getenv("LLM_BUDGET_PROXY_URL", "http://llm-budget-proxy.team1.svc:8080")
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class ModelUsage(BaseModel):  # pylint: disable=too-few-public-methods
+    """Per-model token usage breakdown."""
+
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    num_calls: int
+    cost: float
+
+
+class SessionTokenUsage(BaseModel):  # pylint: disable=too-few-public-methods
+    """Aggregated token usage for a session."""
+
+    context_id: str
+    models: List[ModelUsage]
+    total_prompt_tokens: int
+    total_completion_tokens: int
+    total_tokens: int
+    total_calls: int
+    total_cost: float
+
+
+class SessionTreeUsage(BaseModel):  # pylint: disable=too-few-public-methods
+    """Token usage for a session tree (parent + children)."""
+
+    context_id: str
+    own_usage: SessionTokenUsage
+    children: List[SessionTokenUsage]
+    aggregate: SessionTokenUsage
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_spend_by_request_id(request_id: str) -> List[Dict[str, Any]]:
+    """Fetch spend logs from LiteLLM for a single request_id."""
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if LITELLM_API_KEY:
+        headers["Authorization"] = f"Bearer {LITELLM_API_KEY}"
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        try:
+            response = await client.get(
+                f"{LITELLM_BASE_URL}/spend/logs",
+                headers=headers,
+                params={"request_id": request_id},
+            )
+            response.raise_for_status()
+            data = response.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "LiteLLM /spend/logs returned %s for request_id=%s: %s",
+                exc.response.status_code,
+                request_id,
+                exc.response.text[:200],
+            )
+            return []
+        except httpx.RequestError as exc:
+            logger.warning("LiteLLM request failed for request_id=%s: %s", request_id, exc)
+            return []
+
+    if isinstance(data, list):
+        return data
+    return [data] if isinstance(data, dict) and data else []
+
+
+def _aggregate_by_model(logs: List[Dict[str, Any]], context_id: str) -> SessionTokenUsage:
+    """Group spend logs by model and sum tokens/cost."""
+    by_model: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "num_calls": 0,
+            "cost": 0.0,
+        }
+    )
+
+    for log in logs:
+        model = log.get("model") or "unknown"
+        prompt = log.get("prompt_tokens") or 0
+        completion = log.get("completion_tokens") or 0
+        total = log.get("total_tokens") or (prompt + completion)
+        cost = log.get("spend") or 0.0
+
+        entry = by_model[model]
+        entry["prompt_tokens"] += prompt
+        entry["completion_tokens"] += completion
+        entry["total_tokens"] += total
+        entry["num_calls"] += 1
+        entry["cost"] += cost
+
+    models = [ModelUsage(model=model, **stats) for model, stats in sorted(by_model.items())]
+
+    return SessionTokenUsage(
+        context_id=context_id,
+        models=models,
+        total_prompt_tokens=sum(m.prompt_tokens for m in models),
+        total_completion_tokens=sum(m.completion_tokens for m in models),
+        total_tokens=sum(m.total_tokens for m in models),
+        total_calls=sum(m.num_calls for m in models),
+        total_cost=sum(m.cost for m in models),
+    )
+
+
+def _merge_usages(context_id: str, usages: List[SessionTokenUsage]) -> SessionTokenUsage:
+    """Merge multiple SessionTokenUsage objects into a single aggregate."""
+    by_model: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "num_calls": 0,
+            "cost": 0.0,
+        }
+    )
+    for usage in usages:
+        for m in usage.models:
+            entry = by_model[m.model]
+            entry["prompt_tokens"] += m.prompt_tokens
+            entry["completion_tokens"] += m.completion_tokens
+            entry["total_tokens"] += m.total_tokens
+            entry["num_calls"] += m.num_calls
+            entry["cost"] += m.cost
+
+    models = [ModelUsage(model=model, **stats) for model, stats in sorted(by_model.items())]
+    return SessionTokenUsage(
+        context_id=context_id,
+        models=models,
+        total_prompt_tokens=sum(m.prompt_tokens for m in models),
+        total_completion_tokens=sum(m.completion_tokens for m in models),
+        total_tokens=sum(m.total_tokens for m in models),
+        total_calls=sum(m.num_calls for m in models),
+        total_cost=sum(m.cost for m in models),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+async def _get_request_ids_from_metadata(context_id: str, namespace: str) -> List[str]:
+    """Read llm_request_ids from the session's task metadata."""
+    try:
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT metadata FROM tasks WHERE context_id = $1 LIMIT 1",
+                context_id,
+            )
+        if row and row["metadata"]:
+            meta = (
+                json.loads(row["metadata"]) if isinstance(row["metadata"], str) else row["metadata"]
+            )
+            return meta.get("llm_request_ids", [])
+    except Exception as exc:
+        logger.warning(
+            "Failed to query task metadata for context_id=%s: %s", _safe_log(context_id), exc
+        )
+    return []
+
+
+async def _fetch_from_budget_proxy(context_id: str) -> SessionTokenUsage | None:
+    """Try to fetch session usage from the LLM Budget Proxy."""
+    # Validate context_id to prevent SSRF via path traversal (CWE-918)
+    if not _K8S_NAME_RE.match(context_id) and not re.match(r"^[a-zA-Z0-9_-]+$", context_id):
+        logger.warning("Invalid context_id rejected for budget proxy: %s", _safe_log(context_id))
+        return None
+
+    # Defense-in-depth: re-validate right before URL construction (CWE-918)
+    safe_id = context_id
+    if not re.match(r"^[a-zA-Z0-9_-]+$", safe_id):
+        return None
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.get(f"{LLM_BUDGET_PROXY_URL}/internal/usage/{safe_id}")
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:
+            logger.debug("Budget proxy unavailable for %s: %s", _safe_log(context_id), exc)
+            return None
+
+    if not data.get("call_count"):
+        return None
+
+    models = [
+        ModelUsage(
+            model=m.get("model", "unknown"),
+            prompt_tokens=m.get("prompt_tokens", 0),
+            completion_tokens=m.get("completion_tokens", 0),
+            total_tokens=m.get("total_tokens", 0),
+            num_calls=m.get("num_calls", 0),
+            cost=m.get("cost", 0.0),
+        )
+        for m in data.get("models", [])
+    ]
+    return SessionTokenUsage(
+        context_id=context_id,
+        models=models,
+        total_prompt_tokens=data.get("prompt_tokens", 0),
+        total_completion_tokens=data.get("completion_tokens", 0),
+        total_tokens=data.get("total_tokens", 0),
+        total_calls=data.get("call_count", 0),
+        total_cost=sum(m.cost for m in models),
+    )
+
+
+@router.get(
+    "/sessions/{context_id}",
+    response_model=SessionTokenUsage,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_session_token_usage(context_id: str, namespace: str = "team1"):
+    """Per-model token usage for a single session.
+
+    Queries the LLM Budget Proxy first (authoritative, persists across
+    restarts). Falls back to LiteLLM spend logs if the proxy is unavailable.
+    """
+    # Try budget proxy first
+    proxy_result = await _fetch_from_budget_proxy(context_id)
+    if proxy_result:
+        return proxy_result
+
+    # Fallback: LiteLLM spend logs
+    request_ids = await _get_request_ids_from_metadata(context_id, namespace)
+    logs: List[Dict[str, Any]] = []
+    for rid in request_ids:
+        spend = await _fetch_spend_by_request_id(rid)
+        if spend:
+            logs.extend(spend)
+    return _aggregate_by_model(logs, context_id)
+
+
+@router.get(
+    "/sessions/{context_id}/tree",
+    response_model=SessionTreeUsage,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_session_tree_usage(context_id: str, namespace: str = "team1"):
+    """Token usage for a session including all child sessions."""
+    # 1. Get own usage
+    own_request_ids = await _get_request_ids_from_metadata(context_id, namespace)
+    own_logs: List[Dict[str, Any]] = []
+    for rid in own_request_ids:
+        spend = await _fetch_spend_by_request_id(rid)
+        if spend:
+            own_logs.extend(spend)
+    own_usage = _aggregate_by_model(own_logs, context_id)
+
+    # 2. Find child sessions from the tasks table
+    children_usage: List[SessionTokenUsage] = []
+    try:
+        pool = await get_session_pool(namespace)
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT DISTINCT context_id FROM tasks"
+                " WHERE metadata::json->>'parent_context_id' = $1",
+                context_id,
+            )
+        child_ids = [row["context_id"] for row in rows]
+    except Exception as exc:
+        logger.warning("Failed to query child sessions: %s", exc)
+        child_ids = []
+
+    # 3. Fetch usage for each child
+    for child_id in child_ids:
+        child_request_ids = await _get_request_ids_from_metadata(child_id, namespace)
+        child_logs: List[Dict[str, Any]] = []
+        for rid in child_request_ids:
+            spend = await _fetch_spend_by_request_id(rid)
+            if spend:
+                child_logs.extend(spend)
+        children_usage.append(_aggregate_by_model(child_logs, child_id))
+
+    # 4. Build aggregate
+    all_usages = [own_usage] + children_usage
+    aggregate = _merge_usages(context_id, all_usages)
+
+    return SessionTreeUsage(
+        context_id=context_id,
+        own_usage=own_usage,
+        children=children_usage,
+        aggregate=aggregate,
+    )

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -329,6 +329,18 @@ class MCPInvokeResponse(BaseModel):
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/tools", tags=["tools"])
 
+# Cluster-local URL pattern for SSRF prevention (CWE-918)
+_CLUSTER_LOCAL_URL_RE = re.compile(
+    r"^http://[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+    r"\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.svc\.cluster\.local:\d+$"
+)
+
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
 
 def _build_tool_env_vars(
     env_var_list: Optional[List[EnvVar]] = None,
@@ -639,7 +651,7 @@ async def list_tools(
                 )
         except ApiException as e:
             if e.status != 404:
-                logger.warning(f"Error listing Deployments: {e}")
+                logger.warning("Error listing Deployments: %s", e)
 
         # Query StatefulSets with tool label
         try:
@@ -665,7 +677,7 @@ async def list_tools(
                 )
         except ApiException as e:
             if e.status != 404:
-                logger.warning(f"Error listing StatefulSets: {e}")
+                logger.warning("Error listing StatefulSets: %s", e)
 
         return ToolListResponse(items=tools)
 
@@ -727,7 +739,7 @@ async def get_tool(
         }
     except ApiException as e:
         if e.status != 404:
-            logger.warning(f"Error getting Service '{service_name}': {e}")
+            logger.warning("Error getting Service '%s': %s", _safe_log(service_name), e)
 
     # Build response with workload and service details
     # Return both raw status (for conditions display) and computed readyStatus string
@@ -810,7 +822,7 @@ async def delete_tool(
         deleted_resources.append(f"Build/{name}")
     except ApiException as e:
         if e.status != 404:
-            logger.warning(f"Failed to delete Shipwright Build '{name}': {e}")
+            logger.warning("Failed to delete Shipwright Build '%s': %s", _safe_log(name), e)
 
     # Delete Deployment (if exists)
     try:
@@ -818,7 +830,7 @@ async def delete_tool(
         deleted_resources.append(f"Deployment/{name}")
     except ApiException as e:
         if e.status != 404:
-            logger.warning(f"Failed to delete Deployment '{name}': {e}")
+            logger.warning("Failed to delete Deployment '%s': %s", _safe_log(name), e)
 
     # Delete StatefulSet (if exists)
     try:
@@ -826,7 +838,7 @@ async def delete_tool(
         deleted_resources.append(f"StatefulSet/{name}")
     except ApiException as e:
         if e.status != 404:
-            logger.warning(f"Failed to delete StatefulSet '{name}': {e}")
+            logger.warning("Failed to delete StatefulSet '%s': %s", _safe_log(name), e)
 
     # Delete Service
     service_name = _get_tool_service_name(name)
@@ -835,7 +847,7 @@ async def delete_tool(
         deleted_resources.append(f"Service/{service_name}")
     except ApiException as e:
         if e.status != 404:
-            logger.warning(f"Failed to delete Service '{service_name}': {e}")
+            logger.warning("Failed to delete Service '%s': %s", _safe_log(service_name), e)
 
     if deleted_resources:
         return DeleteResponse(
@@ -1557,7 +1569,7 @@ async def create_tool(
                 status_code=404,
                 detail="Failed to create tool resources. Check cluster connectivity.",
             )
-        logger.error(f"Failed to create tool: {e}")
+        logger.error("Failed to create tool: %s", e)
         raise HTTPException(status_code=e.status, detail=str(e.reason))
 
 
@@ -1646,7 +1658,7 @@ async def get_tool_shipwright_build_info(
         except ApiException as e:
             # BuildRun not found is OK, just means no build has been triggered
             if e.status != 404:
-                logger.warning(f"Failed to get BuildRun for build '{name}': {e}")
+                logger.warning("Failed to get BuildRun for build '%s': %s", _safe_log(name), e)
 
         return response
 
@@ -2036,11 +2048,16 @@ def _get_tool_url(name: str, namespace: str, port: int = DEFAULT_IN_CLUSTER_PORT
     Returns different URL formats based on deployment context:
     - In-cluster: http://{name}-mcp.{namespace}.svc.cluster.local:{port}
     - Off-cluster (local dev): http://{name}.{domain}:8080 (via HTTPRoute)
+
+    Raises ValueError if the generated URL fails SSRF validation (CWE-918).
     """
     if settings.is_running_in_cluster:
         # In-cluster: use service DNS with new naming convention
         service_name = _get_tool_service_name(name)
-        return f"http://{service_name}.{namespace}.svc.cluster.local:{port}"
+        url = f"http://{service_name}.{namespace}.svc.cluster.local:{port}"
+        if not _CLUSTER_LOCAL_URL_RE.match(url):
+            raise ValueError("Invalid tool URL: must be a cluster-local service URL")
+        return url
     else:
         # Off-cluster: use external domain (e.g., localtest.me) via HTTPRoute
         domain = settings.domain_name
@@ -2082,7 +2099,7 @@ async def connect_to_tool(
     tool_url = _get_tool_url(name, namespace, port=service_port)
     mcp_endpoint = f"{tool_url}/mcp"
 
-    logger.info(f"Connecting to MCP server at {mcp_endpoint}")
+    logger.info("Connecting to MCP server at %s", _safe_log(mcp_endpoint))
 
     exit_stack = AsyncExitStack()
     try:
@@ -2096,7 +2113,7 @@ async def connect_to_tool(
             session: ClientSession = await session_context.__aenter__()
             await session.initialize()
 
-            logger.info(f"MCP session initialized for tool '{name}'")
+            logger.info("MCP session initialized for tool '%s'", _safe_log(name))
 
             # List available tools
             response = await session.list_tools()
@@ -2112,18 +2129,18 @@ async def connect_to_tool(
                             ),
                         )
                     )
-                logger.info(f"Listed {len(tools)} tools from MCP server '{name}'")
+                logger.info("Listed %d tools from MCP server '%s'", len(tools), _safe_log(name))
 
             return MCPToolsResponse(tools=tools)
 
     except ConnectionError as e:
-        logger.error(f"Connection error to MCP server: {e}")
+        logger.error("Connection error to MCP server: %s", e)
         raise HTTPException(
             status_code=503,
             detail=f"Failed to connect to MCP server at {tool_url}",
         )
     except Exception as e:
-        logger.error(f"Unexpected error connecting to MCP server: {e}")
+        logger.error("Unexpected error connecting to MCP server: %s", e)
         raise HTTPException(
             status_code=500,
             detail=f"Error connecting to MCP server: {str(e)}",
@@ -2163,12 +2180,16 @@ async def invoke_tool(
             session: ClientSession = await session_context.__aenter__()
             await session.initialize()
 
-            logger.info(f"MCP session initialized for tool invocation on '{name}'")
+            logger.info("MCP session initialized for tool invocation on '%s'", _safe_log(name))
 
             # Call the tool using the MCP client library
             result = await session.call_tool(request.tool_name, request.arguments)
 
-            logger.info(f"Tool '{request.tool_name}' invoked successfully on '{name}'")
+            logger.info(
+                "Tool '%s' invoked successfully on '%s'",
+                _safe_log(request.tool_name),
+                _safe_log(name),
+            )
 
             # Convert the result to a serializable format
             result_data = {}
@@ -2190,7 +2211,7 @@ async def invoke_tool(
             return MCPInvokeResponse(result=result_data)
 
     except ConnectionError as e:
-        logger.error(f"Connection error to MCP server: {e}")
+        logger.error("Connection error to MCP server: %s", e)
         raise HTTPException(
             status_code=503,
             detail=f"Failed to connect to MCP server at {tool_url}",
@@ -2198,7 +2219,7 @@ async def invoke_tool(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Unexpected error invoking MCP tool: {e}")
+        logger.error("Unexpected error invoking MCP tool: %s", e)
         raise HTTPException(
             status_code=500,
             detail=f"Error invoking MCP tool: {str(e)}",

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -20,6 +20,12 @@ from app.core.constants import ENABLED_NAMESPACE_LABEL_KEY, ENABLED_NAMESPACE_LA
 logger = logging.getLogger(__name__)
 
 
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
 def _sanitize(value: str) -> str:
     """Strip newlines and control characters to prevent log injection (CWE-117).
 
@@ -53,7 +59,7 @@ class KubernetesService:
             return kubernetes.client.ApiClient()
 
         except ConfigException as e:
-            logger.error(f"Failed to load Kubernetes config: {e}")
+            logger.error("Failed to load Kubernetes config: %s", e)
             raise
 
     @property
@@ -104,7 +110,7 @@ class KubernetesService:
             )
             return sorted([ns.metadata.name for ns in response.items if ns.metadata])
         except ApiException as e:
-            logger.error(f"Error listing namespaces: {e}")
+            logger.error("Error listing namespaces: %s", e)
             return ["default"]
 
     def list_enabled_namespaces(self) -> List[str]:
@@ -131,7 +137,7 @@ class KubernetesService:
             )
             return response.get("items", [])
         except ApiException as e:
-            logger.error(f"Error listing {plural} in {namespace}: {e}")
+            logger.error("Error listing %s in %s: %s", plural, namespace, e)
             raise
 
     def list_cluster_custom_resources(
@@ -150,7 +156,7 @@ class KubernetesService:
                 label_selector=label_selector,
             )
         except ApiException as e:
-            logger.error(f"Error listing cluster-scoped {plural}: {e}")
+            logger.error("Error listing cluster-scoped %s: %s", plural, e)
             raise
 
     def get_custom_resource(
@@ -171,7 +177,7 @@ class KubernetesService:
                 name=name,
             )
         except ApiException as e:
-            logger.error(f"Error getting {plural}/{name} in {namespace}: {e}")
+            logger.error("Error getting %s/%s in %s: %s", plural, name, namespace, e)
             raise
 
     def delete_custom_resource(
@@ -192,7 +198,7 @@ class KubernetesService:
                 name=name,
             )
         except ApiException as e:
-            logger.error(f"Error deleting {plural}/{name} in {namespace}: {e}")
+            logger.error("Error deleting %s/%s in %s: %s", plural, name, namespace, e)
             raise
 
     def create_custom_resource(
@@ -213,7 +219,7 @@ class KubernetesService:
                 body=body,
             )
         except ApiException as e:
-            logger.error(f"Error creating {plural} in {namespace}: {e}")
+            logger.error("Error creating %s in %s: %s", plural, namespace, e)
             raise
 
     # -------------------------------------------------------------------------
@@ -229,7 +235,7 @@ class KubernetesService:
         """
         try:
             self.core_api.read_namespaced_service_account(name=name, namespace=namespace)
-            logger.debug(f"ServiceAccount '{name}' already exists in {namespace}")
+            logger.debug("ServiceAccount '%s' already exists in %s", name, namespace)
         except ApiException as e:
             if e.status == 404:
                 sa = kubernetes.client.V1ServiceAccount(
@@ -240,9 +246,9 @@ class KubernetesService:
                     ),
                 )
                 self.core_api.create_namespaced_service_account(namespace=namespace, body=sa)
-                logger.info(f"Created ServiceAccount '{name}' in {namespace}")
+                logger.info("Created ServiceAccount '%s' in %s", name, namespace)
             else:
-                logger.error(f"Error checking ServiceAccount '{name}' in {namespace}: {e}")
+                logger.error("Error checking ServiceAccount '%s' in %s: %s", name, namespace, e)
                 raise
 
     # -------------------------------------------------------------------------
@@ -259,7 +265,7 @@ class KubernetesService:
         """
         try:
             self.core_api.read_namespaced_config_map(name=name, namespace=namespace)
-            logger.debug(f"ConfigMap '{name}' already exists in {namespace}")
+            logger.debug("ConfigMap '%s' already exists in %s", name, namespace)
         except ApiException as e:
             if e.status == 404:
                 cm = kubernetes.client.V1ConfigMap(
@@ -273,7 +279,7 @@ class KubernetesService:
                 self.core_api.create_namespaced_config_map(namespace=namespace, body=cm)
                 logger.info("Created ConfigMap '%s' in %s", name, namespace)
             else:
-                logger.error(f"Error checking ConfigMap '{name}' in {namespace}: {e}")
+                logger.error("Error checking ConfigMap '%s' in %s: %s", name, namespace, e)
                 raise
 
     def upsert_configmap(
@@ -360,7 +366,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating Deployment in {namespace}: {e}")
+            logger.error("Error creating Deployment in %s: %s", namespace, e)
             raise
 
     def get_deployment(self, namespace: str, name: str) -> dict:
@@ -372,7 +378,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error getting Deployment {name} in {namespace}: {e}")
+            logger.error("Error getting Deployment %s in %s: %s", name, namespace, e)
             raise
 
     def list_deployments(self, namespace: str, label_selector: Optional[str] = None) -> List[dict]:
@@ -384,7 +390,7 @@ class KubernetesService:
             )
             return [item.to_dict() for item in result.items]
         except ApiException as e:
-            logger.error(f"Error listing Deployments in {namespace}: {e}")
+            logger.error("Error listing Deployments in %s: %s", _safe_log(namespace), _safe_log(e))
             raise
 
     def delete_deployment(self, namespace: str, name: str) -> None:
@@ -395,7 +401,12 @@ class KubernetesService:
                 namespace=namespace,
             )
         except ApiException as e:
-            logger.error(f"Error deleting Deployment {name} in {namespace}: {e}")
+            logger.error(
+                "Error deleting Deployment %s in %s: %s",
+                _safe_log(name),
+                _safe_log(namespace),
+                _safe_log(e),
+            )
             raise
 
     def patch_deployment(self, namespace: str, name: str, body: dict) -> dict:
@@ -408,7 +419,12 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error patching Deployment {name} in {namespace}: {e}")
+            logger.error(
+                "Error patching Deployment %s in %s: %s",
+                _safe_log(name),
+                _safe_log(namespace),
+                _safe_log(e),
+            )
             raise
 
     # -------------------------------------------------------------------------
@@ -424,7 +440,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating Service in {namespace}: {e}")
+            logger.error("Error creating Service in %s: %s", _safe_log(namespace), _safe_log(e))
             raise
 
     def get_service(self, namespace: str, name: str) -> dict:
@@ -436,7 +452,12 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error getting Service {name} in {namespace}: {e}")
+            logger.error(
+                "Error getting Service %s in %s: %s",
+                _safe_log(name),
+                _safe_log(namespace),
+                _safe_log(e),
+            )
             raise
 
     def list_services(self, namespace: str, label_selector: Optional[str] = None) -> List[dict]:
@@ -448,7 +469,7 @@ class KubernetesService:
             )
             return [item.to_dict() for item in result.items]
         except ApiException as e:
-            logger.error(f"Error listing Services in {namespace}: {e}")
+            logger.error("Error listing Services in %s: %s", _safe_log(namespace), _safe_log(e))
             raise
 
     def delete_service(self, namespace: str, name: str) -> None:
@@ -557,7 +578,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating StatefulSet in {namespace}: {e}")
+            logger.error("Error creating StatefulSet in %s: %s", namespace, e)
             raise
 
     def get_statefulset(self, namespace: str, name: str) -> dict:
@@ -569,7 +590,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error getting StatefulSet {name} in {namespace}: {e}")
+            logger.error("Error getting StatefulSet %s in %s: %s", name, namespace, e)
             raise
 
     def list_statefulsets(self, namespace: str, label_selector: Optional[str] = None) -> List[dict]:
@@ -581,7 +602,7 @@ class KubernetesService:
             )
             return [item.to_dict() for item in result.items]
         except ApiException as e:
-            logger.error(f"Error listing StatefulSets in {namespace}: {e}")
+            logger.error("Error listing StatefulSets in %s: %s", namespace, e)
             raise
 
     def delete_statefulset(self, namespace: str, name: str) -> None:
@@ -592,7 +613,7 @@ class KubernetesService:
                 namespace=namespace,
             )
         except ApiException as e:
-            logger.error(f"Error deleting StatefulSet {name} in {namespace}: {e}")
+            logger.error("Error deleting StatefulSet %s in %s: %s", name, namespace, e)
             raise
 
     def patch_statefulset(self, namespace: str, name: str, body: dict) -> dict:
@@ -605,7 +626,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error patching StatefulSet {name} in {namespace}: {e}")
+            logger.error("Error patching StatefulSet %s in %s: %s", name, namespace, e)
             raise
 
     # -------------------------------------------------------------------------
@@ -621,7 +642,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error creating Job in {namespace}: {e}")
+            logger.error("Error creating Job in %s: %s", namespace, e)
             raise
 
     def get_job(self, namespace: str, name: str) -> dict:
@@ -633,7 +654,7 @@ class KubernetesService:
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error getting Job {name} in {namespace}: {e}")
+            logger.error("Error getting Job %s in %s: %s", name, namespace, e)
             raise
 
     def list_jobs(self, namespace: str, label_selector: Optional[str] = None) -> List[dict]:
@@ -645,7 +666,7 @@ class KubernetesService:
             )
             return [item.to_dict() for item in result.items]
         except ApiException as e:
-            logger.error(f"Error listing Jobs in {namespace}: {e}")
+            logger.error("Error listing Jobs in %s: %s", namespace, e)
             raise
 
     def delete_job(self, namespace: str, name: str) -> None:
@@ -658,7 +679,7 @@ class KubernetesService:
                 propagation_policy="Background",
             )
         except ApiException as e:
-            logger.error(f"Error deleting Job {name} in {namespace}: {e}")
+            logger.error("Error deleting Job %s in %s: %s", name, namespace, e)
             raise
 
 

--- a/kagenti/backend/app/services/session_db.py
+++ b/kagenti/backend/app/services/session_db.py
@@ -23,6 +23,13 @@ import asyncpg
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
 # ---------------------------------------------------------------------------
 # Module-level pool cache
 # ---------------------------------------------------------------------------
@@ -93,7 +100,7 @@ def _dsn_for_namespace(namespace: str) -> str:
 
 def _convention_dsn(namespace: str) -> str:
     """Convention-based DSN when no secret is available."""
-    logger.warning("Using convention-based DB fallback for namespace=%s", namespace)
+    logger.warning("Using convention-based DB fallback for namespace=%s", _safe_log(namespace))
     return f"postgresql://kagenti:kagenti@postgres-sessions.{namespace}:5432/sessions"
 
 
@@ -150,11 +157,11 @@ async def get_session_pool(namespace: str) -> asyncpg.Pool:
         if not pool._closed:
             return pool
         # Pool was closed externally — recreate
-        logger.warning("DB pool for namespace=%s was closed — recreating", namespace)
+        logger.warning("DB pool for namespace=%s was closed — recreating", _safe_log(namespace))
         del _pool_cache[namespace]
 
     dsn = _dsn_for_namespace(namespace)
-    logger.info("Creating session DB pool for namespace=%s", namespace)
+    logger.info("Creating session DB pool for namespace=%s", _safe_log(namespace))
     pool = await _create_pool(dsn)
     await _ensure_sessions_schema(pool)
     _pool_cache[namespace] = pool

--- a/kagenti/backend/app/services/shipwright.py
+++ b/kagenti/backend/app/services/shipwright.py
@@ -328,7 +328,7 @@ def extract_resource_config_from_build(
         config_dict = json.loads(config_json)
         return ResourceConfigFromBuild(**config_dict)
     except (json.JSONDecodeError, ValueError) as e:
-        logger.warning(f"Failed to parse resource config from annotation: {e}")
+        logger.warning("Failed to parse resource config from annotation: %s", e)
         return None
 
 

--- a/kagenti/backend/app/services/sidecar_manager.py
+++ b/kagenti/backend/app/services/sidecar_manager.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _safe_log(value: object) -> str:
+    """Sanitize user input for logging (CWE-117 log injection prevention)."""
+    s = str(value) if not isinstance(value, str) else value
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\x00", "")
+
+
 class SidecarType(str, Enum):
     LOOPER = "looper"
     HALLUCINATION_OBSERVER = "hallucination_observer"
@@ -222,13 +228,13 @@ class SidecarManager:
                     )
                     logger.debug(
                         "Persisted sidecar state for session %s (%d sidecars)",
-                        parent_context_id[:12],
+                        _safe_log(parent_context_id[:12]),
                         len(state_to_persist),
                     )
         except Exception:
             logger.warning(
                 "Failed to persist sidecar state for session %s",
-                parent_context_id[:12],
+                _safe_log(parent_context_id[:12]),
                 exc_info=True,
             )
 
@@ -273,8 +279,8 @@ class SidecarManager:
                     except (ValueError, KeyError) as e:
                         logger.warning(
                             "Failed to restore sidecar %s for session %s: %s",
-                            _type_str,
-                            parent_context_id[:12],
+                            _safe_log(_type_str),
+                            _safe_log(parent_context_id[:12]),
                             e,
                         )
 
@@ -283,12 +289,12 @@ class SidecarManager:
                     logger.info(
                         "Restored %d sidecars from DB for session %s",
                         restored_count,
-                        parent_context_id[:12],
+                        _safe_log(parent_context_id[:12]),
                     )
         except Exception:
             logger.warning(
                 "Failed to restore sidecars for session %s",
-                parent_context_id[:12],
+                _safe_log(parent_context_id[:12]),
                 exc_info=True,
             )
 
@@ -372,8 +378,8 @@ class SidecarManager:
         session_sidecars[sidecar_type] = handle
         logger.info(
             "Enabled sidecar %s for session %s",
-            sidecar_type.value,
-            parent_context_id[:12],
+            _safe_log(sidecar_type.value),
+            _safe_log(parent_context_id[:12]),
         )
         await self._persist_sidecar_state(parent_context_id)
         return handle
@@ -400,8 +406,8 @@ class SidecarManager:
         handle.task = None
         logger.info(
             "Disabled sidecar %s for session %s",
-            sidecar_type.value,
-            parent_context_id[:12],
+            _safe_log(sidecar_type.value),
+            _safe_log(parent_context_id[:12]),
         )
         await self._persist_sidecar_state(parent_context_id)
 
@@ -423,9 +429,9 @@ class SidecarManager:
 
         logger.info(
             "Updated config for sidecar %s session %s: %s",
-            sidecar_type.value,
-            parent_context_id[:12],
-            config,
+            _safe_log(sidecar_type.value),
+            _safe_log(parent_context_id[:12]),
+            _safe_log(config),
         )
         await self._persist_sidecar_state(parent_context_id)
         return handle
@@ -471,8 +477,8 @@ class SidecarManager:
                 # TODO: inject corrective message into parent session via A2A
                 logger.info(
                     "Approved intervention %s from %s",
-                    msg_id,
-                    sidecar_type.value,
+                    _safe_log(msg_id),
+                    _safe_log(sidecar_type.value),
                 )
                 return approved
         return None
@@ -493,8 +499,8 @@ class SidecarManager:
                 denied = handle.pending_interventions.pop(i)
                 logger.info(
                     "Denied intervention %s from %s",
-                    msg_id,
-                    sidecar_type.value,
+                    _safe_log(msg_id),
+                    _safe_log(sidecar_type.value),
                 )
                 return denied
         return None

--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -38,7 +38,7 @@ def detect_platform(kube: KubernetesService) -> str:
             )
 
         groups = api_response.get("groups", [])
-        logger.debug(f"Available API groups: {[g.get('name') for g in groups]}")
+        logger.debug("Available API groups: %s", [g.get("name") for g in groups])
 
         for group in groups:
             if group.get("name") == "route.openshift.io":
@@ -48,7 +48,7 @@ def detect_platform(kube: KubernetesService) -> str:
         logger.info("Detected Kubernetes platform (no route.openshift.io API)")
         return "kubernetes"
     except Exception as e:
-        logger.warning(f"Error detecting platform: {e}, defaulting to kubernetes")
+        logger.warning("Error detecting platform: %s, defaulting to kubernetes", e)
         return "kubernetes"
 
 
@@ -115,13 +115,13 @@ def create_httproute(
             body=httproute_manifest,
         )
         logger.info(
-            f"Created HTTPRoute '{name}' in namespace '{namespace}' with hostname '{hostname}'"
+            "Created HTTPRoute '%s' in namespace '%s' with hostname '%s'", name, namespace, hostname
         )
     except ApiException as e:
         if e.status == 409:
-            logger.warning(f"HTTPRoute '{name}' already exists in namespace '{namespace}'")
+            logger.warning("HTTPRoute '%s' already exists in namespace '%s'", name, namespace)
         else:
-            logger.error(f"Failed to create HTTPRoute: {e}")
+            logger.error("Failed to create HTTPRoute: %s", e)
             raise
 
 
@@ -177,12 +177,12 @@ def create_openshift_route(
             plural="routes",
             body=route_manifest,
         )
-        logger.info(f"Created OpenShift Route '{name}' in namespace '{namespace}'")
+        logger.info("Created OpenShift Route '%s' in namespace '%s'", name, namespace)
     except ApiException as e:
         if e.status == 409:
-            logger.warning(f"Route '{name}' already exists in namespace '{namespace}'")
+            logger.warning("Route '%s' already exists in namespace '%s'", name, namespace)
         else:
-            logger.error(f"Failed to create Route: {e}")
+            logger.error("Failed to create Route: %s", e)
             raise
 
 
@@ -229,10 +229,10 @@ def route_exists(
         if e.status == 404:
             return False
         # For other errors, log and return False
-        logger.warning(f"Error checking route existence: {e}")
+        logger.warning("Error checking route existence: %s", e)
         return False
     except Exception as e:
-        logger.warning(f"Unexpected error checking route existence: {e}")
+        logger.warning("Unexpected error checking route existence: %s", e)
         return False
 
 
@@ -256,12 +256,15 @@ def create_route_for_agent_or_tool(
         service_port: Port of the backend service
     """
     logger.info(
-        f"Creating route for {name} in namespace {namespace}, "
-        f"service={service_name}, port={service_port}"
+        "Creating route for %s in namespace %s, service=%s, port=%s",
+        name,
+        namespace,
+        service_name,
+        service_port,
     )
 
     platform = detect_platform(kube)
-    logger.info(f"Detected platform: {platform}")
+    logger.info("Detected platform: %s", platform)
 
     if platform == "openshift":
         create_openshift_route(kube, name, namespace, service_name, service_port)


### PR DESCRIPTION
## Summary
- Add the 10 backend route files that were missing from #982
- sandbox.py, sandbox_deploy.py, sandbox_files.py, sandbox_trigger.py
- sidecar.py, token_usage.py, events.py
- integrations.py, models.py, llm_keys.py
- All routes behind feature flags (disabled by default)
- Cherry-picked from stream1-sandbox-agent

Continues #982 which was merged with only chat.py changes.

## Test plan
- [ ] Backend starts with feature flags enabled
- [ ] Routes accessible at /api/v1/sandbox/*, /api/v1/integrations/*, etc.
- [ ] Routes return 404 when feature flags disabled
- [ ] Tested on HyperShift cluster with full E2E suite (PR #1232)

🤖 Generated with [Claude Code](https://claude.com/claude-code)