### PR TITLE
:bug: Import Kagenti realm

### DIFF
--- a/charts/kagenti-deps/templates/keycloak-k8s.yaml
+++ b/charts/kagenti-deps/templates/keycloak-k8s.yaml
@@ -56,7 +56,7 @@ spec:
       containers:
         - name: keycloak
           image: {{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag }}
-          args: [{{ if .Values.keycloak.database.enabled }}"start"{{ else }}"start-dev"{{ end }}]
+          args: [{{ if .Values.keycloak.database.enabled }}"start"{{ else }}"start-dev"{{ end }}, "--import-realm"]
           env:
             {{- include "kagenti.mergeEnvVars" (dict "defaults" (include "kagenti.keycloak.defaultEnv" . | fromYamlArray) "overrides" .Values.keycloak.extraEnvVars) | nindent 12 }}
           ports:
@@ -88,6 +88,14 @@ spec:
             requests:
               cpu: 100m
               memory: 512Mi
+          volumeMounts:
+            - name: realm-import
+              mountPath: /opt/keycloak/data/import
+              readOnly: true
+      volumes:
+        - name: realm-import
+          configMap:
+            name: keycloak-realm-import
 {{- if .Values.keycloak.database.enabled }}
 ---
 # This is deployment of PostgreSQL with an ephemeral storage for testing: Once the Pod stops, the data is lost.


### PR DESCRIPTION
Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

On a fresh Kind install, Keycloak was starting without importing the kagenti realm. The keycloak-realm-import ConfigMap (created by keycloak-realm-init.yaml) contained the full realm definition but was never consumed because the Keycloak pod had no volume mount for it. The fix mounts the ConfigMap into /opt/keycloak/data/import and adds `--import-realm` to the Keycloak startup args, so the realm is imported atomically before the pod becomes ready.

## Related issue(s)

## (Optional) Testing Instructions

Fixes (no separate issue yet) - seeing `Failed to fetch URL: Required role(s): kagenti-operator` on env var import on agent deploy
