### PR TITLE
feat: add Sandbox to build reconciliation workload check

### DIFF
--- a/kagenti/backend/app/services/reconciliation.py
+++ b/kagenti/backend/app/services/reconciliation.py
@@ -36,8 +36,11 @@ logger = logging.getLogger(__name__)
 
 
 def _workload_exists(kube: KubernetesService, namespace: str, name: str) -> bool:
-    """Check if any workload (Deployment, StatefulSet, or Job) exists for the given name."""
-    for getter in (kube.get_deployment, kube.get_statefulset, kube.get_job):
+    """Check if any workload (Deployment, StatefulSet, Job, or Sandbox) exists for the given name."""
+    getters = [kube.get_deployment, kube.get_statefulset, kube.get_job]
+    if settings.kagenti_feature_flag_agent_sandbox:
+        getters.append(kube.get_sandbox)
+    for getter in getters:
         try:
             getter(namespace=namespace, name=name)
             return True

--- a/kagenti/backend/tests/test_reconciliation.py
+++ b/kagenti/backend/tests/test_reconciliation.py
@@ -86,6 +86,7 @@ def mock_kube():
     kube.get_deployment.side_effect = _api_404()
     kube.get_statefulset.side_effect = _api_404()
     kube.get_job.side_effect = _api_404()
+    kube.get_sandbox.side_effect = _api_404()
     return kube
 
 
@@ -122,6 +123,25 @@ class TestWorkloadExists:
         mock_kube.get_job.return_value = {"metadata": {"name": "agent1"}}
 
         assert _workload_exists(mock_kube, "team1", "agent1") is True
+
+    @patch("app.services.reconciliation.settings")
+    def test_sandbox_exists(self, mock_settings, mock_kube):
+        from app.services.reconciliation import _workload_exists
+
+        mock_settings.kagenti_feature_flag_agent_sandbox = True
+        mock_kube.get_sandbox.side_effect = None
+        mock_kube.get_sandbox.return_value = {"metadata": {"name": "agent1"}}
+
+        assert _workload_exists(mock_kube, "team1", "agent1") is True
+
+    @patch("app.services.reconciliation.settings")
+    def test_sandbox_skipped_when_flag_disabled(self, mock_settings, mock_kube):
+        from app.services.reconciliation import _workload_exists
+
+        mock_settings.kagenti_feature_flag_agent_sandbox = False
+
+        assert _workload_exists(mock_kube, "team1", "agent1") is False
+        mock_kube.get_sandbox.assert_not_called()
 
     def test_no_workload_exists(self, mock_kube):
         from app.services.reconciliation import _workload_exists


### PR DESCRIPTION
## Summary

- When the `agentSandbox` feature flag is enabled, the build reconciliation loop now checks for existing Sandbox resources before attempting to finalize orphaned builds
- Adds `kube.get_sandbox` to `_workload_exists()` conditionally, gated behind `settings.kagenti_feature_flag_agent_sandbox`
- Two new unit tests: sandbox found (returns True), sandbox skipped when flag disabled (returns False, `get_sandbox` not called)

Part of epic #1155 — Adopt agent-sandbox as a fourth workload type.

## Test Plan

- [x] `uv run pytest tests/test_reconciliation.py -v` — all 20 tests pass (18 existing + 2 new)
- [x] Pre-commit hooks pass (ruff format, lint, secrets check)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>