### PR TITLE
feat: Create authbridge-runtime-config for runtime namespaces

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -1916,10 +1916,9 @@ def _build_authbridge_runtime_yaml(
 ) -> str:
     """Build the YAML config for the unified authbridge binary.
 
-    Matches the structure created by the Helm chart in
-    charts/kagenti/templates/agent-namespaces.yaml. The operator reads
-    this as the base for per-agent ConfigMap generation, merging in mode
-    and listener addresses at injection time.
+    The operator reads this as the base for per-agent ConfigMap generation,
+    merging in mode and listener addresses at injection time. The Helm chart
+    creates an equivalent ConfigMap for pre-declared namespaces (see PR #1278).
     """
     identity_type = "spiffe" if spire_enabled else "client-secret"
     config = {
@@ -1961,12 +1960,14 @@ def _ensure_authbridge_configmaps(
     customizations (e.g. pointing at a different Keycloak server) are
     preserved on subsequent agent deploys.
 
-    The ConfigMaps match what the Helm chart creates in
-    charts/kagenti/templates/agent-namespaces.yaml:
-      - authbridge-config: Keycloak URLs for client-registration
+    ConfigMaps created:
+      - authbridge-config: flat key-value Keycloak URLs for client-registration
       - authbridge-runtime-config: YAML config for the unified authbridge binary
       - envoy-config: Envoy proxy listeners and ext-proc integration
       - spiffe-helper-config: SPIFFE workload API socket paths and SVID output
+
+    For Helm-managed namespaces, the Helm chart creates equivalent
+    ConfigMaps at install time (see agent-namespaces.yaml).
     """
     keycloak_url = settings.keycloak_url or DEFAULT_KEYCLOAK_INTERNAL_URL
     realm = settings.effective_keycloak_realm or DEFAULT_KEYCLOAK_REALM

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -1918,7 +1918,8 @@ def _build_authbridge_runtime_yaml(
 
     The operator reads this as the base for per-agent ConfigMap generation,
     merging in mode and listener addresses at injection time. The Helm chart
-    creates an equivalent ConfigMap for pre-declared namespaces (see PR #1278).
+    creates an equivalent ConfigMap for pre-declared namespaces
+    (see charts/kagenti/templates/agent-namespaces.yaml).
     """
     identity_type = "spiffe" if spire_enabled else "client-secret"
     config = {

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -1907,12 +1907,56 @@ async def get_shipwright_build_info(
         raise HTTPException(status_code=e.status, detail=str(e.reason))
 
 
+def _build_authbridge_runtime_yaml(
+    keycloak_url: str,
+    realm: str,
+    issuer: str,
+    spire_enabled: bool,
+) -> str:
+    """Build the YAML config for the unified authbridge binary.
+
+    Matches the structure created by the Helm chart in
+    charts/kagenti/templates/agent-namespaces.yaml. The operator reads
+    this as the base for per-agent ConfigMap generation, merging in mode
+    and listener addresses at injection time.
+    """
+    import yaml as _yaml
+
+    identity_type = "spiffe" if spire_enabled else "client-secret"
+    config = {
+        "mode": "envoy-sidecar",
+        "inbound": {"issuer": issuer},
+        "outbound": {
+            "keycloak_url": keycloak_url,
+            "keycloak_realm": realm,
+            "default_policy": "passthrough",
+        },
+        "identity": {
+            "type": identity_type,
+            "client_id_file": "/shared/client-id.txt",
+            "client_secret_file": "/shared/client-secret.txt",
+        },
+        "bypass": {
+            "inbound_paths": [
+                "/.well-known/*",
+                "/healthz",
+                "/readyz",
+                "/livez",
+            ]
+        },
+    }
+    if spire_enabled:
+        config["identity"]["jwt_svid_path"] = "/opt/jwt_svid.token"
+
+    return _yaml.dump(config, default_flow_style=False)
+
+
 def _ensure_authbridge_configmaps(
     kube: KubernetesService,
     namespace: str,
     spire_enabled: bool = False,
 ) -> None:
-    """Ensure the 3 ConfigMaps required by AuthBridge sidecars exist.
+    """Ensure the 4 ConfigMaps required by AuthBridge sidecars exist.
 
     Creates each ConfigMap only if it does not already exist, so user
     customizations (e.g. pointing at a different Keycloak server) are
@@ -1920,7 +1964,8 @@ def _ensure_authbridge_configmaps(
 
     The ConfigMaps match what the Helm chart creates in
     charts/kagenti/templates/agent-namespaces.yaml:
-      - authbridge-config: Keycloak URLs for go-processor / client-registration
+      - authbridge-config: Keycloak URLs for client-registration
+      - authbridge-runtime-config: YAML config for the unified authbridge binary
       - envoy-config: Envoy proxy listeners and ext-proc integration
       - spiffe-helper-config: SPIFFE workload API socket paths and SVID output
     """
@@ -1930,7 +1975,7 @@ def _ensure_authbridge_configmaps(
     # "iss" claim in JWT tokens issued by Keycloak (split-horizon DNS).
     issuer = f"{settings.effective_keycloak_url}/realms/{realm}"
 
-    # 1. authbridge-config
+    # 1. authbridge-config (flat key-value for client-registration and legacy go-processor)
     kube.ensure_configmap(
         namespace=namespace,
         name="authbridge-config",
@@ -1942,14 +1987,30 @@ def _ensure_authbridge_configmaps(
         },
     )
 
-    # 2. envoy-config
+    # 2. authbridge-runtime-config (YAML config for the unified authbridge binary)
+    # The operator reads this at admission time and creates a per-agent ConfigMap
+    # with mode and listener addresses merged in.
+    kube.ensure_configmap(
+        namespace=namespace,
+        name="authbridge-runtime-config",
+        data={
+            "config.yaml": _build_authbridge_runtime_yaml(
+                keycloak_url=keycloak_url,
+                realm=realm,
+                issuer=issuer,
+                spire_enabled=spire_enabled,
+            )
+        },
+    )
+
+    # 3. envoy-config
     kube.ensure_configmap(
         namespace=namespace,
         name="envoy-config",
         data={"envoy.yaml": DEFAULT_ENVOY_YAML},
     )
 
-    # 3. spiffe-helper-config
+    # 4. spiffe-helper-config
     kube.ensure_configmap(
         namespace=namespace,
         name="spiffe-helper-config",

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import urlparse
 
 import httpx
+import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query
 import kubernetes.client
 from kubernetes.client import ApiException
@@ -1920,8 +1921,6 @@ def _build_authbridge_runtime_yaml(
     this as the base for per-agent ConfigMap generation, merging in mode
     and listener addresses at injection time.
     """
-    import yaml as _yaml
-
     identity_type = "spiffe" if spire_enabled else "client-secret"
     config = {
         "mode": "envoy-sidecar",
@@ -1948,7 +1947,7 @@ def _build_authbridge_runtime_yaml(
     if spire_enabled:
         config["identity"]["jwt_svid_path"] = "/opt/jwt_svid.token"
 
-    return _yaml.dump(config, default_flow_style=False)
+    return yaml.dump(config, default_flow_style=False)
 
 
 def _ensure_authbridge_configmaps(

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -1,0 +1,47 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for _build_authbridge_runtime_yaml helper."""
+
+import yaml
+
+
+def test_build_authbridge_runtime_yaml_client_secret():
+    """Default (non-SPIRE) config uses client-secret identity."""
+    from app.routers.agents import _build_authbridge_runtime_yaml
+
+    result = _build_authbridge_runtime_yaml(
+        keycloak_url="http://keycloak:8080",
+        realm="kagenti",
+        issuer="http://keycloak.example.com/realms/kagenti",
+        spire_enabled=False,
+    )
+    cfg = yaml.safe_load(result)
+
+    assert cfg["mode"] == "envoy-sidecar"
+    assert cfg["inbound"]["issuer"] == "http://keycloak.example.com/realms/kagenti"
+    assert cfg["outbound"]["keycloak_url"] == "http://keycloak:8080"
+    assert cfg["outbound"]["keycloak_realm"] == "kagenti"
+    assert cfg["outbound"]["default_policy"] == "passthrough"
+    assert cfg["identity"]["type"] == "client-secret"
+    assert cfg["identity"]["client_id_file"] == "/shared/client-id.txt"
+    assert cfg["identity"]["client_secret_file"] == "/shared/client-secret.txt"
+    assert "jwt_svid_path" not in cfg["identity"]
+    assert len(cfg["bypass"]["inbound_paths"]) == 4
+
+
+def test_build_authbridge_runtime_yaml_spire_enabled():
+    """SPIRE-enabled config maps to spiffe identity with jwt_svid_path."""
+    from app.routers.agents import _build_authbridge_runtime_yaml
+
+    result = _build_authbridge_runtime_yaml(
+        keycloak_url="http://keycloak:8080",
+        realm="kagenti",
+        issuer="http://keycloak.example.com/realms/kagenti",
+        spire_enabled=True,
+    )
+    cfg = yaml.safe_load(result)
+
+    assert cfg["identity"]["type"] == "spiffe"
+    assert cfg["identity"]["jwt_svid_path"] == "/opt/jwt_svid.token"
+    assert cfg["identity"]["client_id_file"] == "/shared/client-id.txt"

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -27,7 +27,10 @@ def test_build_authbridge_runtime_yaml_client_secret():
     assert cfg["identity"]["client_id_file"] == "/shared/client-id.txt"
     assert cfg["identity"]["client_secret_file"] == "/shared/client-secret.txt"
     assert "jwt_svid_path" not in cfg["identity"]
-    assert len(cfg["bypass"]["inbound_paths"]) == 4
+    bypass_paths = cfg["bypass"]["inbound_paths"]
+    assert len(bypass_paths) == 4
+    assert "/.well-known/*" in bypass_paths
+    assert "/healthz" in bypass_paths
 
 
 def test_build_authbridge_runtime_yaml_spire_enabled():


### PR DESCRIPTION
## Summary

- Backend now creates authbridge-runtime-config ConfigMap (YAML config for the unified authbridge binary) in _ensure_authbridge_configmaps()
- Ensures agents deployed via the UI to namespaces not in the Helm agentNamespaces list have the YAML config
- The operator reads this as the base for per-agent ConfigMap generation (kagenti/kagenti-operator#297)

## Context

Previously only the Helm chart created authbridge-runtime-config at install time for namespaces listed in agentNamespaces. Agents deployed via the backend to runtime-created namespaces had no YAML config, forcing the operator to fall back to minimal defaults.

## Changes

| File | Change |
|------|--------|
| kagenti/backend/app/routers/agents.py | Add _build_authbridge_runtime_yaml() helper and 4th ensure_configmap call |

## Test plan

- [x] ruff check -- passes
- [x] ruff format --check -- passes
- [ ] Deploy agent to a runtime namespace via UI -- verify authbridge-runtime-config ConfigMap is created

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>