### PR TITLE
fix: replace misleading 'Agent CRD not found' error message

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3150,7 +3150,12 @@ async def create_agent(
         if e.status == 404:
             raise HTTPException(
                 status_code=404,
-                detail="Agent CRD not found. Is the kagenti-operator installed?",
+                detail=(
+                    f"Required CRD or resource not found for workload type "
+                    f"'{request.workloadType}'. Ensure the necessary controllers "
+                    f"are installed (e.g. Shipwright for source builds, "
+                    f"agent-sandbox controller for sandbox workloads)."
+                ),
             )
         logger.error(f"Failed to create agent: {e}")
         raise HTTPException(status_code=e.status, detail=str(e.reason))


### PR DESCRIPTION
## Summary

- Replace the legacy "Agent CRD not found" error message in the create-agent 404 handler
- The old message referenced a non-existent Agent CRD (removed during migration)
- New message names the workload type and relevant controllers (Shipwright for source builds, agent-sandbox controller for sandbox workloads)

Refs: https://github.com/kagenti/kagenti/issues/1155

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>