### PR TITLE
fix: aggregate homepage stats across all enabled namespaces

### DIFF
--- a/kagenti/ui-v2/src/pages/HomePage.tsx
+++ b/kagenti/ui-v2/src/pages/HomePage.tsx
@@ -31,7 +31,7 @@ import {
   CheckCircleIcon,
   PlusCircleIcon,
 } from '@patternfly/react-icons';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 
 import { agentService, toolService, namespaceService } from '@/services/api';
 import { useAuth } from '@/contexts/AuthContext';
@@ -156,20 +156,27 @@ export const HomePage: React.FC = () => {
     queryFn: () => namespaceService.list(true),
   });
 
-  // Fetch agents from first namespace (for demo stats)
-  const defaultNamespace = namespaces[0] || 'team1';
-  const { data: agents = [], isLoading: agentsLoading } = useQuery({
-    queryKey: ['agents', defaultNamespace],
-    queryFn: () => agentService.list(defaultNamespace),
-    enabled: namespaces.length > 0,
+  // Fetch agents from ALL enabled namespaces and aggregate
+  const agentQueries = useQueries({
+    queries: namespaces.map((ns: string) => ({
+      queryKey: ['agents', ns],
+      queryFn: () => agentService.list(ns),
+      enabled: namespaces.length > 0,
+    })),
   });
+  const agentsLoading = agentQueries.some((q) => q.isLoading);
+  const agents = agentQueries.flatMap((q) => q.data ?? []);
 
-  // Fetch tools from first namespace
-  const { data: tools = [], isLoading: toolsLoading } = useQuery({
-    queryKey: ['tools', defaultNamespace],
-    queryFn: () => toolService.list(defaultNamespace),
-    enabled: namespaces.length > 0,
+  // Fetch tools from ALL enabled namespaces and aggregate
+  const toolQueries = useQueries({
+    queries: namespaces.map((ns: string) => ({
+      queryKey: ['tools', ns],
+      queryFn: () => toolService.list(ns),
+      enabled: namespaces.length > 0,
+    })),
   });
+  const toolsLoading = toolQueries.some((q) => q.isLoading);
+  const tools = toolQueries.flatMap((q) => q.data ?? []);
 
   const readyAgents = agents.filter((a) => a.status === 'Ready').length;
   const readyTools = tools.filter((t) => t.status === 'Ready').length;


### PR DESCRIPTION
## Summary
- Homepage stat cards and quick-link counts previously used `namespaces[0]` (first alphabetically), showing counts from an arbitrary namespace instead of platform-wide totals
- Replaced `useQuery` with `useQueries` to fetch agents/tools from **all** enabled namespaces and `flatMap` the results

Fixes #1272

## Test plan
- [ ] With multiple `kagenti-enabled=true` namespaces, verify homepage shows aggregate counts
- [ ] With a single namespace, verify behavior is unchanged
- [ ] Verify stat cards and quick-link badges show matching numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)