### PR TITLE
feat: add agent-sandbox to UI types and feature flags

### DIFF
--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -8,12 +8,14 @@ export interface FeatureFlags {
   sandbox: boolean;
   integrations: boolean;
   triggers: boolean;
+  agentSandbox: boolean;
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   sandbox: false,
   integrations: false,
   triggers: false,
+  agentSandbox: false,
 };
 
 let cachedFlags: FeatureFlags | null = null;
@@ -35,6 +37,7 @@ export function useFeatureFlags(): FeatureFlags {
           sandbox: data.sandbox === true,
           integrations: data.integrations === true,
           triggers: data.triggers === true,
+          agentSandbox: data.agentSandbox === true,
         };
         cachedFlags = validated;
         setFlags(validated);

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -5,9 +5,11 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts';
 
 export interface FeatureFlags {
+  /** Sandboxed agent runtime UI and APIs (legacy runtime sandbox). */
   sandbox: boolean;
   integrations: boolean;
   triggers: boolean;
+  /** agent-sandbox (kubernetes-sigs) as a fourth workload type. */
   agentSandbox: boolean;
 }
 

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -201,7 +201,7 @@ export const agentService = {
       };
     }>;
     // Workload type
-    workloadType?: 'deployment' | 'statefulset' | 'job';
+    workloadType?: 'deployment' | 'statefulset' | 'job' | 'sandbox';
     // New fields for deployment method
     deploymentMethod?: 'source' | 'image';
     // Build from source fields

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Workload types for agent deployment
-export type WorkloadType = 'deployment' | 'statefulset' | 'job';
+export type WorkloadType = 'deployment' | 'statefulset' | 'job' | 'sandbox';
 
 // Agent types
 export interface AgentLabels {


### PR DESCRIPTION
## Summary

- Add `'sandbox'` to the `WorkloadType` union type so the UI can represent agent-sandbox workloads
- Add `agentSandbox` boolean to `FeatureFlags` interface, defaults, and API response validation in `useFeatureFlags`
- Add `'sandbox'` to the inline workload type in the agent import API payload

Part of epic #1155 — Adopt agent-sandbox as a fourth workload type.

## Test Plan

- [x] `npx tsc --noEmit` — no type errors
- [x] Pre-commit hooks pass (lint, secrets check)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>