### PR TITLE
fix: Enable Kind image preloading for dev env

### DIFF
--- a/deployments/ansible/kind/preload-images.txt
+++ b/deployments/ansible/kind/preload-images.txt
@@ -20,6 +20,6 @@ quay.io/jetstack/cert-manager-webhook:v1.17.2
 quay.io/keycloak/keycloak:26.5.2
 ghcr.io/shipwright-io/build/shipwright-build-controller:v0.14.0
 ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.14.0
-ghcr.io/kagenti/kagenti/ui-v2:v0.5.0-alpha.11
-ghcr.io/kagenti/kagenti-operator/kagenti-operator:0.2.0-alpha.19
-ghcr.io/kagenti/kagenti/backend:v0.5.0-alpha.11
+ghcr.io/kagenti/kagenti/ui-v2:v0.6.0-alpha.4
+ghcr.io/kagenti/kagenti-operator/kagenti-operator:0.2.0-alpha.30
+ghcr.io/kagenti/kagenti/backend:v0.6.0-alpha.4

--- a/deployments/ansible/kind/preload-images.txt
+++ b/deployments/ansible/kind/preload-images.txt
@@ -13,13 +13,3 @@ docker.io/nginx/nginx-prometheus-exporter:1.4.2
 docker.io/nginxinc/nginx-unprivileged:1.29.1-alpine
 docker.io/prom/prometheus:v3.5.0
 otel/opentelemetry-collector-contrib:0.122.1
-quay.io/containers/buildah:v1.37.5
-quay.io/jetstack/cert-manager-cainjector:v1.17.2
-quay.io/jetstack/cert-manager-controller:v1.17.2
-quay.io/jetstack/cert-manager-webhook:v1.17.2
-quay.io/keycloak/keycloak:26.5.2
-ghcr.io/shipwright-io/build/shipwright-build-controller:v0.14.0
-ghcr.io/shipwright-io/build/shipwright-build-webhook:v0.14.0
-ghcr.io/kagenti/kagenti/ui-v2:v0.6.0-alpha.4
-ghcr.io/kagenti/kagenti-operator/kagenti-operator:0.2.0-alpha.30
-ghcr.io/kagenti/kagenti/backend:v0.6.0-alpha.4

--- a/deployments/envs/dev_values.yaml
+++ b/deployments/envs/dev_values.yaml
@@ -121,7 +121,7 @@ charts:
               default:
                 jwtTTL: "5m"
 
-kind_images_preload: false
+kind_images_preload: true
 # docker or podman
 container_engine: docker
 


### PR DESCRIPTION
## Summary
- Re-enable `kind_images_preload: true` in `dev_values.yaml` to avoid Docker Hub rate limiting (429) during Kind cluster installs
- Bump three stale image versions in `preload-images.txt` to match current releases:
  - `ui-v2`: v0.5.0-alpha.11 → v0.6.0-alpha.4
  - `kagenti-operator`: 0.2.0-alpha.19 → 0.2.0-alpha.30
  - `backend`: v0.5.0-alpha.11 → v0.6.0-alpha.4

## Context
The `kind_images_preload` flag was accidentally disabled in commit 013fd8c0 (collateral damage from ToolHive removal). Without preloading, Kind nodes pull Docker Hub images at runtime, frequently hitting rate limits — causing cascading failures in SPIRE OIDC Discovery Provider rollout and SPIFFE IdP setup jobs.

The flag is set only in `dev_values.yaml` so it only affects `--env dev` (Kind local) installs. Other environments (minimal, auth, ocp, ocp-minimal) are unaffected.

## Test plan
- [ ] Run `./run-install.sh --env dev` on a fresh Kind cluster and verify images are preloaded
- [ ] Confirm SPIRE OIDC Discovery Provider rolls out without ImagePullBackOff
- [ ] Verify no impact on `--env ocp` installs