### PR TITLE
fix: Add authbridge template ConfigMaps for operator propagation

### DIFF
--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -1,0 +1,234 @@
+{{- /*
+  Template ConfigMaps for the operator's namespace ConfigMap propagation.
+
+  The operator copies these from the release namespace (kagenti-system) to
+  agent namespaces that are missing them — e.g. namespaces created via GitOps
+  or manual kubectl instead of the Helm chart.
+
+  The content is identical to what agent-namespaces.yaml and
+  spiffe-namespaces-config.yaml create per agent namespace.
+
+  See: https://github.com/kagenti/kagenti/issues/1336
+*/ -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+data:
+  KEYCLOAK_URL: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
+  KEYCLOAK_REALM: {{ .Values.keycloak.realm | quote }}
+  KEYCLOAK_NAMESPACE: "{{ .Values.keycloak.namespace }}"
+  ISSUER: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+  SPIRE_ENABLED: {{ if .Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
+  CLIENT_AUTH_TYPE: "{{ .Values.authBridge.clientAuthType }}"
+  SPIFFE_IDP_ALIAS: "{{ .Values.authBridge.spiffeIdpAlias }}"
+  JWT_AUDIENCE: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+  EXPECTED_AUDIENCE: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-runtime-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    mode: envoy-sidecar
+    inbound:
+      issuer: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+    outbound:
+      keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
+      keycloak_realm: {{ .Values.keycloak.realm | quote }}
+      default_policy: "passthrough"
+    identity:
+      type: {{ eq .Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" .Values.authBridge.clientAuthType | quote }}
+      client_id_file: "/shared/client-id.txt"
+      client_secret_file: "/shared/client-secret.txt"
+{{- if eq .Values.authBridge.clientAuthType "federated-jwt" }}
+      jwt_svid_path: "/opt/jwt_svid.token"
+{{- end }}
+    bypass:
+      inbound_paths:
+        - "/.well-known/*"
+        - "/healthz"
+        - "/readyz"
+        - "/livez"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9901
+
+    static_resources:
+      listeners:
+      - name: outbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15123
+        listener_filters:
+        - name: envoy.filters.listener.original_dst
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
+        - name: envoy.filters.listener.tls_inspector
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+        filter_chains:
+        - filter_chain_match:
+            transport_protocol: tls
+          filters:
+          - name: envoy.filters.network.tcp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              stat_prefix: outbound_tls_passthrough
+              cluster: original_destination
+        - filter_chain_match:
+            transport_protocol: raw_buffer
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: outbound_http
+              codec_type: AUTO
+              route_config:
+                name: outbound_routes
+                virtual_hosts:
+                - name: catch_all
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: "/"
+                    route:
+                      cluster: original_destination
+                      timeout: 300s
+              http_filters:
+              - name: envoy.filters.http.ext_proc
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: ext_proc_cluster
+                    timeout: 300s
+                  processing_mode:
+                    request_header_mode: SEND
+                    response_header_mode: SKIP
+                    request_body_mode: NONE
+                    response_body_mode: NONE
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      - name: inbound_listener
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 15124
+        listener_filters:
+        - name: envoy.filters.listener.original_dst
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: inbound_http
+              codec_type: AUTO
+              route_config:
+                name: inbound_routes
+                virtual_hosts:
+                - name: local_app
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: "/"
+                    route:
+                      cluster: original_destination
+                      timeout: 300s
+              http_filters:
+              - name: envoy.filters.http.lua
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                  inline_code: |
+                    function envoy_on_request(request_handle)
+                      request_handle:headers():add("x-authbridge-direction", "inbound")
+                    end
+              - name: envoy.filters.http.ext_proc
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: ext_proc_cluster
+                    timeout: 300s
+                  processing_mode:
+                    request_header_mode: SEND
+                    response_header_mode: SKIP
+                    request_body_mode: NONE
+                    response_body_mode: NONE
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      clusters:
+      - name: original_destination
+        connect_timeout: 30s
+        type: ORIGINAL_DST
+        lb_policy: CLUSTER_PROVIDED
+        original_dst_lb_config:
+          use_http_header: false
+
+      - name: ext_proc_cluster
+        connect_timeout: 5s
+        type: STATIC
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: ext_proc_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 9090
+{{- if .Values.spire.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spiffe-helper-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+data:
+  helper.conf: |
+    agent_address = "/spiffe-workload-api/spire-agent.sock"
+    cmd = ""
+    cmd_args = ""
+    svid_file_name = "/opt/svid.pem"
+    svid_key_file_name = "/opt/svid_key.pem"
+    svid_bundle_file_name = "/opt/svid_bundle.pem"
+    cert_file_mode = 0644
+    key_file_mode = 0640
+    jwt_svids = [{jwt_audience="{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}", jwt_svid_file_name="/opt/jwt_svid.token"}]
+    jwt_svid_file_mode = 0644
+    include_federated_domains = true
+{{- end }}


### PR DESCRIPTION
## Summary

- Adds 4 template ConfigMaps (`authbridge-config`, `authbridge-runtime-config`, `envoy-config`, `spiffe-helper-config`) to `kagenti-system` (the release namespace)
- Content is identical to what `agent-namespaces.yaml` and `spiffe-namespaces-config.yaml` create per agent namespace — all values are cluster-wide, nothing namespace-specific
- The operator copies these to agent namespaces that are missing them during AgentRuntime reconciliation

## Merge order

> **Merge this PR first**, then merge the operator PR: kagenti/kagenti-operator#308
>
> The operator gracefully no-ops when templates are absent (logs and skips), so merging in either order is safe — but the fix only works once both are in.

Fixes https://github.com/kagenti/kagenti/issues/1336 (part 1 of 2)

## Test plan

- [ ] `helm template` renders the new ConfigMaps in the release namespace
- [ ] Existing agent-namespace ConfigMaps are unaffected
- [ ] `spiffe-helper-config` template is only rendered when `spire.enabled=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)