### PR TITLE
fix(ci): pass LLM and GitHub secrets to OpenShell E2E workflows

### DIFF
--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -219,8 +219,9 @@ jobs:
         with:
           script: |
             // With continue-on-error, 'result' is always 'success'.
-            // Use 'outcome' to get the real test result (via outputs).
-            const outcome = '${{ needs.e2e-openshell.outputs.test_outcome }}' || '${{ needs.e2e-openshell.result }}';
+            // Use step outcome via job outputs; default to 'failure' if
+            // the output is empty (step skipped or not reached).
+            const outcome = '${{ needs.e2e-openshell.outputs.test_outcome }}' || 'failure';
             const passed = outcome === 'success';
             const emoji = passed ? '✅' : '❌';
             const status = passed ? 'Passed' : 'Failed';

--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -86,6 +86,8 @@ jobs:
     if: needs.authorize.outputs.authorized == 'true'
     timeout-minutes: 90
     continue-on-error: true
+    outputs:
+      test_outcome: ${{ steps.run-tests.outcome }}
     permissions:
       contents: read
     env:
@@ -138,6 +140,7 @@ jobs:
           PULL_SECRET: ${{ secrets.PULL_SECRET }}
 
       - name: Run OpenShell full test (HyperShift)
+        id: run-tests
         run: |
           ./.github/scripts/local-setup/openshell-full-test.sh \
             --platform ocp \
@@ -149,6 +152,8 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
           HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload test results
         if: always()
@@ -213,7 +218,10 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
-            const passed = '${{ needs.e2e-openshell.result }}' === 'success';
+            // With continue-on-error, 'result' is always 'success'.
+            // Use 'outcome' to get the real test result (via outputs).
+            const outcome = '${{ needs.e2e-openshell.outputs.test_outcome }}' || '${{ needs.e2e-openshell.result }}';
+            const passed = outcome === 'success';
             const emoji = passed ? '✅' : '❌';
             const status = passed ? 'Passed' : 'Failed';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -81,6 +81,8 @@ jobs:
         run: ./.github/scripts/local-setup/openshell-full-test.sh
         env:
           PLATFORM: kind
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Collect logs on failure
         if: failure()


### PR DESCRIPTION
## Summary
- Pass `OPENAI_API_KEY` (LiteMaaS) and `GITHUB_TOKEN` to both Kind and HyperShift OpenShell E2E workflows
- Fix HyperShift post-results comment to report actual test outcome (was always showing "Passed" due to `continue-on-error`)

## What this enables
- **+37 LLM tests**: skill execution (PR review, RCA, security scan, code review) and multiturn conversation tests
- **+2 real-world tests**: fetching actual PR diffs from kagenti repo via GitHub API
- **Accurate failure reporting**: HyperShift results comment now correctly shows fail when tests fail

## Changes
- `e2e-openshell-kind.yaml`: add `OPENAI_API_KEY` + `GITHUB_TOKEN` env vars
- `e2e-openshell-hypershift.yaml`: add secrets, step id, job outputs, fix outcome logic

## Test plan
- [ ] Verify Kind E2E run picks up OPENAI_API_KEY and runs LLM tests (should jump from ~70 to ~107 passed)
- [ ] Verify GITHUB_TOKEN enables real_github_pr tests
- [ ] Verify HyperShift post-results comment shows actual pass/fail

Generated with [Claude Code](https://claude.com/claude-code)