### PR TITLE
feat: add agent-sandbox Helm flag and Kind installer support

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -130,6 +130,8 @@ spec:
               value: "{{ .Values.featureFlags.integrations }}"
             - name: KAGENTI_FEATURE_FLAG_TRIGGERS
               value: "{{ .Values.featureFlags.triggers }}"
+            - name: KAGENTI_FEATURE_FLAG_AGENT_SANDBOX
+              value: "{{ .Values.featureFlags.agentSandbox }}"
             - name: KEYCLOAK_URL
               value: {{ .Values.keycloak.url | quote }}
             - name: KEYCLOAK_PUBLIC_URL
@@ -436,6 +438,12 @@ rules:
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- if .Values.featureFlags.agentSandbox }}
+  # agent-sandbox (kubernetes-sigs) Sandbox CRs
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
   {{- if .Values.featureFlags.integrations }}
   # Integration CRDs for repository integrations
   - apiGroups: ["kagenti.io"]

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -10,6 +10,7 @@ featureFlags:
   sandbox: false
   integrations: false
   triggers: false
+  agentSandbox: false
 
 # ------------------------------------------------------------------
 #  Control Panel: Enable or disable components here

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -9,7 +9,8 @@
 #                  (istio-base + istiod), Keycloak, kagenti-operator, kagenti-webhook
 # Optional:        --with-istio (ambient mesh), --with-spire, --with-backend,
 #                  --with-ui, --with-mcp-gateway, --with-kuadrant, --with-otel,
-#                  --with-mlflow, --with-builds, --with-kiali, --with-all
+#                  --with-mlflow, --with-builds, --with-kiali,
+#                  --with-agent-sandbox, --with-all
 #
 # Idempotent: safe to re-run. Uses helm upgrade --install and kubectl apply.
 # Re-running with additional --with-* flags adds components incrementally.
@@ -45,6 +46,7 @@ WITH_MLFLOW=false
 WITH_BUILDS=false
 WITH_KIALI=false
 WITH_KUADRANT=false
+WITH_AGENT_SANDBOX=false
 SKIP_CLUSTER=false
 BUILD_IMAGES=false
 DRY_RUN=false
@@ -61,6 +63,7 @@ TEKTON_VERSION="v0.66.0"
 SHIPWRIGHT_VERSION="v0.14.0"
 MCP_GATEWAY_VERSION="0.6.0"
 KUADRANT_VERSION="1.4.2"
+AGENT_SANDBOX_VERSION="v0.3.10"
 
 # ── Colors & logging ────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
@@ -86,10 +89,12 @@ while [[ $# -gt 0 ]]; do
     --with-mlflow)      WITH_MLFLOW=true; shift ;;
     --with-builds)      WITH_BUILDS=true; shift ;;
     --with-kiali)       WITH_KIALI=true; shift ;;
+    --with-agent-sandbox) WITH_AGENT_SANDBOX=true; shift ;;
     --with-all)
       WITH_ISTIO=true; WITH_SPIRE=true; WITH_BACKEND=true; WITH_UI=true
       WITH_MCP_GATEWAY=true; WITH_KUADRANT=true; WITH_OTEL=true
       WITH_MLFLOW=true; WITH_BUILDS=true; WITH_KIALI=true
+      WITH_AGENT_SANDBOX=true
       shift ;;
     --skip-cluster)     SKIP_CLUSTER=true; shift ;;
     --build-images)     BUILD_IMAGES=true; shift ;;
@@ -112,6 +117,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --with-mlflow       Install MLflow trace backend (auto-enables OTel)"
       echo "  --with-builds       Install Tekton + Shipwright"
       echo "  --with-kiali        Install Kiali + Prometheus (auto-enables Istio)"
+      echo "  --with-agent-sandbox Install agent-sandbox controller (kubernetes-sigs)"
       echo "  --with-all          Enable all optional components"
       echo ""
       echo "Other options:"
@@ -173,6 +179,7 @@ echo "    OTel:          $WITH_OTEL"
 echo "    MLflow:        $WITH_MLFLOW"
 echo "    Builds:        $WITH_BUILDS"
 echo "    Kiali:         $WITH_KIALI"
+echo "    Agent Sandbox: $WITH_AGENT_SANDBOX"
 echo "    Skip cluster:  $SKIP_CLUSTER"
 echo "    Build images:  $BUILD_IMAGES"
 echo ""
@@ -405,6 +412,35 @@ else
   log_success "Gateway API CRDs installed"
 fi
 echo ""
+
+# ============================================================================
+# Step 5b: Install agent-sandbox (optional, --with-agent-sandbox)
+# ============================================================================
+if $WITH_AGENT_SANDBOX; then
+  log_info "Step 5b: agent-sandbox (kubernetes-sigs)"
+
+  if kubectl get crd sandboxes.agents.x-k8s.io &>/dev/null; then
+    log_success "agent-sandbox CRDs already installed — skipping"
+  else
+    log_info "Installing agent-sandbox ${AGENT_SANDBOX_VERSION} (controller)..."
+    run_cmd kubectl apply -f \
+      "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml"
+
+    log_info "Installing agent-sandbox ${AGENT_SANDBOX_VERSION} (extensions)..."
+    run_cmd kubectl apply -f \
+      "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/extensions.yaml"
+
+    if ! $DRY_RUN; then
+      log_info "Waiting for agent-sandbox CRDs to become established..."
+      kubectl wait --for=condition=Established crd \
+        sandboxes.agents.x-k8s.io \
+        --timeout=60s
+    fi
+    _wait_deployment_ready agent-sandbox-controller-manager agent-sandbox-system agent-sandbox
+    log_success "agent-sandbox installed"
+  fi
+  echo ""
+fi
 
 # ============================================================================
 # Step 6: Install kagenti-deps chart (core: Keycloak + toggles)
@@ -965,6 +1001,7 @@ KAGENTI_FLAGS=(
   --set "ui.frontend.enabled=${WITH_UI}"
   --set "components.istio.enabled=${WITH_ISTIO}"
   --set "components.mcpGateway.enabled=${WITH_MCP_GATEWAY}"
+  --set "featureFlags.agentSandbox=${WITH_AGENT_SANDBOX}"
   --set "components.phoenix.enabled=false"
   --set "components.mlflow.enabled=${WITH_MLFLOW}"
   --set "ui.frontend.tag=${KAGENTI_TAG}"

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -436,7 +436,7 @@ if $WITH_AGENT_SANDBOX; then
         sandboxes.agents.x-k8s.io \
         --timeout=60s
     fi
-    _wait_deployment_ready agent-sandbox-controller-manager agent-sandbox-system agent-sandbox
+    _wait_deployment_ready agent-sandbox-controller agent-sandbox-system agent-sandbox
     log_success "agent-sandbox installed"
   fi
   echo ""

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -419,8 +419,9 @@ echo ""
 if $WITH_AGENT_SANDBOX; then
   log_info "Step 5b: agent-sandbox (kubernetes-sigs)"
 
-  if kubectl get crd sandboxes.agents.x-k8s.io &>/dev/null; then
-    log_success "agent-sandbox CRDs already installed — skipping"
+  if kubectl get crd sandboxes.agents.x-k8s.io &>/dev/null \
+     && kubectl get deployment agent-sandbox-controller -n agent-sandbox-system &>/dev/null; then
+    log_success "agent-sandbox already installed — skipping"
   else
     log_info "Installing agent-sandbox ${AGENT_SANDBOX_VERSION} (controller)..."
     run_cmd kubectl apply -f \

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -475,8 +475,11 @@ DEPS_FLAGS=(
 )
 
 log_info "Installing kagenti-deps..."
+# --skip-crds: Gateway API CRDs already installed in Step 5 at a newer version;
+# the bundled crds/ in the chart would conflict with the kubectl field manager.
 run_cmd helm upgrade --install kagenti-deps "$REPO_ROOT/charts/kagenti-deps/" \
   -n kagenti-system --create-namespace --wait --timeout 20m \
+  --skip-crds \
   "${DEPS_FLAGS[@]}"
 
 # Label kagenti-system for shared gateway access


### PR DESCRIPTION
## Summary

- Add `featureFlags.agentSandbox` to the kagenti Helm chart (disabled by default) that controls the `KAGENTI_FEATURE_FLAG_AGENT_SANDBOX` backend env var and `agents.x-k8s.io/sandboxes` RBAC on the backend ClusterRole
- Add `--with-agent-sandbox` flag to `scripts/kind/setup-kagenti.sh` that installs the kubernetes-sigs agent-sandbox controller + extensions and sets the Helm feature flag
- Fix Gateway API CRD field manager conflict in kagenti-deps (`--skip-crds`)

Part of epic #1155 — Adopt agent-sandbox (kubernetes-sigs) as a fourth workload type.

## Propagation chain

```
setup-kagenti.sh --with-agent-sandbox
  ├── kubectl apply manifest.yaml + extensions.yaml (CRDs + controller)
  └── helm --set featureFlags.agentSandbox=true
        ├── KAGENTI_FEATURE_FLAG_AGENT_SANDBOX env var on backend
        ├── agents.x-k8s.io RBAC rules in ClusterRole
        └── /api/v1/config/features → agentSandbox: true → UI
```

## Test plan

- [x] `helm template charts/kagenti/ --set featureFlags.agentSandbox=true` shows RBAC and env var
- [x] `helm template charts/kagenti/ --set featureFlags.agentSandbox=false` — no RBAC block, env var set to `"false"`
- [x] `helm lint charts/kagenti/` passes
- [x] `--with-all` includes `WITH_AGENT_SANDBOX=true`
- [x] `kubectl get crd sandboxes.agents.x-k8s.io` exists after install
- [x] `helm get values kagenti` shows `featureFlags.agentSandbox: true` after install
- [x] agent-sandbox controller running (`agent-sandbox-controller` in `agent-sandbox-system`, 1/1 ready)
- [ ] Full end-to-end: `setup-kagenti.sh --with-agent-sandbox --with-backend --skip-cluster` — backend pod has `KAGENTI_FEATURE_FLAG_AGENT_SANDBOX=true` env var and ClusterRole includes `agents.x-k8s.io` RBAC

**Note:** `setup-kagenti.sh --skip-cluster` hits a pre-existing Istio webhook conflict at Step 3 (`istiod-default-validator` field manager) that halts the script before Step 5b. This is unrelated to this PR — agent-sandbox installation was verified via a prior run that completed successfully.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>