### PR TITLE
fix(installer): Skip DataScienceCluster creation on brownfield RHOAI clusters

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/05_install_rhoai.yaml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/05_install_rhoai.yaml
@@ -48,15 +48,29 @@
     - name: Wait for DataScienceCluster CRD to be available
       command: kubectl wait --for=condition=Established crd/datascienceclusters.datasciencecluster.opendatahub.io --timeout=120s
 
+    - name: Check if a DataScienceCluster already exists
+      command: kubectl get datasciencecluster -o name
+      register: existing_dsc
+      failed_when: false
+      changed_when: false
+
     - name: Validate RHOAI profile
       fail:
         msg: "Invalid rhoai.profile '{{ rhoai.profile }}'. Must be 'minimal' or 'full'."
-      when: rhoai.profile | default('minimal') not in ['minimal', 'full']
+      when:
+        - existing_dsc.stdout | default('') | length == 0
+        - rhoai.profile | default('minimal') not in ['minimal', 'full']
 
     - name: "Create DataScienceCluster ({{ rhoai.profile | default('minimal') }} profile)"
       kubernetes.core.k8s:
         state: present
         template: "rhoai/dsc-{{ rhoai.profile | default('minimal') }}.yaml.j2"
+      when: existing_dsc.stdout | default('') | length == 0
+
+    - name: Skip DataScienceCluster creation (already exists)
+      debug:
+        msg: "Existing DataScienceCluster found ({{ existing_dsc.stdout_lines | join(', ') }}) — skipping creation to preserve existing configuration"
+      when: existing_dsc.stdout | default('') | length > 0
 
     # Right-size RHOAI for test/dev clusters.
     # The RHOAI dashboard requests 2.5 CPU / 5Gi RAM per replica (4 sidecars including


### PR DESCRIPTION
## Summary

When deploying kagenti to a cluster where RHOAI is already installed ("brownfield"), the Ansible installer applies a DataScienceCluster CR using either the minimal or full template. Because the task uses `kubernetes.core.k8s` with `state: present`, this merge-patches the existing DSC, potentially downgrading components — for example, the minimal template sets dashboard, workbenches, and model registry to `Removed`, overwriting whatever the operator had previously configured as `Managed`.

This PR adds a pre-check in `05_install_rhoai.yaml` that detects any existing DataScienceCluster and skips creation if one is found. The shared trust setup and all other RHOAI tasks still run unconditionally.

## Changes

- New task `Check if a DataScienceCluster already exists` runs `kubectl get datasciencecluster -o name` (name-agnostic — works regardless of what the DSC is called)
- Profile validation is skipped when an existing DSC is found (no point validating a profile we won't apply)
- DSC creation is gated on no existing DSC
- A debug message logs which DSC was found when skipping, for operator visibility

## Testing

Validated on OCP 4.20.17 with RHOAI 3.3.1 pre-installed:
- Installer detected the existing `default-dsc` DataScienceCluster and skipped creation
- Shared trust cert-manager setup ran successfully
- Existing DSC configuration (dashboard, workbenches, model registry all `Managed`) was preserved
- Greenfield path is unchanged — when no DSC exists, creation proceeds as before