### PR TITLE
🌱 Replace Ansible installer with setup-kagenti.sh in HyperShift CI

### DIFF
--- a/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
+++ b/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
@@ -32,27 +32,19 @@ fi
 
 echo "Deploying Kagenti to cluster..."
 
-# Set Python interpreter for Ansible (required in CI where .venv doesn't exist)
-ANSIBLE_PYTHON_INTERPRETER=$(which python3)
-export ANSIBLE_PYTHON_INTERPRETER
-
-# Create minimal secrets file for CI with auto-generated values
+# Create secrets file for setup-kagenti.sh (helm -f charts/kagenti/.secrets.yaml)
 # Use MAIN_REPO_ROOT so secrets are shared across worktrees
-SECRETS_FILE="$MAIN_REPO_ROOT/deployments/envs/.secret_values.yaml"
+SECRETS_FILE="$MAIN_REPO_ROOT/charts/kagenti/.secrets.yaml"
 if [ ! -f "$SECRETS_FILE" ]; then
     # Use real OPENAI_API_KEY from env if available (passed from GitHub secrets)
     OPENAI_KEY="${OPENAI_API_KEY:-ci-test-openai-key}"
     echo "Creating secrets file for CI..."
     cat > "$SECRETS_FILE" <<EOF
 # Auto-generated secrets for CI
-global: {}
-charts:
-  kagenti:
-    values:
-      secrets:
-        githubUser: "ci-user"
-        githubToken: "ci-token-placeholder"
-        openaiApiKey: "${OPENAI_KEY}"
+secrets:
+  githubUser: "ci-user"
+  githubToken: "ci-token-placeholder"
+  openaiApiKey: "${OPENAI_KEY}"
 EOF
 fi
 

--- a/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
+++ b/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
@@ -55,7 +55,7 @@ cd "$REPO_ROOT"
 # Wait for nodes - increased timeout for autoscaling scenarios
 # Autoscaling can take 5-10 minutes to provision new nodes
 echo "Waiting for cluster nodes to be ready..."
-MAX_RETRIES=60
+MAX_RETRIES=90
 RETRY_DELAY=10
 for i in $(seq 1 $MAX_RETRIES); do
     # Count nodes that are NOT in Ready status

--- a/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
+++ b/.github/scripts/hypershift/ci/70-deploy-kagenti.sh
@@ -84,8 +84,10 @@ done
 # This is required for installing OpenShift operators via Subscriptions
 echo "Waiting for OLM to be available..."
 for i in $(seq 1 $MAX_RETRIES); do
-    if kubectl api-resources | grep -q "subscriptions.*operators.coreos.com" 2>/dev/null; then
-        echo "OLM Subscription API is available"
+    if kubectl get crd subscriptions.operators.coreos.com &>/dev/null && \
+       kubectl get clusteroperator operator-lifecycle-manager \
+           -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null | grep -q "True"; then
+        echo "OLM Subscription CRD and ClusterOperator are available"
         break
     fi
     echo "[$i/$MAX_RETRIES] Waiting for OLM..."

--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -648,8 +648,7 @@ else
 export KUBECONFIG=$CLUSTER_KUBECONFIG
 oc get nodes
 
-./.github/scripts/kagenti-operator/30-run-installer.sh --env ocp
-./.github/scripts/kagenti-operator/41-wait-crds.sh
+./scripts/ocp/setup-kagenti.sh --kagenti-repo .
 
 ./.github/scripts/kagenti-operator/71-build-weather-tool.sh
 ./.github/scripts/kagenti-operator/72-deploy-weather-tool.sh

--- a/.github/scripts/local-setup/README.md
+++ b/.github/scripts/local-setup/README.md
@@ -85,8 +85,7 @@ oc login https://api.your-cluster.example.com:6443 -u kubeadmin -p <password>
 oc login https://api.your-cluster.example.com:6443 -u kubeadmin -p <password>
 
 # Install Kagenti platform
-./.github/scripts/kagenti-operator/30-run-installer.sh --env ocp
-./.github/scripts/kagenti-operator/41-wait-crds.sh
+./scripts/ocp/setup-kagenti.sh --kagenti-repo .
 
 # Deploy agents and tools, run E2E tests
 ./.github/scripts/kagenti-operator/71-build-weather-tool.sh

--- a/.github/scripts/local-setup/hypershift-full-test.sh
+++ b/.github/scripts/local-setup/hypershift-full-test.sh
@@ -81,7 +81,7 @@ MODES:
 
 PHASES:
     cluster-create    Create HyperShift cluster (~15 min)
-    kagenti-install   Install Kagenti platform via Ansible
+    kagenti-install   Install Kagenti platform
     agents            Build and deploy test agents (weather-tool, weather-agent)
     test              Run backend E2E tests (pytest)
     ui-tests          Run UI E2E tests (Playwright)
@@ -953,17 +953,17 @@ if [ "$RUN_INSTALL" = "true" ]; then
 
     if [ "$CLEAN_KAGENTI" = "true" ]; then
         log_step "Uninstalling Kagenti (--clean-kagenti)..."
-        ./deployments/ansible/cleanup-install.sh || true
+        ./scripts/ocp/cleanup-kagenti.sh --yes || true
     fi
 
     log_step "Installing Kagenti platform..."
-    INSTALLER_ARGS=(--env "$KAGENTI_ENV")
+    SETUP_ARGS=(--kagenti-repo "$REPO_ROOT")
     if [ "$NO_RHOAI" = "true" ]; then
-        INSTALLER_ARGS+=(--extra-vars '{"rhoai": {"enabled": false}}')
-    elif [ -n "$RHOAI_PROFILE" ]; then
-        INSTALLER_ARGS+=(--extra-vars "{\"rhoai\": {\"enabled\": true, \"profile\": \"$RHOAI_PROFILE\"}}")
+        # --skip-mlflow disables kagenti-operator MLflow integration (--enable-mlflow flag + RBAC).
+        # RHOAI MLflow CR creation and OTEL endpoint setup still auto-detect via CRD presence.
+        SETUP_ARGS+=(--skip-mlflow)
     fi
-    ./.github/scripts/kagenti-operator/30-run-installer.sh "${INSTALLER_ARGS[@]}"
+    ./scripts/ocp/setup-kagenti.sh "${SETUP_ARGS[@]}"
 
     log_step "Waiting for CRDs..."
     ./.github/scripts/kagenti-operator/41-wait-crds.sh
@@ -1095,8 +1095,8 @@ fi
 
 if [ "$RUN_KAGENTI_UNINSTALL" = "true" ]; then
     log_phase "PHASE 5: Uninstall Kagenti Platform"
-    log_step "Running cleanup-install.sh..."
-    ./deployments/ansible/cleanup-install.sh || {
+    log_step "Running cleanup-kagenti.sh..."
+    ./scripts/ocp/cleanup-kagenti.sh --yes || {
         log_error "Kagenti uninstall failed (non-fatal)"
     }
 else

--- a/deployments/ansible/roles/kagenti_installer/defaults/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/defaults/main.yml
@@ -9,3 +9,4 @@ rhoai:
   profile: minimal
   channel: fast-3.x
   kserve_mode: raw
+  mlflow: false

--- a/deployments/ansible/roles/kagenti_installer/templates/rhoai/dsc-full.yaml.j2
+++ b/deployments/ansible/roles/kagenti_installer/templates/rhoai/dsc-full.yaml.j2
@@ -37,3 +37,7 @@ spec:
       registriesNamespace: rhoai-model-registries
     trainingoperator:
       managementState: Removed
+{% if rhoai.mlflow | default(false) %}
+    mlflowoperator:
+      managementState: Managed
+{% endif %}

--- a/deployments/ansible/roles/kagenti_installer/templates/rhoai/dsc-minimal.yaml.j2
+++ b/deployments/ansible/roles/kagenti_installer/templates/rhoai/dsc-minimal.yaml.j2
@@ -36,3 +36,7 @@ spec:
       managementState: Removed
     trainingoperator:
       managementState: Removed
+{% if rhoai.mlflow | default(false) %}
+    mlflowoperator:
+      managementState: Managed
+{% endif %}

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -139,4 +139,5 @@ rhoai:
   profile: minimal    # minimal or full
   channel: fast-3.x
   kserve_mode: raw    # raw (no mesh needed) or serverless (deprecated)
+  mlflow: true         # Include mlflowoperator as Managed in the DSC
   scale_down: false    # Scale RHOAI operator/dashboard to 1 replica (test/dev clusters only)

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -567,6 +567,10 @@ EOF
     log_info "MLflow OTEL values: otel.mlflow.enabled=true, endpoint=${MLFLOW_TRACES_ENDPOINT}"
   fi
 
+  # Keycloak public URL is needed by the realm-init audience mapper.
+  # Construct from DOMAIN (known since Step 2) so it's correct on first install.
+  local _kc_public_url="https://keycloak-${KC_NAMESPACE}.${DOMAIN}"
+
   if helm status kagenti-deps -n kagenti-system &>/dev/null; then
     # Upgrade path: skip hooks (the kiali hook will fail on any cluster where
     # cluster-monitoring-config is managed by another operator)
@@ -574,6 +578,7 @@ EOF
     run_cmd helm upgrade kagenti-deps "$KAGENTI_REPO/charts/kagenti-deps/" \
       -n kagenti-system \
       --set spire.trustDomain="${DOMAIN}" \
+      --set "keycloak.publicUrl=${_kc_public_url}" \
       --set components.kiali.enabled=false \
       --set components.rhoai.enabled=true \
       --set components.mlflow.enabled=false \
@@ -596,6 +601,7 @@ EOF
   run_cmd helm install kagenti-deps "$KAGENTI_REPO/charts/kagenti-deps/" \
     -n kagenti-system --create-namespace \
     --set spire.trustDomain="${DOMAIN}" \
+    --set "keycloak.publicUrl=${_kc_public_url}" \
     --set components.kiali.enabled=false \
     --set components.rhoai.enabled=true \
     --set components.mlflow.enabled=false \
@@ -918,6 +924,24 @@ fi
 
 log_info "Keycloak: realm=$KC_REALM namespace=$KC_NAMESPACE"
 
+# Read the actual Keycloak admin credentials from the operator-managed secret.
+# The RHBK operator creates keycloak-initial-admin with a random password.
+# The kagenti chart creates keycloak-admin-secret in agent namespaces for the
+# client-registration sidecar — these must match, otherwise client-registration
+# can't authenticate to the master realm to register per-agent OAuth clients.
+KC_ADMIN_FLAGS=()
+_kc_admin_user=$($KUBECTL get secret keycloak-initial-admin -n "$KC_NAMESPACE" \
+  -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+_kc_admin_pass=$($KUBECTL get secret keycloak-initial-admin -n "$KC_NAMESPACE" \
+  -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+if [ -n "$_kc_admin_user" ] && [ -n "$_kc_admin_pass" ]; then
+  KC_ADMIN_FLAGS+=(--set "keycloak.adminUsername=${_kc_admin_user}")
+  KC_ADMIN_FLAGS+=(--set "keycloak.adminPassword=${_kc_admin_pass}")
+  log_success "Keycloak admin credentials read from keycloak-initial-admin"
+else
+  log_warn "Could not read keycloak-initial-admin — agent client-registration may fail"
+fi
+
 # Build operator image override flags
 OPERATOR_IMAGE_FLAGS=()
 if [ -n "$OPERATOR_IMAGE" ]; then
@@ -936,6 +960,7 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   -f "$SECRETS_FILE" \
   "${KAGENTI_UI_FLAGS[@]}" \
   "${OPERATOR_IMAGE_FLAGS[@]}" \
+  "${KC_ADMIN_FLAGS[@]}" \
   --set "agentOAuthSecret.spiffePrefix=spiffe://${DOMAIN}/sa" \
   --set uiOAuthSecret.useServiceAccountCA=false \
   --set agentOAuthSecret.useServiceAccountCA=false \


### PR DESCRIPTION
## Summary

Replaces the Ansible installer with `scripts/ocp/setup-kagenti.sh` in the HyperShift E2E CI pipeline. This eliminates the 4-hop install chain (70-deploy → fulltest → 30-run-installer → run-install.sh → ansible-playbook) and calls `setup-kagenti.sh` directly. Additionally, this way of deploying kagenti on OCP is the new standard for now.

## Changes

- **70-deploy-kagenti.sh** — drop `ANSIBLE_PYTHON_INTERPRETER`, write secrets in flat helm format to `charts/kagenti/.secrets.yaml` instead of nested Ansible format at `deployments/envs/.secret_values.yaml`
- **hypershift-full-test.sh** — PHASE 2 install/clean and PHASE 5 uninstall now use `setup-kagenti.sh` / `cleanup-kagenti.sh`; `--no-rhoai` maps to `--skip-mlflow`
- **create-cluster.sh** — replace `30-run-installer.sh --env ocp` + `41-wait-crds.sh` with single `setup-kagenti.sh --kagenti-repo .` call
- **README.md** — update quick-start OCP instructions to match

The Kind path (`30-run-installer.sh`) is unchanged.

## Test Plan

- [ ] `/run-e2e` on this PR to validate HyperShift CI pipeline end-to-end
- [ ] Verify Kind CI workflow is unaffected (does not touch `30-run-installer.sh`)