### PR TITLE
build(deps-dev): bump test toolchain minor versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
 test = [
     # Testing framework
     "pytest>=7.4.0",
-    "pytest-cov>=6.0.0",
+    "pytest-cov>=7.1.0",
     "pytest-timeout>=2.1.0",
-    "pytest-xdist>=3.3.0",  # For parallel test execution
+    "pytest-xdist>=3.8.0",  # For parallel test execution
     "pytest-asyncio>=0.21.0",  # For async test support
 
     # Kubernetes client
@@ -38,7 +38,7 @@ test = [
     "pyasn1>=0.6.3",  # Minimum version for CVE-2026-23490, CVE-2026-30922 fixes
 
     # HTTP requests
-    "requests>=2.31.0",
+    "requests>=2.33.1",
     "httpx>=0.24.0",  # For A2A client
 
     # A2A protocol client


### PR DESCRIPTION
## Summary

- Bumps pytest-cov >=6.0.0 → >=7.1.0
- Bumps pytest-xdist >=3.3.0 → >=3.8.0
- Bumps requests >=2.31.0 → >=2.33.1

All are dev-only test dependencies with no known breaking changes.

## Supersedes

Once merged, close the following individual Dependabot PRs:
- #1217 (pytest-xdist)
- #1212 (pytest-cov)
- #1209 (requests)

## Test plan

- [ ] CI passes
- [ ] E2E test suite runs without regressions

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>