### PR TITLE
feat: add Sandbox workload type to agent UI pages

### DIFF
--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -28,10 +28,9 @@ router = APIRouter(prefix="/config", tags=["config"])
 @router.get(
     "/features",
     response_model=FeatureFlagsResponse,
-    dependencies=[Depends(require_roles(ROLE_VIEWER))],
 )
 async def get_feature_flags() -> FeatureFlagsResponse:
-    """Return enabled feature flags for UI gating. Requires ROLE_VIEWER."""
+    """Return enabled feature flags for UI gating (public, no auth required)."""
     return FeatureFlagsResponse(
         sandbox=settings.kagenti_feature_flag_sandbox,
         integrations=settings.kagenti_feature_flag_integrations,

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 
 import { useState, useEffect } from 'react';
-import { useAuth } from '@/contexts';
 
 export interface FeatureFlags {
   /** Sandboxed agent runtime UI and APIs (legacy runtime sandbox). */
@@ -23,16 +22,12 @@ const DEFAULT_FLAGS: FeatureFlags = {
 let cachedFlags: FeatureFlags | null = null;
 
 export function useFeatureFlags(): FeatureFlags {
-  const { isAuthenticated, token } = useAuth();
   const [flags, setFlags] = useState<FeatureFlags>(cachedFlags ?? DEFAULT_FLAGS);
 
   useEffect(() => {
-    if (cachedFlags || !isAuthenticated || !token) return;
+    if (cachedFlags) return;
     const controller = new AbortController();
-    fetch('/api/v1/config/features', {
-      signal: controller.signal,
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    fetch('/api/v1/config/features', { signal: controller.signal })
       .then(res => res.ok ? res.json() : DEFAULT_FLAGS)
       .then((data) => {
         const validated: FeatureFlags = {
@@ -46,7 +41,7 @@ export function useFeatureFlags(): FeatureFlags {
       })
       .catch((e) => { if (e?.name !== 'AbortError') console.debug('Feature flags fetch failed:', e); });
     return () => controller.abort();
-  }, [isAuthenticated, token]);
+  }, []);
 
   return flags;
 }

--- a/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
@@ -3,6 +3,7 @@
 
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { workloadTypeColor } from '@/utils/workloadType';
 import {
   PageSection,
   Title,
@@ -121,15 +122,7 @@ export const AgentCatalogPage: React.FC = () => {
   const renderWorkloadType = (workloadType: string | undefined) => {
     const type = workloadType || 'deployment';
     const label = type.charAt(0).toUpperCase() + type.slice(1);
-    let color: 'grey' | 'orange' | 'gold' | 'purple' = 'grey';
-    if (type === 'job') {
-      color = 'orange';
-    } else if (type === 'statefulset') {
-      color = 'gold';
-    } else if (type === 'sandbox') {
-      color = 'purple';
-    }
-    return <Label color={color} isCompact>{label}</Label>;
+    return <Label color={workloadTypeColor(type)} isCompact>{label}</Label>;
   };
 
   const renderStatusBadge = (status: string) => {

--- a/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
@@ -121,11 +121,13 @@ export const AgentCatalogPage: React.FC = () => {
   const renderWorkloadType = (workloadType: string | undefined) => {
     const type = workloadType || 'deployment';
     const label = type.charAt(0).toUpperCase() + type.slice(1);
-    let color: 'grey' | 'orange' | 'gold' = 'grey';
+    let color: 'grey' | 'orange' | 'gold' | 'purple' = 'grey';
     if (type === 'job') {
       color = 'orange';
     } else if (type === 'statefulset') {
       color = 'gold';
+    } else if (type === 'sandbox') {
+      color = 'purple';
     }
     return <Label color={color} isCompact>{label}</Label>;
   };

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -424,7 +424,7 @@ export const AgentDetailPage: React.FC = () => {
                       <DescriptionListGroup>
                         <DescriptionListTerm>Workload Type</DescriptionListTerm>
                         <DescriptionListDescription>
-                          <Label color={workloadType === 'job' ? 'orange' : workloadType === 'statefulset' ? 'gold' : 'grey'} isCompact>
+                          <Label color={workloadType === 'sandbox' ? 'purple' : workloadType === 'job' ? 'orange' : workloadType === 'statefulset' ? 'gold' : 'grey'} isCompact>
                             {workloadType.charAt(0).toUpperCase() + workloadType.slice(1)}
                           </Label>
                         </DescriptionListDescription>
@@ -989,8 +989,8 @@ export const AgentDetailPage: React.FC = () => {
                 >
                   {yaml.dump(
                     {
-                      apiVersion: agent.workloadType === 'statefulset' ? 'apps/v1' : agent.workloadType === 'job' ? 'batch/v1' : 'apps/v1',
-                      kind: agent.workloadType === 'statefulset' ? 'StatefulSet' : agent.workloadType === 'job' ? 'Job' : 'Deployment',
+                      apiVersion: agent.workloadType === 'sandbox' ? 'agents.x-k8s.io/v1alpha1' : agent.workloadType === 'statefulset' ? 'apps/v1' : agent.workloadType === 'job' ? 'batch/v1' : 'apps/v1',
+                      kind: agent.workloadType === 'sandbox' ? 'Sandbox' : agent.workloadType === 'statefulset' ? 'StatefulSet' : agent.workloadType === 'job' ? 'Job' : 'Deployment',
                       metadata: {
                         ...agent.metadata,
                         managedFields: undefined,

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { workloadTypeColor, WORKLOAD_META } from '@/utils/workloadType';
 import {
   PageSection,
   Title,
@@ -100,15 +101,6 @@ interface AgentCard {
   defaultInputModes?: string[];
   defaultOutputModes?: string[];
   skills?: AgentCardSkill[];
-}
-
-function workloadTypeColor(type: string): 'grey' | 'orange' | 'gold' | 'purple' {
-  switch (type) {
-    case 'sandbox': return 'purple';
-    case 'job': return 'orange';
-    case 'statefulset': return 'gold';
-    default: return 'grey';
-  }
 }
 
 export const AgentDetailPage: React.FC = () => {
@@ -998,8 +990,8 @@ export const AgentDetailPage: React.FC = () => {
                 >
                   {yaml.dump(
                     {
-                      apiVersion: agent.workloadType === 'sandbox' ? 'agents.x-k8s.io/v1alpha1' : agent.workloadType === 'statefulset' ? 'apps/v1' : agent.workloadType === 'job' ? 'batch/v1' : 'apps/v1',
-                      kind: agent.workloadType === 'sandbox' ? 'Sandbox' : agent.workloadType === 'statefulset' ? 'StatefulSet' : agent.workloadType === 'job' ? 'Job' : 'Deployment',
+                      apiVersion: (WORKLOAD_META[agent.workloadType ?? 'deployment'] ?? WORKLOAD_META.deployment).apiVersion,
+                      kind: (WORKLOAD_META[agent.workloadType ?? 'deployment'] ?? WORKLOAD_META.deployment).kind,
                       metadata: {
                         ...agent.metadata,
                         managedFields: undefined,

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -102,6 +102,15 @@ interface AgentCard {
   skills?: AgentCardSkill[];
 }
 
+function workloadTypeColor(type: string): 'grey' | 'orange' | 'gold' | 'purple' {
+  switch (type) {
+    case 'sandbox': return 'purple';
+    case 'job': return 'orange';
+    case 'statefulset': return 'gold';
+    default: return 'grey';
+  }
+}
+
 export const AgentDetailPage: React.FC = () => {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
@@ -424,7 +433,7 @@ export const AgentDetailPage: React.FC = () => {
                       <DescriptionListGroup>
                         <DescriptionListTerm>Workload Type</DescriptionListTerm>
                         <DescriptionListDescription>
-                          <Label color={workloadType === 'sandbox' ? 'purple' : workloadType === 'job' ? 'orange' : workloadType === 'statefulset' ? 'gold' : 'grey'} isCompact>
+                          <Label color={workloadTypeColor(workloadType)} isCompact>
                             {workloadType.charAt(0).toUpperCase() + workloadType.slice(1)}
                           </Label>
                         </DescriptionListDescription>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1004,10 +1004,10 @@ export const ImportAgentPage: React.FC = () => {
                   aria-label="Workload type selector"
                 >
                   {[
-                    { value: 'deployment', label: 'Deployment (Recommended)' },
+                    { value: 'deployment', label: features.agentSandbox ? 'Deployment' : 'Deployment (Recommended)' },
                     { value: 'statefulset', label: 'StatefulSet' },
                     { value: 'job', label: 'Job' },
-                    ...(features.agentSandbox ? [{ value: 'sandbox', label: 'Sandbox (agent-sandbox)' }] : []),
+                    ...(features.agentSandbox ? [{ value: 'sandbox', label: 'Sandbox (Recommended)' }] : []),
                   ].map((opt) => (
                     <FormSelectOption key={opt.value} value={opt.value} label={opt.label} />
                   ))}

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -165,7 +165,9 @@ export const ImportAgentPage: React.FC = () => {
   const [showImportModal, setShowImportModal] = useState(false);
 
   // Workload type
-  const [workloadType, setWorkloadType] = useState<'deployment' | 'statefulset' | 'job' | 'sandbox'>('deployment');
+  const [workloadType, setWorkloadType] = useState<'deployment' | 'statefulset' | 'job' | 'sandbox'>(
+    features.agentSandbox ? 'sandbox' : 'deployment'
+  );
 
   // HTTPRoute/Route creation
   const [createHttpRoute, setCreateHttpRoute] = useState(false);

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -41,6 +41,7 @@ import { agentService, ShipwrightBuildConfig } from '@/services/api';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
 import { EnvImportModal } from '@/components/EnvImportModal';
 import { BuildStrategySelector } from '@/components/BuildStrategySelector';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 
 // Example agent subfolders from the original UI
 const AGENT_EXAMPLES = [
@@ -107,6 +108,7 @@ interface ServicePort {
 
 export const ImportAgentPage: React.FC = () => {
   const navigate = useNavigate();
+  const features = useFeatureFlags();
 
   // Deployment method
   const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
@@ -163,7 +165,7 @@ export const ImportAgentPage: React.FC = () => {
   const [showImportModal, setShowImportModal] = useState(false);
 
   // Workload type
-  const [workloadType, setWorkloadType] = useState<'deployment' | 'statefulset' | 'job'>('deployment');
+  const [workloadType, setWorkloadType] = useState<'deployment' | 'statefulset' | 'job' | 'sandbox'>('deployment');
 
   // HTTPRoute/Route creation
   const [createHttpRoute, setCreateHttpRoute] = useState(false);
@@ -989,12 +991,17 @@ export const ImportAgentPage: React.FC = () => {
                 <FormSelect
                   id="workloadType"
                   value={workloadType}
-                  onChange={(_e, value) => setWorkloadType(value as 'deployment' | 'statefulset' | 'job')}
+                  onChange={(_e, value) => setWorkloadType(value as 'deployment' | 'statefulset' | 'job' | 'sandbox')}
                   aria-label="Workload type selector"
                 >
-                  <FormSelectOption value="deployment" label="Deployment (Recommended)" />
-                  <FormSelectOption value="statefulset" label="StatefulSet" />
-                  <FormSelectOption value="job" label="Job" />
+                  {[
+                    { value: 'deployment', label: 'Deployment (Recommended)' },
+                    { value: 'statefulset', label: 'StatefulSet' },
+                    { value: 'job', label: 'Job' },
+                    ...(features.agentSandbox ? [{ value: 'sandbox', label: 'Sandbox (agent-sandbox)' }] : []),
+                  ].map((opt) => (
+                    <FormSelectOption key={opt.value} value={opt.value} label={opt.label} />
+                  ))}
                 </FormSelect>
                 <FormHelperText>
                   <HelperText>
@@ -1002,6 +1009,7 @@ export const ImportAgentPage: React.FC = () => {
                       {workloadType === 'deployment' && 'Standard deployment for long-running agents with auto-restart'}
                       {workloadType === 'statefulset' && 'For stateful agents requiring stable network identity and persistent storage'}
                       {workloadType === 'job' && 'For batch/one-time agents that run to completion. Note: Jobs may not expose an agent card or support HTTPRoute-based external access.'}
+                      {workloadType === 'sandbox' && 'Kubernetes-native sandbox with stable identity, persistent storage, and lifecycle management (pause/resume/expire)'}
                     </HelperTextItem>
                   </HelperText>
                 </FormHelperText>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 IBM Corp.
 // Licensed under the Apache License, Version 2.0
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidEnvVarName, isValidContainerImage, isValidImageTag } from '../utils/validation';
 import { newRouteRowId } from '../utils/routeRowId';
@@ -168,6 +168,13 @@ export const ImportAgentPage: React.FC = () => {
   const [workloadType, setWorkloadType] = useState<'deployment' | 'statefulset' | 'job' | 'sandbox'>(
     features.agentSandbox ? 'sandbox' : 'deployment'
   );
+
+  // Sync default when feature flags load async (first page load before cache is warm)
+  useEffect(() => {
+    if (features.agentSandbox) {
+      setWorkloadType(prev => prev === 'deployment' ? 'sandbox' : prev);
+    }
+  }, [features.agentSandbox]);
 
   // HTTPRoute/Route creation
   const [createHttpRoute, setCreateHttpRoute] = useState(false);

--- a/kagenti/ui-v2/src/utils/workloadType.ts
+++ b/kagenti/ui-v2/src/utils/workloadType.ts
@@ -1,0 +1,18 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+export function workloadTypeColor(type: string): 'grey' | 'orange' | 'gold' | 'purple' {
+  switch (type) {
+    case 'sandbox': return 'purple';
+    case 'job': return 'orange';
+    case 'statefulset': return 'gold';
+    default: return 'grey';
+  }
+}
+
+export const WORKLOAD_META: Record<string, { apiVersion: string; kind: string }> = {
+  sandbox: { apiVersion: 'agents.x-k8s.io/v1alpha1', kind: 'Sandbox' },
+  statefulset: { apiVersion: 'apps/v1', kind: 'StatefulSet' },
+  job: { apiVersion: 'batch/v1', kind: 'Job' },
+  deployment: { apiVersion: 'apps/v1', kind: 'Deployment' },
+};


### PR DESCRIPTION
## Summary

- **ImportAgentPage**: Add Sandbox as 4th workload type option in the dropdown, gated behind `agentSandbox` feature flag. Uses array `.map()` pattern for PatternFly `FormSelect` compatibility (conditional JSX children don't work with native `<select>`)
- **AgentCatalogPage**: Render purple label for sandbox workload type in the agents table
- **AgentDetailPage**: Purple label + correct `agents.x-k8s.io/v1alpha1` apiVersion and `Sandbox` kind in YAML dump
- **Feature flags endpoint**: Make `GET /api/v1/config/features` public (no auth required) so feature flags load before login — flags are non-sensitive UI configuration
- **useFeatureFlags hook**: Remove auth dependency, fetch flags unconditionally on mount

Part of #1155

## Test plan

- [ ] Verify Sandbox appears as 4th option in Import Agent workload dropdown when `agentSandbox` flag is enabled
- [ ] Verify Sandbox does NOT appear when flag is disabled
- [ ] Verify purple "Sandbox" label renders in Agent Catalog table
- [ ] Verify Agent Detail page shows correct apiVersion/kind for sandbox agents
- [ ] Verify `/api/v1/config/features` returns flags without auth token
- [ ] Verify other workload types (Deployment, StatefulSet, Job) are unaffected

Assisted-By: Claude (Anthropic AI)