### PR TITLE
fix: make DEFAULT_INTERNAL_REGISTRY configurable via env var

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -114,6 +114,10 @@ spec:
                   optional: true
             - name: ENABLE_AUTH
               value: "{{ .Values.ui.auth.enabled }}"
+            {{- if .Values.ui.backend.defaultRegistryUrl }}
+            - name: DEFAULT_REGISTRY_URL
+              value: {{ .Values.ui.backend.defaultRegistryUrl | quote }}
+            {{- end }}
             # Feature flags
             - name: KAGENTI_FEATURE_FLAG_SANDBOX
               value: "{{ .Values.featureFlags.sandbox }}"

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -84,6 +84,8 @@ ui:
   backend:
     image: ghcr.io/kagenti/kagenti/backend
     tag: latest
+    # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
+    defaultRegistryUrl: ""
     resources:
       limits:
         cpu: 250m

--- a/deployments/envs/ocp_minimal_values.yaml
+++ b/deployments/envs/ocp_minimal_values.yaml
@@ -100,6 +100,8 @@ charts:
       ui:
         auth:
           enabled: true
+        backend:
+          defaultRegistryUrl: "image-registry.openshift-image-registry.svc:5000"
       uiOAuthSecret:
         # for a OCP with self-signed certs for routes it should be true.
         # for a OCP with CA-signed certs for routes it should be false.

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -100,6 +100,8 @@ charts:
       ui:
         auth:
           enabled: true
+        backend:
+          defaultRegistryUrl: "image-registry.openshift-image-registry.svc:5000"
       uiOAuthSecret:
         # for a OCP with self-signed certs for routes it should be true.
         # for a OCP with CA-signed certs for routes it should be false.

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -57,6 +57,9 @@ class Settings(BaseSettings):
     shipwright_default_strategy: str = "buildah-insecure-push"  # Default for dev
     shipwright_default_timeout: str = "15m"
 
+    # Default registry for source-based builds (override via DEFAULT_REGISTRY_URL env var)
+    default_registry_url: str = "registry.cr-system.svc.cluster.local:5000"
+
     # Build reconciliation settings
     build_reconciliation_interval: int = 30  # seconds between reconciliation scans
     enable_build_reconciliation: bool = True  # enable/disable the reconciliation loop

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -113,8 +113,8 @@ SHIPWRIGHT_STRATEGY_INSECURE = "buildah-insecure-push"
 # For external registries with TLS (quay.io, ghcr.io, docker.io)
 SHIPWRIGHT_STRATEGY_SECURE = "buildah"
 
-# Default internal registry URL (for dev/kind clusters)
-DEFAULT_INTERNAL_REGISTRY = "registry.cr-system.svc.cluster.local:5000"
+# Default internal registry URL (configurable via DEFAULT_REGISTRY_URL env var)
+DEFAULT_INTERNAL_REGISTRY = settings.default_registry_url
 
 # Default resource limits
 DEFAULT_RESOURCE_LIMITS = {"cpu": "500m", "memory": "1Gi"}

--- a/kagenti/backend/tests/test_shipwright_shared.py
+++ b/kagenti/backend/tests/test_shipwright_shared.py
@@ -506,3 +506,33 @@ class TestExtractBuildRunInfo:
 
         assert info["phase"] == "Failed"
         assert info["failureMessage"] == "Build failed: Dockerfile not found"
+
+
+class TestDefaultRegistryUrlConfig:
+    """Tests for DEFAULT_INTERNAL_REGISTRY configurability via env var."""
+
+    def test_default_value_is_kind_registry(self):
+        """Default value should be the Kind dev registry."""
+        assert DEFAULT_INTERNAL_REGISTRY == "registry.cr-system.svc.cluster.local:5000"
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        """DEFAULT_REGISTRY_URL env var should override the default."""
+        monkeypatch.setenv(
+            "DEFAULT_REGISTRY_URL", "image-registry.openshift-image-registry.svc:5000"
+        )
+
+        from pydantic_settings import BaseSettings
+        from app.core.config import Settings
+
+        fresh_settings = Settings()
+        assert (
+            fresh_settings.default_registry_url
+            == "image-registry.openshift-image-registry.svc:5000"
+        )
+
+    def test_openshift_registry_is_internal(self):
+        """OpenShift internal registry should be detected as internal (svc.cluster.local absent but still in-cluster)."""
+        ocp_registry = "image-registry.openshift-image-registry.svc:5000"
+        # OpenShift registry doesn't contain svc.cluster.local, so it gets secure strategy
+        result = select_build_strategy(ocp_registry)
+        assert result == SHIPWRIGHT_STRATEGY_SECURE


### PR DESCRIPTION
## Summary

- Make `DEFAULT_INTERNAL_REGISTRY` configurable via `DEFAULT_REGISTRY_URL` environment variable (Pydantic Settings)
- Wire through Helm chart as `ui.backend.defaultRegistryUrl` with conditional env var injection
- Set OpenShift internal registry (`image-registry.openshift-image-registry.svc:5000`) in `ocp_values.yaml` and `ocp_minimal_values.yaml`

Closes #1242

## Changes

| File | Change |
|------|--------|
| `kagenti/backend/app/core/config.py` | Add `default_registry_url` setting with Kind default |
| `kagenti/backend/app/core/constants.py` | Use `settings.default_registry_url` instead of hardcoded value |
| `charts/kagenti/values.yaml` | Add `ui.backend.defaultRegistryUrl` (empty = use Python default) |
| `charts/kagenti/templates/ui.yaml` | Conditionally set `DEFAULT_REGISTRY_URL` env var |
| `deployments/envs/ocp_values.yaml` | Set OpenShift internal registry |
| `deployments/envs/ocp_minimal_values.yaml` | Set OpenShift internal registry |
| `kagenti/backend/tests/test_shipwright_shared.py` | Add 3 tests for configurable registry |

## Test plan

- [x] Existing unit tests pass (36/36 in `test_shipwright_shared.py`)
- [x] New tests verify: default value, env var override, OCP registry strategy selection
- [ ] Deploy to Kind cluster — verify source builds still use `registry.cr-system.svc.cluster.local:5000`
- [ ] Deploy to OpenShift — verify source builds use `image-registry.openshift-image-registry.svc:5000`

## Backward compatibility

No breaking changes. Without `DEFAULT_REGISTRY_URL` env var or Helm value, behavior is identical to before (Kind dev registry default).