### PR TITLE
build(deps): Bump node and nginx Docker digests in ui-v2

### DIFF
--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 # Stage 1: Build the React application
-FROM node:25-alpine@sha256:ad82ecad30371c43f4057aaa4800a8ed88f9446553a2d21323710c7b937177fc AS builder
+FROM node:25-alpine@sha256:bdf2cca6fe3dabd014ea60163eca3f0f7015fbd5c7ee1b0e9ccb4ced6eb02ef4 AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ COPY ui-v2/ .
 RUN npm run build
 
 # Stage 2: Serve with nginx
-FROM nginx:1.29-alpine@sha256:582c496ccf79d8aa6f8203a79d32aaf7ffd8b13362c60a701a2f9ac64886c93d
+FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
 
 # Copy nginx configuration
 COPY ui-v2/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- Bumps `node:25-alpine` digest from `ad82eca` to `bdf2cca`
- Bumps `nginx:1.29-alpine` digest from `582c496` to `5616878`

Bundles Dependabot PRs #1279 and #1281 into a single update since both modify the same Dockerfile.

## Test plan
- [ ] CI passes (pre-commit, security scans)
- [ ] Verify image pulls succeed in Kind deployment

Supersedes #1279 and #1281.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>