### PR TITLE
🐛 Fix spiffe-idp-setup Dockerfile COPY paths for CI build context

### DIFF
--- a/kagenti/auth/spiffe-idp-setup/Dockerfile
+++ b/kagenti/auth/spiffe-idp-setup/Dockerfile
@@ -1,22 +1,22 @@
-# Dockerfile for SPIFFE Identity Provider Setup Job
-FROM python:3.12-slim
+# Use minimal Python base image
+FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
 
+# Set work directory
 WORKDIR /app
 
-# Copy requirements and install dependencies
-COPY requirements.txt .
+# Install dependencies from requirements.txt
+COPY auth/spiffe-idp-setup/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the setup script
-COPY setup_spiffe_idp.py .
+# Copy the script
+COPY auth/spiffe-idp-setup/setup_spiffe_idp.py .
 
-# Make script executable
-RUN chmod +x setup_spiffe_idp.py
-
-# Create non-root user and switch to it
-RUN useradd -r -u 1000 -s /bin/false appuser && \
+# Create non-root user for runtime security
+RUN useradd -u 1001 -m appuser && \
     chown -R appuser:appuser /app
-USER appuser
+
+# Switch to non-root user
+USER 1001
 
 # Run the setup script
 CMD ["python3", "setup_spiffe_idp.py"]


### PR DESCRIPTION
## Summary

- Fix `COPY` paths in `kagenti/auth/spiffe-idp-setup/Dockerfile` to use full paths relative to the `./kagenti` build context (matching all other auth image Dockerfiles)
- Bump base image to `python:3.14-slim` with SHA pin (matches sibling Dockerfiles)
- Use UID 1001 (matches sibling pattern)

## Root Cause

The Dockerfile used `COPY requirements.txt .` and `COPY setup_spiffe_idp.py .`, but the CI build context is `./kagenti` — the files are at `auth/spiffe-idp-setup/requirements.txt` relative to the context root. This caused every `main` push build to fail with:

```
ERROR: failed to calculate checksum: "/requirements.txt": not found
```

The `spiffe-idp-setup` image has **never been published** because of this. Worse, the failure cancels all sibling matrix jobs (backend, ui-v2, oauth-secret images).

## Test plan

- [x] Local build with CI-matching context: `docker build -f kagenti/auth/spiffe-idp-setup/Dockerfile kagenti/`
- [x] Smoke test: `docker run --rm <image> python3 -c "import keycloak; print('ok')"`
- [ ] CI Build-Publish workflow passes after merge

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>