### PR TITLE
fix: resolve spiffe-idp-setup-job crash-loop on HyperShift clusters

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -838,10 +838,13 @@
 
 #
 #  Patch SPIRE OIDC Discovery Provider ConfigMap
-#  WORKAROUND: The SPIRE helm chart (versions <=0.28.2) does not render the set_key_use
-#  configuration option into the ConfigMap, even though the SPIRE binary supports it.
+#  WORKAROUND: Neither the SPIRE helm chart (versions <=0.28.2) nor the ZTWIM operator (OCP 4.19+)
+#  configures the set_key_use option in the OIDC Discovery Provider ConfigMap.
 #  Keycloak's SPIFFE provider requires "use": "sig" field in JWKS keys.
 #  This task patches the ConfigMap post-install to add set_key_use: true.
+#
+#  NOTE: The SPIFFE IdP setup job (below) depends on this patch. If this block's
+#  `when` condition changes, verify the job condition still aligns. See issue #1267.
 #
 # Patch SPIRE OIDC ConfigMap with set_key_use (must run AFTER kagenti-deps installs SPIRE)
 - name: Patch SPIRE OIDC ConfigMap with set_key_use
@@ -898,34 +901,20 @@
             patched_oidc_config: "{{ spire_oidc_config | combine({'set_key_use': true}) }}"
 
         - name: Apply patched ConfigMap
-          kubernetes.core.k8s:
-            state: present
-            definition:
-              apiVersion: v1
-              kind: ConfigMap
-              metadata:
-                name: spire-spiffe-oidc-discovery-provider
-                namespace: "{{ charts.spire.server_namespace }}"
-                annotations:
-                  meta.helm.sh/release-name: spire
-                  meta.helm.sh/release-namespace: "{{ charts.spire.namespace }}"
-                labels:
-                  app.kubernetes.io/managed-by: Helm
-              data:
-                oidc-discovery-provider.conf: "{{ patched_oidc_config | to_json }}"
-                default.conf: "{{ spire_oidc_cm_data['default.conf'] }}"
-                spiffe-helper.conf: "{{ spire_oidc_cm_data['spiffe-helper.conf'] }}"
+          command: >
+            kubectl patch configmap spire-spiffe-oidc-discovery-provider
+            -n {{ charts.spire.server_namespace }}
+            --type merge
+            -p '{"data":{"oidc-discovery-provider.conf":{{ patched_oidc_config | to_json | to_json }}}}'
           register: oidc_cm_patch_result
 
         - name: Restart SPIRE OIDC Discovery Provider deployment
           command: kubectl rollout restart deployment/spire-spiffe-oidc-discovery-provider -n {{ charts.spire.server_namespace }}
-          when: oidc_cm_patch_result.changed
 
         - name: Wait for SPIRE OIDC Discovery Provider rollout
           command: >
             kubectl rollout status deployment/spire-spiffe-oidc-discovery-provider
             -n {{ charts.spire.server_namespace }} --timeout=2m
-          when: oidc_cm_patch_result.changed
           register: oidc_rollout_result
           retries: 3
           delay: 10
@@ -934,7 +923,6 @@
         - name: Log OIDC ConfigMap patch status
           debug:
             msg: "✅ SPIRE OIDC ConfigMap patched with set_key_use: true and deployment restarted"
-          when: oidc_cm_patch_result.changed
       when:
         - spire_oidc_config is defined
         - not (set_key_use_present | default(false) | bool)
@@ -958,9 +946,16 @@
         msg: "⚠️  Warning: spire-spiffe-oidc-discovery-provider ConfigMap not found. Skipping set_key_use patch."
       when: spire_oidc_cm_check.resources | length == 0
   when: >
-    (charts.spire.enabled | default(false)) and
-    (charts.spire.values['spiffe-oidc-discovery-provider'].enabled | default(true)) and
-    (not (enable_openshift | default(false)) or (use_spire_helm_chart | default(false)))
+    (
+      (charts.spire.enabled | default(false)) and
+      (charts.spire.values['spiffe-oidc-discovery-provider'].enabled | default(true)) and
+      (not (enable_openshift | default(false)) or (use_spire_helm_chart | default(false)))
+    ) or
+    (
+      (enable_openshift | default(false)) and
+      (not (use_spire_helm_chart | default(false))) and
+      (charts['kagenti-deps']['values']['components']['spire']['enabled'] | default(false))
+    )
 
 # Run SPIFFE IdP setup job AFTER set_key_use patch completes
 # This ensures the job doesn't fail due to missing "use" field in JWKS

--- a/kagenti/auth/spiffe-idp-setup/setup_spiffe_idp.py
+++ b/kagenti/auth/spiffe-idp-setup/setup_spiffe_idp.py
@@ -148,13 +148,24 @@ def wait_for_spire(max_attempts: int = 30, delay_seconds: int = 10) -> bool:
                     continue
 
                 # Check if keys have "use" field (required for Keycloak)
+                # Retry instead of failing immediately — the OIDC provider may
+                # still be reloading after a ConfigMap patch + rollout restart.
                 first_key = keys[0]
                 if "use" not in first_key:
-                    logger.error(f"  ❌ JWKS keys missing 'use' field!")
-                    logger.error(f"  SPIRE must be configured with set_key_use: true")
-                    logger.error(
-                        f"  Configure SPIRE OIDC provider with setKeyUse: true in Helm values"
+                    logger.warning(
+                        f"  JWKS keys missing 'use' field (attempt {attempt}/{max_attempts})"
                     )
+                    logger.warning(
+                        f"  SPIRE OIDC provider may still be reloading config"
+                    )
+                    if attempt < max_attempts:
+                        logger.info(f"  Retrying in {delay_seconds} seconds...")
+                        time.sleep(delay_seconds)
+                        continue
+                    logger.error(
+                        f"  ❌ JWKS keys still missing 'use' field after {max_attempts} attempts"
+                    )
+                    logger.error(f"  Ensure SPIRE is configured with set_key_use: true")
                     return False
 
                 logger.info(f"  ✅ SPIRE OIDC Discovery Provider is ready")

--- a/kagenti/tests/e2e/common/test_platform_health.py
+++ b/kagenti/tests/e2e/common/test_platform_health.py
@@ -76,6 +76,9 @@ class TestPlatformHealth:
         Checks that no pods are currently in a CrashLoopBackOff state
         or have recently restarted (within the last 5 minutes).
         Initial startup restarts are ignored.
+        Excludes Job pods since they use restartPolicy: OnFailure and
+        transient restarts are expected — test_all_jobs_completed checks
+        Job completion separately.
         """
         pods = k8s_client.list_pod_for_all_namespaces(watch=False)
 
@@ -84,6 +87,10 @@ class TestPlatformHealth:
         recent_restart_threshold = timedelta(minutes=5)
 
         for pod in pods.items:
+            # Skip Job pods — they restart on failure by design
+            if _is_job_pod(pod):
+                continue
+
             # Check if pod is in CrashLoopBackOff state
             if pod.status.container_statuses:
                 for container in pod.status.container_statuses:


### PR DESCRIPTION
## Summary

Fixes the `kagenti-spiffe-idp-setup-job` crash-loop on HyperShift/OCP clusters that blocks all HyperShift E2E testing.

**Root Cause**: Condition mismatch in the Ansible installer — the `set_key_use` ConfigMap patch (line 960) is gated on `charts.spire.enabled` (Helm SPIRE only), while the SPIFFE IdP setup job (line 1212) is gated on `charts.kagenti-deps.values.components.spire.enabled` (any SPIRE including ZTWIM). On HyperShift with ZTWIM, the patch is skipped but the job runs, finds JWKS keys without the `"use"` field, and crash-loops.

### Changes

1. **Ansible `set_key_use` patch** (`main.yml`): Extended the `when` condition to also run on OpenShift when ZTWIM manages SPIRE. Switched from `kubernetes.core.k8s` (which hardcoded Helm annotations) to `kubectl patch --type merge` for ConfigMap updates, making it work for both Helm and ZTWIM-managed ConfigMaps.

2. **`setup_spiffe_idp.py`**: Changed the missing `"use"` field check from an immediate failure to a retry loop (consistent with the "no keys" case). The OIDC provider may still be reloading after a ConfigMap patch + rollout restart.

3. **`test_platform_health.py`**: Applied the existing `_is_job_pod()` filter to `test_no_crashlooping_pods`, consistent with `test_no_failed_pods`. Job pods use `restartPolicy: OnFailure` and transient restarts are expected — `test_all_jobs_completed` checks Job completion separately.

## Test plan

- [x] HyperShift E2E: verify `set_key_use` patch tasks are no longer skipped on OpenShift
- [x] HyperShift E2E: verify `kagenti-spiffe-idp-setup-job` completes successfully
- [x] HyperShift E2E: verify `test_no_crashlooping_pods` passes
- [x] Kind E2E: verify no regression (patch + job still work on Helm SPIRE path)

Closes #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)