### PR TITLE
fix: read UI test credentials from kagenti-test-user secret

### DIFF
--- a/.github/scripts/common/92-run-ui-tests.sh
+++ b/.github/scripts/common/92-run-ui-tests.sh
@@ -51,14 +51,19 @@ if [ -z "${KAGENTI_UI_URL:-}" ]; then
 fi
 export KAGENTI_UI_URL
 
-# Auto-detect Keycloak credentials from cluster secret
+# Auto-detect Keycloak credentials from kagenti-test-user secret (kagenti realm).
+# Falls back to keycloak-initial-admin (master realm) for backwards compatibility.
 if [ -z "${KEYCLOAK_USER:-}" ]; then
-    KC_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "admin")
+    KC_USER=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null \
+        || kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null \
+        || echo "admin")
     export KEYCLOAK_USER="$KC_USER"
     log_info "Keycloak user: $KC_USER"
 fi
 if [ -z "${KEYCLOAK_PASSWORD:-}" ]; then
-    KC_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "admin")
+    KC_PASS=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null \
+        || kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null \
+        || echo "admin")
     export KEYCLOAK_PASSWORD="$KC_PASS"
     log_info "Keycloak password: ${KC_PASS:0:4}..."
 fi

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -124,6 +124,9 @@ jobs:
         if: success()
         run: bash .github/scripts/common/86-print-version-matrix.sh
 
+      - name: Setup test credentials
+        run: bash .github/scripts/common/87-setup-test-credentials.sh
+
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -125,6 +125,9 @@ jobs:
         if: success()
         run: bash .github/scripts/common/86-print-version-matrix.sh
 
+      - name: Setup test credentials
+        run: bash .github/scripts/common/87-setup-test-credentials.sh
+
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh

--- a/charts/kagenti-deps/templates/mlflow.yaml
+++ b/charts/kagenti-deps/templates/mlflow.yaml
@@ -157,6 +157,7 @@ spec:
           ALLOWED_HOSTS="mlflow.{{ .Values.domain | default "localtest.me" }}:*,mlflow:*,mlflow.{{ .Release.Namespace }}:5000,mlflow.{{ .Release.Namespace }}.svc.cluster.local:5000,localhost:*,127.0.0.1:*"
           ALLOWED_HOSTS="$ALLOWED_HOSTS,mlflow.{{ .Values.domain | default "localtest.me" }},mlflow,mlflow.{{ .Release.Namespace }},mlflow.{{ .Release.Namespace }}.svc.cluster.local,localhost,127.0.0.1"
           {{- end }}
+          export MLFLOW_SERVER_ALLOWED_HOSTS="$ALLOWED_HOSTS" && \
           {{- if .Values.mlflow.auth.enabled }}
           # Set MLflow config via environment variables (used by mlflow_oidc_auth.app)
           # Both BACKEND_STORE_URI and TRACKING_URI needed for otel_router to use PostgreSQL


### PR DESCRIPTION
## Summary

- `92-run-ui-tests.sh` reads Keycloak credentials from `kagenti-test-user` secret (kagenti realm) instead of `keycloak-initial-admin` (master realm)
- Falls back to `keycloak-initial-admin` for environments where `kagenti-test-user` doesn't exist yet

## Root Cause

`87-setup-test-credentials.sh` generates a random password for the `admin` user in the kagenti realm and stores it in the `kagenti-test-user` secret. The Playwright auth setup authenticates against the kagenti realm via the UI's OAuth flow. But `92-run-ui-tests.sh` was reading the master realm admin password from `keycloak-initial-admin` — which doesn't work for kagenti realm login, causing "Invalid username or password" and a 30s timeout on every retry.

PR #1296 updated `show-services.sh` and `access-ui.sh` to use `kagenti-test-user` but missed this script.

Fixes #1297

## Test plan

- [x] CI E2E tests pass (Playwright auth setup succeeds with correct credentials)
- [x] Verify fallback works when `kagenti-test-user` secret doesn't exist

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>