### PR TITLE
Fix broken links to kagenti-extensions authbridge paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,6 @@ pre-commit install --hook-type pre-commit --hook-type commit-msg
 - [Components](docs/components.md)
 - [AI Ops / Claude Code](docs/ai-ops/README.md)
 - [Demos](docs/demos/README.md)
-- [AuthBridge Demos](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/README.md) — Zero-trust agent demos (weather agent, github issue, webhook, multi-target) in kagenti-extensions
+- [AuthBridge Demos](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/README.md) — Zero-trust agent demos (weather agent, github issue, webhook, multi-target) in kagenti-extensions
 - [Skills and Patterns](docs/skills/README.md)
 - [Keycloak Patterns](docs/auth/keycloak-patterns.md)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ From the UI you can:
 - Test agents interactively
 - Monitor traces and network traffic
 
-To learn how to deploy agents and MCP tools, follow the **[Weather Agent Demo](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md)** — the recommended getting-started tutorial that walks you through deploying an agent and tool via the UI and chatting with it end-to-end. For more demos, see the [full demo list](./docs/demos/README.md).
+To learn how to deploy agents and MCP tools, follow the **[Weather Agent Demo](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md)** — the recommended getting-started tutorial that walks you through deploying an agent and tool via the UI and chatting with it end-to-end. For more demos, see the [full demo list](./docs/demos/README.md).
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This directory contains the official Kagenti project documentation.
 If you are new to Kagenti, we recommend the following flow to get started with a local Kind cluster. 
 
 1. [Installation Guide](./install.md): Step-by-step instructions to start a Kind cluster and install all prerequisite components
-2. [Quickstart Weather Agent](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md): Deploy your first agent with AuthBridge security.
+2. [Quickstart Weather Agent](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md): Deploy your first agent with AuthBridge security.
 
 Kagenti is built on existing open-source cloud-native technologies. 
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -436,7 +436,7 @@ kubectl get route kagenti-ui -n kagenti-system -o jsonpath='{.status.ingress[0].
 
 ## Identity & Auth Bridge
 
-**Repository**: [kagenti/kagenti-extensions/AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge)
+**Repository**: [kagenti/kagenti-extensions/AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)
 
 Kagenti provides a unified framework for identity and authorization in agentic systems, replacing static credentials with dynamic, short-lived tokens. We call this collection of assets **Auth Bridge**.
 
@@ -446,8 +446,8 @@ Kagenti provides a unified framework for identity and authorization in agentic s
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| **[Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge/client-registration)** | Automatic OAuth2/OIDC client provisioning using SPIFFE ID | `AuthBridge/client-registration` |
-| **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge/AuthProxy)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
+| **[Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/client-registration)** | Automatic OAuth2/OIDC client provisioning using SPIFFE ID | `AuthBridge/client-registration` |
+| **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
 | **[SPIRE](https://spiffe.io/docs/latest/spire-about/)** | Workload identity and attestation | External |
 | **[Keycloak](https://www.keycloak.org/)** | Identity provider and access management | External |
 
@@ -518,7 +518,7 @@ An Envoy-based sidecar that handles both **inbound JWT validation** and **outbou
 | Feature | Description |
 |---------|-------------|
 | **User Management** | Create and manage Kagenti users |
-| **Client Registration** | OAuth clients for agents and UI (e.g. automated Keycloak Client registration via [Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge/client-registration) component) |
+| **Client Registration** | OAuth clients for agents and UI (e.g. automated Keycloak Client registration via [Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/client-registration) component) |
 | **Token Exchange** | Exchange tokens between audiences ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) |
 | **SSO** | Single sign-on across Kagenti components |
 

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -8,9 +8,9 @@ Detailed overview of the identity concepts are covered in the [Kagenti Identity 
 
 Check the details for running various demos:
 
-- **AuthBridge Demos (with zero-trust security)** - [All AuthBridge demos](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/README.md) in kagenti-extensions, including:
-  - [Weather Agent](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md) — Getting-started demo with inbound JWT validation
-  - [GitHub Issue Agent](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/github-issue/demo.md) — Full demo with token exchange and scope-based access control ([demo recording](https://youtu.be/5SpTwERN2jU))
+- **AuthBridge Demos (with zero-trust security)** - [All AuthBridge demos](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/README.md) in kagenti-extensions, including:
+  - [Weather Agent](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md) — Getting-started demo with inbound JWT validation
+  - [GitHub Issue Agent](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/github-issue/demo.md) — Full demo with token exchange and scope-based access control ([demo recording](https://youtu.be/5SpTwERN2jU))
 - **Interactive online demo at KubeCon NA 2025**: [Tutorial: Build-a-Bot Workshop: Enabling Trusted Agents With SPIRE + MCP](https://red.ht/3WL5Loc)
 - **Identity & Auth Demo** - [Slack Authentication](./demo-slack-research-agent.md): Deploy an agent and MCP Server tool to talk to the Slack API
 - **Generic Agent Demo** - [Generic Agent](./demo-generic-agent.md): Deploy a generic agent and two MCP Server tools
@@ -22,9 +22,9 @@ Check the details for running various demos:
 
 Different demos showcase capabilities relevant to different personas:
 
-- **Agent Developers** → Start with the [Weather Agent with AuthBridge](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md) for framework basics with zero-trust security
+- **Agent Developers** → Start with the [Weather Agent with AuthBridge](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md) for framework basics with zero-trust security
 - **Tool Developers** → Try [Slack Authentication](./demo-slack-research-agent.md) for MCP integration
-- **Security Specialists** → Focus on the [GitHub Issue Agent with AuthBridge](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/github-issue/demo.md) for token exchange and scope-based access control
+- **Security Specialists** → Focus on the [GitHub Issue Agent with AuthBridge](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/github-issue/demo.md) for token exchange and scope-based access control
 - **Platform Operators** → All demos showcase operational aspects
 
 **👥 [Find Your Persona](../../PERSONAS_AND_ROLES.md#overview)** to understand which demo best matches your role.

--- a/docs/demos/demo-github-issue.md
+++ b/docs/demos/demo-github-issue.md
@@ -10,8 +10,8 @@ Choose your deployment method:
 
 | Guide | Description |
 |-------|-------------|
-| **[UI Deployment](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/github-issue/demo-ui.md)** | Import agent and tool via the Kagenti dashboard |
-| **[Manual Deployment](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/github-issue/demo-manual.md)** | Deploy everything via `kubectl` and YAML manifests |
+| **[UI Deployment](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/github-issue/demo-ui.md)** | Import agent and tool via the Kagenti dashboard |
+| **[Manual Deployment](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/github-issue/demo-manual.md)** | Deploy everything via `kubectl` and YAML manifests |
 
 ## Why It Moved
 
@@ -38,5 +38,5 @@ to create fine-grained PAT tokens:
 
 ## All Available Demos
 
-See the [AuthBridge Demos Index](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/README.md)
+See the [AuthBridge Demos Index](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/README.md)
 for a complete list of demos with a recommended learning path.

--- a/docs/demos/demo-weather-agent.md
+++ b/docs/demos/demo-weather-agent.md
@@ -6,7 +6,7 @@
 
 ## New Location
 
-**[Weather Agent Demo with AuthBridge](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md)**
+**[Weather Agent Demo with AuthBridge](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md)**
 — Deploy the Weather Agent via the Kagenti UI with automatic SPIFFE identity
 registration and inbound JWT validation.
 
@@ -27,5 +27,5 @@ not include AuthBridge security features. The new demo in `kagenti-extensions`:
 
 ## All Available Demos
 
-See the [AuthBridge Demos Index](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/README.md)
+See the [AuthBridge Demos Index](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/README.md)
 for a complete list of demos with a recommended learning path.

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -34,7 +34,7 @@ mcp-controller-666f8cf9bf-dcpbc      1/1     Running   0          30h
 
 ### Register Weather MCP Server
 
-The Weather Service Tool can be installed using the Kagenti UI [as usual](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md#step-3-import-the-weather-tool-via-kagenti-ui). Once it is
+The Weather Service Tool can be installed using the Kagenti UI [as usual](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-3-import-the-weather-tool-via-kagenti-ui). Once it is
 installed, to register it with the Gateway, create an [`HTTPRoute`](https://gateway-api.sigs.k8s.io/api-types/httproute/):
 
 ```
@@ -94,7 +94,7 @@ The `weather-service` deployment can be edited manually or patched via a command
 Once the Gateway implementation has stabilized, `MCP_URL` can be set to this
 value by default, so we do not need to set this environment variable for every
 agent. To check if the weather service is working, simply use the chatbot
-exposed by the Weather Service Agent to query for weather information. Instructions for chatting with the agent can be referred to [here](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md#step-7-chat-via-kagenti-ui).
+exposed by the Weather Service Agent to query for weather information. Instructions for chatting with the agent can be referred to [here](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-7-chat-via-kagenti-ui).
 
 ### Limitations
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -11,7 +11,7 @@ In practice, the Authorization Pattern within the Agentic Platform enables:
 ## 📚 Related Documentation
 
 - **[Kagenti Identity Overview](./2025-10.Kagenti-Identity.pdf)** - High-level architectural concepts
-- **[AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge)** - Complete end-to-end installation and demo with SPIFFE, Client Registration, and AuthProxy
+- **[AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** - Complete end-to-end installation and demo with SPIFFE, Client Registration, and AuthProxy
 - **[Token Exchange Deep Dive](../kagenti/examples/identity/token_exchange.md)** - Detailed OAuth2 token exchange flows
 - **[Client Registration Examples](../kagenti/examples/identity/keycloak_token_exchange/README.md)** - Practical integration examples
 - **[Personas and Roles](../PERSONAS_AND_ROLES.md#23-security-and-identity-specialist)** - Security and identity specialist persona
@@ -610,7 +610,7 @@ tool_response = requests.post(
 
 ## 🌉 AuthBridge Component
 
-The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge) provides a complete, hands-on implementation of Kagenti's identity and authorization patterns. It combines **Client Registration** and **AuthProxy** to demonstrate the full zero-trust authentication flow.
+The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete, hands-on implementation of Kagenti's identity and authorization patterns. It combines **Client Registration** and **AuthProxy** to demonstrate the full zero-trust authentication flow.
 
 ### What AuthBridge Demonstrates
 
@@ -677,7 +677,7 @@ The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/ma
 
 ### Installation and Hands-On Demo
 
-The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge) provides a complete end-to-end example:
+The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete end-to-end example:
 
 ```bash
 # Clone and deploy
@@ -692,15 +692,15 @@ curl -H "Authorization: Bearer $TOKEN" http://auth-target-service:8081/test
 # Returns: "authorized"
 ```
 
-For detailed installation and demo instructions please see the [AuthBridge Demo](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge)
+For detailed installation and demo instructions please see the [AuthBridge Demo](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)
 
 ### AuthBridge Documentation
 
 For complete documentation, see:
 
-- **[AuthBridge README](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge)** - Full demo instructions
-- **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge/AuthProxy)** - Token validation and exchange proxy
-- **[Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge/client-registration)** - Automatic Keycloak client registration
+- **[AuthBridge README](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** - Full demo instructions
+- **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** - Token validation and exchange proxy
+- **[Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/client-registration)** - Automatic Keycloak client registration
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -350,7 +350,7 @@ kubectl get secret keycloak-initial-admin -n keycloak \
 
 ## Keycloak Admin Credentials for Agent Namespaces
 
-The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/AuthBridge) stack (separate sidecars or a single [combined `authbridge` container](authbridge-combined-sidecar.md)) needs Keycloak admin credentials for automatic OAuth2 client registration. These credentials are stored in a Kubernetes Secret called `keycloak-admin-secret` in each agent namespace.
+The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) stack (separate sidecars or a single [combined `authbridge` container](authbridge-combined-sidecar.md)) needs Keycloak admin credentials for automatic OAuth2 client registration. These credentials are stored in a Kubernetes Secret called `keycloak-admin-secret` in each agent namespace.
 
 ### Automatic Provisioning
 

--- a/docs/new-tool.md
+++ b/docs/new-tool.md
@@ -268,4 +268,4 @@ This approach allows agents to access multiple tools through a single endpoint, 
 - [Importing a New Agent](./new-agent.md)
 - [MCP Gateway Instructions](./gateway.md)
 - [Components Overview](./components.md)
-- [Demo: Weather Agent and Tool](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/weather-agent/demo-ui.md)
+- [Demo: Weather Agent and Tool](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md)

--- a/kagenti/demo-setup/keycloak-config/github/README.md
+++ b/kagenti/demo-setup/keycloak-config/github/README.md
@@ -1,7 +1,7 @@
 # Keycloak Configuration for GitHub Issue Demo
 
 This script configures Keycloak for the
-[GitHub Issue Demo](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/github-issue/demo.md).
+[GitHub Issue Demo](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/github-issue/demo.md).
 Logging into Kagenti with accounts of different
 permissions affects the results those accounts receive.
 


### PR DESCRIPTION
## Summary
- Fix 29 broken cross-repo links across 12 documentation files after the kagenti-extensions repo refactored directory names (`AuthBridge` → `authbridge`, `AuthProxy` → `authproxy`)
- Affected files: README.md, CLAUDE.md, docs/README.md, docs/components.md, docs/demos/README.md, docs/demos/demo-github-issue.md, docs/demos/demo-weather-agent.md, docs/gateway.md, docs/identity-guide.md, docs/install.md, docs/new-tool.md, kagenti/demo-setup/keycloak-config/github/README.md

## Test plan
- [ ] Verify links resolve correctly on the PR diff view (GitHub renders markdown links)
- [ ] Spot-check a few links manually (e.g. [authbridge/demos/weather-agent/demo-ui.md](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md))

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>