### PR TITLE
fix: Use HTTPS for SPIFFE IdP setup job bundle endpoint

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1170,7 +1170,7 @@
                       - name: SPIFFE_TRUST_DOMAIN
                         value: "spiffe://{{ kagenti_deps_values.domain }}"
                       - name: SPIFFE_BUNDLE_ENDPOINT
-                        value: "http://spire-spiffe-oidc-discovery-provider.{{ charts.spire.server_namespace }}.svc.cluster.local/keys"
+                        value: "https://spire-spiffe-oidc-discovery-provider.{{ charts.spire.server_namespace }}.svc.cluster.local/keys"
                       - name: SPIFFE_IDP_ALIAS
                         value: "{{ kagenti_deps_values.authBridge.spiffeIdpAlias | default('spire-spiffe') }}"
 


### PR DESCRIPTION
## Problem

The `kagenti-spiffe-idp-setup-job` connects to `spire-spiffe-oidc-discovery-provider` using HTTP on port 80, but the Service only exposes HTTPS on port 443. The job loops through all 30 retry attempts and times out with:

```
Connection to spire-spiffe-oidc-discovery-provider...svc.cluster.local timed out. (connect timeout=5)
```

This is non-blocking (the ansible playbook continues past it), but produces alarming-looking errors in the logs.

## Solution

Change the `SPIFFE_BUNDLE_ENDPOINT` env var URL scheme from `http://` to `https://` in the job definition in `deployments/ansible/roles/kagenti_installer/tasks/main.yml`. The default HTTPS port (443) matches the service definition.

## Verification

Tested on OCP 4.20.18 (fresh RHPDS cluster, us-east-2):

1. **Service only serves HTTPS** — confirmed by inspecting the `spire-spiffe-oidc-discovery-provider` Service, which exposes only port 443.

2. **HTTPS endpoint works** — verified from within the job pod:
   ```python
   >>> urllib.request.urlopen('https://spire-spiffe-oidc-discovery-provider.zero-trust-workload-identity-manager.svc.cluster.local:443/keys')
   <http.client.HTTPResponse ...>  # 200 OK, valid JWKS
   ```

3. **The OIDC Discovery Provider is configured for HTTPS** — the `SpireOIDCDiscoveryProvider` operand CR uses `jwtIssuer: "https://..."` (see `charts/kagenti-deps/templates/spire-operand.yaml`).

Fixes #1320