### PR TITLE
build(deps): bump python base image digest across all Dockerfiles

### DIFF
--- a/kagenti/auth/agent-oauth-secret/Dockerfile
+++ b/kagenti/auth/agent-oauth-secret/Dockerfile
@@ -1,7 +1,7 @@
 # This file has been modified with the assistance of Bob
 
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
+FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/api-oauth-secret/Dockerfile
+++ b/kagenti/auth/api-oauth-secret/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
+FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/mlflow-oauth-secret/Dockerfile
+++ b/kagenti/auth/mlflow-oauth-secret/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
+FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/ui-oauth-secret/Dockerfile
+++ b/kagenti/auth/ui-oauth-secret/Dockerfile
@@ -1,7 +1,7 @@
 # This file has been modified with the assistance of Bob
 
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
+FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/backend/Dockerfile
+++ b/kagenti/backend/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 # Stage 1: Build stage with uv
-FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca AS builder
+FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa AS builder
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ RUN uv venv /app/.venv && \
     uv pip install --no-cache .
 
 # Stage 2: Runtime stage
-FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
+FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Updates `python:3.14-slim` digest from `fb83750` to `bc389f7` in all 5 Dockerfiles
- Bundles identical Dependabot PRs #1203, #1205, #1206, #1207, #1208 into a single atomic update

## Files changed

| Dockerfile | Component |
|------------|-----------|
| `kagenti/backend/Dockerfile` | Backend (2 FROM lines) |
| `kagenti/auth/ui-oauth-secret/Dockerfile` | UI OAuth secret |
| `kagenti/auth/agent-oauth-secret/Dockerfile` | Agent OAuth secret |
| `kagenti/auth/api-oauth-secret/Dockerfile` | API OAuth secret |
| `kagenti/auth/mlflow-oauth-secret/Dockerfile` | MLflow OAuth secret |

## Supersedes

Once merged, close the following individual Dependabot PRs:
- #1203
- #1205
- #1206
- #1207
- #1208

## Test plan

- [x] CI passes on this PR
- [x] Container images build successfully

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>