### PR TITLE
fix: address upgrade issues from v0.6.0-alpha.4 to alpha.5

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1152,8 +1152,8 @@
                         echo "SPIRE OIDC discovery provider is ready"
                 containers:
                   - name: setup-spiffe-idp
-                    image: "{{ kagenti_deps_values.spiffeIdp.image.repository }}:{{ kagenti_deps_values.spiffeIdp.image.tag | default('latest') }}"
-                    imagePullPolicy: "{{ kagenti_deps_values.spiffeIdp.image.pullPolicy | default('IfNotPresent') }}"
+                    image: "{{ ((kagenti_deps_values.spiffeIdp | default({})).image | default({})).repository | default('ghcr.io/kagenti/kagenti/spiffe-idp-setup') }}:{{ ((kagenti_deps_values.spiffeIdp | default({})).image | default({})).tag | default('latest') }}"
+                    imagePullPolicy: "{{ ((kagenti_deps_values.spiffeIdp | default({})).image | default({})).pullPolicy | default('IfNotPresent') }}"
                     env:
                       - name: KEYCLOAK_BASE_URL
                         value: "{{ kagenti_deps_values.keycloak.url }}"
@@ -1172,7 +1172,9 @@
                       - name: SPIFFE_BUNDLE_ENDPOINT
                         value: "https://spire-spiffe-oidc-discovery-provider.{{ charts.spire.server_namespace }}.svc.cluster.local/keys"
                       - name: SPIFFE_IDP_ALIAS
-                        value: "{{ kagenti_deps_values.authBridge.spiffeIdpAlias | default('spire-spiffe') }}"
+                        value: "{{ (kagenti_deps_values.authBridge | default({})).spiffeIdpAlias | default('spire-spiffe') }}"
+                      - name: SPIFFE_TLS_VERIFY
+                        value: "{{ 'false' if (enable_openshift | default(false)) else 'true' }}"
 
     - name: Wait for SPIFFE IdP setup job to complete
       kubernetes.core.k8s_info:
@@ -1816,6 +1818,23 @@
 #
 #  MCP Gateway
 #
+- name: Remove legacy mcp.kagenti.com CRDs (pre-v0.6.0 migration)
+  block:
+    - name: Check for legacy mcp.kagenti.com CRDs
+      command: kubectl get crd mcpgatewayextensions.mcp.kagenti.com
+      register: legacy_mcp_crd_check
+      failed_when: false
+      changed_when: false
+
+    - name: Delete legacy mcp.kagenti.com CRDs
+      command: "kubectl delete crd {{ item }} --ignore-not-found"
+      loop:
+        - mcpgatewayextensions.mcp.kagenti.com
+        - mcpserverregistrations.mcp.kagenti.com
+        - mcpvirtualservers.mcp.kagenti.com
+      when: legacy_mcp_crd_check.rc == 0
+  when: charts.mcpGateway.enabled | default(false)
+
 - name: Install/upgrade mcp-gateway chart
   kubernetes.core.helm:
     release_name: mcp-gateway

--- a/kagenti/auth/spiffe-idp-setup/setup_spiffe_idp.py
+++ b/kagenti/auth/spiffe-idp-setup/setup_spiffe_idp.py
@@ -23,6 +23,7 @@ Environment Variables:
     SPIFFE_TRUST_DOMAIN: SPIFFE trust domain (default: spiffe://localtest.me)
     SPIFFE_BUNDLE_ENDPOINT: JWKS URL (default: http://spire-spiffe-oidc-discovery-provider.spire-server.svc.cluster.local/keys)
     SPIFFE_IDP_ALIAS: Identity Provider alias (default: spire-spiffe)
+    SPIFFE_TLS_VERIFY: Enable TLS verification for SPIRE endpoint (default: true, set to "false" to disable)
     SPIRE_NAMESPACE: SPIRE server namespace for validation (default: spire-server)
 """
 
@@ -64,6 +65,7 @@ SPIFFE_IDP_ALIAS = os.getenv("SPIFFE_IDP_ALIAS", "spire-spiffe")
 SPIRE_NAMESPACE = os.getenv("SPIRE_NAMESPACE", "spire-server")
 # TLS verification - defaults to True (secure), set KEYCLOAK_TLS_VERIFY=false to disable
 KEYCLOAK_TLS_VERIFY = os.getenv("KEYCLOAK_TLS_VERIFY", "true").lower() != "false"
+SPIFFE_TLS_VERIFY = os.getenv("SPIFFE_TLS_VERIFY", "true").lower() != "false"
 
 
 def read_keycloak_credentials() -> Tuple[str, str]:
@@ -136,7 +138,9 @@ def wait_for_spire(max_attempts: int = 30, delay_seconds: int = 10) -> bool:
             logger.info(
                 f"Attempt {attempt}/{max_attempts}: Checking SPIRE availability..."
             )
-            response = requests.get(SPIFFE_BUNDLE_ENDPOINT, timeout=5)
+            response = requests.get(
+                SPIFFE_BUNDLE_ENDPOINT, timeout=5, verify=SPIFFE_TLS_VERIFY
+            )
 
             if response.status_code == 200:
                 jwks = response.json()


### PR DESCRIPTION
## Summary

Fixes three upgrade-path gaps that cause sequential failures when upgrading from v0.6.0-alpha.4 to v0.6.0-alpha.5:

- **SPIFFE IdP job (`spiffeIdp` attribute error):** The `spiffeIdp` section was added to kagenti-deps values in alpha.5. On upgrade, `helm get values --all` may return stale values missing this key. Added defensive `| default({})` chains with a hardcoded fallback image.
- **SPIFFE TLS verification:** Added `SPIFFE_TLS_VERIFY` env var to the IdP setup job and Python script. On OpenShift, the OIDC discovery provider uses service-serving certificates that aren't in the container's trust store — TLS verification is now disabled for OCP.
- **MCP Gateway CRD migration:** The mcp-gateway chart upgraded from v0.5.0 (`mcp.kagenti.com`) to v0.6.0 (`mcp.kuadrant.io`). Helm does not upgrade CRDs, so added a pre-upgrade step that detects and removes legacy `mcp.kagenti.com` CRDs before the chart install.

Closes #1325

## Test plan

- [ ] Fresh install on Kind: verify SPIFFE IdP job runs successfully with default fallback image
- [ ] Upgrade from alpha.4 to alpha.5 on OCP: verify all three errors are resolved
- [ ] Fresh install on OCP with ZTWIM: verify `SPIFFE_TLS_VERIFY=false` is passed and OIDC endpoint is reachable
- [ ] MCP Gateway upgrade: verify old CRDs are deleted when present, no-op on fresh install (CRDs don't exist)
- [ ] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)