### PR TITLE
Add authbridge-unified-config ConfigMap to agent namespaces

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -313,6 +313,46 @@ data:
                     address: 127.0.0.1
                     port_value: 9090
 ---
+# ——————————————————————————————————————————————————————————————————————————————
+#  ConfigMap for Unified AuthBridge in Namespace: {{ . }}
+#  YAML config for the authbridge-unified binary (cmd/authbridge).
+#  Used when the operator's UnifiedAuthBridge feature gate is enabled.
+#  The binary reads this at startup; credential files are loaded at runtime
+#  from /shared/ (written by client-registration sidecar).
+# ——————————————————————————————————————————————————————————————————————————————
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-unified-config
+  namespace: {{ . }}
+  labels:
+    {{- include "kagenti.labels" $root | nindent 4 }}
+data:
+  config.yaml: |
+    mode: envoy-sidecar
+    inbound:
+      issuer: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
+    outbound:
+      keycloak_url: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
+      keycloak_realm: {{ $root.Values.keycloak.realm | quote }}
+      default_policy: "passthrough"
+    identity:
+      # Map Helm clientAuthType to authbridge identity.type:
+      #   "client-secret"  → "client-secret" (traditional)
+      #   "federated-jwt"  → "spiffe" (SPIFFE JWT-SVID authentication)
+      type: {{ eq $root.Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" $root.Values.authBridge.clientAuthType | quote }}
+      client_id_file: "/shared/client-id.txt"
+      client_secret_file: "/shared/client-secret.txt"
+{{- if eq $root.Values.authBridge.clientAuthType "federated-jwt" }}
+      jwt_svid_path: "/opt/jwt_svid.token"
+{{- end }}
+    bypass:
+      inbound_paths:
+        - "/.well-known/*"
+        - "/healthz"
+        - "/readyz"
+        - "/livez"
+---
 {{- if $.Values.openshift }}
 # ——————————————————————————————————————————————————————————————————————————————
 #  SCC RoleBinding for Pipeline SA in Namespace: {{ . }}


### PR DESCRIPTION
## Summary

Adds `authbridge-unified-config` ConfigMap to each agent namespace in the Helm chart. This is the YAML config file consumed by the unified authbridge binary (`cmd/authbridge` in kagenti-extensions).

Key features:
- Derives `token_url`, `issuer`, and `jwks_url` from `keycloak_url` + `keycloak_realm` (no hardcoded URLs)
- Identity type follows `authBridge.clientAuthType` Helm value (`client-secret` or `federated-jwt`)
- `jwt_svid_path` only included when `federated-jwt` is configured
- Credential files loaded at runtime from `/shared/` (written by client-registration sidecar)
- Default mode: `envoy-sidecar` with `passthrough` outbound policy

The ConfigMap is inert until the kagenti-operator is updated to mount it (behind a feature gate). No behavioral change to existing deployments.

## Related

- kagenti-extensions `v0.5.0-alpha.1` — unified authbridge binary
- kagenti-extensions #279 — modular token exchange library design
- Next: kagenti-operator PR to add `UnifiedAuthBridge` feature gate

## Test plan

- [x] `helm template` renders correctly for both `client-secret` and `federated-jwt` auth types
- [x] ConfigMap created per namespace (team1, team2)
- [ ] CI passes

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
