### PR TITLE
🐛 bug: fix TypeError crash on null Kubernetes status conditions

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -363,7 +363,7 @@ def _is_deployment_ready(resource_data: dict) -> str:
     Also maintains backward compatibility with Agent CRD status format.
     """
     status = resource_data.get("status", {})
-    conditions = status.get("conditions", [])
+    conditions = status.get("conditions") or []
 
     # Check for Kubernetes Deployment conditions (type=Available)
     for condition in conditions:
@@ -647,7 +647,7 @@ async def list_agents(
 
                     # Determine status from Agent CRD
                     agent_status = "Not Ready"
-                    for cond in status.get("conditions", []):
+                    for cond in status.get("conditions") or []:
                         if cond.get("type") == "Ready" and cond.get("status") == "True":
                             agent_status = "Ready"
                             break
@@ -1024,7 +1024,7 @@ async def list_migratable_agents(
         # Determine status
         status = agent.get("status", {})
         agent_status = "Unknown"
-        for cond in status.get("conditions", []):
+        for cond in status.get("conditions") or []:
             if cond.get("type") == "Ready":
                 agent_status = "Ready" if cond.get("status") == "True" else "Not Ready"
                 break
@@ -1669,7 +1669,7 @@ async def get_shipwright_buildrun_status(
 
         # Extract conditions
         conditions = []
-        for cond in status.get("conditions", []):
+        for cond in status.get("conditions") or []:
             conditions.append(
                 BuildStatusCondition(
                     type=cond.get("type", ""),
@@ -2909,7 +2909,7 @@ async def finalize_shipwright_build(
         buildrun_status = latest_buildrun.get("status", {})
 
         # Check if build succeeded
-        conditions = buildrun_status.get("conditions", [])
+        conditions = buildrun_status.get("conditions") or []
         build_succeeded = False
         failure_message = None
         for cond in conditions:

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -410,7 +410,7 @@ def _get_workload_status(workload: dict) -> str:
     available_replicas = status.get("available_replicas") or status.get("availableReplicas", 0)
 
     # Check conditions for more detail
-    conditions = status.get("conditions", [])
+    conditions = status.get("conditions") or []
     for condition in conditions:
         cond_type = condition.get("type", "")
         cond_status = condition.get("status", "")

--- a/kagenti/backend/app/services/shipwright.py
+++ b/kagenti/backend/app/services/shipwright.py
@@ -368,7 +368,7 @@ def extract_buildrun_info(
     """
     metadata = buildrun.get("metadata", {})
     status = buildrun.get("status", {})
-    conditions = status.get("conditions", [])
+    conditions = status.get("conditions") or []
 
     # Parse phase
     phase, failure_message = parse_buildrun_phase(conditions)
@@ -397,7 +397,7 @@ def is_build_succeeded(buildrun: Dict[str, Any]) -> bool:
     Returns:
         True if the build succeeded, False otherwise
     """
-    conditions = buildrun.get("status", {}).get("conditions", [])
+    conditions = buildrun.get("status", {}).get("conditions") or []
     phase, _ = parse_buildrun_phase(conditions)
     return phase == "Succeeded"
 

--- a/kagenti/backend/tests/test_null_conditions.py
+++ b/kagenti/backend/tests/test_null_conditions.py
@@ -1,0 +1,91 @@
+"""
+Tests for handling null conditions in Kubernetes status responses.
+
+Kubernetes resources that haven't fully reconciled can have
+`status.conditions: null` rather than an empty list or a missing key.
+This caused TypeError crashes when iterating over conditions.
+
+See: https://github.com/kagenti/kagenti/pull/1241
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.routers.tools import _get_workload_status  # noqa: E402
+from app.routers.agents import _is_deployment_ready  # noqa: E402
+
+
+class TestNullConditionsHandling:
+    """Verify status functions don't crash when conditions is None."""
+
+    def test_tool_workload_status_with_null_conditions(self):
+        """_get_workload_status should not crash when conditions is null."""
+        workload = {
+            "spec": {"replicas": 1},
+            "status": {
+                "readyReplicas": 0,
+                "availableReplicas": 0,
+                "conditions": None,
+            },
+        }
+        result = _get_workload_status(workload)
+        assert result == "Not Ready"
+
+    def test_tool_workload_status_with_missing_conditions(self):
+        """_get_workload_status should handle missing conditions key."""
+        workload = {
+            "spec": {"replicas": 1},
+            "status": {
+                "readyReplicas": 0,
+                "availableReplicas": 0,
+            },
+        }
+        result = _get_workload_status(workload)
+        assert result == "Not Ready"
+
+    def test_tool_workload_status_with_empty_conditions(self):
+        """_get_workload_status should handle empty conditions list."""
+        workload = {
+            "spec": {"replicas": 1},
+            "status": {
+                "readyReplicas": 0,
+                "availableReplicas": 0,
+                "conditions": [],
+            },
+        }
+        result = _get_workload_status(workload)
+        assert result == "Not Ready"
+
+    def test_tool_workload_status_ready_with_null_conditions(self):
+        """Ready workload should still return Ready even with null conditions."""
+        workload = {
+            "spec": {"replicas": 1},
+            "status": {
+                "readyReplicas": 1,
+                "availableReplicas": 1,
+                "conditions": None,
+            },
+        }
+        result = _get_workload_status(workload)
+        assert result == "Ready"
+
+    def test_agent_deployment_ready_with_null_conditions(self):
+        """_is_deployment_ready should not crash when conditions is null."""
+        resource = {
+            "spec": {"replicas": 1},
+            "status": {
+                "readyReplicas": 0,
+                "availableReplicas": 0,
+                "conditions": None,
+            },
+        }
+        result = _is_deployment_ready(resource)
+        assert result == "Not Ready"
+
+    def test_agent_deployment_ready_with_missing_status(self):
+        """_is_deployment_ready should handle completely missing status."""
+        resource = {"spec": {"replicas": 1}}
+        result = _is_deployment_ready(resource)
+        assert result == "Not Ready"

--- a/kagenti/backend/tests/test_tool_workloads.py
+++ b/kagenti/backend/tests/test_tool_workloads.py
@@ -656,7 +656,7 @@ def _get_deployment_status(deployment: dict) -> str:
     if available_replicas > 0 and ready_replicas > 0:
         return "Ready"
 
-    conditions = status.get("conditions", [])
+    conditions = status.get("conditions") or []
     for condition in conditions:
         if condition.get("type") == "Progressing" and condition.get("status") == "True":
             reason = condition.get("reason", "")


### PR DESCRIPTION
## Summary

- Fix `TypeError: 'NoneType' object is not iterable` crash when listing tools or agents whose Kubernetes resources have `status.conditions: null`
- Replace `.get("conditions", [])` with `.get("conditions") or []` across all status-parsing code paths
- Affects `routers/tools.py`, `routers/agents.py`, and `services/shipwright.py` (8 occurrences total)

## Root cause

`dict.get(key, default)` only returns the default when the key is **missing**. Kubernetes resources that haven't fully reconciled have `conditions: null` in their status — the key exists with value `None`. Iterating over `None` raises `TypeError`.

## Test plan

- [ ] Deploy agents/tools to a fresh cluster and verify the catalog pages load without 500 errors
- [ ] Verify agents/tools in various states (Ready, Progressing, Not Ready) render correctly
- [ ] Confirm Shipwright build status parsing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)