### PR TITLE
Add serviceAccount and pod configuration to kagenti-operator

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -225,6 +225,11 @@ kagenti-webhook-chart:
 # ------------------------------------------------------------------
 kagenti-operator-chart:
   controllerManager:
+    serviceAccount:
+      annotations: {}
+    pod:
+      labels: {}
+      annotations: {}
     container:
       cmd: /manager
       image:


### PR DESCRIPTION
Closes #1340

## Summary
This PR adds configuration options for serviceAccount annotations and pod labels/annotations to the kagenti-operator-chart, enabling better integration with cluster policies and monitoring systems.

## Changes
- Added `serviceAccount.annotations` configuration option
- Added `pod.labels` configuration option  
- Added `pod.annotations` configuration option

## Design Decisions
- Follows existing Helm chart patterns used in other kagenti charts
- Uses empty maps as defaults to maintain backward compatibility
- Aligns with Kubernetes best practices for operator configuration

## Testing
- Validated YAML syntax
- Confirmed backward compatibility with existing deployments
- Verified configuration structure matches Helm chart conventions