### PR TITLE
Feat: Provide API access to AuthBridge config and statistics

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -193,6 +193,14 @@ data:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
         filter_chains:
+        - filter_chain_match:
+            destination_port: 9093
+          filters:
+          - name: envoy.filters.network.tcp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              stat_prefix: outbound_passthrough_9093
+              cluster: original_destination
         # TLS passthrough: forward HTTPS traffic as-is via TCP proxy
         - filter_chain_match:
             transport_protocol: tls

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -390,7 +390,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
-  - apiGroups: ["discovery.k8s.io/v1"]
+  - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["list"]
   {{- if .Values.featureFlags.sandbox }}

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -390,6 +390,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io/v1"]
+    resources: ["endpointslices"]
+    verbs: ["list"]
   {{- if .Values.featureFlags.sandbox }}
   # Sandbox-specific: create pods, exec, logs, and mutate configmaps/secrets/PVCs
   - apiGroups: [""]

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -74,6 +74,7 @@ class Settings(BaseSettings):
     kagenti_feature_flag_integrations: bool = False
     kagenti_feature_flag_triggers: bool = False
     kagenti_feature_flag_agent_sandbox: bool = False
+    kagenti_feature_flag_authbridge_api: bool = True # @@@ ecs Make False
     kagenti_feature_flag_sidecars: bool = (
         False  # sidecar agents (looper, hallucination, context guardian)
     )

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
     kagenti_feature_flag_integrations: bool = False
     kagenti_feature_flag_triggers: bool = False
     kagenti_feature_flag_agent_sandbox: bool = False
-    kagenti_feature_flag_authbridge_api: bool = True # @@@ ecs Make False
+    kagenti_feature_flag_authbridge_api: bool = False
     kagenti_feature_flag_sidecars: bool = (
         False  # sidecar agents (looper, hallucination, context guardian)
     )

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -199,6 +199,14 @@ static_resources:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     filter_chains:
     - filter_chain_match:
+        destination_port: 9093
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: outbound_passthrough_9093
+          cluster: original_destination
+    - filter_chain_match:
         transport_protocol: tls
       filters:
       - name: envoy.filters.network.tcp_proxy

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -14,7 +14,6 @@ import ipaddress
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import urlparse
-from urllib.request import urlopen
 
 import httpx
 import yaml
@@ -3866,7 +3865,9 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
         raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
 
 
-@router.get("/{namespace}/{name}/identity-config", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
+@router.get(
+    "/{namespace}/{name}/identity-config", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
+)
 async def get_agent_identity_config(
     namespace: str,
     name: str,
@@ -3890,14 +3891,25 @@ async def get_agent_identity_config(
     for endpoint_slice in endpoint_slices.get("items", []):
         for endpoint in endpoint_slice.get("endpoints", []):
             for address in endpoint.get("addresses", []):
-                attempts = attempts+1
+                attempts += 1
                 # AuthBridge serves config and status on port 9093
                 url = f"http://{address}:9093/config"
                 try:
-                    r = urlopen(url, timeout=10)
-                    data = json.loads(r.read())
-                    data["AuthBridge"] = True
-                    return data
+                    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+                        logger.debug(f"Making HTTP request to {url}")
+                        response = await client.get(url)
+                        response.raise_for_status()
+
+                        # Validate content isn't too large (max 1MB)
+                        content = response.text
+                        if len(content) > 1024 * 1024:
+                            raise HTTPException(
+                                status_code=413, detail="File content too large (max 1MB)"
+                            )
+
+                        data = json.loads(content)
+                        data["AuthBridge"] = True
+                        return data
                 except Exception as e:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
@@ -3907,10 +3919,13 @@ async def get_agent_identity_config(
     if attempts == 0:
         raise HTTPException(status_code=404, detail=f"{name} not found")
 
-    logger.info(f"Could not invoke any AuthBridge endpoints for {namespace}/{name}")
+    logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
     return {"AuthBridge": False}
 
-@router.get("/{namespace}/{name}/identity-status", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
+
+@router.get(
+    "/{namespace}/{name}/identity-status", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
+)
 async def get_agent_identity_status(
     namespace: str,
     name: str,
@@ -3930,14 +3945,25 @@ async def get_agent_identity_status(
     for endpoint_slice in endpoint_slices.get("items", []):
         for endpoint in endpoint_slice.get("endpoints", []):
             for address in endpoint.get("addresses", []):
-                attempts = attempts+1
+                attempts += 1
                 # AuthBridge serves config and status on port 9093
                 url = f"http://{address}:9093/stats"
                 try:
-                    r = urlopen(url, timeout=10)
-                    data = json.loads(r.read())
-                    data["AuthBridge"] = True
-                    return data
+                    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+                        logger.debug(f"Making HTTP request to {url}")
+                        response = await client.get(url)
+                        response.raise_for_status()
+
+                        # Validate content isn't too large (max 1MB)
+                        content = response.text
+                        if len(content) > 1024 * 1024:
+                            raise HTTPException(
+                                status_code=413, detail="File content too large (max 1MB)"
+                            )
+
+                        data = json.loads(content)
+                        data["AuthBridge"] = True
+                        return data
                 except Exception as e:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
@@ -3947,5 +3973,5 @@ async def get_agent_identity_status(
     if attempts == 0:
         raise HTTPException(status_code=404, detail=f"{name} not found")
 
-    logger.info(f"Could not invoke any AuthBridge endpoints for {namespace}/{name}")
+    logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
     return {"AuthBridge": False}

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3885,7 +3885,7 @@ if settings.kagenti_feature_flag_authbridge_api:
         try:
             addresses = _get_service_endpoints(kube=kube, namespace=namespace, name=name)
         except ApiException as e:
-            raise HTTPException(status_code=502, detail=str(e.reason))
+            raise HTTPException(status_code=502, detail=e.reason)
 
         attempts = 0
         for address in addresses:
@@ -3897,13 +3897,14 @@ if settings.kagenti_feature_flag_authbridge_api:
                 data["AuthBridge"] = True
                 return data
             except Exception:
-                # It isn't an error for an enpoint to be unreachable, only for all pods to be unreachable
+                # It isn't an error for an endpoint to be unreachable, only for all pods to be unreachable
                 logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
 
         if attempts == 0:
             raise HTTPException(status_code=404, detail=f"{name} not found")
 
         logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
+        # We return HTTP 200 if no pods respond - this might be a valid agent w/o AuthBridge
         return {"AuthBridge": False}
 
     @router.get(
@@ -3924,7 +3925,7 @@ if settings.kagenti_feature_flag_authbridge_api:
         try:
             addresses = _get_service_endpoints(kube=kube, namespace=namespace, name=name)
         except ApiException as e:
-            raise HTTPException(status_code=502, detail=str(e.reason))
+            raise HTTPException(status_code=502, detail=e.reason)
 
         attempts = 0
         for address in addresses:
@@ -3936,13 +3937,14 @@ if settings.kagenti_feature_flag_authbridge_api:
                 data["AuthBridge"] = True
                 return data
             except Exception:
-                # It isn't an error for an enpoint to be unreachable, only for all pods to be unreachable
+                # It isn't an error for an endpoint to be unreachable, only for all pods to be unreachable
                 logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
 
         if attempts == 0:
             raise HTTPException(status_code=404, detail=f"{name} not found")
 
         logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
+        # We return HTTP 200 if no pods respond - this might be a valid agent w/o AuthBridge
         return {"AuthBridge": False}
 
 

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3864,7 +3864,9 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
         logger.error(f"Unexpected error fetching URL {request.url}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
 
+
 if settings.kagenti_feature_flag_authbridge_api:
+
     @router.get(
         "/{namespace}/{name}/identity-config", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
     )
@@ -3903,7 +3905,6 @@ if settings.kagenti_feature_flag_authbridge_api:
 
         logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
         return {"AuthBridge": False}
-
 
     @router.get(
         "/{namespace}/{name}/identity-status", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
@@ -3945,8 +3946,7 @@ if settings.kagenti_feature_flag_authbridge_api:
         return {"AuthBridge": False}
 
 
-def _get_service_endpoints(
-    kube: KubernetesService, namespace: str, name: str) -> List[str]:
+def _get_service_endpoints(kube: KubernetesService, namespace: str, name: str) -> List[str]:
     """
     Get addresses for a K8s service
     """

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3910,7 +3910,7 @@ async def get_agent_identity_config(
                         data = json.loads(content)
                         data["AuthBridge"] = True
                         return data
-                except Exception as e:
+                except Exception:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
                     logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
@@ -3964,7 +3964,7 @@ async def get_agent_identity_status(
                         data = json.loads(content)
                         data["AuthBridge"] = True
                         return data
-                except Exception as e:
+                except Exception:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
                     logger.info("Failed to talk to url %s; skipping", url, exc_info=True)

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3864,90 +3864,89 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
         logger.error(f"Unexpected error fetching URL {request.url}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
 
+if settings.kagenti_feature_flag_authbridge_api:
+    @router.get(
+        "/{namespace}/{name}/identity-config", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
+    )
+    async def get_agent_identity_config(
+        namespace: str,
+        name: str,
+        kube: KubernetesService = Depends(get_kubernetes_service),
+    ) -> dict:
+        """
+        Fetch the AuthBridge configuration for an Agent.
+        """
 
-@router.get(
-    "/{namespace}/{name}/identity-config", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
-)
-async def get_agent_identity_config(
-    namespace: str,
-    name: str,
-    kube: KubernetesService = Depends(get_kubernetes_service),
-) -> dict:
-    """
-    Fetch the AuthBridge configuration for an Agent.
-    """
+        namespace = sanitize_log(namespace)
+        name = sanitize_log(name)
 
-    namespace = sanitize_log(namespace)
-    name = sanitize_log(name)
-
-    try:
-        addresses = _get_service_endpoints(namespace=namespace, name=name)
-    except ApiException as e:
-        raise HTTPException(status_code=502, detail=str(e.reason))
-
-    attempts = 0
-    for address in addresses:
-        attempts += 1
-        # AuthBridge serves config and status on port 9093
-        url = f"http://{address}:9093/config"
         try:
-            data = await _fetch_authbridge_json(url)
-            data["AuthBridge"] = True
-            return data
-        except Exception:
-            logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
-            pass
+            addresses = _get_service_endpoints(kube=kube, namespace=namespace, name=name)
+        except ApiException as e:
+            raise HTTPException(status_code=502, detail=str(e.reason))
 
-    if attempts == 0:
-        raise HTTPException(status_code=404, detail=f"{name} not found")
+        attempts = 0
+        for address in addresses:
+            attempts += 1
+            # AuthBridge serves config and status on port 9093
+            url = f"http://{address}:9093/config"
+            try:
+                data = await _fetch_authbridge_json(url)
+                data["AuthBridge"] = True
+                return data
+            except Exception:
+                # It isn't an error for an enpoint to be unreachable, only for all pods to be unreachable
+                logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
 
-    logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
-    return {"AuthBridge": False}
+        if attempts == 0:
+            raise HTTPException(status_code=404, detail=f"{name} not found")
+
+        logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
+        return {"AuthBridge": False}
 
 
-@router.get(
-    "/{namespace}/{name}/identity-status", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
-)
-async def get_agent_identity_status(
-    namespace: str,
-    name: str,
-    kube: KubernetesService = Depends(get_kubernetes_service),
-) -> dict:
-    """
-    Fetch the AuthBridge statistics and status for an Agent.
-    """
+    @router.get(
+        "/{namespace}/{name}/identity-status", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
+    )
+    async def get_agent_identity_status(
+        namespace: str,
+        name: str,
+        kube: KubernetesService = Depends(get_kubernetes_service),
+    ) -> dict:
+        """
+        Fetch the AuthBridge statistics and status for an Agent.
+        """
 
-    namespace = sanitize_log(namespace)
-    name = sanitize_log(name)
+        namespace = sanitize_log(namespace)
+        name = sanitize_log(name)
 
-    try:
-        addresses = _get_service_endpoints(namespace=namespace, name=name)
-    except ApiException as e:
-        raise HTTPException(status_code=502, detail=str(e.reason))
-
-    attempts = 0
-    for address in addresses:
-        attempts += 1
-        # AuthBridge serves config and status on port 9093
-        url = f"http://{address}:9093/stats"
         try:
-            data = await _fetch_authbridge_json(url)
-            data["AuthBridge"] = True
-            return data
-        except Exception:
-            logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
-            pass
+            addresses = _get_service_endpoints(kube=kube, namespace=namespace, name=name)
+        except ApiException as e:
+            raise HTTPException(status_code=502, detail=str(e.reason))
 
-    if attempts == 0:
-        raise HTTPException(status_code=404, detail=f"{name} not found")
+        attempts = 0
+        for address in addresses:
+            attempts += 1
+            # AuthBridge serves config and status on port 9093
+            url = f"http://{address}:9093/stats"
+            try:
+                data = await _fetch_authbridge_json(url)
+                data["AuthBridge"] = True
+                return data
+            except Exception:
+                # It isn't an error for an enpoint to be unreachable, only for all pods to be unreachable
+                logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
 
-    logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
-    return {"AuthBridge": False}
+        if attempts == 0:
+            raise HTTPException(status_code=404, detail=f"{name} not found")
+
+        logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
+        return {"AuthBridge": False}
 
 
 def _get_service_endpoints(
-    namespace: str, name: str, kube: KubernetesService = Depends(get_kubernetes_service)
-) -> List[str]:
+    kube: KubernetesService, namespace: str, name: str) -> List[str]:
     """
     Get addresses for a K8s service
     """

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3886,12 +3886,14 @@ async def get_agent_identity_config(
     except ApiException as e:
         raise HTTPException(status_code=502, detail=str(e.reason))
 
+    attempts = 0
     for endpoint_slice in endpoint_slices.get("items", []):
         for endpoint in endpoint_slice.get("endpoints", []):
             for address in endpoint.get("addresses", []):
+                attempts = attempts+1
+                # AuthBridge serves config and status on port 9093
+                url = f"http://{address}:9093/config"
                 try:
-                    # AuthBridge serves config and status on port 9093
-                    url = f"http://{address}:9093/config"
                     r = urlopen(url, timeout=10)
                     data = json.loads(r.read())
                     data["AuthBridge"] = True
@@ -3899,7 +3901,11 @@ async def get_agent_identity_config(
                 except Exception as e:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
+                    logger.info(msg=f"Failed to talk to url {url}: {e}; skipping")
                     pass
+
+    if attempts == 0:
+        raise HTTPException(status_code=404, detail=f"{name} not found")
 
     logger.info(f"Could not invoke any AuthBridge endpoints for {namespace}/{name}")
     return {"AuthBridge": False}
@@ -3920,12 +3926,14 @@ async def get_agent_identity_status(
     except ApiException as e:
         raise HTTPException(status_code=502, detail=str(e.reason))
 
+    attempts = 0
     for endpoint_slice in endpoint_slices.get("items", []):
         for endpoint in endpoint_slice.get("endpoints", []):
             for address in endpoint.get("addresses", []):
+                attempts = attempts+1
+                # AuthBridge serves config and status on port 9093
+                url = f"http://{address}:9093/stats"
                 try:
-                    # AuthBridge serves config and status on port 9093
-                    url = f"http://{address}:9093/stats"
                     r = urlopen(url, timeout=10)
                     data = json.loads(r.read())
                     data["AuthBridge"] = True
@@ -3933,7 +3941,11 @@ async def get_agent_identity_status(
                 except Exception as e:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
+                    logger.info(msg=f"Failed to talk to url {url}: {e}; skipping")
                     pass
+
+    if attempts == 0:
+        raise HTTPException(status_code=404, detail=f"{name} not found")
 
     logger.info(f"Could not invoke any AuthBridge endpoints for {namespace}/{name}")
     return {"AuthBridge": False}

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3913,7 +3913,7 @@ async def get_agent_identity_config(
                 except Exception as e:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
-                    logger.info(msg=f"Failed to talk to url {url}: {e}; skipping")
+                    logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
                     pass
 
     if attempts == 0:
@@ -3967,7 +3967,7 @@ async def get_agent_identity_status(
                 except Exception as e:
                     # Ignore exceptions -- it could mean a pod is not ready,
                     # Check the next endpoint.
-                    logger.info(msg=f"Failed to talk to url {url}: {e}; skipping")
+                    logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
                     pass
 
     if attempts == 0:

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3877,44 +3877,26 @@ async def get_agent_identity_config(
     Fetch the AuthBridge configuration for an Agent.
     """
 
-    # It would be better to check the workload for AuthBridge first, perhaps by
-    # checking for `kagenti.io/inject` label, or explicitly fetching sidecar.
-    # TODO define mechanism to used metadata rather than explicitly contacting instances
+    namespace = sanitize_log(namespace)
+    name = sanitize_log(name)
 
-    # Try to get Endpoint Slices
     try:
-        endpoint_slices = kube.get_endpoint_slices(namespace=namespace, name=name)
+        addresses = _get_service_endpoints(namespace=namespace, name=name)
     except ApiException as e:
         raise HTTPException(status_code=502, detail=str(e.reason))
 
     attempts = 0
-    for endpoint_slice in endpoint_slices.get("items", []):
-        for endpoint in endpoint_slice.get("endpoints", []):
-            for address in endpoint.get("addresses", []):
-                attempts += 1
-                # AuthBridge serves config and status on port 9093
-                url = f"http://{address}:9093/config"
-                try:
-                    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-                        logger.debug(f"Making HTTP request to {url}")
-                        response = await client.get(url)
-                        response.raise_for_status()
-
-                        # Validate content isn't too large (max 1MB)
-                        content = response.text
-                        if len(content) > 1024 * 1024:
-                            raise HTTPException(
-                                status_code=413, detail="File content too large (max 1MB)"
-                            )
-
-                        data = json.loads(content)
-                        data["AuthBridge"] = True
-                        return data
-                except Exception:
-                    # Ignore exceptions -- it could mean a pod is not ready,
-                    # Check the next endpoint.
-                    logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
-                    pass
+    for address in addresses:
+        attempts += 1
+        # AuthBridge serves config and status on port 9093
+        url = f"http://{address}:9093/config"
+        try:
+            data = await _fetch_authbridge_json(url)
+            data["AuthBridge"] = True
+            return data
+        except Exception:
+            logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
+            pass
 
     if attempts == 0:
         raise HTTPException(status_code=404, detail=f"{name} not found")
@@ -3935,43 +3917,70 @@ async def get_agent_identity_status(
     Fetch the AuthBridge statistics and status for an Agent.
     """
 
-    # Try to get Endpoint Slices for the Agent
+    namespace = sanitize_log(namespace)
+    name = sanitize_log(name)
+
     try:
-        endpoint_slices = kube.get_endpoint_slices(namespace=namespace, name=name)
+        addresses = _get_service_endpoints(namespace=namespace, name=name)
     except ApiException as e:
         raise HTTPException(status_code=502, detail=str(e.reason))
 
     attempts = 0
-    for endpoint_slice in endpoint_slices.get("items", []):
-        for endpoint in endpoint_slice.get("endpoints", []):
-            for address in endpoint.get("addresses", []):
-                attempts += 1
-                # AuthBridge serves config and status on port 9093
-                url = f"http://{address}:9093/stats"
-                try:
-                    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-                        logger.debug(f"Making HTTP request to {url}")
-                        response = await client.get(url)
-                        response.raise_for_status()
-
-                        # Validate content isn't too large (max 1MB)
-                        content = response.text
-                        if len(content) > 1024 * 1024:
-                            raise HTTPException(
-                                status_code=413, detail="File content too large (max 1MB)"
-                            )
-
-                        data = json.loads(content)
-                        data["AuthBridge"] = True
-                        return data
-                except Exception:
-                    # Ignore exceptions -- it could mean a pod is not ready,
-                    # Check the next endpoint.
-                    logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
-                    pass
+    for address in addresses:
+        attempts += 1
+        # AuthBridge serves config and status on port 9093
+        url = f"http://{address}:9093/stats"
+        try:
+            data = await _fetch_authbridge_json(url)
+            data["AuthBridge"] = True
+            return data
+        except Exception:
+            logger.info("Failed to talk to url %s; skipping", url, exc_info=True)
+            pass
 
     if attempts == 0:
         raise HTTPException(status_code=404, detail=f"{name} not found")
 
     logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
     return {"AuthBridge": False}
+
+
+def _get_service_endpoints(
+    namespace: str, name: str, kube: KubernetesService = Depends(get_kubernetes_service)
+) -> List[str]:
+    """
+    Get addresses for a K8s service
+    """
+
+    addresses: list[str] = []
+    endpoint_slices = kube.get_endpoint_slices(namespace=namespace, name=name)
+
+    for endpoint_slice in endpoint_slices.get("items", []):
+        for endpoint in endpoint_slice.get("endpoints", []):
+            for address in endpoint.get("addresses", []):
+                addresses.append(address)
+
+    return addresses
+
+
+async def _fetch_authbridge_json(url: str) -> dict:
+    """
+    Fetch JSON from an AuthBridge sidecar endpoint.
+
+    Raises on HTTP errors, oversized responses, or non-dict payloads.
+    """
+
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        logger.debug("Making HTTP request to %s", url)
+        response = await client.get(url)
+        response.raise_for_status()
+
+        content = response.text
+        if len(content) > 1024 * 1024:
+            raise HTTPException(status_code=502, detail="File content too large (max 1MB)")
+
+        data = json.loads(content)
+        if not isinstance(data, dict):
+            raise HTTPException(status_code=502, detail="File content not AuthBridge JSON")
+
+        return data

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -14,6 +14,7 @@ import ipaddress
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import urlparse
+from urllib.request import urlopen
 
 import httpx
 import yaml
@@ -3863,3 +3864,76 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
     except Exception as e:
         logger.error(f"Unexpected error fetching URL {request.url}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+
+
+@router.get("/{namespace}/{name}/identity-config", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
+async def get_agent_identity_config(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> dict:
+    """
+    Fetch the AuthBridge configuration for an Agent.
+    """
+
+    # It would be better to check the workload for AuthBridge first, perhaps by
+    # checking for `kagenti.io/inject` label, or explicitly fetching sidecar.
+    # TODO define mechanism to used metadata rather than explicitly contacting instances
+
+    # Try to get Endpoint Slices
+    try:
+        endpoint_slices = kube.get_endpoint_slices(namespace=namespace, name=name)
+    except ApiException as e:
+        raise HTTPException(status_code=502, detail=str(e.reason))
+
+    for endpoint_slice in endpoint_slices.get("items", []):
+        for endpoint in endpoint_slice.get("endpoints", []):
+            for address in endpoint.get("addresses", []):
+                try:
+                    # AuthBridge serves config and status on port 9093
+                    url = f"http://{address}:9093/config"
+                    r = urlopen(url, timeout=10)
+                    data = json.loads(r.read())
+                    data["AuthBridge"] = True
+                    return data
+                except Exception as e:
+                    # Ignore exceptions -- it could mean a pod is not ready,
+                    # Check the next endpoint.
+                    pass
+
+    logger.info(f"Could not invoke any AuthBridge endpoints for {namespace}/{name}")
+    return {"AuthBridge": False}
+
+@router.get("/{namespace}/{name}/identity-status", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
+async def get_agent_identity_status(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> dict:
+    """
+    Fetch the AuthBridge statistics and status for an Agent.
+    """
+
+    # Try to get Endpoint Slices for the Agent
+    try:
+        endpoint_slices = kube.get_endpoint_slices(namespace=namespace, name=name)
+    except ApiException as e:
+        raise HTTPException(status_code=502, detail=str(e.reason))
+
+    for endpoint_slice in endpoint_slices.get("items", []):
+        for endpoint in endpoint_slice.get("endpoints", []):
+            for address in endpoint.get("addresses", []):
+                try:
+                    # AuthBridge serves config and status on port 9093
+                    url = f"http://{address}:9093/stats"
+                    r = urlopen(url, timeout=10)
+                    data = json.loads(r.read())
+                    data["AuthBridge"] = True
+                    return data
+                except Exception as e:
+                    # Ignore exceptions -- it could mean a pod is not ready,
+                    # Check the next endpoint.
+                    pass
+
+    logger.info(f"Could not invoke any AuthBridge endpoints for {namespace}/{name}")
+    return {"AuthBridge": False}

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -506,7 +506,7 @@ class KubernetesService:
                 namespace=namespace, label_selector=f"kubernetes.io/service-name={name}"
             )
             return result.to_dict()
-        except ApiException as e:
+        except ApiException:
             logger.error(
                 "Error getting EndpointSlices for Service %s/%s", namespace, name, exc_info=True
             )

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -501,6 +501,8 @@ class KubernetesService:
 
     def get_endpoint_slices(self, namespace: str, name: str) -> dict:
         """Get a EndpointSlices for a named Service."""
+        namespace = _sanitize(namespace)
+        name = _sanitize(name)
         try:
             result = self.discovery_v1_api.list_namespaced_endpoint_slice(
                 namespace=namespace, label_selector=f"kubernetes.io/service-name={name}"

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -47,6 +47,7 @@ class KubernetesService:
         self._batch_api: Optional[kubernetes.client.BatchV1Api] = None
         self._rbac_api: Optional[kubernetes.client.RbacAuthorizationV1Api] = None
         self._apis_api: Optional[kubernetes.client.ApisApi] = None
+        self._discovery_v1_api: Optional[kubernetes.client.DiscoveryApi] = None
 
     def _load_config(self) -> kubernetes.client.ApiClient:
         """Load Kubernetes configuration (in-cluster or kubeconfig)."""
@@ -105,6 +106,13 @@ class KubernetesService:
         if self._apis_api is None:
             self._apis_api = kubernetes.client.ApisApi(self.api_client)
         return self._apis_api
+
+    @property
+    def discovery_v1_api(self) -> kubernetes.client.DiscoveryApi:
+        """Get DiscoveryV1Api client for EndpointSlices"""
+        if self._discovery_v1_api is None:
+            self._discovery_v1_api = kubernetes.client.DiscoveryV1Api(self.api_client)
+        return self._discovery_v1_api
 
     def is_running_in_cluster(self) -> bool:
         """Check if running inside a Kubernetes cluster."""
@@ -489,6 +497,18 @@ class KubernetesService:
             return result.to_dict()
         except ApiException as e:
             logger.error(f"Error getting Service {name} in {namespace}: {e}")
+            raise
+
+    def get_endpoint_slices(self, namespace: str, name: str) -> dict:
+        """Get a EndpointSlices for a named Service."""
+        try:
+            result = self.discovery_v1_api.list_namespaced_endpoint_slice(
+                namespace=namespace,
+                label_selector=f"kubernetes.io/service-name={name}"
+            )
+            return result.to_dict()
+        except ApiException as e:
+            logger.error(f"Error getting EndpointSlices for Service {name} in {namespace}: {e}")
             raise
 
     def list_services(self, namespace: str, label_selector: Optional[str] = None) -> List[dict]:

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -508,7 +508,7 @@ class KubernetesService:
             return result.to_dict()
         except ApiException as e:
             logger.error(
-                f"Error getting EndpointSlices for Service %s/%s", namespace, name, exc_info=True
+                "Error getting EndpointSlices for Service %s/%s", namespace, name, exc_info=True
             )
             raise
 

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -47,7 +47,7 @@ class KubernetesService:
         self._batch_api: Optional[kubernetes.client.BatchV1Api] = None
         self._rbac_api: Optional[kubernetes.client.RbacAuthorizationV1Api] = None
         self._apis_api: Optional[kubernetes.client.ApisApi] = None
-        self._discovery_v1_api: Optional[kubernetes.client.DiscoveryApi] = None
+        self._discovery_v1_api: Optional[kubernetes.client.DiscoveryV1Api] = None
 
     def _load_config(self) -> kubernetes.client.ApiClient:
         """Load Kubernetes configuration (in-cluster or kubeconfig)."""
@@ -108,7 +108,7 @@ class KubernetesService:
         return self._apis_api
 
     @property
-    def discovery_v1_api(self) -> kubernetes.client.DiscoveryApi:
+    def discovery_v1_api(self) -> kubernetes.client.DiscoveryV1Api:
         """Get DiscoveryV1Api client for EndpointSlices"""
         if self._discovery_v1_api is None:
             self._discovery_v1_api = kubernetes.client.DiscoveryV1Api(self.api_client)
@@ -503,12 +503,13 @@ class KubernetesService:
         """Get a EndpointSlices for a named Service."""
         try:
             result = self.discovery_v1_api.list_namespaced_endpoint_slice(
-                namespace=namespace,
-                label_selector=f"kubernetes.io/service-name={name}"
+                namespace=namespace, label_selector=f"kubernetes.io/service-name={name}"
             )
             return result.to_dict()
         except ApiException as e:
-            logger.error(f"Error getting EndpointSlices for Service {name} in {namespace}: {e}")
+            logger.error(
+                f"Error getting EndpointSlices for Service %s/%s", namespace, name, exc_info=True
+            )
             raise
 
     def list_services(self, namespace: str, label_selector: Optional[str] = None) -> List[dict]:


### PR DESCRIPTION
## Summary

For #1366

Introduces two new kagenti-backend endpoints:
/{namespace}/{name}/identity-config
/{namespace}/{name}/identity-status

## (Optional) Testing Instructions

Deploy Kagenti.  Enable this feature with

```bash
oc -n kagenti-system set env deployment/kagenti-backend KAGENTI_FEATURE_FLAG_AUTHBRIDGE_API=TRUE
```

Deploy an Agent and then curl the Kagenti API:

```bash
curl -v -H "Authorization: Bearer ${KAGENTI_TOKEN}" 'http://localhost:8000/api/v1/agents/team1/my-weather-service-with-authbridge/identity-config'
curl -v -H "Authorization: Bearer ${KAGENTI_TOKEN}" 'http://localhost:8000/api/v1/agents/team1/my-weather-service-with-authbridge/identity-status'
```

(Note that getting a Kagenti token has been difficult.  I go into Keycloak, Kagenti realm, and Kagenti client, and check Allow Direct Access Grants.  Then I do

```bash
KAGENTI_TOKEN=$(curl -s -X POST \
    http://keycloak.localtest.me:8080/realms/kagenti/protocol/openid-connect/token \
    -d "grant_type=password&client_id=kagenti&username=admin&password=${KAGENTI_UI_PW}" | jq --raw-output ".access_token")
echo KAGENTI_TOKEN is $KAGENTI_TOKEN
```
)