### PR TITLE
debug: investigate Kind CI CPU exhaustion with Kuadrant + MLflow

### DIFF
--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -84,6 +84,21 @@ jobs:
       - name: Build dependency overrides from source
         run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
+      # DEBUG: Capture node resource usage before agent deployment
+      - name: Debug node resources (pre-agent)
+        run: |
+          echo "=== Node Allocatable ==="
+          kubectl get node -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}CPU: {.status.allocatable.cpu}{"\t"}Mem: {.status.allocatable.memory}{"\n"}{end}'
+          echo ""
+          echo "=== Total CPU Requests ==="
+          kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\t"}{range .spec.containers[*]}{.resources.requests.cpu}{" "}{end}{"\n"}{end}' | grep -v "^$" | sort
+          echo ""
+          echo "=== Pod Count ==="
+          kubectl get pods -A --no-headers | wc -l
+          echo ""
+          echo "=== Pending/Failed Pods ==="
+          kubectl get pods -A --field-selector 'status.phase!=Running,status.phase!=Succeeded' --no-headers 2>/dev/null || echo "None"
+
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
       - name: Build weather-tool image

--- a/deployments/envs/dev_values.yaml
+++ b/deployments/envs/dev_values.yaml
@@ -35,7 +35,7 @@ charts:
         phoenix:
           enabled: false
         mlflow:
-          enabled: false  # Disabled for Kind - requires full OTEL instrumentation
+          enabled: true
         mcpInspector:
           enabled: true
         metricsServer:


### PR DESCRIPTION
## Purpose

Diagnostic PR to understand why Kind CI fails with `Insufficient cpu` when both
Kuadrant (upstream #1262) and MLflow (PR #1243) are enabled.

Adds a diagnostic step that captures:
- Node allocatable CPU/memory
- Per-pod CPU requests
- Total pod count
- Pending/failed pods

This PR is NOT for merge — it's for gathering data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)