### PR TITLE
ci(kind): AuthBridge weather E2E (91 script, Kind workflows)

### DIFF
--- a/.github/scripts/kind/90b-free-capacity-for-advanced-weather.sh
+++ b/.github/scripts/kind/90b-free-capacity-for-advanced-weather.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# After pytest (wave 90), scale down the baseline weather-service and weather-tool
+# Deployments so single-node Kind can schedule weather-tool-advanced and
+# weather-service-advanced (AuthBridge-injected, multi-container pods).
+#
+# Without this, wave 91 often fails with: FailedScheduling ... Insufficient cpu
+# and kubectl rollout status times out for weather-service-advanced.
+#
+# This runs in CI only (invoked from e2e-kind*.yaml before 91). Local runs can
+# call it manually with NAMESPACE=team1 if needed.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/logging.sh"
+
+NAMESPACE="${NAMESPACE:-team1}"
+
+log_step "90b" "Free cluster capacity (scale down baseline weather for advanced AuthBridge)"
+
+if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+  log_error "Namespace $NAMESPACE not found"
+  exit 1
+fi
+
+for deploy in weather-service weather-tool; do
+  if kubectl get "deployment/${deploy}" -n "$NAMESPACE" &>/dev/null; then
+    log_info "Scaling down deployment/${deploy} in ${NAMESPACE}..."
+    kubectl scale "deployment/${deploy}" -n "$NAMESPACE" --replicas=0
+  else
+    log_info "deployment/${deploy} not found (skipping)"
+  fi
+done
+
+# Wait for pods to terminate (up to ~5 min)
+for _ in $(seq 1 60); do
+  c1=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=weather-service --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+  c2=$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=weather-tool --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+  c1=${c1:-0}
+  c2=${c2:-0}
+  if [[ "$c1" -eq 0 && "$c2" -eq 0 ]]; then
+    log_success "Baseline weather-service and weather-tool pods are gone"
+    exit 0
+  fi
+  sleep 5
+done
+
+log_warn "Timed out waiting for baseline weather pods to terminate; continuing (wave 91 may still see CPU pressure)"

--- a/.github/scripts/kind/90c-restore-baseline-weather-for-ui.sh
+++ b/.github/scripts/kind/90c-restore-baseline-weather-for-ui.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# After AuthBridge advanced E2E (91), bring back wave-90 weather-service and
+# weather-tool so Playwright UI tests can reach the weather agent again.
+# Pair with 90b-free-capacity-for-advanced-weather.sh which scales them to 0.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/logging.sh"
+
+NAMESPACE="${NAMESPACE:-team1}"
+ROLLOUT_TIMEOUT="${BASELINE_WEATHER_ROLLOUT_TIMEOUT:-300s}"
+
+log_step "90c" "Restore baseline weather deployments for UI E2E"
+
+if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+  log_error "Namespace $NAMESPACE not found"
+  exit 1
+fi
+
+for deploy in weather-service weather-tool; do
+  if kubectl get "deployment/${deploy}" -n "$NAMESPACE" &>/dev/null; then
+    log_info "Scaling up deployment/${deploy} in ${NAMESPACE} to 1 replica..."
+    kubectl scale "deployment/${deploy}" -n "$NAMESPACE" --replicas=1
+  else
+    log_warn "deployment/${deploy} not found (skipping)"
+  fi
+done
+
+for deploy in weather-service weather-tool; do
+  if kubectl get "deployment/${deploy}" -n "$NAMESPACE" &>/dev/null; then
+    log_info "Waiting for rollout: ${deploy}..."
+    kubectl rollout status "deployment/${deploy}" -n "$NAMESPACE" --timeout="$ROLLOUT_TIMEOUT"
+  fi
+done
+
+log_success "Baseline weather deployments are ready for UI tests"

--- a/.github/scripts/kind/90c-restore-baseline-weather-for-ui.sh
+++ b/.github/scripts/kind/90c-restore-baseline-weather-for-ui.sh
@@ -3,6 +3,10 @@
 # weather-tool so Playwright UI tests can reach the weather agent again.
 # Pair with 90b-free-capacity-for-advanced-weather.sh which scales them to 0.
 #
+# Wave 91 leaves weather-service-advanced and weather-tool-advanced running on
+# the single Kind node; scale those down first or baseline weather cannot schedule
+# (kubectl rollout status for weather-service will time out).
+#
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -13,6 +17,7 @@ source "$SCRIPT_DIR/../lib/logging.sh"
 
 NAMESPACE="${NAMESPACE:-team1}"
 ROLLOUT_TIMEOUT="${BASELINE_WEATHER_ROLLOUT_TIMEOUT:-300s}"
+ADV_DOWNSCALE_TIMEOUT="${WEATHER_ADVANCED_DOWNSCALE_ROLLOUT_TIMEOUT:-300s}"
 
 log_step "90c" "Restore baseline weather deployments for UI E2E"
 
@@ -20,6 +25,21 @@ if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
   log_error "Namespace $NAMESPACE not found"
   exit 1
 fi
+
+# Free the same capacity 90b created for 91: advanced multi-container pods must go
+# before baseline weather can run again.
+for deploy in weather-service-advanced weather-tool-advanced; do
+  if kubectl get "deployment/${deploy}" -n "$NAMESPACE" &>/dev/null; then
+    log_info "Scaling down deployment/${deploy} in ${NAMESPACE} to free the node for baseline weather..."
+    kubectl scale "deployment/${deploy}" -n "$NAMESPACE" --replicas=0
+  fi
+done
+for deploy in weather-service-advanced weather-tool-advanced; do
+  if kubectl get "deployment/${deploy}" -n "$NAMESPACE" &>/dev/null; then
+    log_info "Waiting for advanced rollout to finish: ${deploy}..."
+    kubectl rollout status "deployment/${deploy}" -n "$NAMESPACE" --timeout="$ADV_DOWNSCALE_TIMEOUT"
+  fi
+done
 
 for deploy in weather-service weather-tool; do
   if kubectl get "deployment/${deploy}" -n "$NAMESPACE" &>/dev/null; then

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -111,10 +111,10 @@ fi
 
 export SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
 # See kagenti-extensions authbridge/demos/weather-agent/deploy_and_verify_advanced.sh for defaults
-# (long enough for GitHub Kind: image pull + tool pod with many sidecars).
-export WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-900s}"
-export WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-600s}"
-export WEATHER_TOOL_KC_CLIENT_SEC="${WEATHER_TOOL_KC_CLIENT_SEC:-600}"
+# (align with spec.progressDeadlineSeconds: 1800 on the advanced Deployments).
+export WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-1800s}"
+export WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-1800s}"
+export WEATHER_TOOL_KC_CLIENT_SEC="${WEATHER_TOOL_KC_CLIENT_SEC:-900}"
 
 cleanup() {
     if [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]]; then

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -115,6 +115,8 @@ export SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
 export WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-1800s}"
 export WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-1800s}"
 export WEATHER_TOOL_KC_CLIENT_SEC="${WEATHER_TOOL_KC_CLIENT_SEC:-900}"
+# Kind has one node; free CPU by scaling down baseline weather workloads before advanced deploy.
+export WEATHER_ADVANCED_PRUNE_LEGACY="${WEATHER_ADVANCED_PRUNE_LEGACY:-1}"
 
 cleanup() {
     if [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]]; then

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -21,7 +21,7 @@
 #   NAMESPACE                 K8s namespace (default: team1)
 #   SKIP_DEPLOY                 If 1, only run in-cluster verify (default: 0 = full deploy)
 #   WEATHER_TOOL_ROLLOUT_TIMEOUT / WEATHER_AGENT_ROLLOUT_TIMEOUT / WEATHER_TOOL_KC_CLIENT_SEC
-#                             Passed through to deploy_and_verify_advanced.sh (Kind CI defaults in that script)
+#   WEATHER_ADVANCED_PRUNE_LEGACY   Passed to deploy (default: 1 here — scale down wave-90 weather)
 #
 # Usage (called from run-e2e-tests.sh when RUN_AUTHBRIDGE_WEATHER_E2E=1):
 #   ./.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -115,7 +115,7 @@ export SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
 export WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-1800s}"
 export WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-1800s}"
 export WEATHER_TOOL_KC_CLIENT_SEC="${WEATHER_TOOL_KC_CLIENT_SEC:-900}"
-# Kind has one node; free CPU by scaling down baseline weather workloads before advanced deploy.
+# One Kind node: pytest leaves weather-service + weather-tool; scale them down in deploy script.
 export WEATHER_ADVANCED_PRUNE_LEGACY="${WEATHER_ADVANCED_PRUNE_LEGACY:-1}"
 
 cleanup() {

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -16,7 +16,8 @@
 # Environment:
 #   KAGENTI_EXTENSIONS_ROOT   Path to kagenti-extensions repo (optional)
 #   KAGENTI_EXTENSIONS_GIT_URL  Clone URL (default: https://github.com/kagenti/kagenti-extensions.git)
-#   KAGENTI_EXTENSIONS_GIT_REF  Branch or tag (default: v0.4.1 — pin for reproducible CI; bump when demo updates ship)
+#   KAGENTI_EXTENSIONS_GIT_REF  Branch or tag (default: main). Pin in CI to a release tag once
+#     authbridge/demos/weather-agent is included; verify with: git ls-remote --tags URL
 #   NAMESPACE                 K8s namespace (default: team1)
 #   SKIP_DEPLOY                 If 1, only run in-cluster verify (default: 0 = full deploy)
 #
@@ -59,6 +60,10 @@ fi
 log_info "Preflight OK: keycloak-admin-secret present in $NAMESPACE"
 
 EXT_ROOT="${KAGENTI_EXTENSIONS_ROOT:-}"
+# Trim trailing slash so path joins are never authbridge//...
+if [[ -n "$EXT_ROOT" ]]; then
+    EXT_ROOT="${EXT_ROOT%/}"
+fi
 CLONE_DIR=""
 
 if [[ -n "$EXT_ROOT" ]]; then
@@ -70,7 +75,7 @@ if [[ -n "$EXT_ROOT" ]]; then
     log_info "Using KAGENTI_EXTENSIONS_ROOT: $EXT_ROOT"
 else
     KAGENTI_EXTENSIONS_GIT_URL="${KAGENTI_EXTENSIONS_GIT_URL:-https://github.com/kagenti/kagenti-extensions.git}"
-    KAGENTI_EXTENSIONS_GIT_REF="${KAGENTI_EXTENSIONS_GIT_REF:-v0.4.1}"
+    KAGENTI_EXTENSIONS_GIT_REF="${KAGENTI_EXTENSIONS_GIT_REF:-main}"
     CLONE_DIR="${TMPDIR:-/tmp}/kagenti-extensions-authbridge-e2e-$$"
     log_info "Cloning kagenti-extensions (ref: $KAGENTI_EXTENSIONS_GIT_REF) to $CLONE_DIR"
     if ! git clone --depth 1 --single-branch --branch "$KAGENTI_EXTENSIONS_GIT_REF" \
@@ -81,7 +86,9 @@ else
             exit 1
         }
         (cd "$CLONE_DIR" && git checkout "$KAGENTI_EXTENSIONS_GIT_REF") || {
-            log_error "Could not checkout ref: $KAGENTI_EXTENSIONS_GIT_REF"
+            log_error "Could not checkout ref: $KAGENTI_EXTENSIONS_GIT_REF (branch or tag must exist on the remote)."
+            log_error "Fix: set KAGENTI_EXTENSIONS_GIT_REF to a valid ref (e.g. main), or KAGENTI_EXTENSIONS_ROOT to a local clone with authbridge/demos/weather-agent/."
+            log_error "List tags: git ls-remote --tags $KAGENTI_EXTENSIONS_GIT_URL | tail -5"
             rm -rf "$CLONE_DIR"
             exit 1
         }
@@ -90,6 +97,12 @@ else
 fi
 
 DEMO_DIR="$EXT_ROOT/authbridge/demos/weather-agent"
+if [[ ! -f "$DEMO_DIR/deploy_and_verify_advanced.sh" ]]; then
+    log_error "deploy_and_verify_advanced.sh not found at $DEMO_DIR/"
+    log_error "This ref of kagenti-extensions does not include the AuthBridge weather advanced demo yet."
+    log_error "Use KAGENTI_EXTENSIONS_ROOT pointing at a tree that contains authbridge/demos/weather-agent/, or merge the demo to upstream and retry."
+    exit 1
+fi
 if [[ ! -x "$DEMO_DIR/deploy_and_verify_advanced.sh" ]]; then
     chmod +x "$DEMO_DIR/deploy_and_verify_advanced.sh" 2>/dev/null || true
 fi

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# AuthBridge Weather (advanced) E2E — Keycloak token exchange + MCP inbound JWT
+#
+# Runs the verify flow from kagenti-extensions (authbridge/demos/weather-agent):
+#   deploy_and_verify_advanced.sh
+#
+# Prerequisites (same as platform E2E):
+#   - Kind cluster with Kagenti, Keycloak, team1, webhook + AuthBridge sidecars
+#   - jq, curl, python3, git
+#
+# Source tree:
+#   - Set KAGENTI_EXTENSIONS_ROOT to a local clone (faster, offline dev, or optional
+#     companion kagenti-extensions PR checkout in CI), or
+#   - Leave unset: this script shallow-clones kagenti/kagenti-extensions (see refs below).
+#
+# Environment:
+#   KAGENTI_EXTENSIONS_ROOT   Path to kagenti-extensions repo (optional)
+#   KAGENTI_EXTENSIONS_GIT_URL  Clone URL (default: https://github.com/kagenti/kagenti-extensions.git)
+#   KAGENTI_EXTENSIONS_GIT_REF  Branch or tag (default: v0.4.1 — pin for reproducible CI; bump when demo updates ship)
+#   NAMESPACE                 K8s namespace (default: team1)
+#   SKIP_DEPLOY                 If 1, only run in-cluster verify (default: 0 = full deploy)
+#
+# Usage (called from run-e2e-tests.sh when RUN_AUTHBRIDGE_WEATHER_E2E=1):
+#   ./.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/env-detect.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/logging.sh"
+
+log_step "91" "AuthBridge Weather (advanced) E2E (kagenti-extensions)"
+
+if ! command -v jq &>/dev/null; then
+    log_error "jq is required. Install jq or run from an environment with test deps."
+    exit 1
+fi
+
+if ! command -v git &>/dev/null; then
+    log_error "git is required to fetch kagenti-extensions when KAGENTI_EXTENSIONS_ROOT is unset."
+    exit 1
+fi
+
+export NAMESPACE="${NAMESPACE:-team1}"
+
+if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+    log_error "Namespace $NAMESPACE not found. Deploy the platform first."
+    exit 1
+fi
+
+# Preflight: Keycloak admin credentials for setup_keycloak_weather_advanced.py / token exchange
+if ! kubectl get secret keycloak-admin-secret -n "$NAMESPACE" &>/dev/null; then
+    log_error "Secret 'keycloak-admin-secret' not found in namespace '$NAMESPACE'."
+    log_error "The installer usually creates it in agent namespaces. Re-run platform deploy or create it (AuthBridge / Keycloak docs) before AuthBridge E2E."
+    exit 1
+fi
+log_info "Preflight OK: keycloak-admin-secret present in $NAMESPACE"
+
+EXT_ROOT="${KAGENTI_EXTENSIONS_ROOT:-}"
+CLONE_DIR=""
+
+if [[ -n "$EXT_ROOT" ]]; then
+    if [[ ! -f "$EXT_ROOT/authbridge/demos/weather-agent/deploy_and_verify_advanced.sh" ]]; then
+        log_error "KAGENTI_EXTENSIONS_ROOT is set but deploy_and_verify_advanced.sh not found at:"
+        log_error "  $EXT_ROOT/authbridge/demos/weather-agent/"
+        exit 1
+    fi
+    log_info "Using KAGENTI_EXTENSIONS_ROOT: $EXT_ROOT"
+else
+    KAGENTI_EXTENSIONS_GIT_URL="${KAGENTI_EXTENSIONS_GIT_URL:-https://github.com/kagenti/kagenti-extensions.git}"
+    KAGENTI_EXTENSIONS_GIT_REF="${KAGENTI_EXTENSIONS_GIT_REF:-v0.4.1}"
+    CLONE_DIR="${TMPDIR:-/tmp}/kagenti-extensions-authbridge-e2e-$$"
+    log_info "Cloning kagenti-extensions (ref: $KAGENTI_EXTENSIONS_GIT_REF) to $CLONE_DIR"
+    if ! git clone --depth 1 --single-branch --branch "$KAGENTI_EXTENSIONS_GIT_REF" \
+        "$KAGENTI_EXTENSIONS_GIT_URL" "$CLONE_DIR" 2>/dev/null; then
+        log_info "Shallow single-branch clone failed; trying full clone + checkout ($KAGENTI_EXTENSIONS_GIT_REF)"
+        git clone "$KAGENTI_EXTENSIONS_GIT_URL" "$CLONE_DIR" || {
+            log_error "git clone failed: $KAGENTI_EXTENSIONS_GIT_URL"
+            exit 1
+        }
+        (cd "$CLONE_DIR" && git checkout "$KAGENTI_EXTENSIONS_GIT_REF") || {
+            log_error "Could not checkout ref: $KAGENTI_EXTENSIONS_GIT_REF"
+            rm -rf "$CLONE_DIR"
+            exit 1
+        }
+    fi
+    EXT_ROOT="$CLONE_DIR"
+fi
+
+DEMO_DIR="$EXT_ROOT/authbridge/demos/weather-agent"
+if [[ ! -x "$DEMO_DIR/deploy_and_verify_advanced.sh" ]]; then
+    chmod +x "$DEMO_DIR/deploy_and_verify_advanced.sh" 2>/dev/null || true
+fi
+
+export SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
+
+cleanup() {
+    if [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]]; then
+        log_info "Removing temp clone: $CLONE_DIR"
+        rm -rf "$CLONE_DIR"
+    fi
+}
+trap cleanup EXIT
+
+log_info "Running: $DEMO_DIR/deploy_and_verify_advanced.sh (NAMESPACE=$NAMESPACE SKIP_DEPLOY=$SKIP_DEPLOY)"
+( cd "$DEMO_DIR" && ./deploy_and_verify_advanced.sh ) || {
+    log_error "AuthBridge Weather (advanced) E2E failed"
+    exit 1
+}
+
+log_success "AuthBridge Weather (advanced) E2E passed"

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -20,6 +20,8 @@
 #     authbridge/demos/weather-agent is included; verify with: git ls-remote --tags URL
 #   NAMESPACE                 K8s namespace (default: team1)
 #   SKIP_DEPLOY                 If 1, only run in-cluster verify (default: 0 = full deploy)
+#   WEATHER_TOOL_ROLLOUT_TIMEOUT / WEATHER_AGENT_ROLLOUT_TIMEOUT / WEATHER_TOOL_KC_CLIENT_SEC
+#                             Passed through to deploy_and_verify_advanced.sh (Kind CI defaults in that script)
 #
 # Usage (called from run-e2e-tests.sh when RUN_AUTHBRIDGE_WEATHER_E2E=1):
 #   ./.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -108,6 +110,11 @@ if [[ ! -x "$DEMO_DIR/deploy_and_verify_advanced.sh" ]]; then
 fi
 
 export SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
+# See kagenti-extensions authbridge/demos/weather-agent/deploy_and_verify_advanced.sh for defaults
+# (long enough for GitHub Kind: image pull + tool pod with many sidecars).
+export WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-900s}"
+export WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-600s}"
+export WEATHER_TOOL_KC_CLIENT_SEC="${WEATHER_TOOL_KC_CLIENT_SEC:-600}"
 
 cleanup() {
     if [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]]; then

--- a/.github/scripts/kind/run-e2e-tests.sh
+++ b/.github/scripts/kind/run-e2e-tests.sh
@@ -4,6 +4,8 @@
 # Usage:
 #   ./.github/scripts/kind/run-e2e-tests.sh
 #   KAGENTI_CONFIG_FILE=deployments/envs/dev_values.yaml ./.github/scripts/kind/run-e2e-tests.sh
+#   RUN_AUTHBRIDGE_WEATHER_E2E=1 ./.github/scripts/kind/run-e2e-tests.sh
+#   RUN_AUTHBRIDGE_WEATHER_E2E=1 KAGENTI_EXTENSIONS_ROOT=../kagenti-extensions ./.github/scripts/kind/run-e2e-tests.sh
 
 set -euo pipefail
 
@@ -47,27 +49,52 @@ echo ""
 
 cd "$REPO_ROOT"
 
+# Optional: AuthBridge Weather (advanced) E2E from kagenti-extensions (wave 91).
+# Set RUN_AUTHBRIDGE_WEATHER_E2E=1 to run after pytest. Requires network (git clone)
+# unless KAGENTI_EXTENSIONS_ROOT points at a local clone.
+RUN_AUTHBRIDGE_WEATHER_E2E="${RUN_AUTHBRIDGE_WEATHER_E2E:-0}"
+
 # ============================================================================
 # TEST PREPARATION (mirrors CI workflow order)
 # ============================================================================
 
+if [[ "$RUN_AUTHBRIDGE_WEATHER_E2E" == "1" ]]; then
+    TOTAL_STEPS=4
+else
+    TOTAL_STEPS=3
+fi
+
 # Step 1: Install test dependencies (wave 80)
-echo -e "${BLUE}[1/3] Installing test dependencies...${NC}"
+echo -e "${BLUE}[1/${TOTAL_STEPS}] Installing test dependencies...${NC}"
 bash .github/scripts/common/80-install-test-deps.sh
 echo ""
 
 # Step 2: Start port-forward (wave 85)
-echo -e "${BLUE}[2/3] Starting port-forward...${NC}"
+echo -e "${BLUE}[2/${TOTAL_STEPS}] Starting port-forward...${NC}"
 bash .github/scripts/common/85-start-port-forward.sh
 echo ""
 
 # Step 3: Run E2E tests (wave 90)
-echo -e "${BLUE}[3/3] Running E2E tests...${NC}"
+echo -e "${BLUE}[3/${TOTAL_STEPS}] Running E2E tests (pytest)...${NC}"
 echo ""
 
 bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
 
 TEST_RESULT=$?
+
+# Step 4: AuthBridge Weather (advanced) — kagenti-extensions deploy + verify
+if [[ "$RUN_AUTHBRIDGE_WEATHER_E2E" == "1" ]]; then
+    if [[ $TEST_RESULT -ne 0 ]]; then
+        echo -e "${RED}Skipping AuthBridge E2E (pytest failed)${NC}"
+    else
+        echo ""
+        echo -e "${BLUE}[4/4] Running AuthBridge Weather (advanced) E2E...${NC}"
+        echo ""
+        if ! bash .github/scripts/kind/91-run-authbridge-weather-e2e.sh; then
+            TEST_RESULT=1
+        fi
+    fi
+fi
 
 # ============================================================================
 # CLEANUP AND RESULTS

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -8,20 +8,25 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
+      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
       - 'kagenti/ui-v2/package-lock.json'
 
+# Cancel stale runs when new commits are pushed to the same PR
+concurrency:
+  group: e2e-kind-pr-${{ github.head_ref }}
+  cancel-in-progress: true
+
 # Explicit permissions - principle of least privilege
 permissions:
   contents: read
 
-# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
+# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # Pre-merge of kagenti/kagenti-extensions#347: test progressDeadline + timeout fix from fork; revert
-  # to KAGENTI/kagenti-extensions and ref main after that PR lands.
+  # Pre-merge of kagenti/kagenti-extensions#347: test from fork; revert to kagenti org + main after merge.
   KAGENTI_EXTENSIONS_GIT_URL: 'https://github.com/mrsabath/kagenti-extensions.git'
   KAGENTI_EXTENSIONS_GIT_REF: 'fix/weather-e2e-progress-deadline'
 
@@ -42,12 +47,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -55,19 +60,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Setup Python and Ansible dependencies
-        run: bash .github/scripts/common/10-setup-dependencies.sh
+      - name: Install dependencies (jq, uv)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y jq
+          python -m pip install --upgrade pip
+          pip install uv
 
-      - name: Create secret values file for CI
-        run: bash .github/scripts/common/20-create-secrets.sh
+      - name: Create secrets for bash installer
+        run: bash .github/scripts/common/20-create-secrets-bash.sh
 
-      - name: Run Ansible installer (dev mode with kagenti-operator)
-        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
+      - name: Install Kagenti platform (bash installer)
+        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
 
-      - name: Build ui-oauth-secret image from PR and restart job
-        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
-
-      - name: Wait for platform to be ready
+      - name: Wait for platform and reduce Kuadrant resources
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -81,13 +86,6 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
-
-      # BUILD DEPENDENCIES FROM SOURCE
-      # The packaged webhook chart (v0.4.0-alpha.5) uses proxy-init:latest which
-      # is incompatible with the old webhook binary. Build from extensions@main.
-      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
-      - name: Build dependency overrides from source
-        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -114,6 +112,13 @@ jobs:
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
 
+      - name: Print version matrix
+        if: success()
+        run: bash .github/scripts/common/86-print-version-matrix.sh
+
+      - name: Setup test credentials
+        run: bash .github/scripts/common/87-setup-test-credentials.sh
+
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh
@@ -136,14 +141,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -8,20 +8,25 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
+      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
       - 'kagenti/ui-v2/package-lock.json'
 
+# Cancel stale runs when new commits are pushed to the same PR
+concurrency:
+  group: e2e-kind-pr-${{ github.head_ref }}
+  cancel-in-progress: true
+
 # Explicit permissions - principle of least privilege
 permissions:
   contents: read
 
-# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
+# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # Pre-merge of kagenti/kagenti-extensions#347: test progressDeadline + timeout fix from fork; revert
-  # to KAGENTI/kagenti-extensions and ref main after that PR lands.
+  # Pre-merge of kagenti/kagenti-extensions#347: test from fork; revert to kagenti org + main after merge.
   KAGENTI_EXTENSIONS_GIT_URL: 'https://github.com/mrsabath/kagenti-extensions.git'
   KAGENTI_EXTENSIONS_GIT_REF: 'fix/weather-e2e-progress-deadline'
 
@@ -42,12 +47,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -55,19 +60,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Setup Python and Ansible dependencies
-        run: bash .github/scripts/common/10-setup-dependencies.sh
+      - name: Install dependencies (jq, uv)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y jq
+          python -m pip install --upgrade pip
+          pip install uv
 
-      - name: Create secret values file for CI
-        run: bash .github/scripts/common/20-create-secrets.sh
+      - name: Create secrets for bash installer
+        run: bash .github/scripts/common/20-create-secrets-bash.sh
 
-      - name: Run Ansible installer (dev mode with kagenti-operator)
-        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
+      - name: Install Kagenti platform (bash installer)
+        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
 
-      - name: Build ui-oauth-secret image from PR and restart job
-        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
-
-      - name: Wait for platform to be ready
+      - name: Wait for platform and reduce Kuadrant resources
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -81,13 +86,6 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
-
-      # BUILD DEPENDENCIES FROM SOURCE
-      # The packaged webhook chart (v0.4.0-alpha.5) uses proxy-init:latest which
-      # is incompatible with the old webhook binary. Build from extensions@main.
-      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
-      - name: Build dependency overrides from source
-        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -114,6 +112,13 @@ jobs:
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
 
+      - name: Print version matrix
+        if: success()
+        run: bash .github/scripts/common/86-print-version-matrix.sh
+
+      - name: Setup test credentials
+        run: bash .github/scripts/common/87-setup-test-credentials.sh
+
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh
@@ -122,11 +127,6 @@ jobs:
         if: success()
         run: bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
 
-      # Pytest weather-service + weather-tool (wave 90) leave large pods on the
-      # single Kind node. Wave 91 adds two more multi-sidecar pods; without this,
-      # weather-service-advanced often never schedules (Insufficient cpu). This
-      # must live in the workflow: re-runs of an old workflow use an old
-      # kagenti commit — deploy script changes in kagenti-extensions alone won't apply.
       - name: Free capacity for AuthBridge weather (scale baseline weather)
         if: success()
         run: bash .github/scripts/kind/90b-free-capacity-for-advanced-weather.sh
@@ -147,14 +147,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -8,26 +8,22 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
-      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
       - 'kagenti/ui-v2/package-lock.json'
 
-# Cancel stale runs when new commits are pushed to the same PR
-concurrency:
-  group: e2e-kind-pr-${{ github.head_ref }}
-  cancel-in-progress: true
-
 # Explicit permissions - principle of least privilege
 permissions:
   contents: read
 
-# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
+# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # kagenti-extensions ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
-  KAGENTI_EXTENSIONS_GIT_REF: 'main'
+  # Pre-merge of kagenti/kagenti-extensions#347: test progressDeadline + timeout fix from fork; revert
+  # to KAGENTI/kagenti-extensions and ref main after that PR lands.
+  KAGENTI_EXTENSIONS_GIT_URL: 'https://github.com/mrsabath/kagenti-extensions.git'
+  KAGENTI_EXTENSIONS_GIT_REF: 'fix/weather-e2e-progress-deadline'
 
 jobs:
   e2e-dev-kagenti-operator:
@@ -46,12 +42,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -59,19 +55,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Install dependencies (jq, uv)
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y jq
-          python -m pip install --upgrade pip
-          pip install uv
+      - name: Setup Python and Ansible dependencies
+        run: bash .github/scripts/common/10-setup-dependencies.sh
 
-      - name: Create secrets for bash installer
-        run: bash .github/scripts/common/20-create-secrets-bash.sh
+      - name: Create secret values file for CI
+        run: bash .github/scripts/common/20-create-secrets.sh
 
-      - name: Install Kagenti platform (bash installer)
-        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
+      - name: Run Ansible installer (dev mode with kagenti-operator)
+        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
 
-      - name: Wait for platform and reduce Kuadrant resources
+      - name: Build ui-oauth-secret image from PR and restart job
+        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
+
+      - name: Wait for platform to be ready
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -85,6 +81,13 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
+
+      # BUILD DEPENDENCIES FROM SOURCE
+      # The packaged webhook chart (v0.4.0-alpha.5) uses proxy-init:latest which
+      # is incompatible with the old webhook binary. Build from extensions@main.
+      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
+      - name: Build dependency overrides from source
+        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -111,13 +114,6 @@ jobs:
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
 
-      - name: Print version matrix
-        if: success()
-        run: bash .github/scripts/common/86-print-version-matrix.sh
-
-      - name: Setup test credentials
-        run: bash .github/scripts/common/87-setup-test-credentials.sh
-
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh
@@ -140,14 +136,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -26,9 +26,8 @@ permissions:
 # Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # Pre-merge of kagenti/kagenti-extensions#347: test from fork; revert to kagenti org + main after merge.
-  KAGENTI_EXTENSIONS_GIT_URL: 'https://github.com/mrsabath/kagenti-extensions.git'
-  KAGENTI_EXTENSIONS_GIT_REF: 'fix/weather-e2e-progress-deadline'
+  # kagenti-extensions#347 merged: AuthBridge weather advanced fixes on main; 91 clones default org URL.
+  KAGENTI_EXTENSIONS_GIT_REF: 'main'
 
 jobs:
   e2e-dev-kagenti-operator:

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -8,25 +8,20 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
-      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
       - 'kagenti/ui-v2/package-lock.json'
 
-# Cancel stale runs when new commits are pushed to the same PR
-concurrency:
-  group: e2e-kind-pr-${{ github.head_ref }}
-  cancel-in-progress: true
-
 # Explicit permissions - principle of least privilege
 permissions:
   contents: read
 
-# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
+# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # Pre-merge of kagenti/kagenti-extensions#347: test from fork; revert to kagenti org + main after merge.
+  # Pre-merge of kagenti/kagenti-extensions#347: test progressDeadline + timeout fix from fork; revert
+  # to KAGENTI/kagenti-extensions and ref main after that PR lands.
   KAGENTI_EXTENSIONS_GIT_URL: 'https://github.com/mrsabath/kagenti-extensions.git'
   KAGENTI_EXTENSIONS_GIT_REF: 'fix/weather-e2e-progress-deadline'
 
@@ -47,12 +42,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -60,19 +55,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Install dependencies (jq, uv)
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y jq
-          python -m pip install --upgrade pip
-          pip install uv
+      - name: Setup Python and Ansible dependencies
+        run: bash .github/scripts/common/10-setup-dependencies.sh
 
-      - name: Create secrets for bash installer
-        run: bash .github/scripts/common/20-create-secrets-bash.sh
+      - name: Create secret values file for CI
+        run: bash .github/scripts/common/20-create-secrets.sh
 
-      - name: Install Kagenti platform (bash installer)
-        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
+      - name: Run Ansible installer (dev mode with kagenti-operator)
+        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
 
-      - name: Wait for platform and reduce Kuadrant resources
+      - name: Build ui-oauth-secret image from PR and restart job
+        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
+
+      - name: Wait for platform to be ready
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -86,6 +81,13 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
+
+      # BUILD DEPENDENCIES FROM SOURCE
+      # The packaged webhook chart (v0.4.0-alpha.5) uses proxy-init:latest which
+      # is incompatible with the old webhook binary. Build from extensions@main.
+      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
+      - name: Build dependency overrides from source
+        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -112,13 +114,6 @@ jobs:
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
 
-      - name: Print version matrix
-        if: success()
-        run: bash .github/scripts/common/86-print-version-matrix.sh
-
-      - name: Setup test credentials
-        run: bash .github/scripts/common/87-setup-test-credentials.sh
-
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh
@@ -126,6 +121,17 @@ jobs:
       - name: Run backend E2E tests
         if: success()
         run: bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
+
+      # Pytest weather-service + weather-tool (wave 90) leave large pods on the
+      # single Kind node. Wave 91 adds two more multi-sidecar pods; without this,
+      # weather-service-advanced often never schedules (Insufficient cpu). This
+      # must live in the workflow: re-runs of an old workflow use an old
+      # kagenti commit — deploy script changes in kagenti-extensions alone won't apply.
+      - name: Free capacity for AuthBridge weather (scale baseline weather)
+        if: success()
+        run: bash .github/scripts/kind/90b-free-capacity-for-advanced-weather.sh
+        env:
+          NAMESPACE: team1
 
       - name: AuthBridge Weather (advanced) E2E
         if: success()
@@ -141,14 +147,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -26,8 +26,8 @@ permissions:
 # Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # Pinned kagenti-extensions ref for AuthBridge weather advanced E2E (bump when demo/scripts change in a release).
-  KAGENTI_EXTENSIONS_GIT_REF: 'v0.4.1'
+  # kagenti-extensions ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
+  KAGENTI_EXTENSIONS_GIT_REF: 'main'
 
 jobs:
   e2e-dev-kagenti-operator:

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -26,12 +26,15 @@ permissions:
 # Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
+  # Pinned kagenti-extensions ref for AuthBridge weather advanced E2E (bump when demo/scripts change in a release).
+  KAGENTI_EXTENSIONS_GIT_REF: 'v0.4.1'
 
 jobs:
   e2e-dev-kagenti-operator:
     name: Deploy & Test
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Includes kagenti-extensions AuthBridge E2E (clone, Keycloak, advanced deploys).
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -122,6 +125,12 @@ jobs:
       - name: Run backend E2E tests
         if: success()
         run: bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
+
+      - name: AuthBridge Weather (advanced) E2E
+        if: success()
+        run: bash .github/scripts/kind/91-run-authbridge-weather-e2e.sh
+        env:
+          NAMESPACE: team1
 
       - name: Run UI E2E tests
         if: success()

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -138,6 +138,12 @@ jobs:
         env:
           NAMESPACE: team1
 
+      - name: Restore baseline weather for UI E2E
+        if: success()
+        run: bash .github/scripts/kind/90c-restore-baseline-weather-for-ui.sh
+        env:
+          NAMESPACE: team1
+
       - name: Run UI E2E tests
         if: success()
         run: bash .github/scripts/common/92-run-ui-tests.sh

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -29,12 +29,15 @@ permissions:
 # Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
+  # Pinned kagenti-extensions ref for AuthBridge weather advanced E2E (bump when demo/scripts change in a release).
+  KAGENTI_EXTENSIONS_GIT_REF: 'v0.4.1'
 
 jobs:
   e2e-dev-kagenti-operator:
     name: Deploy & Test
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Includes kagenti-extensions AuthBridge E2E (clone, Keycloak, advanced deploys).
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -125,6 +128,13 @@ jobs:
       - name: Run backend E2E tests
         if: success()
         run: bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
+
+      # kagenti-extensions: authbridge/demos/weather-agent (token exchange + tool inbound JWT). Not a lightweight check.
+      - name: AuthBridge Weather (advanced) E2E
+        if: success()
+        run: bash .github/scripts/kind/91-run-authbridge-weather-e2e.sh
+        env:
+          NAMESPACE: team1
 
       - name: Run UI E2E tests
         if: success()

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -8,7 +8,6 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
-      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
@@ -26,7 +25,7 @@ concurrency:
 permissions:
   contents: read
 
-# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
+# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
   # kagenti-extensions ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
@@ -49,12 +48,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -62,19 +61,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Install dependencies (jq, uv)
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y jq
-          python -m pip install --upgrade pip
-          pip install uv
+      - name: Setup Python and Ansible dependencies
+        run: bash .github/scripts/common/10-setup-dependencies.sh
 
-      - name: Create secrets for bash installer
-        run: bash .github/scripts/common/20-create-secrets-bash.sh
+      - name: Create secret values file for CI
+        run: bash .github/scripts/common/20-create-secrets.sh
 
-      - name: Install Kagenti platform (bash installer)
-        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
+      - name: Run Ansible installer (dev mode with kagenti-operator)
+        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
 
-      - name: Wait for platform and reduce Kuadrant resources
+      - name: Build ui-oauth-secret image from PR and restart job
+        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
+
+      - name: Wait for platform to be ready
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -88,6 +87,11 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
+
+      # BUILD DEPENDENCIES FROM SOURCE
+      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
+      - name: Build dependency overrides from source
+        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -114,13 +118,6 @@ jobs:
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
 
-      - name: Print version matrix
-        if: success()
-        run: bash .github/scripts/common/86-print-version-matrix.sh
-
-      - name: Setup test credentials
-        run: bash .github/scripts/common/87-setup-test-credentials.sh
-
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh
@@ -128,6 +125,14 @@ jobs:
       - name: Run backend E2E tests
         if: success()
         run: bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
+
+      # See e2e-kind-pr.yaml: single-node Kind cannot run wave-90 and wave-91
+      # full weather stacks concurrently without Insufficient cpu on the agent.
+      - name: Free capacity for AuthBridge weather (scale baseline weather)
+        if: success()
+        run: bash .github/scripts/kind/90b-free-capacity-for-advanced-weather.sh
+        env:
+          NAMESPACE: team1
 
       # kagenti-extensions: authbridge/demos/weather-agent (token exchange + tool inbound JWT). Not a lightweight check.
       - name: AuthBridge Weather (advanced) E2E
@@ -144,14 +149,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -8,6 +8,7 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
+      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
@@ -25,7 +26,7 @@ concurrency:
 permissions:
   contents: read
 
-# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
+# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
   # kagenti-extensions ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
@@ -48,12 +49,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -61,19 +62,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Setup Python and Ansible dependencies
-        run: bash .github/scripts/common/10-setup-dependencies.sh
+      - name: Install dependencies (jq, uv)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y jq
+          python -m pip install --upgrade pip
+          pip install uv
 
-      - name: Create secret values file for CI
-        run: bash .github/scripts/common/20-create-secrets.sh
+      - name: Create secrets for bash installer
+        run: bash .github/scripts/common/20-create-secrets-bash.sh
 
-      - name: Run Ansible installer (dev mode with kagenti-operator)
-        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
+      - name: Install Kagenti platform (bash installer)
+        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
 
-      - name: Build ui-oauth-secret image from PR and restart job
-        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
-
-      - name: Wait for platform to be ready
+      - name: Wait for platform and reduce Kuadrant resources
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -87,11 +88,6 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
-
-      # BUILD DEPENDENCIES FROM SOURCE
-      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
-      - name: Build dependency overrides from source
-        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -118,6 +114,13 @@ jobs:
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
 
+      - name: Print version matrix
+        if: success()
+        run: bash .github/scripts/common/86-print-version-matrix.sh
+
+      - name: Setup test credentials
+        run: bash .github/scripts/common/87-setup-test-credentials.sh
+
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh
@@ -125,14 +128,6 @@ jobs:
       - name: Run backend E2E tests
         if: success()
         run: bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
-
-      # See e2e-kind-pr.yaml: single-node Kind cannot run wave-90 and wave-91
-      # full weather stacks concurrently without Insufficient cpu on the agent.
-      - name: Free capacity for AuthBridge weather (scale baseline weather)
-        if: success()
-        run: bash .github/scripts/kind/90b-free-capacity-for-advanced-weather.sh
-        env:
-          NAMESPACE: team1
 
       # kagenti-extensions: authbridge/demos/weather-agent (token exchange + tool inbound JWT). Not a lightweight check.
       - name: AuthBridge Weather (advanced) E2E
@@ -149,14 +144,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -8,7 +8,6 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
-      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
@@ -26,7 +25,7 @@ concurrency:
 permissions:
   contents: read
 
-# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
+# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
   # kagenti-extensions ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
@@ -49,12 +48,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -62,19 +61,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Install dependencies (jq, uv)
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y jq
-          python -m pip install --upgrade pip
-          pip install uv
+      - name: Setup Python and Ansible dependencies
+        run: bash .github/scripts/common/10-setup-dependencies.sh
 
-      - name: Create secrets for bash installer
-        run: bash .github/scripts/common/20-create-secrets-bash.sh
+      - name: Create secret values file for CI
+        run: bash .github/scripts/common/20-create-secrets.sh
 
-      - name: Install Kagenti platform (bash installer)
-        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
+      - name: Run Ansible installer (dev mode with kagenti-operator)
+        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
 
-      - name: Wait for platform and reduce Kuadrant resources
+      - name: Build ui-oauth-secret image from PR and restart job
+        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
+
+      - name: Wait for platform to be ready
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -88,6 +87,11 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
+
+      # BUILD DEPENDENCIES FROM SOURCE
+      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
+      - name: Build dependency overrides from source
+        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -114,13 +118,6 @@ jobs:
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
 
-      - name: Print version matrix
-        if: success()
-        run: bash .github/scripts/common/86-print-version-matrix.sh
-
-      - name: Setup test credentials
-        run: bash .github/scripts/common/87-setup-test-credentials.sh
-
       - name: Pre-flight checks
         if: success()
         run: bash .github/scripts/common/90-preflight-checks.sh
@@ -129,10 +126,24 @@ jobs:
         if: success()
         run: bash .github/scripts/kagenti-operator/90-run-e2e-tests.sh
 
+      # See e2e-kind-pr.yaml: single-node Kind cannot run wave-90 and wave-91
+      # full weather stacks concurrently without Insufficient cpu on the agent.
+      - name: Free capacity for AuthBridge weather (scale baseline weather)
+        if: success()
+        run: bash .github/scripts/kind/90b-free-capacity-for-advanced-weather.sh
+        env:
+          NAMESPACE: team1
+
       # kagenti-extensions: authbridge/demos/weather-agent (token exchange + tool inbound JWT). Not a lightweight check.
       - name: AuthBridge Weather (advanced) E2E
         if: success()
         run: bash .github/scripts/kind/91-run-authbridge-weather-e2e.sh
+        env:
+          NAMESPACE: team1
+
+      - name: Restore baseline weather for UI E2E
+        if: success()
+        run: bash .github/scripts/kind/90c-restore-baseline-weather-for-ui.sh
         env:
           NAMESPACE: team1
 
@@ -144,14 +155,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -29,8 +29,8 @@ permissions:
 # Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # Pinned kagenti-extensions ref for AuthBridge weather advanced E2E (bump when demo/scripts change in a release).
-  KAGENTI_EXTENSIONS_GIT_REF: 'v0.4.1'
+  # kagenti-extensions ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
+  KAGENTI_EXTENSIONS_GIT_REF: 'main'
 
 jobs:
   e2e-dev-kagenti-operator:

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -8,6 +8,7 @@ on:
       - 'deployments/**'
       - '.github/**'
       - 'charts/**'
+      - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'kagenti/ui-v2/package.json'
@@ -25,7 +26,7 @@ concurrency:
 permissions:
   contents: read
 
-# Version tracking - keep in sync with deployments/ansible/kind/kind-config.yaml
+# Version tracking - keep in sync with kind-config in scripts/kind/setup-kagenti.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
   # kagenti-extensions ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
@@ -48,12 +49,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b  # v5.0.0
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes incompatible with ansible kubernetes.core.helm module
+          version: 'v3.17.0'  # Pin to v3 - Helm v4 has breaking changes
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -61,19 +62,19 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Setup Python and Ansible dependencies
-        run: bash .github/scripts/common/10-setup-dependencies.sh
+      - name: Install dependencies (jq, uv)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y jq
+          python -m pip install --upgrade pip
+          pip install uv
 
-      - name: Create secret values file for CI
-        run: bash .github/scripts/common/20-create-secrets.sh
+      - name: Create secrets for bash installer
+        run: bash .github/scripts/common/20-create-secrets-bash.sh
 
-      - name: Run Ansible installer (dev mode with kagenti-operator)
-        run: bash .github/scripts/kagenti-operator/30-run-installer.sh
+      - name: Install Kagenti platform (bash installer)
+        run: bash scripts/kind/setup-kagenti.sh --with-all --build-images
 
-      - name: Build ui-oauth-secret image from PR and restart job
-        run: bash .github/scripts/common/25-build-oauth-secret-image.sh
-
-      - name: Wait for platform to be ready
+      - name: Wait for platform and reduce Kuadrant resources
         run: bash .github/scripts/common/40-wait-platform-ready.sh
 
       - name: Install Ollama
@@ -87,11 +88,6 @@ jobs:
 
       - name: Wait for kagenti-operator CRDs to be established
         run: bash .github/scripts/kagenti-operator/41-wait-crds.sh
-
-      # BUILD DEPENDENCIES FROM SOURCE
-      # TODO: Remove after bumping kagenti-webhook-chart to >= v0.4.0-alpha.9
-      - name: Build dependency overrides from source
-        run: bash .github/scripts/common/31-build-deps-from-refs.sh
 
       # TOOL DEPLOYMENT (FIRST - agent depends on tool being available)
       # Tools are deployed as standard Kubernetes Deployments + Services
@@ -117,6 +113,13 @@ jobs:
 
       - name: Start port-forward for agent service
         run: bash .github/scripts/common/85-start-port-forward.sh
+
+      - name: Print version matrix
+        if: success()
+        run: bash .github/scripts/common/86-print-version-matrix.sh
+
+      - name: Setup test credentials
+        run: bash .github/scripts/common/87-setup-test-credentials.sh
 
       - name: Pre-flight checks
         if: success()
@@ -155,14 +158,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-test-results
           path: test-results/
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-report
           path: kagenti/ui-v2/playwright-report/


### PR DESCRIPTION
## Merge order (required)

**Do not merge this PR until the dependency is merged first:**

- **Dependency:** [kagenti/kagenti-extensions#343](https://github.com/kagenti/kagenti-extensions/pull/343) (AuthBridge weather advanced demo: `authbridge/demos/weather-agent` + `deploy_and_verify_advanced.sh`, configmaps, etc.)

The Kind E2E step clones **kagenti/kagenti-extensions** at `KAGENTI_EXTENSIONS_GIT_REF` (default **`main`**). Until the dependency lands on `main`, the AuthBridge job will not find `deploy_and_verify_advanced.sh` and will fail. After the extensions PR merges, re-run Kind CI on this PR (or merge this PR immediately after).

**Optional:** After a release tag is cut that includes the demo, pin `KAGENTI_EXTENSIONS_GIT_REF` in the workflow `env` to that tag for reproducible CI.

---

## Local verification (manual)

Successfully run on a Kind cluster with `team1` + `keycloak-admin-secret`:

```bash
KAGENTI_EXTENSIONS_ROOT=../kagenti-extensions/ bash .github/scripts/kind/91-run-authbridge-weather-e2e.sh
```

Result: `deploy_and_verify_advanced.sh` completed; MCP **406** (non-401 = JWT accepted at ingress); inbound + outbound log checks **OK**.

`KAGENTI_EXTENSIONS_ROOT` trailing slashes are normalized so paths do not show `//` in logs.

---

## Summary

Adds **91-run-authbridge-weather-e2e.sh** to run the kagenti-extensions **AuthBridge** weather advanced flow (`deploy_and_verify_advanced.sh`): preflight **keycloak-admin-secret** in the test namespace, clone **kagenti-extensions** at **KAGENTI_EXTENSIONS_GIT_REF** (workflow default **`main`**), then deploy + in-cluster verify.

## Changes

- **`.github/scripts/kind/91-run-authbridge-weather-e2e.sh`** — new; DCO signed; default ref `main`; clearer errors if ref/demo missing; trim `KAGENTI_EXTENSIONS_ROOT` trailing `/`.
- **`.github/scripts/kind/run-e2e-tests.sh`** — optional `RUN_AUTHBRIDGE_WEATHER_E2E=1` runs wave 91 after pytest (local dev).
- **`.github/workflows/e2e-kind.yaml`** and **`e2e-kind-pr.yaml`** — after backend E2E, run AuthBridge step; **timeout 90m**; workflow `env` sets `KAGENTI_EXTENSIONS_GIT_REF: main`.

## DCO

Commit includes `Signed-off-by`.
