### PR TITLE
fix(mlflow): use internal Keycloak URL for OIDC discovery

### DIFF
--- a/kagenti/auth/mlflow-oauth-secret/mlflow_oauth_secret.py
+++ b/kagenti/auth/mlflow-oauth-secret/mlflow_oauth_secret.py
@@ -575,9 +575,12 @@ def main() -> None:
         )
 
         # Construct OIDC discovery URL (well-known endpoint)
+        # Use the internal Keycloak URL so MLflow can fetch the document
+        # server-side.  The discovery response itself contains the public
+        # authorization_endpoint (set by KC_HOSTNAME) which the browser
+        # will be redirected to.
         oidc_discovery_url = (
-            f"{keycloak_public_url}/realms/{keycloak_realm}/"
-            ".well-known/openid-configuration"
+            f"{keycloak_url}/realms/{keycloak_realm}/.well-known/openid-configuration"
         )
 
         # Construct OIDC token URL for OAuth2 client credentials flow


### PR DESCRIPTION
## Summary

- Switch `OIDC_DISCOVERY_URL` in the mlflow-oauth-secret job to use the internal Keycloak service URL (`keycloak_url`) instead of the public URL (`keycloak_public_url`)
- Fixes MLflow SSO login on Kind clusters where `keycloak.localtest.me` resolves to `127.0.0.1` inside pods, causing "Failed to initiate OIDC login"
- No behavior change on OpenShift: when `KEYCLOAK_URL` is not set, `keycloak_url` falls back to the route URL (which is resolvable from inside the cluster)

## Root Cause

`mlflow-oidc-auth` fetches the OIDC discovery document server-side via `requests.get(OIDC_DISCOVERY_URL)`. In Kind, `.localtest.me` resolves to `127.0.0.1` — which inside a pod is the pod's own loopback, not the host. The connection is refused and login fails.

The discovery response itself contains the public `authorization_endpoint` (set by Keycloak's `KC_HOSTNAME`), so browser redirects still use the correct external URL regardless of which URL is used for server-side fetching.

## Test plan

- [x] Verified on Kind: MLflow SSO returns 302 redirect (was returning `{"detail":"Failed to initiate OIDC login"}`)
- [ ] Verify on OpenShift: MLflow SSO login still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)