### PR TITLE
chore: Update installation version to v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cd kagenti
 
 # Check out the latest stable release (recommended)
 # Find the current version at https://github.com/kagenti/kagenti/releases/latest
-git checkout v0.5.0
+git checkout v0.5.1
 
 # Copy and configure secrets
 cp deployments/envs/secret_values.yaml.example deployments/envs/.secret_values.yaml


### PR DESCRIPTION
Closes #1314

## Summary
This PR updates the recommended installation version in README.md from v0.5.0 to v0.5.1 to reflect the latest stable release.

## Changes
- Updated version reference in installation instructions from `v0.5.0` to `v0.5.1`

## Motivation
Users following the installation guide should be directed to the most recent stable version to ensure they benefit from the latest features, improvements, and bug fixes.

## Testing
- Verified the change is limited to the version string in README.md
- No functional changes or code modifications
- Documentation update only