### PR TITLE
fix: auto-install Ansible collections before playbook run

### DIFF
--- a/deployments/ansible/collections-reqs.yml
+++ b/deployments/ansible/collections-reqs.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: kubernetes.core
-    version: ">=2.4.0"
+    version: ">=6.3.0"

--- a/deployments/ansible/run-install.sh
+++ b/deployments/ansible/run-install.sh
@@ -266,6 +266,19 @@ fi
 # Enable task timing — shows duration of each task in the output
 export ANSIBLE_CALLBACKS_ENABLED=ansible.posix.profile_tasks
 
+# Ensure required Ansible collections are installed/upgraded before running the
+# playbook. This prevents stale user-level collections (e.g. ~/.ansible/collections)
+# from shadowing the versions needed by the installer. (fixes #856)
+COLLECTIONS_REQ="$SCRIPT_DIR/collections-reqs.yml"
+if [[ -f "$COLLECTIONS_REQ" ]]; then
+  echo "Ensuring required Ansible collections are up to date..."
+  if command -v uv >/dev/null 2>&1; then
+    uv run ansible-galaxy collection install -r "$COLLECTIONS_REQ" --upgrade
+  else
+    ansible-galaxy collection install -r "$COLLECTIONS_REQ" --upgrade
+  fi
+fi
+
 # Call ansible-playbook via the 'uv' wrapper when available so uv manages deps/venv.
 # Fall back to ansible-playbook if uv is not present.
 if command -v uv >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- **Pin `kubernetes.core >= 6.3.0`** in `collections-reqs.yml` — version 6.3.0 includes the upstream deprecation fix ([kubernetes.core#1070](https://github.com/ansible-collections/kubernetes.core/pull/1070))
- **Add automatic `ansible-galaxy collection install --upgrade`** to `run-install.sh` before running the playbook, so stale user-level collections (`~/.ansible/collections`) don't shadow the versions needed by the installer

## Root Cause

When `run-install.sh` runs `uv run ansible-playbook`, Ansible's collection discovery checks `~/.ansible/collections` (user dir) **before** the venv-bundled collections. Users with an older `kubernetes.core` (e.g. 6.2.0) installed there saw deprecation warnings from `ansible.module_utils._text` imports.

The `collections-reqs.yml` file existed but was only documented as a manual step in the README — the script never ran it automatically.

## Test plan

- [ ] Run `deployments/ansible/run-install.sh --env dev` on a fresh clone — no deprecation warnings
- [ ] Run with an older `kubernetes.core` in `~/.ansible/collections` — the `--upgrade` step replaces it automatically

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)