### PR TITLE
⬆️ Upgrade operator to v0.2.0-alpha.26, swap to authbridge-unified

### DIFF
--- a/.github/scripts/common/87-setup-test-credentials.sh
+++ b/.github/scripts/common/87-setup-test-credentials.sh
@@ -216,6 +216,33 @@ E2E_CLIENT_SECRET=$(kc_api GET "$KEYCLOAK_URL/admin/realms/$REALM/clients/$CLIEN
 log_success "Service account client ready (client_id=$E2E_CLIENT_ID)"
 
 # ============================================================================
+# 4b. Attach agent audience scopes to the E2E test client
+#     Client-registration creates agent-*-aud scopes as realm defaults, but
+#     realm defaults don't retroactively apply to existing clients. We need
+#     to explicitly add them so the E2E test token contains the aud claim
+#     that AuthBridge requires for inbound JWT validation.
+# ============================================================================
+
+log_info "Attaching agent audience scopes to $E2E_CLIENT_ID..."
+REALM_DEFAULT_SCOPES=$(kc_api GET "$KEYCLOAK_URL/admin/realms/$REALM/default-default-client-scopes")
+AGENT_SCOPE_IDS=$(echo "$REALM_DEFAULT_SCOPES" | python3 -c "
+import sys, json
+scopes = json.load(sys.stdin)
+for s in scopes:
+    if s['name'].startswith('agent-') and s['name'].endswith('-aud'):
+        print(s['id'], s['name'])
+" 2>/dev/null || echo "")
+
+if [ -n "$AGENT_SCOPE_IDS" ]; then
+    while IFS=' ' read -r scope_id scope_name; do
+        kc_api PUT "$KEYCLOAK_URL/admin/realms/$REALM/clients/$CLIENT_INTERNAL_ID/default-client-scopes/$scope_id" >/dev/null
+        log_info "  Added scope '$scope_name' to $E2E_CLIENT_ID"
+    done <<< "$AGENT_SCOPE_IDS"
+else
+    log_info "  No agent audience scopes found (agents may not be deployed yet)"
+fi
+
+# ============================================================================
 # 5. Update kagenti-test-user secret with verified credentials
 # ============================================================================
 

--- a/.github/scripts/common/87-setup-test-credentials.sh
+++ b/.github/scripts/common/87-setup-test-credentials.sh
@@ -225,6 +225,8 @@ kubectl create secret generic kagenti-test-user \
     --from-literal=username="$TEST_USER" \
     --from-literal=password="$TEST_PASS" \
     --from-literal=realm="$REALM" \
+    --from-literal=client_id="$E2E_CLIENT_ID" \
+    --from-literal=client_secret="$E2E_CLIENT_SECRET" \
     --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1
 
 # ============================================================================

--- a/.github/scripts/common/99-collect-logs.sh
+++ b/.github/scripts/common/99-collect-logs.sh
@@ -34,6 +34,27 @@ echo "=== AuthBridge Unified ConfigMap ==="
 kubectl get configmap authbridge-unified-config -n team1 -o jsonpath='{.data.config\.yaml}' || true
 
 echo ""
+echo "=== Weather Service Pod Details (containers, labels, annotations) ==="
+WS_POD=$(kubectl get pod -n team1 -l app.kubernetes.io/name=weather-service --no-headers 2>/dev/null | head -1 | awk '{print $1}')
+if [ -n "$WS_POD" ]; then
+    echo "Containers:"
+    kubectl get pod "$WS_POD" -n team1 -o jsonpath='{range .spec.containers[*]}  {.name} ({.image}){"\n"}{end}' || true
+    echo "Init containers:"
+    kubectl get pod "$WS_POD" -n team1 -o jsonpath='{range .spec.initContainers[*]}  {.name} ({.image}){"\n"}{end}' || true
+    echo "Pod labels:"
+    kubectl get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.labels}' 2>/dev/null | python3 -m json.tool 2>/dev/null || kubectl get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.labels}' || true
+    echo ""
+    echo "Pod annotations:"
+    kubectl get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.annotations}' 2>/dev/null | python3 -m json.tool 2>/dev/null || kubectl get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.annotations}' || true
+else
+    echo "(weather-service pod not found)"
+fi
+
+echo ""
+echo "=== Kagenti Operator Logs (injection decisions, last 30 lines) ==="
+kubectl logs -n kagenti-system deployment/kagenti-controller-manager --tail=50 2>/dev/null | grep -E 'injection decision|inject|client-registration|credential|error|ERROR' | tail -30 || true
+
+echo ""
 echo "=== Shipwright Build Status ==="
 kubectl get builds -n team1 || true
 kubectl get buildruns -n team1 || true

--- a/.github/scripts/common/99-collect-logs.sh
+++ b/.github/scripts/common/99-collect-logs.sh
@@ -22,6 +22,18 @@ echo "=== Weather Service Logs ==="
 kubectl logs -n team1 deployment/weather-service --tail=50 --all-containers=true || true
 
 echo ""
+echo "=== Weather Service Envoy-Proxy Logs (last 50 lines) ==="
+kubectl logs -n team1 deployment/weather-service -c envoy-proxy --tail=50 || true
+
+echo ""
+echo "=== Weather Service Client-Registration Logs (last 30 lines) ==="
+kubectl logs -n team1 deployment/weather-service -c kagenti-client-registration --tail=30 || true
+
+echo ""
+echo "=== AuthBridge Unified ConfigMap ==="
+kubectl get configmap authbridge-unified-config -n team1 -o jsonpath='{.data.config\.yaml}' || true
+
+echo ""
 echo "=== Shipwright Build Status ==="
 kubectl get builds -n team1 || true
 kubectl get buildruns -n team1 || true

--- a/.github/scripts/hypershift/ci/85-collect-failure-info.sh
+++ b/.github/scripts/hypershift/ci/85-collect-failure-info.sh
@@ -105,6 +105,17 @@ if [ -n "${KUBECONFIG:-}" ] && [ -f "${KUBECONFIG:-}" ]; then
     oc get deployment weather-service -n team1 -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{.valueFrom.secretKeyRef.name}{"\n"}{end}' 2>/dev/null || echo "(not available)"
 
     echo ""
+    echo "=== SPIFFE IdP Setup Job Logs ==="
+    SPIFFE_POD=$(oc get pods -n kagenti-system -l app=kagenti-spiffe-idp-setup --no-headers 2>/dev/null | head -1 | awk '{print $1}')
+    if [ -n "$SPIFFE_POD" ]; then
+        oc logs "$SPIFFE_POD" -n kagenti-system -c setup-spiffe-idp --tail=50 2>/dev/null || echo "(logs not available)"
+        echo "Previous logs:"
+        oc logs "$SPIFFE_POD" -n kagenti-system -c setup-spiffe-idp --previous --tail=30 2>/dev/null || echo "(no previous logs)"
+    else
+        echo "(spiffe-idp-setup pod not found)"
+    fi
+
+    echo ""
     echo "=== Kagenti Operator Logs (injection decisions, last 50 lines) ==="
     oc logs -n kagenti-system deployment/kagenti-controller-manager --tail=50 2>/dev/null | grep -E 'injection decision|inject|client-registration|credential|error|ERROR' | tail -30 || echo "(not available)"
 

--- a/.github/scripts/hypershift/ci/85-collect-failure-info.sh
+++ b/.github/scripts/hypershift/ci/85-collect-failure-info.sh
@@ -84,8 +84,29 @@ if [ -n "${KUBECONFIG:-}" ] && [ -f "${KUBECONFIG:-}" ]; then
     oc get configmap authbridge-unified-config -n team1 -o jsonpath='{.data.config\.yaml}' 2>/dev/null || echo "(not found)"
 
     echo ""
+    echo "=== Weather Service Pod Details (containers, labels, annotations) ==="
+    WS_POD=$(oc get pod -n team1 -l app.kubernetes.io/name=weather-service --no-headers 2>/dev/null | head -1 | awk '{print $1}')
+    if [ -n "$WS_POD" ]; then
+        echo "Containers:"
+        oc get pod "$WS_POD" -n team1 -o jsonpath='{range .spec.containers[*]}  {.name} ({.image}){"\n"}{end}' 2>/dev/null
+        echo "Init containers:"
+        oc get pod "$WS_POD" -n team1 -o jsonpath='{range .spec.initContainers[*]}  {.name} ({.image}){"\n"}{end}' 2>/dev/null
+        echo "Pod labels:"
+        oc get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.labels}' 2>/dev/null | python3 -m json.tool 2>/dev/null || oc get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.labels}' 2>/dev/null
+        echo ""
+        echo "Pod annotations:"
+        oc get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.annotations}' 2>/dev/null | python3 -m json.tool 2>/dev/null || oc get pod "$WS_POD" -n team1 -o jsonpath='{.metadata.annotations}' 2>/dev/null
+    else
+        echo "(weather-service pod not found)"
+    fi
+
+    echo ""
     echo "=== Weather Service Agent Env Vars (LLM config) ==="
     oc get deployment weather-service -n team1 -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{.valueFrom.secretKeyRef.name}{"\n"}{end}' 2>/dev/null || echo "(not available)"
+
+    echo ""
+    echo "=== Kagenti Operator Logs (injection decisions, last 50 lines) ==="
+    oc logs -n kagenti-system deployment/kagenti-controller-manager --tail=50 2>/dev/null | grep -E 'injection decision|inject|client-registration|credential|error|ERROR' | tail -30 || echo "(not available)"
 
     echo ""
     echo "=== Weather Tool MCP Logs (last 30 lines) ==="

--- a/.github/scripts/hypershift/ci/85-collect-failure-info.sh
+++ b/.github/scripts/hypershift/ci/85-collect-failure-info.sh
@@ -72,6 +72,18 @@ if [ -n "${KUBECONFIG:-}" ] && [ -f "${KUBECONFIG:-}" ]; then
     oc logs -n team1 deployment/weather-service --tail=50 2>/dev/null || echo "(not available)"
 
     echo ""
+    echo "=== Weather Service Envoy-Proxy Logs (last 50 lines) ==="
+    oc logs -n team1 deployment/weather-service -c envoy-proxy --tail=50 2>/dev/null || echo "(not available)"
+
+    echo ""
+    echo "=== Weather Service Client-Registration Logs (last 30 lines) ==="
+    oc logs -n team1 deployment/weather-service -c kagenti-client-registration --tail=30 2>/dev/null || echo "(not available)"
+
+    echo ""
+    echo "=== AuthBridge Unified ConfigMap ==="
+    oc get configmap authbridge-unified-config -n team1 -o jsonpath='{.data.config\.yaml}' 2>/dev/null || echo "(not found)"
+
+    echo ""
     echo "=== Weather Service Agent Env Vars (LLM config) ==="
     oc get deployment weather-service -n team1 -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{.valueFrom.secretKeyRef.name}{"\n"}{end}' 2>/dev/null || echo "(not available)"
 

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "0.1.2"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-alpha.25
+  version: 0.2.0-alpha.26
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -226,7 +226,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-alpha.24
+        tag: 0.2.0-alpha.26
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -245,10 +245,10 @@ kagenti-operator-chart:
   # Pin sidecar image tags injected by the AuthBridge webhook.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.10
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.10
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.4.0-alpha.10
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.4.0-alpha.10
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-unified:v0.5.0-alpha.2
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.2
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.2
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.2
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -245,10 +245,10 @@ kagenti-operator-chart:
   # Pin sidecar image tags injected by the AuthBridge webhook.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-unified:v0.5.0-alpha.2
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.2
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.2
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.2
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-unified:v0.5.0-alpha.3
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.3
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.3
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.3
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1207,7 +1207,8 @@
   when: >
     charts['kagenti-deps']['enabled'] | default(false) and
     charts['kagenti-deps']['values']['components']['spire']['enabled'] | default(false) and
-    charts['kagenti-deps']['values']['components']['keycloak']['enabled'] | default(false)
+    charts['kagenti-deps']['values']['components']['keycloak']['enabled'] | default(false) and
+    (charts['kagenti'] | default({})).get('values', {}).get('authBridge', {}).get('clientAuthType', 'client-secret') == 'federated-jwt'
 
 #  RHOAI (Red Hat OpenShift AI) - wait for operator and create DataScienceCluster
 #  The operator subscription is created by the kagenti-deps Helm chart.

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1849,6 +1849,38 @@
         kagenti_openshift_overrides: "{{ kagenti_openshift_overrides | combine({'keycloak': {'publicUrl': 'https://' + keycloak_route_host.stdout}}, recursive=True) }}"
       when: keycloak_route_host.rc == 0 and keycloak_route_host.stdout | trim | length > 0
 
+    # Read the actual Keycloak master admin credentials on OpenShift.
+    # The RHBK operator creates keycloak-initial-admin with a random password.
+    # The Helm chart creates keycloak-admin-secret in agent namespaces for the
+    # client-registration sidecar. These must match — client-registration
+    # authenticates to the master realm to register OAuth clients.
+    - name: Read Keycloak initial admin username
+      command: >-
+        kubectl get secret {{ (charts['kagenti'] | default({})).get('values', {}).get('keycloak', {}).get('adminSecretName', 'keycloak-initial-admin') }}
+        -n {{ (charts['kagenti'] | default({})).get('values', {}).get('keycloak', {}).get('namespace', 'keycloak') }}
+        -o jsonpath='{.data.username}'
+      register: keycloak_admin_username_b64
+      failed_when: false
+      changed_when: false
+
+    - name: Read Keycloak initial admin password
+      command: >-
+        kubectl get secret {{ (charts['kagenti'] | default({})).get('values', {}).get('keycloak', {}).get('adminSecretName', 'keycloak-initial-admin') }}
+        -n {{ (charts['kagenti'] | default({})).get('values', {}).get('keycloak', {}).get('namespace', 'keycloak') }}
+        -o jsonpath='{.data.password}'
+      register: keycloak_admin_password_b64
+      failed_when: false
+      changed_when: false
+
+    - name: Override keycloak admin credentials from initial-admin secret
+      set_fact:
+        kagenti_openshift_overrides: "{{ kagenti_openshift_overrides | combine({'keycloak': {'adminUsername': (keycloak_admin_username_b64.stdout | b64decode), 'adminPassword': (keycloak_admin_password_b64.stdout | b64decode)}}, recursive=True) }}"
+      when:
+        - keycloak_admin_username_b64.rc == 0
+        - keycloak_admin_password_b64.rc == 0
+        - keycloak_admin_username_b64.stdout | trim | length > 0
+        - keycloak_admin_password_b64.stdout | trim | length > 0
+
     - name: Debug kagenti OpenShift overrides
       debug:
         msg: "Kagenti OpenShift overrides: {{ kagenti_openshift_overrides }}"

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1832,6 +1832,23 @@
         kagenti_openshift_overrides: "{{ kagenti_openshift_overrides | combine({'agentOAuthSecret': {'spiffePrefix': 'spiffe://' + ocp_trust_domain + '/sa'}}, recursive=True) }}"
       when: ocp_trust_domain is defined and ocp_trust_domain | trim | length > 0
 
+    # Discover Keycloak public URL from OpenShift Route.
+    # The authbridge-unified sidecar fetches JWKS at startup and validates JWT
+    # issuer claims, so keycloak.publicUrl must be the externally-reachable URL
+    # that matches the "iss" claim in tokens issued by Keycloak.
+    - name: Discover Keycloak Route host on OpenShift
+      command: >-
+        kubectl get route keycloak -n {{ (charts['kagenti'] | default({})).get('values', {}).get('keycloak', {}).get('namespace', 'keycloak') }}
+        -o jsonpath='{.spec.host}'
+      register: keycloak_route_host
+      failed_when: false
+      changed_when: false
+
+    - name: Override keycloak.publicUrl from discovered Route
+      set_fact:
+        kagenti_openshift_overrides: "{{ kagenti_openshift_overrides | combine({'keycloak': {'publicUrl': 'https://' + keycloak_route_host.stdout}}, recursive=True) }}"
+      when: keycloak_route_host.rc == 0 and keycloak_route_host.stdout | trim | length > 0
+
     - name: Debug kagenti OpenShift overrides
       debug:
         msg: "Kagenti OpenShift overrides: {{ kagenti_openshift_overrides }}"

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1207,8 +1207,7 @@
   when: >
     charts['kagenti-deps']['enabled'] | default(false) and
     charts['kagenti-deps']['values']['components']['spire']['enabled'] | default(false) and
-    charts['kagenti-deps']['values']['components']['keycloak']['enabled'] | default(false) and
-    (charts['kagenti'] | default({})).get('values', {}).get('authBridge', {}).get('clientAuthType', 'client-secret') == 'federated-jwt'
+    charts['kagenti-deps']['values']['components']['keycloak']['enabled'] | default(false)
 
 #  RHOAI (Red Hat OpenShift AI) - wait for operator and create DataScienceCluster
 #  The operator subscription is created by the kagenti-deps Helm chart.

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -29,6 +29,7 @@ spec:
         kagenti.io/type: agent
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
+        kagenti.io/client-registration-inject: "true"
         app.kubernetes.io/name: weather-service
     spec:
       serviceAccountName: weather-service

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -28,6 +28,7 @@ spec:
         kagenti.io/type: agent
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
+        kagenti.io/client-registration-inject: "true"
         app.kubernetes.io/name: weather-service
     spec:
       serviceAccountName: weather-service

--- a/kagenti/tests/conftest.py
+++ b/kagenti/tests/conftest.py
@@ -243,6 +243,27 @@ def keycloak_agent_token(k8s_client) -> Optional[str]:
     password = base64.b64decode(secret.data["password"]).decode("utf-8")
     realm = base64.b64decode(secret.data["realm"]).decode("utf-8")
 
+    # Use the confidential kagenti-e2e-tests client when available.
+    # This client inherits realm default scopes (including agent audience scopes
+    # created by client-registration), so the token will contain the aud claim
+    # that AuthBridge requires for inbound JWT validation.
+    # Falls back to admin-cli (public client) when client credentials are absent.
+    client_id = "admin-cli"
+    token_data: dict = {
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+    }
+    if "client_id" in secret.data and "client_secret" in secret.data:
+        client_id = base64.b64decode(secret.data["client_id"]).decode("utf-8")
+        client_secret = base64.b64decode(secret.data["client_secret"]).decode("utf-8")
+        token_data["client_id"] = client_id
+        token_data["client_secret"] = client_secret
+        print(f"\n[keycloak_agent_token] Using confidential client '{client_id}'")
+    else:
+        token_data["client_id"] = client_id
+        print(f"\n[keycloak_agent_token] Using public client '{client_id}' (no client credentials in secret)")
+
     keycloak_base_url = os.environ.get("KEYCLOAK_URL", "http://localhost:8081")
     token_url = f"{keycloak_base_url}/realms/{realm}/protocol/openid-connect/token"
     verify_ssl = _keycloak_ssl_verify()
@@ -250,12 +271,7 @@ def keycloak_agent_token(k8s_client) -> Optional[str]:
     try:
         response = requests.post(
             token_url,
-            data={
-                "grant_type": "password",
-                "client_id": "admin-cli",
-                "username": username,
-                "password": password,
-            },
+            data=token_data,
             timeout=10,
             verify=verify_ssl,
         )
@@ -263,7 +279,7 @@ def keycloak_agent_token(k8s_client) -> Optional[str]:
             token = response.json()["access_token"]
             print(
                 f"\n[keycloak_agent_token] Acquired token for realm={realm} "
-                f"user={username} (token length={len(token)})"
+                f"user={username} client={client_id} (token length={len(token)})"
             )
             return token
         print(

--- a/kagenti/tests/conftest.py
+++ b/kagenti/tests/conftest.py
@@ -262,7 +262,9 @@ def keycloak_agent_token(k8s_client) -> Optional[str]:
         print(f"\n[keycloak_agent_token] Using confidential client '{client_id}'")
     else:
         token_data["client_id"] = client_id
-        print(f"\n[keycloak_agent_token] Using public client '{client_id}' (no client credentials in secret)")
+        print(
+            f"\n[keycloak_agent_token] Using public client '{client_id}' (no client credentials in secret)"
+        )
 
     keycloak_base_url = os.environ.get("KEYCLOAK_URL", "http://localhost:8081")
     token_url = f"{keycloak_base_url}/realms/{realm}/protocol/openid-connect/token"


### PR DESCRIPTION
## Summary

- Bump kagenti-operator subchart from `0.2.0-alpha.25` → `0.2.0-alpha.26`
- Bump operator image tag from `0.2.0-alpha.24` → `0.2.0-alpha.26`
- Swap envoy-proxy sidecar from `envoy-with-processor` → `authbridge-unified` (unified binary: Envoy + authbridge in one container)
- Bump all authbridge extension images from `v0.4.0-alpha.10` → `v0.5.0-alpha.2`

## Dependencies

All merged and released:
- kagenti/kagenti-extensions#322 — fix multi-arch Envoy build
- kagenti/kagenti-operator#289 — operator authbridge-unified support
- #1254 — `authbridge-unified-config` ConfigMap in agent namespaces

## Test plan

- [ ] `helm template` renders correct image references
- [ ] Kind deploy with full platform — operator injects `authbridge-unified` sidecar
- [ ] Weather agent works from UI with token exchange
- [ ] Verify AMD64 Envoy binary runs correctly (no exit code 126)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>