### PR TITLE
feat: :wrench: Update MCP gateway to v0.6.0 and enable gateway tracing

### DIFF
--- a/.github/scripts/kagenti-operator/41-wait-crds.sh
+++ b/.github/scripts/kagenti-operator/41-wait-crds.sh
@@ -11,9 +11,9 @@ log_step "41" "Waiting for Kagenti Operator CRDs"
 # deploy agents using standard Kubernetes Deployments + Services directly.
 # Only keeping CRDs that are still actively used in CI.
 CRDS=(
-    "mcpserverregistrations.mcp.kagenti.com"
-    "mcpvirtualservers.mcp.kagenti.com"
-    "mcpgatewayextensions.mcp.kagenti.com"
+    "mcpserverregistrations.mcp.kuadrant.io"
+    "mcpvirtualservers.mcp.kuadrant.io"
+    "mcpgatewayextensions.mcp.kuadrant.io"
 )
 
 for crd in "${CRDS[@]}"; do

--- a/CLAUDE-ORG.md
+++ b/CLAUDE-ORG.md
@@ -189,7 +189,7 @@ mcp-gateway/
 
 **CRD**:
 ```yaml
-apiVersion: mcp.kagenti.com/v1alpha1
+apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: weather-tool-servers

--- a/PERSONAS_AND_ROLES.md
+++ b/PERSONAS_AND_ROLES.md
@@ -122,7 +122,7 @@ Kagenti is a cloud-native middleware platform that provides framework-neutral, s
 **CRDs Managed**:
 
 - `agents.agent.kagenti.dev/v1alpha1` (legacy, being replaced by standard Deployments)
-- `mcpserverregistrations.mcp.kagenti.com/v1alpha1`
+- `mcpserverregistrations.mcp.kuadrant.io/v1alpha1`
 
 **Technical Skills**:
 

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -227,6 +227,11 @@ otel:
           traces:
             span:
               - 'IsMatch(name, "^a2a\\..*")'
+              - 'attributes["http.method"] != nil'
+              - 'attributes["mcp.method.name"] == "initialize"'
+              - 'attributes["mcp.method.name"] == "notifications/initialized"'
+              - 'attributes["mcp.method.name"] == "notifications/cancelled"'
+              - 'attributes["mcp.method.name"] == "tools/list"'
         transform/genai_to_openinference:
           trace_statements:
             - context: span
@@ -289,6 +294,11 @@ otel:
           traces:
             span:
               - 'IsMatch(name, "^a2a\\..*")'
+              - 'attributes["http.method"] != nil'
+              - 'attributes["mcp.method.name"] == "initialize"'
+              - 'attributes["mcp.method.name"] == "notifications/initialized"'
+              - 'attributes["mcp.method.name"] == "notifications/cancelled"'
+              - 'attributes["mcp.method.name"] == "tools/list"'
       service:
         pipelines:
           traces/mlflow:

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-alpha.25
-digest: sha256:9c7dc6af74081c4545cf71def6dc6c4dc700739682acd212d5562f2e6c4182fc
-generated: "2026-04-09T12:10:36.627835-04:00"
+  version: 0.2.0-alpha.26
+digest: sha256:480de61974052a540cd086536be68d63f98a517f3c4e6bf7d07e94e3838df367
+generated: "2026-04-17T15:42:08.267754-06:00"

--- a/charts/kagenti/templates/mcp-gateway.yaml
+++ b/charts/kagenti/templates/mcp-gateway.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.components.mcpGateway.enabled }}
+# Gateway resource for mcp-gateway. The mcp-gateway controller (v0.6.0+)
+# manages the broker-router deployment and routes automatically via the
+# MCPGatewayExtension CR created by the mcp-gateway Helm chart.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -10,11 +13,10 @@ metadata:
     gateway.io/name: mcp-gateway
     istio: ingressgateway
     {{- include "kagenti.labels" . | nindent 4 }}
-
 spec:
   gatewayClassName: istio
   listeners:
-    - name: mcp # going to the Broker, and no hostname field
+    - name: mcp
       hostname: "{{ .Values.mcpGateway.hostname }}"
       port: 8080
       protocol: HTTP
@@ -24,69 +26,10 @@ spec:
     - name: mcps
       port: 8080
       protocol: HTTP
-      hostname: '*.mcp.local' # this hostname can be any wildcard. It is here to simplify routing, ensure the MCP Server routes attach to this listener only, can be protected by the AuthPolicy and routed to via envoy and the MCPRouter.
+      hostname: '*.mcp.local'
       allowedRoutes:
         namespaces:
-          from: All #any namespace can register an MCP server route
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: ReferenceGrant
-metadata:
-  name: allow-mcp-gateway-extension
-  namespace: "{{ .Values.mcpGateway.namespaces.gatewaySystem }}"
-spec:
-  from:
-    - group: mcp.kagenti.com
-      kind: MCPGatewayExtension
-      namespace: "{{ .Values.mcpGateway.namespaces.mcpSystem }}"
-  to:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  namespace: "{{ .Values.mcpGateway.namespaces.mcpSystem }}"
-  name: mcp-route
-  labels:
-    {{- include "kagenti.labels" . | nindent 4 }}
-spec:
-  parentRefs:
-    - name: http
-      namespace: kagenti-system
-    - name: mcp-gateway
-      namespace: "{{ .Values.mcpGateway.namespaces.gatewaySystem }}"
-  hostnames:
-  - "{{ .Values.mcpGateway.hostname }}"
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /mcp
-      filters:
-        - type: ResponseHeaderModifier
-          responseHeaderModifier:
-            add:
-              - name: Access-Control-Allow-Origin
-                value: "*"
-              - name: Access-Control-Allow-Methods
-                value: "GET, POST, PUT, DELETE, OPTIONS, HEAD"
-              - name: Access-Control-Allow-Headers
-                value: "Content-Type, Authorization, Accept, Origin, X-Requested-With"
-              - name: Access-Control-Max-Age
-                value: "3600"
-              - name: Access-Control-Allow-Credentials
-                value: "true"
-      backendRefs:
-        - name: mcp-gateway-broker
-          port: 8080
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /.well-known/oauth-protected-resource
-      backendRefs:
-        - name: mcp-gateway-broker
-          port: 8080
+          from: All
 ---
 {{- if .Values.openshift }}
 apiVersion: route.openshift.io/v1

--- a/deployments/ansible/cleanup-install.sh
+++ b/deployments/ansible/cleanup-install.sh
@@ -33,7 +33,7 @@ for ns in "${TEAM_NAMESPACES[@]}"; do
     kubectl delete agents.agent.kagenti.dev --all -n "$ns" --ignore-not-found 2>/dev/null || true
     kubectl delete agentcards.agent.kagenti.dev --all -n "$ns" --ignore-not-found 2>/dev/null || true
     # Delete MCP Gateway CRs
-    kubectl delete mcpserverregistrations.mcp.kagenti.com --all -n "$ns" --ignore-not-found 2>/dev/null || true
+    kubectl delete mcpserverregistrations.mcp.kuadrant.io --all -n "$ns" --ignore-not-found 2>/dev/null || true
   fi
 done
 echo ""

--- a/deployments/ansible/default_values.yaml
+++ b/deployments/ansible/default_values.yaml
@@ -95,19 +95,20 @@ charts:
   mcpGateway:
     enabled: false
     namespace: mcp-system
-    version: 0.5.0
+    version: 0.6.0
     values:
       # See https://github.com/Kuadrant/mcp-gateway/blob/main/charts/mcp-gateway/values.yaml
       # for an example Helm values file for this chart.
       image:
-        # Container image tag to use for the broker-router
-        tag: v0.5.0
+        # Container image tag to use for the broker-router (deployed by controller)
+        tag: v0.6.0
       imageController:
         # Container image tag to use for the controller
-        tag: v0.5.0
-      broker:
-        # Start an instance of the broker
-        create: true
+        tag: v0.6.0
+      mcpGatewayExtension:
+        gatewayRef:
+          # Name of the listener on the Gateway to target (required in v0.6.0+)
+          sectionName: mcp
 
   ####################################################################
   # kuadrant operator (AuthPolicy for MCP Gateway)

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -2004,6 +2004,44 @@
     - (charts['kagenti'] | default({})).get('enabled', false) | bool
     - (charts['kagenti'] | default({})).get('chart') is defined
 
+# The kagenti chart creates the Gateway resource that MCPGatewayExtension targets,
+# so wait for the broker-router only after kagenti is installed.
+- name: Wait for mcp-gateway broker-router deployment
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: mcp-gateway
+    namespace: "{{ charts.mcpGateway.namespace | default('mcp-system') }}"
+  register: broker_router_deploy
+  retries: 30
+  delay: 10
+  until: broker_router_deploy.resources | length > 0
+  when: charts.mcpGateway.enabled | default(false)
+
+- name: Patch mcp-gateway broker-router with OTEL env vars
+  kubernetes.core.k8s:
+    api_version: apps/v1
+    kind: Deployment
+    name: mcp-gateway
+    namespace: "{{ charts.mcpGateway.namespace | default('mcp-system') }}"
+    state: patched
+    definition:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: mcp-gateway
+                env:
+                  - name: NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                    value: "http://{{ charts['kagenti-deps']['values']['otel']['collector']['service'] }}:8335"
+                  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                    value: "http/protobuf"
+  when: charts.mcpGateway.enabled | default(false)
+
 # TektonConfig patching (set-security-context, SCC defaults, pruner) is now
 # handled by kagenti-operator's TektonConfigReconciler. The operator is deployed
 # as part of the kagenti chart above, so we wait for TektonConfig to be Ready

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -2005,7 +2005,8 @@
     - (charts['kagenti'] | default({})).get('chart') is defined
 
 # The kagenti chart creates the Gateway resource that MCPGatewayExtension targets,
-# so wait for the broker-router only after kagenti is installed.
+# so wait for the broker-router only after kagenti is installed, using retries: 30,
+# delay: 10 = ~5 minutes for the controller to reconcile and create the deployment.
 - name: Wait for mcp-gateway broker-router deployment
   kubernetes.core.k8s_info:
     api_version: apps/v1
@@ -2018,6 +2019,8 @@
   until: broker_router_deploy.resources | length > 0
   when: charts.mcpGateway.enabled | default(false)
 
+# The container name "mcp-gateway" matches the upstream kuadrant/mcp-gateway chart. Strategic merge
+# patch uses container name as the merge key — update if upstream renames it.
 - name: Patch mcp-gateway broker-router with OTEL env vars
   kubernetes.core.k8s:
     api_version: apps/v1

--- a/docs/components.md
+++ b/docs/components.md
@@ -285,7 +285,7 @@ spec:
 
 ```yaml
 # MCPServerRegistration - Register with the gateway
-apiVersion: mcp.kagenti.com/v1alpha1
+apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: weather-tool-servers

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -64,7 +64,7 @@ spec:
 and then create an `MCPServerRegistration` Custom Resource:
 
 ```
-echo 'apiVersion: mcp.kagenti.com/v1alpha1
+echo 'apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: weather-tool-servers
@@ -147,7 +147,7 @@ echo $ACCESS_TOKEN
 Now, store the access token as a secret to be used by Broker to access the Slack MCP server:
 ```
 kubectl create secret generic slack-server-access-token --from-literal=token="Bearer $ACCESS_TOKEN" --namespace=default
-kubectl label secret slack-server-access-token mcp.kagenti.com/credential=true
+kubectl label secret slack-server-access-token mcp.kuadrant.io/credential=true
 ```
 
 Next, we create the HttpRoute resource for the Slack MCP server:
@@ -180,7 +180,7 @@ EOF
 Finally, we create the MCPServerRegistration resource with the access token:
 ```
 kubectl apply -f - <<EOF
-apiVersion: mcp.kagenti.com/v1alpha1
+apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: slack-tool-servers

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -59,7 +59,7 @@ SPIRE_VERSION="0.27.0"
 GATEWAY_API_VERSION="v1.4.0"
 TEKTON_VERSION="v0.66.0"
 SHIPWRIGHT_VERSION="v0.14.0"
-MCP_GATEWAY_VERSION="0.5.0"
+MCP_GATEWAY_VERSION="0.6.0"
 KUADRANT_VERSION="1.4.2"
 
 # ── Colors & logging ────────────────────────────────────────────────────────


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Update to use latest MCP gateway [v0.6.0](https://github.com/Kuadrant/mcp-gateway/releases/tag/v0.6.0) - the main change is the CRD name and the switch to the controller. This version also provides MCP gateway router tracing, where some of the detailed traces (like initialize, notifications, etc. are filtered out in the Otel collector config by default). Here, we patch the env vars (i.e. use user-provided env vars) to enable the traces to be collected.

Testing with the weather agent and updated weather tool (https://github.com/kagenti/agent-examples/pull/255) can provide a trace like the following
<img width="1196" height="883" alt="Screenshot 2026-04-21 at 1 21 20 PM" src="https://github.com/user-attachments/assets/c47bb5fd-0c9d-4e48-9c9d-2fb3bb8ac50c" />


## Related issue(s)

Fixes #1135 

Assisted-By: Claude (Anthropic AI) [noreply@anthropic.com](mailto:noreply@anthropic.com) for finding what was necessary to update MCP gateway to this version
