### PR TITLE
ci(openshell): add experimental E2E workflows for Kind and HyperShift

### DIFF
--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -3,14 +3,11 @@
 # Experimental, non-voting workflow for the OpenShell PoC on HyperShift.
 # Triggered by /run-e2e-openshell comment on PRs or manual dispatch.
 #
-# Usage:
-#   - Maintainer reviews PR code for security
-#   - Maintainer comments: /run-e2e-openshell
-#   - Workflow runs OpenShell E2E on a HyperShift cluster
+# Uses the unified openshell-full-test.sh script with --platform ocp.
 #
-# Security:
-#   - Only users with write permission can trigger
-#   - Non-voting: never blocks merge (continue-on-error: true)
+# Note: LLM-dependent tests skip without .env.maas credentials.
+# Custom agent images (ADK, Claude SDK) need Shipwright builds on OCP.
+# The weather agent uses a public ghcr.io image and works without builds.
 #
 name: "[Experimental] E2E OpenShell (HyperShift)"
 
@@ -19,16 +16,12 @@ on:
     types: [created]
   workflow_dispatch:
 
-# No workflow-level permissions - jobs define their own
 permissions: {}
 
 env:
   OCP_VERSION: '4.20.11'
 
 jobs:
-  # ==========================================================================
-  # Authorization: Validate comment and user permission
-  # ==========================================================================
   authorize:
     name: Authorize
     runs-on: ubuntu-latest
@@ -39,254 +32,131 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-      statuses: write
     outputs:
-      authorized: ${{ steps.check-permission.outputs.has-permission }}
+      authorized: ${{ steps.check.outputs.has-permission }}
       pr_number: ${{ steps.pr-info.outputs.number }}
       pr_sha: ${{ steps.pr-info.outputs.sha }}
       cluster_suffix: ${{ steps.pr-info.outputs.cluster_suffix }}
     steps:
-      - name: Check user write permission
-        id: check-permission
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+      - name: Check write permission
+        id: check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
-            // For workflow_dispatch, the user already has permissions
             if (context.eventName === 'workflow_dispatch') {
               core.setOutput('has-permission', 'true');
-              core.setOutput('check-result', 'true');
               return;
             }
-
-            const username = context.payload.comment.user.login;
-            console.log(`Checking permission for user: ${username}`);
-
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: username
+              owner: context.repo.owner, repo: context.repo.repo,
+              username: context.payload.comment.user.login
             });
+            const ok = ['admin', 'write'].includes(data.permission);
+            core.setOutput('has-permission', ok.toString());
+            if (!ok) core.setFailed(`No write permission: ${data.permission}`);
 
-            const permission = data.permission;
-            const hasWriteAccess = ['admin', 'write'].includes(permission);
-            console.log(`User ${username} has permission: ${permission} (write access: ${hasWriteAccess})`);
-
-            core.setOutput('has-permission', hasWriteAccess.toString());
-            core.setOutput('check-result', hasWriteAccess.toString());
-
-            if (!hasWriteAccess) {
-              core.setFailed(`User ${username} does not have write permission (has: ${permission})`);
-            }
-
-      - name: Get PR information
+      - name: Get PR info
         id: pr-info
-        if: steps.check-permission.outputs.check-result == 'true' && github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        if: steps.check.outputs.has-permission == 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner: context.repo.owner, repo: context.repo.repo,
               pull_number: context.issue.number
             });
             core.setOutput('number', pr.number);
             core.setOutput('sha', pr.head.sha);
             core.setOutput('cluster_suffix', `ospr${pr.number}`);
-            console.log(`PR #${pr.number} at commit ${pr.head.sha}`);
 
-      - name: React to comment with rocket
-        if: steps.check-permission.outputs.check-result == 'true' && github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+      - name: React with rocket
+        if: steps.check.outputs.has-permission == 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket'
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: context.payload.comment.id, content: 'rocket'
             });
 
-      - name: Post starting comment
-        if: steps.check-permission.outputs.check-result == 'true' && github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `### [Experimental] OpenShell E2E Tests Started
-
-            **Triggered by:** @${{ github.event.comment.user.login }}
-            **Commit:** \`${{ steps.pr-info.outputs.sha }}\`
-            **Workflow Run:** [View logs](${runUrl})
-
-            OpenShell PoC tests are running on OpenShift ${{ env.OCP_VERSION }}. This is experimental and non-voting.
-
-            ---
-            <sub>To re-run, comment \`/run-e2e-openshell\` again.</sub>`
-            });
-
-  # ==========================================================================
-  # E2E Tests Job
-  # ==========================================================================
   e2e-openshell:
     name: OpenShell PoC (HyperShift)
     runs-on: ubuntu-latest
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
     timeout-minutes: 90
-    # Non-voting: never blocks merge
     continue-on-error: true
     permissions:
       contents: read
     env:
-      CLUSTER_SUFFIX: ${{ needs.authorize.outputs.cluster_suffix || github.run_number }}
+      CLUSTER_SUFFIX: ${{ needs.authorize.outputs.cluster_suffix || 'osmanual' }}
+      MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.authorize.outputs.pr_sha || github.sha }}
 
-      - name: Validate secrets are configured
-        run: bash .github/scripts/hypershift/ci/00-validate-secrets.sh
-        env:
-          HYPERSHIFT_MGMT_KUBECONFIG: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          PULL_SECRET: ${{ secrets.PULL_SECRET }}
-          BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
-          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
-          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.12'
 
-      - name: Setup credentials
-        run: bash .github/scripts/hypershift/ci/10-setup-credentials.sh
-        env:
-          HYPERSHIFT_MGMT_KUBECONFIG: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
-          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
-          PULL_SECRET: ${{ secrets.PULL_SECRET }}
+      - name: Install tools (kubectl, Helm, oc, hcp)
+        run: |
+          bash .github/scripts/hypershift/ci/20-install-tools.sh
+          bash .github/scripts/common/10-setup-dependencies.sh
 
-      - name: Install tools
-        run: bash .github/scripts/hypershift/ci/20-install-tools.sh
-        env:
-          OCP_VERSION: ${{ env.OCP_VERSION }}
+      - name: Install Helm v3
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+        with:
+          version: 'v3.17.0'
 
-      - name: Setup Go
+      - name: Setup Go (for hcp CLI)
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: '1.24'
           cache: false
 
-      - name: Build hcp CLI from source
+      - name: Build hcp CLI
         run: bash .github/scripts/hypershift/ci/30-build-hcp-cli.sh
 
       - name: Clone hypershift-automation
         run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
 
-      - name: Verify management cluster access
-        run: bash .github/scripts/hypershift/ci/50-verify-mgmt-access.sh
-
-      - name: Cleanup any existing cluster
-        run: bash .github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
-          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
-          CLUSTER_SUFFIX: ${{ env.CLUSTER_SUFFIX }}
-
-      - name: Create HyperShift cluster
-        id: create-cluster
-        run: bash .github/scripts/hypershift/create-cluster.sh "${{ env.CLUSTER_SUFFIX }}"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
-          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
-          BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
-          OCP_VERSION: ${{ env.OCP_VERSION }}
-
-      - name: Deploy Kagenti (OpenShell profile)
-        if: success()
-        run: bash .github/scripts/hypershift/ci/70-deploy-kagenti.sh
-        env:
-          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-          KAGENTI_ENV: openshell
-
-      - name: Set up Python
-        if: success()
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
-        with:
-          python-version: '3.11'
-
       - name: Install uv
-        if: success()
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        if: success()
         run: uv sync --frozen
 
-      - name: Deploy OpenShell gateway
-        if: success()
-        run: kubectl apply -k deployments/openshell/
+      - name: Setup credentials
+        run: bash .github/scripts/hypershift/ci/10-setup-credentials.sh
         env:
-          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+          HYPERSHIFT_MGMT_KUBECONFIG: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
+          PULL_SECRET: ${{ secrets.PULL_SECRET }}
 
-      - name: Wait for OpenShell pods
-        if: success()
+      - name: Run OpenShell full test (HyperShift)
         run: |
-          kubectl wait --for=condition=ready pod --all -n openshell-system --timeout=120s 2>/dev/null || \
-            echo "No pods in openshell-system yet (gateway may be config-only). Continuing."
+          ./.github/scripts/local-setup/openshell-full-test.sh \
+            --platform ocp \
+            --skip-cluster-destroy \
+            "${{ env.CLUSTER_SUFFIX }}"
         env:
-          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-
-      - name: Install test dependencies
-        if: success()
-        run: bash .github/scripts/common/80-install-test-deps.sh
-        env:
-          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-
-      - name: Setup test credentials
-        if: success()
-        run: bash .github/scripts/common/87-setup-test-credentials.sh
-        env:
-          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-
-      - name: Run OpenShell E2E tests
-        if: success()
-        run: |
-          TEST_DIR="kagenti/tests/e2e/openshell"
-          if [ -d "$TEST_DIR" ]; then
-            uv run pytest "$TEST_DIR" -v
-          else
-            echo "No tests at $TEST_DIR yet. Skipping."
-          fi
-        env:
-          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-          KAGENTI_CONFIG_FILE: deployments/envs/dev_values_openshell.yaml
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
+          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
         with:
           name: openshell-hypershift-e2e-results
           path: test-results/
 
-      - name: Collect cluster info on failure
-        if: failure()
-        run: bash .github/scripts/hypershift/ci/85-collect-failure-info.sh
-        env:
-          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-
-  # ==========================================================================
-  # Cleanup Job
-  # ==========================================================================
   cleanup:
     name: Cleanup
     runs-on: ubuntu-latest
@@ -295,14 +165,9 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    env:
-      CLUSTER_SUFFIX: ${{ needs.authorize.outputs.cluster_suffix || github.run_number }}
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ needs.authorize.outputs.pr_sha || github.sha }}
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup credentials
         run: bash .github/scripts/hypershift/ci/10-setup-credentials.sh
@@ -313,8 +178,6 @@ jobs:
 
       - name: Install tools
         run: bash .github/scripts/hypershift/ci/20-install-tools.sh
-        env:
-          OCP_VERSION: ${{ env.OCP_VERSION }}
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
@@ -322,13 +185,13 @@ jobs:
           go-version: '1.24'
           cache: false
 
-      - name: Build hcp CLI from source
+      - name: Build hcp CLI
         run: bash .github/scripts/hypershift/ci/30-build-hcp-cli.sh
 
       - name: Clone hypershift-automation
         run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
 
-      - name: Destroy HyperShift cluster
+      - name: Destroy cluster
         run: bash .github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -336,11 +199,8 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
           HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
-          CLUSTER_SUFFIX: ${{ env.CLUSTER_SUFFIX }}
+          CLUSTER_SUFFIX: ${{ needs.authorize.outputs.cluster_suffix || 'osmanual' }}
 
-  # ==========================================================================
-  # Post Results
-  # ==========================================================================
   post-results:
     name: Post Results
     runs-on: ubuntu-latest
@@ -349,42 +209,16 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Post success comment
-        if: needs.e2e-openshell.result == 'success'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+      - name: Post result comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
+            const passed = '${{ needs.e2e-openshell.result }}' === 'success';
+            const emoji = passed ? '✅' : '❌';
+            const status = passed ? 'Passed' : 'Failed';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner: context.repo.owner, repo: context.repo.repo,
               issue_number: ${{ needs.authorize.outputs.pr_number }},
-              body: `### [Experimental] OpenShell E2E Tests Passed
-
-            **Commit:** \`${{ needs.authorize.outputs.pr_sha }}\`
-            **Result:** All OpenShell PoC tests passed
-            **Workflow Run:** [View logs](${runUrl})
-
-            ---
-            <sub>This is an experimental, non-voting check. To re-run, comment \`/run-e2e-openshell\` again.</sub>`
-            });
-
-      - name: Post failure comment
-        if: needs.e2e-openshell.result == 'failure'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ needs.authorize.outputs.pr_number }},
-              body: `### [Experimental] OpenShell E2E Tests Failed
-
-            **Commit:** \`${{ needs.authorize.outputs.pr_sha }}\`
-            **Result:** OpenShell PoC tests failed - check the logs
-            **Workflow Run:** [View logs](${runUrl})
-
-            ---
-            <sub>This is an experimental, non-voting check. To re-run, comment \`/run-e2e-openshell\` again.</sub>`
+              body: `### ${emoji} [Experimental] OpenShell E2E Tests ${status}\n\n**Commit:** \`${{ needs.authorize.outputs.pr_sha }}\`\n**Workflow:** [View logs](${runUrl})\n\n---\n<sub>Non-voting. Re-run: \`/run-e2e-openshell\`</sub>`
             });

--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: ${{ needs.authorize.outputs.pr_sha || github.sha }}
 
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: openshell-hypershift-e2e-results
           path: test-results/
@@ -167,7 +167,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Setup credentials
         run: bash .github/scripts/hypershift/ci/10-setup-credentials.sh

--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -1,0 +1,390 @@
+# OpenShell PoC E2E Tests (HyperShift)
+#
+# Experimental, non-voting workflow for the OpenShell PoC on HyperShift.
+# Triggered by /run-e2e-openshell comment on PRs or manual dispatch.
+#
+# Usage:
+#   - Maintainer reviews PR code for security
+#   - Maintainer comments: /run-e2e-openshell
+#   - Workflow runs OpenShell E2E on a HyperShift cluster
+#
+# Security:
+#   - Only users with write permission can trigger
+#   - Non-voting: never blocks merge (continue-on-error: true)
+#
+name: "[Experimental] E2E OpenShell (HyperShift)"
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+# No workflow-level permissions - jobs define their own
+permissions: {}
+
+env:
+  OCP_VERSION: '4.20.11'
+
+jobs:
+  # ==========================================================================
+  # Authorization: Validate comment and user permission
+  # ==========================================================================
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/run-e2e-openshell'))
+    permissions:
+      pull-requests: write
+      contents: read
+      statuses: write
+    outputs:
+      authorized: ${{ steps.check-permission.outputs.has-permission }}
+      pr_number: ${{ steps.pr-info.outputs.number }}
+      pr_sha: ${{ steps.pr-info.outputs.sha }}
+      cluster_suffix: ${{ steps.pr-info.outputs.cluster_suffix }}
+    steps:
+      - name: Check user write permission
+        id: check-permission
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            // For workflow_dispatch, the user already has permissions
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('has-permission', 'true');
+              core.setOutput('check-result', 'true');
+              return;
+            }
+
+            const username = context.payload.comment.user.login;
+            console.log(`Checking permission for user: ${username}`);
+
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: username
+            });
+
+            const permission = data.permission;
+            const hasWriteAccess = ['admin', 'write'].includes(permission);
+            console.log(`User ${username} has permission: ${permission} (write access: ${hasWriteAccess})`);
+
+            core.setOutput('has-permission', hasWriteAccess.toString());
+            core.setOutput('check-result', hasWriteAccess.toString());
+
+            if (!hasWriteAccess) {
+              core.setFailed(`User ${username} does not have write permission (has: ${permission})`);
+            }
+
+      - name: Get PR information
+        id: pr-info
+        if: steps.check-permission.outputs.check-result == 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('number', pr.number);
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('cluster_suffix', `ospr${pr.number}`);
+            console.log(`PR #${pr.number} at commit ${pr.head.sha}`);
+
+      - name: React to comment with rocket
+        if: steps.check-permission.outputs.check-result == 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: Post starting comment
+        if: steps.check-permission.outputs.check-result == 'true' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### [Experimental] OpenShell E2E Tests Started
+
+            **Triggered by:** @${{ github.event.comment.user.login }}
+            **Commit:** \`${{ steps.pr-info.outputs.sha }}\`
+            **Workflow Run:** [View logs](${runUrl})
+
+            OpenShell PoC tests are running on OpenShift ${{ env.OCP_VERSION }}. This is experimental and non-voting.
+
+            ---
+            <sub>To re-run, comment \`/run-e2e-openshell\` again.</sub>`
+            });
+
+  # ==========================================================================
+  # E2E Tests Job
+  # ==========================================================================
+  e2e-openshell:
+    name: OpenShell PoC (HyperShift)
+    runs-on: ubuntu-latest
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    timeout-minutes: 90
+    # Non-voting: never blocks merge
+    continue-on-error: true
+    permissions:
+      contents: read
+    env:
+      CLUSTER_SUFFIX: ${{ needs.authorize.outputs.cluster_suffix || github.run_number }}
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ needs.authorize.outputs.pr_sha || github.sha }}
+
+      - name: Validate secrets are configured
+        run: bash .github/scripts/hypershift/ci/00-validate-secrets.sh
+        env:
+          HYPERSHIFT_MGMT_KUBECONFIG: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          PULL_SECRET: ${{ secrets.PULL_SECRET }}
+          BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+
+      - name: Setup credentials
+        run: bash .github/scripts/hypershift/ci/10-setup-credentials.sh
+        env:
+          HYPERSHIFT_MGMT_KUBECONFIG: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          PULL_SECRET: ${{ secrets.PULL_SECRET }}
+
+      - name: Install tools
+        run: bash .github/scripts/hypershift/ci/20-install-tools.sh
+        env:
+          OCP_VERSION: ${{ env.OCP_VERSION }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
+        with:
+          go-version: '1.24'
+          cache: false
+
+      - name: Build hcp CLI from source
+        run: bash .github/scripts/hypershift/ci/30-build-hcp-cli.sh
+
+      - name: Clone hypershift-automation
+        run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
+
+      - name: Verify management cluster access
+        run: bash .github/scripts/hypershift/ci/50-verify-mgmt-access.sh
+
+      - name: Cleanup any existing cluster
+        run: bash .github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+          CLUSTER_SUFFIX: ${{ env.CLUSTER_SUFFIX }}
+
+      - name: Create HyperShift cluster
+        id: create-cluster
+        run: bash .github/scripts/hypershift/create-cluster.sh "${{ env.CLUSTER_SUFFIX }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+          BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
+          OCP_VERSION: ${{ env.OCP_VERSION }}
+
+      - name: Deploy Kagenti (OpenShell profile)
+        if: success()
+        run: bash .github/scripts/hypershift/ci/70-deploy-kagenti.sh
+        env:
+          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+          KAGENTI_ENV: openshell
+
+      - name: Set up Python
+        if: success()
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        if: success()
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        if: success()
+        run: uv sync --frozen
+
+      - name: Deploy OpenShell gateway
+        if: success()
+        run: kubectl apply -k deployments/openshell/
+        env:
+          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+
+      - name: Wait for OpenShell pods
+        if: success()
+        run: |
+          kubectl wait --for=condition=ready pod --all -n openshell-system --timeout=120s 2>/dev/null || \
+            echo "No pods in openshell-system yet (gateway may be config-only). Continuing."
+        env:
+          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+
+      - name: Install test dependencies
+        if: success()
+        run: bash .github/scripts/common/80-install-test-deps.sh
+        env:
+          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+
+      - name: Setup test credentials
+        if: success()
+        run: bash .github/scripts/common/87-setup-test-credentials.sh
+        env:
+          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+
+      - name: Run OpenShell E2E tests
+        if: success()
+        run: |
+          TEST_DIR="kagenti/tests/e2e/openshell"
+          if [ -d "$TEST_DIR" ]; then
+            uv run pytest "$TEST_DIR" -v
+          else
+            echo "No tests at $TEST_DIR yet. Skipping."
+          fi
+        env:
+          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+          KAGENTI_CONFIG_FILE: deployments/envs/dev_values_openshell.yaml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: openshell-hypershift-e2e-results
+          path: test-results/
+
+      - name: Collect cluster info on failure
+        if: failure()
+        run: bash .github/scripts/hypershift/ci/85-collect-failure-info.sh
+        env:
+          KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
+
+  # ==========================================================================
+  # Cleanup Job
+  # ==========================================================================
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    needs: [authorize, e2e-openshell]
+    if: always() && needs.authorize.outputs.authorized == 'true'
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      CLUSTER_SUFFIX: ${{ needs.authorize.outputs.cluster_suffix || github.run_number }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ needs.authorize.outputs.pr_sha || github.sha }}
+
+      - name: Setup credentials
+        run: bash .github/scripts/hypershift/ci/10-setup-credentials.sh
+        env:
+          HYPERSHIFT_MGMT_KUBECONFIG: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          PULL_SECRET: ${{ secrets.PULL_SECRET }}
+
+      - name: Install tools
+        run: bash .github/scripts/hypershift/ci/20-install-tools.sh
+        env:
+          OCP_VERSION: ${{ env.OCP_VERSION }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
+        with:
+          go-version: '1.24'
+          cache: false
+
+      - name: Build hcp CLI from source
+        run: bash .github/scripts/hypershift/ci/30-build-hcp-cli.sh
+
+      - name: Clone hypershift-automation
+        run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
+
+      - name: Destroy HyperShift cluster
+        run: bash .github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+          CLUSTER_SUFFIX: ${{ env.CLUSTER_SUFFIX }}
+
+  # ==========================================================================
+  # Post Results
+  # ==========================================================================
+  post-results:
+    name: Post Results
+    runs-on: ubuntu-latest
+    needs: [authorize, e2e-openshell]
+    if: always() && needs.authorize.outputs.authorized == 'true' && github.event_name != 'workflow_dispatch'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post success comment
+        if: needs.e2e-openshell.result == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.authorize.outputs.pr_number }},
+              body: `### [Experimental] OpenShell E2E Tests Passed
+
+            **Commit:** \`${{ needs.authorize.outputs.pr_sha }}\`
+            **Result:** All OpenShell PoC tests passed
+            **Workflow Run:** [View logs](${runUrl})
+
+            ---
+            <sub>This is an experimental, non-voting check. To re-run, comment \`/run-e2e-openshell\` again.</sub>`
+            });
+
+      - name: Post failure comment
+        if: needs.e2e-openshell.result == 'failure'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.authorize.outputs.pr_number }},
+              body: `### [Experimental] OpenShell E2E Tests Failed
+
+            **Commit:** \`${{ needs.authorize.outputs.pr_sha }}\`
+            **Result:** OpenShell PoC tests failed - check the logs
+            **Workflow Run:** [View logs](${runUrl})
+
+            ---
+            <sub>This is an experimental, non-voting check. To re-run, comment \`/run-e2e-openshell\` again.</sub>`
+            });

--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -126,7 +126,7 @@ jobs:
         run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
 
       - name: Install dependencies
         run: uv sync --frozen

--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -1,0 +1,80 @@
+# OpenShell PoC E2E Tests (Kind)
+#
+# Experimental, non-voting workflow for the OpenShell PoC.
+# Runs the openshell-full-test.sh script which handles cluster creation,
+# platform install, OpenShell gateway deployment, and E2E tests.
+#
+# This workflow never blocks merge (continue-on-error: true).
+#
+name: "[Experimental] E2E OpenShell (Kind)"
+
+on:
+  push:
+    branches: ["feat/openshell-*"]
+    paths:
+      - 'deployments/openshell/**'
+      - 'kagenti/tests/e2e/openshell/**'
+      - '.github/scripts/local-setup/openshell-full-test.sh'
+      - '.github/workflows/e2e-openshell-kind.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: openshell-kind-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-openshell:
+    name: OpenShell PoC (Kind)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Non-voting: never blocks merge
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+        with:
+          version: 'v3.17.0'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Free up disk space
+        run: bash .github/scripts/common/05-free-disk-space.sh
+
+      - name: Setup Python and Ansible dependencies
+        run: bash .github/scripts/common/10-setup-dependencies.sh
+
+      - name: Install Python project dependencies
+        run: uv sync --frozen
+
+      - name: Run OpenShell full test
+        run: ./.github/scripts/local-setup/openshell-full-test.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: openshell-e2e-test-results
+          path: test-results/
+
+      - name: Collect logs on failure
+        if: failure()
+        run: bash .github/scripts/common/99-collect-logs.sh

--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -2,9 +2,13 @@
 #
 # Experimental, non-voting workflow for the OpenShell PoC.
 # Runs the openshell-full-test.sh script which handles cluster creation,
-# platform install, OpenShell gateway deployment, and E2E tests.
+# platform install, OpenShell gateway deployment, agent builds, and E2E tests.
 #
 # This workflow never blocks merge (continue-on-error: true).
+#
+# Note: LLM-dependent tests (PR review, code review) are SKIPPED in CI
+# because there's no .env.maas file. Set OPENSHELL_LLM_AVAILABLE=true
+# and provide LiteMaaS credentials to enable them.
 #
 name: "[Experimental] E2E OpenShell (Kind)"
 
@@ -15,6 +19,7 @@ on:
       - 'deployments/openshell/**'
       - 'kagenti/tests/e2e/openshell/**'
       - '.github/scripts/local-setup/openshell-full-test.sh'
+      - '.github/scripts/local-setup/openshell-build-agents.sh'
       - '.github/workflows/e2e-openshell-kind.yaml'
   workflow_dispatch:
 
@@ -29,29 +34,36 @@ jobs:
   e2e-openshell:
     name: OpenShell PoC (Kind)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # Non-voting: never blocks merge
+    timeout-minutes: 45
     continue-on-error: true
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install kubectl
         uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
 
-      - name: Install Helm
+      - name: Install Helm v3
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
           version: 'v3.17.0'
 
+      - name: Install Kind
+        run: |
+          KIND_VERSION="v0.27.0"
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac1f950a3cb4083c8c3c04dc0  # v3.10.0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -67,14 +79,22 @@ jobs:
 
       - name: Run OpenShell full test
         run: ./.github/scripts/local-setup/openshell-full-test.sh
+        env:
+          PLATFORM: kind
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
         with:
-          name: openshell-e2e-test-results
-          path: test-results/
+          name: openshell-kind-e2e-results
+          path: |
+            test-results/
+            /tmp/kagenti/
 
       - name: Collect logs on failure
         if: failure()
-        run: bash .github/scripts/common/99-collect-logs.sh
+        run: |
+          mkdir -p /tmp/kagenti/ci-logs
+          kubectl get pods -A > /tmp/kagenti/ci-logs/all-pods.txt 2>&1 || true
+          kubectl logs -n openshell-system openshell-gateway-0 --tail=100 > /tmp/kagenti/ci-logs/gateway.log 2>&1 || true
+          kubectl get events -n team1 --sort-by='.lastTimestamp' > /tmp/kagenti/ci-logs/team1-events.txt 2>&1 || true

--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
@@ -63,7 +63,7 @@ jobs:
           kind version
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac1f950a3cb4083c8c3c04dc0  # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Install uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
@@ -82,15 +82,6 @@ jobs:
         env:
           PLATFORM: kind
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
-        with:
-          name: openshell-kind-e2e-results
-          path: |
-            test-results/
-            /tmp/kagenti/
-
       - name: Collect logs on failure
         if: failure()
         run: |
@@ -98,3 +89,12 @@ jobs:
           kubectl get pods -A > /tmp/kagenti/ci-logs/all-pods.txt 2>&1 || true
           kubectl logs -n openshell-system openshell-gateway-0 --tail=100 > /tmp/kagenti/ci-logs/gateway.log 2>&1 || true
           kubectl get events -n team1 --sort-by='.lastTimestamp' > /tmp/kagenti/ci-logs/team1-events.txt 2>&1 || true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: openshell-kind-e2e-results
+          path: |
+            test-results/
+            /tmp/kagenti/

--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac1f950a3cb4083c8c3c04dc0  # v3.10.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
 
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh


### PR DESCRIPTION
## Summary

Add experimental, non-voting CI workflows for the OpenShell PoC.
**Must merge to main first** so GitHub Actions can discover the workflows for PR-triggered events.

## Workflows

| File | Trigger | Voting? |
|------|---------|---------|
| `e2e-openshell-kind.yaml` | Push to `feat/openshell-*` + path filter | No (`continue-on-error: true`) |
| `e2e-openshell-hypershift.yaml` | `/run-e2e-openshell` comment + manual | No (`continue-on-error: true`) |

## Why merge first?

- `push` triggers on non-default branches only work if the workflow file exists on the default branch
- `issue_comment` triggers ALWAYS run from the default branch
- Without this, the OpenShell PoC PR (#1300) can't use CI

## Test infrastructure

The actual test scripts, agents, and tests live in PR #1300 (`feat/openshell-poc`).
These workflows just call `openshell-full-test.sh` which is self-contained.

## Test plan
- [ ] Verify workflow appears in Actions tab after merge
- [ ] Verify `/run-e2e-openshell` comment triggers HyperShift workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)