### PR TITLE
Fix: Add MLflow to dashboard

### DIFF
--- a/charts/kagenti/templates/ui-routes-job.yaml
+++ b/charts/kagenti/templates/ui-routes-job.yaml
@@ -112,6 +112,9 @@ data:
       {{- if .Values.components.phoenix.enabled }}
       "kagenti-system,phoenix,true,TRACES_DASHBOARD_URL"
       {{- end }}
+      {{- if .Values.components.mlflow.enabled }}
+      "kagenti-system,mlflow,true,MLFLOW_DASHBOARD_URL"
+      {{- end }}
       "kagenti-system,kagenti-api,true,API_URL"
       "istio-system,kiali,true,NETWORK_TRAFFIC_DASHBOARD_URL"
       "keycloak,keycloak,true,KEYCLOAK_CONSOLE_URL"

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -17,6 +17,11 @@ data:
   {{- else }}
   TRACES_DASHBOARD_URL: ""
   {{- end }}
+  {{- if .Values.components.mlflow.enabled }}
+  MLFLOW_DASHBOARD_URL: "http://mlflow.{{ .Values.ui.domainName }}:8080"
+  {{- else }}
+  MLFLOW_DASHBOARD_URL: ""
+  {{- end }}
   NETWORK_TRAFFIC_DASHBOARD_URL: "http://kiali.{{ .Values.ui.domainName }}:8080"
   MCP_INSPECTOR_URL: "http://mcp-inspector.{{ .Values.ui.domainName }}:8080"
   MCP_PROXY_FULL_ADDRESS: "http://mcp-proxy.{{ .Values.ui.domainName }}:8080"
@@ -136,6 +141,12 @@ spec:
                   name: "{{ .Values.ui.configmap }}"
                   key: "NETWORK_TRAFFIC_DASHBOARD_URL"
                   optional: {{ (not .Values.openshift) }}
+            - name: MLFLOW_DASHBOARD_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ .Values.ui.configmap }}"
+                  key: "MLFLOW_DASHBOARD_URL"
+                  optional: true
             - name: MCP_INSPECTOR_URL
               valueFrom:
                 configMapKeyRef:

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -27,6 +27,8 @@ components:
     enabled: true
   phoenix:
     enabled: false
+  mlflow:
+    enabled: false
 
 # Secrets — override via a .secrets.yaml file or --set secrets.<key>=<value>.
 # githubUser/githubToken are optional: only needed to deploy agents/tools from

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     # External service URLs (read from ConfigMap via environment variables)
     traces_dashboard_url: str = ""
     network_dashboard_url: str = ""
+    mlflow_dashboard_url: str = ""
     mcp_inspector_url: str = ""
     mcp_proxy_full_address: str = ""
     keycloak_console_url: str = ""

--- a/kagenti/backend/app/models/responses.py
+++ b/kagenti/backend/app/models/responses.py
@@ -71,6 +71,7 @@ class DashboardConfigResponse(BaseModel):
 
     traces: str
     network: str
+    mlflow: str
     mcpInspector: str
     mcpProxy: str
     keycloakConsole: str

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -56,6 +56,7 @@ async def get_dashboard_config() -> DashboardConfigResponse:
     return DashboardConfigResponse(
         traces=settings.traces_dashboard_url,
         network=settings.network_dashboard_url or f"http://kiali.{domain}:8080",
+        mlflow=settings.mlflow_dashboard_url or f"http://mlflow.{domain}:8080",
         mcpInspector=settings.mcp_inspector_url or f"http://mcp-inspector.{domain}:8080",
         mcpProxy=settings.mcp_proxy_full_address or f"http://mcp-proxy.{domain}:8080",
         keycloakConsole=(

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -56,7 +56,7 @@ async def get_dashboard_config() -> DashboardConfigResponse:
     return DashboardConfigResponse(
         traces=settings.traces_dashboard_url,
         network=settings.network_dashboard_url or f"http://kiali.{domain}:8080",
-        mlflow=settings.mlflow_dashboard_url or f"http://mlflow.{domain}:8080",
+        mlflow=settings.mlflow_dashboard_url,
         mcpInspector=settings.mcp_inspector_url or f"http://mcp-inspector.{domain}:8080",
         mcpProxy=settings.mcp_proxy_full_address or f"http://mcp-proxy.{domain}:8080",
         keycloakConsole=(

--- a/kagenti/backend/tests/test_dashboard_config.py
+++ b/kagenti/backend/tests/test_dashboard_config.py
@@ -36,6 +36,7 @@ class TestDashboardConfigPhoenixToggle:
             with patch("app.routers.config.settings") as mock_settings:
                 mock_settings.traces_dashboard_url = ""
                 mock_settings.network_dashboard_url = ""
+                mock_settings.mlflow_dashboard_url = ""
                 mock_settings.mcp_inspector_url = ""
                 mock_settings.mcp_proxy_full_address = ""
                 mock_settings.keycloak_console_url = ""
@@ -57,6 +58,7 @@ class TestDashboardConfigPhoenixToggle:
             with patch("app.routers.config.settings") as mock_settings:
                 mock_settings.traces_dashboard_url = phoenix_url
                 mock_settings.network_dashboard_url = ""
+                mock_settings.mlflow_dashboard_url = ""
                 mock_settings.mcp_inspector_url = ""
                 mock_settings.mcp_proxy_full_address = ""
                 mock_settings.keycloak_console_url = ""

--- a/kagenti/backend/tests/test_dashboard_config.py
+++ b/kagenti/backend/tests/test_dashboard_config.py
@@ -70,3 +70,24 @@ class TestDashboardConfigPhoenixToggle:
                 assert response.status_code == 200
                 data = response.json()
                 assert data["traces"] == phoenix_url
+
+    def test_mlflow_dashboard_url_non_empty(self, client):
+        """When MLFLOW_DASHBOARD_URL is set, it should be returned."""
+        mlflow_url = "http://mlflow.localtest.me:8080"
+        with patch("app.core.auth.settings") as mock_auth_settings:
+            mock_auth_settings.enable_auth = False
+            with patch("app.routers.config.settings") as mock_settings:
+                mock_settings.traces_dashboard_url = ""
+                mock_settings.network_dashboard_url = ""
+                mock_settings.mlflow_dashboard_url = mlflow_url
+                mock_settings.mcp_inspector_url = ""
+                mock_settings.mcp_proxy_full_address = ""
+                mock_settings.keycloak_console_url = ""
+                mock_settings.domain_name = "localtest.me"
+                mock_settings.effective_keycloak_url = "http://keycloak.localtest.me:8080"
+                mock_settings.effective_keycloak_realm = "kagenti"
+
+                response = client.get("/api/v1/config/dashboards")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["mlflow"] == mlflow_url

--- a/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
+++ b/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
@@ -161,16 +161,30 @@ export const ObservabilityPage: React.FC = () => {
           )}
         </Grid>
 
-        <Alert
-          variant="info"
-          title="Note"
-          isInline
-          style={{ marginTop: '24px' }}
-        >
-          Ensure that the observability tools ({tracesUrl ? 'Phoenix for traces, ' : ''}Kiali for
-          service mesh{mlflowUrl ? ', and MLflow for experiment tracking' : ''}) are properly
-          configured and accessible from your environment.
-        </Alert>
+        {(() => {
+          const tools = [
+            tracesUrl && 'Phoenix for traces',
+            'Kiali for service mesh',
+            mlflowUrl && 'MLflow for experiment tracking',
+          ].filter(Boolean) as string[];
+          const toolList =
+            tools.length <= 1
+              ? tools.join('')
+              : tools.length === 2
+              ? tools.join(' and ')
+              : `${tools.slice(0, -1).join(', ')}, and ${tools[tools.length - 1]}`;
+          return (
+            <Alert
+              variant="info"
+              title="Note"
+              isInline
+              style={{ marginTop: '24px' }}
+            >
+              Ensure that the observability tools ({toolList}) are properly
+              configured and accessible from your environment.
+            </Alert>
+          );
+        })()}
       </PageSection>
     </>
   );

--- a/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
+++ b/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
@@ -22,6 +22,7 @@ import {
   ChartLineIcon,
   NetworkIcon,
   ExternalLinkAltIcon,
+  CubesIcon,
 } from '@patternfly/react-icons';
 import { useQuery } from '@tanstack/react-query';
 
@@ -93,6 +94,7 @@ export const ObservabilityPage: React.FC = () => {
   // The backend provides fallback URLs if the ConfigMap values are not set
   const tracesUrl = dashboards?.traces || '';
   const networkUrl = dashboards?.network || '';
+  const mlflowUrl = dashboards?.mlflow || '';
 
   return (
     <>
@@ -141,6 +143,17 @@ export const ObservabilityPage: React.FC = () => {
               icon={<NetworkIcon />}
               url={networkUrl}
               buttonText="Open Kiali"
+              isLoading={isLoading}
+            />
+          </GridItem>
+
+          <GridItem md={6}>
+            <DashboardCard
+              title="MLflow"
+              description="Track experiments, model runs, and LLM traces with MLflow."
+              icon={<CubesIcon />}
+              url={mlflowUrl}
+              buttonText="Open MLflow"
               isLoading={isLoading}
             />
           </GridItem>

--- a/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
+++ b/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
@@ -147,16 +147,18 @@ export const ObservabilityPage: React.FC = () => {
             />
           </GridItem>
 
-          <GridItem md={6}>
-            <DashboardCard
-              title="MLflow"
-              description="Track experiments, model runs, and LLM traces with MLflow."
-              icon={<CubesIcon />}
-              url={mlflowUrl}
-              buttonText="Open MLflow"
-              isLoading={isLoading}
-            />
-          </GridItem>
+          {mlflowUrl && (
+            <GridItem md={6}>
+              <DashboardCard
+                title="MLflow"
+                description="Track experiments, model runs, and LLM traces with MLflow."
+                icon={<CubesIcon />}
+                url={mlflowUrl}
+                buttonText="Open MLflow"
+                isLoading={isLoading}
+              />
+            </GridItem>
+          )}
         </Grid>
 
         <Alert
@@ -165,9 +167,9 @@ export const ObservabilityPage: React.FC = () => {
           isInline
           style={{ marginTop: '24px' }}
         >
-          Ensure that the observability tools ({tracesUrl ? 'Phoenix for traces and ' : ''}Kiali for
-          service mesh) are properly configured and accessible from your
-          environment.
+          Ensure that the observability tools ({tracesUrl ? 'Phoenix for traces, ' : ''}Kiali for
+          service mesh{mlflowUrl ? ', and MLflow for experiment tracking' : ''}) are properly
+          configured and accessible from your environment.
         </Alert>
       </PageSection>
     </>

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -693,6 +693,7 @@ export const toolShipwrightService = {
 export interface DashboardConfig {
   traces: string;
   network: string;
+  mlflow: string;
   mcpInspector: string;
   mcpProxy: string;
   keycloakConsole: string;


### PR DESCRIPTION
## Summary

Resolves #1108 by adding a new card to the UI.

## (Optional) Testing Instructions

Install Kagenti with MLflow.  Visit the dashboard ( http://kagenti-ui.localtest.me:8080/observability ) and verify a UI panel and link appears.