### PR TITLE
fix: Pass empty secret_values_file when default is missing

### DIFF
--- a/deployments/ansible/run-install.sh
+++ b/deployments/ansible/run-install.sh
@@ -190,7 +190,9 @@ if [[ -n "$SECRET_FILE" ]]; then
 
   # Check existence: if the user explicitly provided --secret and the file
   # is missing, fail early. If we're using the default and it's missing,
-  # warn and skip adding the secret (the playbook will behave accordingly).
+  # warn and skip. We must pass an empty secret_values_file to override the
+  # default in default_values.yaml (secrets.file), otherwise the playbook
+  # resolves that default path, stats it, and fails.
   if [[ -f "$secret_resolved" ]]; then
     JSON_ENTRIES+=("\"secret_values_file\": \"$secret_resolved\"")
   else
@@ -199,6 +201,7 @@ if [[ -n "$SECRET_FILE" ]]; then
       exit 2
     else
       echo "WARNING: default secret values file not found at $secret_resolved; continuing without secrets." >&2
+      JSON_ENTRIES+=("\"secret_values_file\": \"\"")
     fi
   fi
 fi


### PR DESCRIPTION
## Problem

`run-install.sh` and the ansible playbook disagree about whether `.secret_values.yaml` is required:

1. **Wrapper** (`run-install.sh`): When the default `.secret_values.yaml` is missing, prints `WARNING: ...continuing without secrets` and does NOT pass `secret_values_file` to ansible.

2. **Playbook** (`01_setup_vars.yaml`): Falls through to `secrets.file` from `default_values.yaml` (which is hardcoded to `../envs/.secret_values.yaml`), resolves the path, stats it, and fails hard:
   ```
   Secret values file '.../envs/.secret_values.yaml' not found.
   ```

The user sees "continuing without secrets" followed immediately by a hard failure — the wrapper promises something the playbook doesn't deliver.

## Root Cause

`default_values.yaml` line 13 defines `secrets.file: "../envs/.secret_values.yaml"`. The playbook's variable resolution on line 6 of `01_setup_vars.yaml` is:

```yaml
secret_values_file: "{{ secret_values_file | default(secrets.file | default('')) }}"
```

When the wrapper doesn't pass `secret_values_file`, `secrets.file` kicks in as the default, pointing to a file that doesn't exist.

## Solution

When the default file is missing, the wrapper now explicitly passes `secret_values_file: ""` in the extra-vars. This overrides the `secrets.file` default. All downstream conditional blocks in `01_setup_vars.yaml` are gated on `secret_values_file | length > 0`, so they are cleanly skipped:

- Path resolution (line 17): `when: ... secret_values_file | length > 0` → **skipped**
- Stat check (line 23): `when: secret_values_file_resolved is defined ...` → **skipped** (never set)
- Fail task (line 28): same guard → **skipped**
- include_vars (line 34): same guard → **skipped**

## Verification

Traced the variable resolution through both paths:

**Before fix** (no `.secret_values.yaml`):
```
wrapper: WARNING, no secret_values_file passed
playbook: secret_values_file = "" | default("../envs/.secret_values.yaml") = "../envs/.secret_values.yaml"
playbook: stat("../envs/.secret_values.yaml") → not found → FAIL
```

**After fix** (no `.secret_values.yaml`):
```
wrapper: WARNING, passes secret_values_file=""
playbook: secret_values_file = "" | default(...) = "" (defined, so default doesn't trigger)
playbook: "" | length > 0 → false → all blocks skipped ✓
```

The explicit `--secret` path is unchanged: if a user passes `--secret <path>` and the file is missing, the wrapper still fails early with `exit 2`.

Fixes #1321