### PR TITLE
fix(otel): use RHOAI MLflow gateway URL (status.url) for trace export instead of internal service URL

### DIFF
--- a/charts/kagenti-deps/templates/_helpers.tpl
+++ b/charts/kagenti-deps/templates/_helpers.tpl
@@ -99,7 +99,7 @@ not concatenated (e.g. service.extensions).
 {{- if and $.Values.openshift $rhoaiMlflow -}}
 {{- $mlflowExp := dig "exporters" "otlphttp/mlflow" dict $config -}}
 {{- if $mlflowExp -}}
-{{- $_ := set $mlflowExp "tls" (dict "ca_file" "/etc/pki/service-ca/service-ca.pem") -}}
+{{- $_ := set $mlflowExp "tls" (dict) -}}
 {{- end -}}
 {{- if $.Values.otel.collector.rhoaiMlflowAuthConfig -}}
 {{- $config = mustMergeOverwrite $config (deepCopy $.Values.otel.collector.rhoaiMlflowAuthConfig) -}}

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -21,20 +21,6 @@ metadata:
     "helm.sh/resource-policy": keep
 data: {}
 {{- end }}
-{{- if and $.Values.openshift ($.Values.otel.mlflow).enabled }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: otel-service-ca
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kagenti.labels" . | nindent 4 }}
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
-    "helm.sh/resource-policy": keep
-data: {}
-{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -110,11 +96,6 @@ spec:
               mountPath: /etc/pki/ingress-ca
               readOnly: true
             {{- end }}
-            {{- if and $.Values.openshift ($.Values.otel.mlflow).enabled }}
-            - name: service-ca
-              mountPath: /etc/pki/service-ca
-              readOnly: true
-            {{- end }}
           ports:
             - containerPort: 4317
               name: otlp-grpc
@@ -147,17 +128,6 @@ spec:
             items:
               - key: ca-bundle.crt
                 path: ingress-ca.pem
-        {{- end }}
-        {{- if and $.Values.openshift ($.Values.otel.mlflow).enabled }}
-        # OpenShift service-serving CA for RHOAI MLflow endpoint TLS verification.
-        # The service-ca-operator auto-injects the CA bundle via annotation.
-        - name: service-ca
-          configMap:
-            name: otel-service-ca
-            optional: true
-            items:
-              - key: service-ca.crt
-                path: service-ca.pem
         {{- end }}
 ---
 apiVersion: v1

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -273,8 +273,9 @@ otel:
       exporters:
         otlphttp/mlflow:
           # Default points to the in-cluster MLflow deployed by kagenti-deps.
-          # Override with the DSC-managed MLflow service when otel.mlflow.enabled=true:
-          # https://<mlflow-svc>.<namespace>.svc.cluster.local:8443/v1/traces
+          # For RHOAI (otel.mlflow.enabled=true), setup-kagenti.sh overrides this
+          # with the MLflow CR gateway URL (status.url + /v1/traces). TLS is
+          # verified via the container's system CA pool (Let's Encrypt trusted by default).
           traces_endpoint: http://mlflow:5000/v1/traces
           tls:
             insecure: true

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -308,8 +308,8 @@ EOF
 
 _mlflow_wait_ready() {
   if $DRY_RUN; then
-    MLFLOW_TRACES_ENDPOINT="https://${MLFLOW_INSTANCE_NAME}.${MLFLOW_NAMESPACE}.svc.cluster.local:8443/v1/traces"
-    echo "  [dry-run] would wait for MLflow Service and pod in $MLFLOW_NAMESPACE"
+    MLFLOW_TRACES_ENDPOINT="https://mlflow-gateway.${DOMAIN}/v1/traces"
+    echo "  [dry-run] would wait for MLflow Service, pod, and gateway URL in $MLFLOW_NAMESPACE"
     return 0
   fi
 
@@ -326,9 +326,6 @@ _mlflow_wait_ready() {
   done
   log_success "MLflow Service found"
 
-  MLFLOW_TRACES_ENDPOINT="https://${MLFLOW_INSTANCE_NAME}.${MLFLOW_NAMESPACE}.svc.cluster.local:8443/v1/traces"
-  log_success "MLflow traces endpoint: $MLFLOW_TRACES_ENDPOINT"
-
   log_info "Waiting for MLflow pod to be Running..."
   tries=0
   while ! $KUBECTL get pods -n "$MLFLOW_NAMESPACE" \
@@ -337,7 +334,7 @@ _mlflow_wait_ready() {
     tries=$((tries + 1))
     if [ $tries -ge 60 ]; then
       log_warn "MLflow pod not Running after 5m — proceeding anyway (OTEL will retry)"
-      return 0
+      break
     fi
     sleep 5
   done
@@ -349,11 +346,30 @@ _mlflow_wait_ready() {
     tries=$((tries + 1))
     if [ $tries -ge 12 ]; then
       log_warn "MLflow Service has no ready endpoints after 1m — proceeding anyway"
-      return 0
+      break
     fi
     sleep 5
   done
-  log_success "MLflow is ready"
+
+  # Resolve the gateway URL from the MLflow CR status.url (mirrors the
+  # kagenti-operator's resolveTrackingURI logic). TLS is verified via the
+  # container's system CA pool (Let's Encrypt trusted by default).
+  log_info "Waiting for MLflow gateway URL (status.url)..."
+  local gateway_url=""
+  tries=0
+  while [ -z "$gateway_url" ]; do
+    gateway_url=$($KUBECTL get mlflow "$MLFLOW_INSTANCE_NAME" -n "$MLFLOW_NAMESPACE" \
+      -o jsonpath='{.status.url}' 2>/dev/null || echo "")
+    [ -n "$gateway_url" ] && break
+    tries=$((tries + 1))
+    if [ $tries -ge 60 ]; then
+      log_error "MLflow CR status.url not populated after 5m"
+      exit 1
+    fi
+    sleep 5
+  done
+  MLFLOW_TRACES_ENDPOINT="${gateway_url%/}/v1/traces"
+  log_success "MLflow traces endpoint (gateway): $MLFLOW_TRACES_ENDPOINT"
 }
 
 _mlflow_grant_otel_rbac() {


### PR DESCRIPTION
## Summary
When deploying Kagenti on OpenShift with RHOAI MLflow, the OTel Collector was targeting MLflow's internal service URL, requiring the service-serving CA certificate to be mounted into the collector pod. This PR switches the collector to use the MLflow CR's `status.url` gateway URL — the same URL the kagenti-operator already uses for agent `MLFLOW_TRACKING_URI` injection — removing the need for custom CA machinery. TLS is verified via the container's system CA pool (Let's Encrypt trusted by default on ROSA).

## Changes
- `setup-kagenti.sh` — resolve `MLFLOW_TRACES_ENDPOINT` from MLflow CR `status.url` (mirrors operator's `resolveTrackingURI` logic) instead of hard-coding the internal service URL; the return 0 early-exit is replaced with break so that if the MLflow pod isn't ready after 5m, the script falls through to the status.url polling loop (which exits 1 after another 5m) — catching real deployment failures instead of silently exporting to a potentially wrong URL (worst-case wait increases from ~6m to ~11m).
- `_helpers.tpl` — replace `insecure: true` TLS config with `tls: {}` in the RHOAI MLflow exporter block so HTTPS is verified via the container's system CA pool
- `otel-collector.yaml` — remove `otel-service-ca` ConfigMap, its volume, and volume mount (only needed for the now-removed internal service path).

## Test Plan
- [ ] Prompt an agent and confirm traces appear in the MLflow UI under the target workspace and experiment
- [ ] Verify OTel collector logs show no TLS or authentication errors
- [ ] Confirm `setup-kagenti.sh` correctly reads `status.url` from the MLflow CR and populates `MLFLOW_TRACES_ENDPOINT`