### PR TITLE
fix(auth): ensure realm-admin role and show correct UI credentials

### DIFF
--- a/.github/scripts/kagenti-operator/36-fix-keycloak-admin.sh
+++ b/.github/scripts/kagenti-operator/36-fix-keycloak-admin.sh
@@ -6,9 +6,9 @@
 # password. This script:
 #   1. Reads the operator-generated credentials from the secret
 #   2. Logs in with those credentials
-#   3. Creates a permanent admin/admin user (if not exists)
+#   3. Creates a permanent admin user with generated password (if not exists)
 #   4. Creates the demo realm (if not exists)
-#   5. Updates the keycloak-initial-admin secret to admin/admin
+#   5. Updates the keycloak-initial-admin secret to generated credentials
 #
 # Idempotent — safe to run multiple times.
 #

--- a/.github/scripts/kind/access-ui.sh
+++ b/.github/scripts/kind/access-ui.sh
@@ -40,8 +40,12 @@ echo ""
 
 # Get Keycloak status and credentials
 KEYCLOAK_STATUS=$(kubectl get pods -n keycloak -l app.kubernetes.io/name=keycloak -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Not Found")
-KEYCLOAK_USER=$(kubectl get secret -n keycloak keycloak-initial-admin -o jsonpath='{.data.username}' 2>/dev/null | base64 -d || echo "N/A")
-KEYCLOAK_PASS=$(kubectl get secret -n keycloak keycloak-initial-admin -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo "N/A")
+KEYCLOAK_USER=$(kubectl get secret -n keycloak keycloak-initial-admin -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
+KEYCLOAK_PASS=$(kubectl get secret -n keycloak keycloak-initial-admin -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
+
+# Kagenti realm credentials for UI login (falls back to master realm)
+UI_USER=$(kubectl get secret -n keycloak kagenti-test-user -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "$KEYCLOAK_USER")
+UI_PASS=$(kubectl get secret -n keycloak kagenti-test-user -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "$KEYCLOAK_PASS")
 
 DOMAIN_NAME="${DOMAIN_NAME:-localtest.me}"
 
@@ -57,7 +61,7 @@ echo ""
 UI_STATUS=$(kubectl get pods -n kagenti-system -l app=kagenti-ui -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Not Found")
 echo -e "${BLUE}Kagenti UI:${NC}"
 echo "  Status:   $UI_STATUS"
-echo -e "  Login:    ${GREEN}Use Keycloak credentials above (admin/admin)${NC}"
+echo -e "  Login:    ${GREEN}${UI_USER} / ${UI_PASS}${NC}  (kagenti realm)"
 echo "  URL:      http://kagenti-ui.${DOMAIN_NAME}:8080"
 echo "  Port-forward: kubectl port-forward -n kagenti-system svc/http-istio 8080:80"
 echo ""
@@ -122,7 +126,7 @@ echo ""
 echo "Access Kagenti UI:"
 echo "  1. Ensure port-forward is running (see above)"
 echo "  2. Visit: http://kagenti-ui.${DOMAIN_NAME}:8080"
-echo -e "  3. Login with: ${GREEN}admin / admin${NC}"
+echo -e "  3. Login with: ${GREEN}${UI_USER} / ${UI_PASS}${NC}"
 echo ""
 echo "Troubleshooting 'Restart login cookie not found' error:"
 echo "  - Make sure port-forward is running on port 8080"

--- a/.github/scripts/local-setup/show-services.sh
+++ b/.github/scripts/local-setup/show-services.sh
@@ -145,9 +145,10 @@ fi
 KC_ADMIN_USER=$($CLI get secret -n keycloak keycloak-initial-admin -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
 KC_ADMIN_PASS=$($CLI get secret -n keycloak keycloak-initial-admin -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
 
-# App user (master realm) - same as Keycloak admin for master realm login
-APP_USER="$KC_ADMIN_USER"
-APP_PASS="$KC_ADMIN_PASS"
+# App user (kagenti realm) - for UI and MLflow login
+# Falls back to master realm credentials if kagenti-test-user secret doesn't exist
+APP_USER=$($CLI get secret -n keycloak kagenti-test-user -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "$KC_ADMIN_USER")
+APP_PASS=$($CLI get secret -n keycloak kagenti-test-user -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "$KC_ADMIN_PASS")
 
 KUBEADMIN_PASS=""
 if [ "$ENV_TYPE" = "hypershift" ]; then
@@ -167,7 +168,7 @@ if [ "$VERBOSE" = "false" ]; then
     echo ""
 
     # Credentials
-    echo -e "${GREEN}Kagenti UI & MLflow:${NC}  ${APP_USER} / ${APP_PASS}  ${DIM}(master realm)${NC}"
+    echo -e "${GREEN}Kagenti UI & MLflow:${NC}  ${APP_USER} / ${APP_PASS}  ${DIM}(kagenti realm)${NC}"
     echo -e "${GREEN}Keycloak Admin:${NC}       ${KC_ADMIN_USER} / ${KC_ADMIN_PASS}  ${DIM}(master realm)${NC}"
     if [ -n "$KUBEADMIN_PASS" ]; then
         echo -e "${GREEN}kubeadmin:${NC}            kubeadmin / ${KUBEADMIN_PASS}"
@@ -278,7 +279,7 @@ echo -e "${CYAN}        (Services using Keycloak - use credentials below)       
 echo "##########################################################################"
 echo ""
 
-echo -e "${GREEN}App Login (Kagenti UI & MLflow):${NC} ${YELLOW}(master realm)${NC}"
+echo -e "${GREEN}App Login (Kagenti UI & MLflow):${NC} ${YELLOW}(kagenti realm)${NC}"
 echo "  Username: ${APP_USER}"
 echo "  Password: ${APP_PASS}"
 echo ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 # Show service URLs
 ./.github/scripts/local-setup/show-services.sh
 
-# Access UI at http://kagenti-ui.localtest.me:8080 (admin/admin)
+# Access UI at http://kagenti-ui.localtest.me:8080 (see show-services.sh for credentials)
 ```
 
 ## Repository Structure

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Use `deployments/ansible/run-install.sh --help` for options. For more detailed i
 .github/scripts/local-setup/show-services.sh
 
 open http://kagenti-ui.localtest.me:8080
-# Login with credentials from show-services.sh output (default: admin / admin)
+# Login with credentials from show-services.sh output
 ```
 
 From the UI you can:

--- a/deployments/envs/secret_values.yaml.example
+++ b/deployments/envs/secret_values.yaml.example
@@ -31,6 +31,6 @@ charts:
         quayToken: 
       keycloak:
         # Keycloak admin credentials for agent namespace secrets (keycloak-admin-secret).
-        # Used by the AuthBridge client-registration sidecar. Default: admin/admin.
+        # Used by the AuthBridge client-registration sidecar. Override for production.
         adminUsername: admin
         adminPassword: admin

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -122,7 +122,7 @@ Make sure to run `kagenti/demo-setup/keycloak-config/slack/set_up_slack_demo.py`
 
 Now, we need to obtain an access token the MCP Broker can use to initialize with the Slack MCP server to list available tools.
 
-In the Kagenti UI, login to Keycloak admin console as `admin/admin`, and then perform the following steps:
+In the Kagenti UI, login to Keycloak admin console with credentials from `show-services.sh`, and then perform the following steps:
 - Go to Clients
 - Go to `kagenti` client which should open settings
 - Under Settings > Capability Config and enable Direct access grants

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -122,7 +122,7 @@ Make sure to run `kagenti/demo-setup/keycloak-config/slack/set_up_slack_demo.py`
 
 Now, we need to obtain an access token the MCP Broker can use to initialize with the Slack MCP server to list available tools.
 
-In the Kagenti UI, login to Keycloak admin console with credentials from `show-services.sh`, and then perform the following steps:
+In the Kagenti UI, login to Keycloak admin console with credentials from `.github/scripts/local-setup/show-services.sh`, and then perform the following steps:
 - Go to Clients
 - Go to `kagenti` client which should open settings
 - Under Settings > Capability Config and enable Direct access grants

--- a/docs/install.md
+++ b/docs/install.md
@@ -433,7 +433,7 @@ open http://spire-tornjak-ui.localtest.me:8080/
 
 ```bash
 open http://keycloak.localtest.me:8080/
-# Login: admin / admin
+# Login: see show-services.sh output for credentials
 ```
 
 ### UI Functionality

--- a/docs/install.md
+++ b/docs/install.md
@@ -433,7 +433,7 @@ open http://spire-tornjak-ui.localtest.me:8080/
 
 ```bash
 open http://keycloak.localtest.me:8080/
-# Login: see show-services.sh output for credentials
+# Login: see .github/scripts/local-setup/show-services.sh output for credentials
 ```
 
 ### UI Functionality

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -395,14 +395,11 @@ def main() -> None:
                             {
                                 "name": "admin",
                                 "description": (
-                                    "Admin realm role for Kagenti "
-                                    "backend RBAC mapping"
+                                    "Admin realm role for Kagenti backend RBAC mapping"
                                 ),
                             }
                         )
-                        logger.info(
-                            f"Created 'admin' realm role in '{keycloak_realm}'"
-                        )
+                        logger.info(f"Created 'admin' realm role in '{keycloak_realm}'")
                     except Exception:
                         logger.info(
                             "'admin' realm role already exists, skipping creation"

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -324,7 +324,7 @@ def main() -> None:
                 raise
 
             # Create a default user so the UI has someone to log in as.
-            # Uses the same credentials as the Keycloak admin (e.g. admin/admin).
+            # Uses the same credentials as the Keycloak admin.
             # Only creates if absent; never resets an existing user's password.
             # User creation is FATAL when bootstrap is enabled — without a
             # user the UI login will fail downstream.
@@ -354,68 +354,70 @@ def main() -> None:
                         f"Created default user '{keycloak_admin_username}' "
                         f"in realm '{keycloak_realm}'"
                     )
-
-                    # Grant realm-admin client role so the user can access
-                    # the Keycloak admin console for this realm.
-                    try:
-                        realm_mgmt_client_id = keycloak_admin.get_client_id(
-                            "realm-management"
-                        )
-                        realm_admin_role = keycloak_admin.get_client_role(
-                            realm_mgmt_client_id, "realm-admin"
-                        )
-                        keycloak_admin.assign_client_role(
-                            user_id, realm_mgmt_client_id, [realm_admin_role]
-                        )
-                        logger.info(
-                            f"Assigned 'realm-admin' role to "
-                            f"'{keycloak_admin_username}' in realm "
-                            f"'{keycloak_realm}'"
-                        )
-                    except Exception as role_err:
-                        logger.warning(
-                            f"Could not assign realm-admin role (non-fatal): {role_err}"
-                        )
-
-                    # Create and assign an 'admin' realm role. The Kagenti
-                    # backend maps this to kagenti-admin (which inherits
-                    # kagenti-operator and kagenti-viewer) via a temporary
-                    # mapping in auth.py until proper realm roles are
-                    # provisioned by a dedicated Keycloak setup job.
-                    try:
-                        try:
-                            keycloak_admin.create_realm_role(
-                                {
-                                    "name": "admin",
-                                    "description": (
-                                        "Admin realm role for Kagenti "
-                                        "backend RBAC mapping"
-                                    ),
-                                }
-                            )
-                            logger.info(
-                                f"Created 'admin' realm role in '{keycloak_realm}'"
-                            )
-                        except Exception:
-                            logger.info(
-                                "'admin' realm role already exists, skipping creation"
-                            )
-
-                        admin_realm_role = keycloak_admin.get_realm_role("admin")
-                        keycloak_admin.assign_realm_roles(user_id, [admin_realm_role])
-                        logger.info(
-                            f"Assigned 'admin' realm role to "
-                            f"'{keycloak_admin_username}' in realm "
-                            f"'{keycloak_realm}'"
-                        )
-                    except Exception as role_err:
-                        logger.warning(
-                            f"Could not assign admin realm role (non-fatal): {role_err}"
-                        )
                 else:
+                    user_id = existing_users[0]["id"]
                     logger.info(
                         f"User '{keycloak_admin_username}' already exists "
-                        f"in realm '{keycloak_realm}', skipping"
+                        f"in realm '{keycloak_realm}', ensuring roles"
+                    )
+
+                # Ensure realm-admin client role so the user can access
+                # the Keycloak admin console for this realm.
+                # Idempotent — Keycloak ignores duplicate role assignments.
+                try:
+                    realm_mgmt_client_id = keycloak_admin.get_client_id(
+                        "realm-management"
+                    )
+                    realm_admin_role = keycloak_admin.get_client_role(
+                        realm_mgmt_client_id, "realm-admin"
+                    )
+                    keycloak_admin.assign_client_role(
+                        user_id, realm_mgmt_client_id, [realm_admin_role]
+                    )
+                    logger.info(
+                        f"Ensured 'realm-admin' role for "
+                        f"'{keycloak_admin_username}' in realm "
+                        f"'{keycloak_realm}'"
+                    )
+                except Exception as role_err:
+                    logger.warning(
+                        f"Could not assign realm-admin role (non-fatal): {role_err}"
+                    )
+
+                # Ensure 'admin' realm role. The Kagenti backend maps this
+                # to kagenti-admin (which inherits kagenti-operator and
+                # kagenti-viewer) via a temporary mapping in auth.py until
+                # proper realm roles are provisioned by a dedicated
+                # Keycloak setup job.
+                try:
+                    try:
+                        keycloak_admin.create_realm_role(
+                            {
+                                "name": "admin",
+                                "description": (
+                                    "Admin realm role for Kagenti "
+                                    "backend RBAC mapping"
+                                ),
+                            }
+                        )
+                        logger.info(
+                            f"Created 'admin' realm role in '{keycloak_realm}'"
+                        )
+                    except Exception:
+                        logger.info(
+                            "'admin' realm role already exists, skipping creation"
+                        )
+
+                    admin_realm_role = keycloak_admin.get_realm_role("admin")
+                    keycloak_admin.assign_realm_roles(user_id, [admin_realm_role])
+                    logger.info(
+                        f"Ensured 'admin' realm role for "
+                        f"'{keycloak_admin_username}' in realm "
+                        f"'{keycloak_realm}'"
+                    )
+                except Exception as role_err:
+                    logger.warning(
+                        f"Could not assign admin realm role (non-fatal): {role_err}"
                     )
             except Exception as e:
                 logger.error(

--- a/kagenti/examples/identity/keycloak_token_exchange/README.md
+++ b/kagenti/examples/identity/keycloak_token_exchange/README.md
@@ -155,7 +155,7 @@ Port forward Keycloak
 kubectl port-forward statefulset/keycloak -n keycloak 8080:8080
 ```
 
-1. Access Keycloak `http://localhost:8080` (admin/admin)
+1. Access Keycloak `http://localhost:8080` (credentials from `keycloak-initial-admin` secret)
 2. Create a new realm `Demo` [this is case-sensitive]
 3. Select that realm, go to `Users` on the sidebar, and create a new user. 
 4. Once that user is created, set a password by going to `Users > <username> > Credentials` where Credentials is in the top breadcrumbs. Set the password. Keep note of the credentials you used. 


### PR DESCRIPTION
## Summary

- **Fix Keycloak console access**: `auth_secret.py` now assigns `realm-admin` client role and `admin` realm role idempotently for both new and existing users. Previously, roles were only assigned during user creation — if the realm import created the user first, role assignment was skipped entirely, leaving the admin user without Keycloak console access.
- **Fix UI login credentials display**: `show-services.sh` and `access-ui.sh` now read credentials from the `kagenti-test-user` secret (kagenti realm) instead of the master realm `keycloak-initial-admin` secret. The UI authenticates against the kagenti realm, where the password is randomly generated by `87-setup-test-credentials.sh`.
- **Remove stale `admin/admin` references**: All hardcoded `admin/admin` credential references removed from docs, scripts, and code comments across 8 files.

## Root Cause

On Kind, `keycloak-realm-init.yaml` creates the `admin` user in the kagenti realm via `--import-realm` (at Keycloak startup). This import assigns the `admin` realm role but cannot assign client roles like `realm-admin`. When `auth_secret.py` runs later, it finds the user already exists and skips the entire role assignment block — so `realm-admin` is never granted. Without this role, the user cannot access the Keycloak admin console from the Kagenti UI Admin page.

## Test plan

- [ ] Deploy to Kind with `kind-full-test.sh --skip-cluster-destroy`
- [ ] Verify `show-services.sh` displays kagenti realm credentials (not master realm)
- [ ] Log into Kagenti UI with displayed credentials
- [ ] Navigate to Admin page → Open Keycloak Console — verify access works
- [ ] Verify no regressions on HyperShift/OpenShift deployments

Fixes the "You do not have permission to access this resource" error when accessing Keycloak console from Kagenti UI.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>