### PR TITLE
feat(ci): trigger OpenShell Kind with /run-e2e-openshell for secret access

### DIFF
--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -6,12 +6,17 @@
 #
 # This workflow never blocks merge (continue-on-error: true).
 #
-# LLM-dependent tests run when OPENAI_API_KEY secret is configured.
-# The fulltest script picks up the key from the environment (no .env.maas needed).
+# Triggers:
+#   - /run-e2e-openshell comment: runs with secrets (LLM tests enabled)
+#   - pull_request: runs without secrets on fork PRs (LLM tests skip)
+#   - push to main: post-merge validation with secrets
+#   - workflow_dispatch: manual trigger with secrets
 #
 name: "[Experimental] E2E OpenShell (Kind)"
 
 on:
+  issue_comment:
+    types: [created]
   pull_request:
     branches: [main]
     paths:
@@ -34,19 +39,69 @@ concurrency:
   group: openshell-kind-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
+  # ── Authorization (issue_comment only) ─────────────────────────
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/run-e2e-openshell'))
+    permissions:
+      pull-requests: write
+      contents: read
+    outputs:
+      authorized: ${{ steps.check.outputs.has-permission }}
+      pr_sha: ${{ steps.pr-info.outputs.sha }}
+    steps:
+      - name: Check write permission
+        id: check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            if (context.eventName !== 'issue_comment') {
+              core.setOutput('has-permission', 'true');
+              return;
+            }
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner, repo: context.repo.repo,
+              username: context.payload.comment.user.login
+            });
+            const ok = ['admin', 'write'].includes(data.permission);
+            core.setOutput('has-permission', ok.toString());
+            if (!ok) core.setFailed(`No write permission: ${data.permission}`);
+
+      - name: Get PR info
+        id: pr-info
+        if: steps.check.outputs.has-permission == 'true' && github.event_name == 'issue_comment'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('sha', pr.head.sha);
+
+  # ── E2E Test Job ───────────────────────────────────────────────
   e2e-openshell:
     name: OpenShell PoC (Kind)
     runs-on: ubuntu-latest
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
     timeout-minutes: 45
     continue-on-error: true
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          ref: ${{ needs.authorize.outputs.pr_sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6

--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -36,7 +36,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: openshell-kind-${{ github.head_ref || github.ref }}
+  group: openshell-kind-${{ github.event.issue.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}
@@ -85,6 +85,16 @@ jobs:
               pull_number: context.issue.number
             });
             core.setOutput('sha', pr.head.sha);
+
+      - name: React with rocket
+        if: steps.check.outputs.has-permission == 'true' && github.event_name == 'issue_comment'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: context.payload.comment.id, content: 'rocket'
+            });
 
   # ── E2E Test Job ───────────────────────────────────────────────
   e2e-openshell:


### PR DESCRIPTION
## Summary
Add `issue_comment` trigger to the OpenShell Kind workflow so `/run-e2e-openshell` fires **both** Kind and HyperShift OpenShell E2E jobs.

## Problem
The `pull_request` trigger runs in fork context — GitHub blocks secret access. `OPENAI_API_KEY` was empty, causing all 30 LLM tests to skip. The HyperShift workflow already uses `issue_comment` and gets the secret (`***` in logs).

## Fix
- Add `issue_comment` trigger with authorization check (same pattern as HyperShift workflow)
- `/run-e2e-openshell` now triggers **both** Kind + HyperShift OpenShell E2E
- Keep `pull_request` trigger for path-based runs (LLM tests skip but infra tests still run)
- Checkout PR SHA via GitHub API for `issue_comment` trigger

## Expected impact
- CI LLM tests: 50 passed → ~80 passed (30 skill/multiturn tests unlocked)
- Single comment triggers both OpenShell E2E environments

## Test plan
- [ ] Comment `/run-e2e-openshell` on a PR and verify both Kind + HyperShift workflows run
- [ ] Verify Kind run shows `OPENAI_API_KEY: ***` (not empty)
- [ ] Verify LLM tests execute instead of skipping

Generated with [Claude Code](https://claude.com/claude-code)