### PR TITLE
feat: switch sandbox to SandboxTemplate + SandboxClaim workflow

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -439,9 +439,12 @@ rules:
     resources: ["routes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   {{- if .Values.featureFlags.agentSandbox }}
-  # agent-sandbox (kubernetes-sigs) Sandbox CRs
+  # agent-sandbox (kubernetes-sigs) — read Sandboxes, manage Templates + Claims
   - apiGroups: ["agents.x-k8s.io"]
     resources: ["sandboxes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxtemplates", "sandboxclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   {{- end }}
   {{- if .Values.featureFlags.integrations }}

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -74,6 +74,12 @@ AGENT_SANDBOX_CRD_GROUP = "agents.x-k8s.io"
 AGENT_SANDBOX_CRD_VERSION = "v1alpha1"
 AGENT_SANDBOX_PLURAL = "sandboxes"
 
+# agent-sandbox extensions (SandboxTemplate, SandboxClaim)
+AGENT_SANDBOX_EXT_GROUP = "extensions.agents.x-k8s.io"
+AGENT_SANDBOX_EXT_VERSION = "v1alpha1"
+AGENT_SANDBOX_TEMPLATE_PLURAL = "sandboxtemplates"
+AGENT_SANDBOX_CLAIM_PLURAL = "sandboxclaims"
+
 # Supported workload types (sandbox added conditionally at startup)
 _BASE_WORKLOAD_TYPES = (
     WORKLOAD_TYPE_DEPLOYMENT,

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -63,6 +63,8 @@ from app.core.constants import (
     WORKLOAD_TYPE_SANDBOX,
     AGENT_SANDBOX_CRD_GROUP,
     AGENT_SANDBOX_CRD_VERSION,
+    AGENT_SANDBOX_EXT_GROUP,
+    AGENT_SANDBOX_EXT_VERSION,
     SUPPORTED_WORKLOAD_TYPES,
     # Migration constants (Phase 4)
     MIGRATION_SOURCE_ANNOTATION,
@@ -654,21 +656,21 @@ async def list_agents(
                 )
             )
 
-        # Query Sandboxes with agent label (feature-flagged)
+        # Query SandboxClaims with agent label (feature-flagged)
         if settings.kagenti_feature_flag_agent_sandbox:
             try:
-                sandboxes = kube.list_sandboxes(
+                claims = kube.list_sandbox_claims(
                     namespace=namespace,
                     label_selector=label_selector,
                 )
-                for sandbox in sandboxes:
-                    metadata = sandbox.get("metadata", {})
+                for claim in claims:
+                    metadata = claim.get("metadata", {})
                     name = metadata.get("name", "")
                     if name in agent_names:
                         logger.warning(
-                            f"Duplicate agent name '{name}' detected: Sandbox skipped because "
-                            f"a workload with the same name already exists in namespace '{namespace}'. "
-                            "This may indicate a configuration issue."
+                            f"Duplicate agent name '{name}' detected: SandboxClaim skipped "
+                            f"because a workload with the same name already exists in "
+                            f"namespace '{namespace}'. This may indicate a configuration issue."
                         )
                         continue
                     agent_names.add(name)
@@ -678,8 +680,8 @@ async def list_agents(
                         AgentSummary(
                             name=name,
                             namespace=metadata.get("namespace", namespace),
-                            description=_get_sandbox_description(sandbox),
-                            status=_is_sandbox_ready(sandbox),
+                            description=_get_sandbox_description(claim),
+                            status=_is_sandbox_ready(claim),
                             labels=_extract_labels(labels),
                             workloadType=WORKLOAD_TYPE_SANDBOX,
                             createdAt=_format_timestamp(
@@ -690,11 +692,11 @@ async def list_agents(
                     )
             except ApiException as e:
                 if e.status == 404:
-                    logger.debug("Sandbox CRD not installed")
+                    logger.debug("SandboxClaim CRD not installed")
                 elif e.status == 403:
-                    logger.debug("Sandbox RBAC: insufficient permissions")
+                    logger.debug("SandboxClaim RBAC: insufficient permissions")
                 else:
-                    logger.warning(f"Failed to list Sandboxes: {e.reason}")
+                    logger.warning(f"Failed to list SandboxClaims: {e.reason}")
 
         # Backward compatibility: Also list legacy Agent CRDs (during migration period)
         if settings.enable_legacy_agent_crd:
@@ -798,10 +800,10 @@ async def get_agent(
             if e.status != 404:
                 raise HTTPException(status_code=e.status, detail=str(e.reason))
 
-    # If still not found, try Sandbox (feature-flagged)
+    # If still not found, try SandboxClaim (feature-flagged)
     if workload is None and settings.kagenti_feature_flag_agent_sandbox:
         try:
-            workload = kube.get_sandbox(namespace=namespace, name=name)
+            workload = kube.get_sandbox_claim(namespace=namespace, name=name)
             workload_type = WORKLOAD_TYPE_SANDBOX
         except ApiException as e:
             if e.status != 404:
@@ -933,16 +935,24 @@ async def delete_agent(
         else:
             logger.warning("Failed to delete Job '%s': %s", safe_name, e.reason)
 
-    # Delete the Sandbox (if exists)
+    # Delete the SandboxClaim + SandboxTemplate (if exists)
     if settings.kagenti_feature_flag_agent_sandbox:
         try:
-            kube.delete_sandbox(namespace=namespace, name=name)
-            messages.append(f"Sandbox '{name}' deleted")
+            kube.delete_sandbox_claim(namespace=namespace, name=name)
+            messages.append(f"SandboxClaim '{name}' deleted")
         except ApiException as e:
             if e.status == 404:
-                logger.debug("Sandbox '%s' not found (may be other workload type)", safe_name)
+                logger.debug("SandboxClaim '%s' not found (may be other workload type)", safe_name)
             else:
-                logger.warning("Failed to delete Sandbox '%s': %s", safe_name, e.reason)
+                logger.warning("Failed to delete SandboxClaim '%s': %s", safe_name, e.reason)
+        try:
+            kube.delete_sandbox_template(namespace=namespace, name=name)
+            messages.append(f"SandboxTemplate '{name}' deleted")
+        except ApiException as e:
+            if e.status == 404:
+                logger.debug("SandboxTemplate '%s' not found", safe_name)
+            else:
+                logger.warning("Failed to delete SandboxTemplate '%s': %s", safe_name, e.reason)
 
     # Delete the Service
     try:
@@ -2835,12 +2845,12 @@ def _build_job_manifest(
     return manifest
 
 
-def _build_sandbox_manifest(
+def _build_sandbox_template_manifest(
     request: "CreateAgentRequest",
     image: str,
     shipwright_build_name: Optional[str] = None,
 ) -> dict:
-    """Build a Sandbox CR manifest for an agent (agents.x-k8s.io/v1alpha1)."""
+    """Build a SandboxTemplate manifest (extensions.agents.x-k8s.io/v1alpha1)."""
     env_vars = _build_env_vars(request)
     labels = _build_common_labels(request, WORKLOAD_TYPE_SANDBOX)
 
@@ -2855,8 +2865,8 @@ def _build_sandbox_manifest(
         container_port = request.servicePorts[0].targetPort
 
     manifest = {
-        "apiVersion": f"{AGENT_SANDBOX_CRD_GROUP}/{AGENT_SANDBOX_CRD_VERSION}",
-        "kind": "Sandbox",
+        "apiVersion": f"{AGENT_SANDBOX_EXT_GROUP}/{AGENT_SANDBOX_EXT_VERSION}",
+        "kind": "SandboxTemplate",
         "metadata": {
             "name": request.name,
             "namespace": request.namespace,
@@ -2913,6 +2923,34 @@ def _build_sandbox_manifest(
         ]
 
     return manifest
+
+
+def _build_sandbox_claim_manifest(
+    request: "CreateAgentRequest",
+    shipwright_build_name: Optional[str] = None,
+) -> dict:
+    """Build a SandboxClaim manifest (extensions.agents.x-k8s.io/v1alpha1)."""
+    labels = _build_common_labels(request, WORKLOAD_TYPE_SANDBOX)
+
+    annotations: Dict[str, str] = {
+        KAGENTI_DESCRIPTION_ANNOTATION: f"Agent '{request.name}' deployed from UI.",
+    }
+    if shipwright_build_name:
+        annotations["kagenti.io/shipwright-build"] = shipwright_build_name
+
+    return {
+        "apiVersion": f"{AGENT_SANDBOX_EXT_GROUP}/{AGENT_SANDBOX_EXT_VERSION}",
+        "kind": "SandboxClaim",
+        "metadata": {
+            "name": request.name,
+            "namespace": request.namespace,
+            "labels": labels,
+            "annotations": annotations,
+        },
+        "spec": {
+            "sandboxTemplateRef": {"name": request.name},
+        },
+    }
 
 
 @router.post(
@@ -3031,15 +3069,23 @@ async def create_agent(
                 )
                 logger.info(f"Created Job '{request.name}' in namespace '{request.namespace}'")
             elif request.workloadType == WORKLOAD_TYPE_SANDBOX:
-                workload_manifest = _build_sandbox_manifest(
+                template_manifest = _build_sandbox_template_manifest(
                     request=request,
                     image=request.containerImage,
                 )
-                kube.create_sandbox(
+                kube.create_sandbox_template(
                     namespace=request.namespace,
-                    body=workload_manifest,
+                    body=template_manifest,
                 )
-                logger.info(f"Created Sandbox '{request.name}' in namespace '{request.namespace}'")
+                claim_manifest = _build_sandbox_claim_manifest(request=request)
+                kube.create_sandbox_claim(
+                    namespace=request.namespace,
+                    body=claim_manifest,
+                )
+                logger.info(
+                    f"Created SandboxTemplate + SandboxClaim '{request.name}' "
+                    f"in namespace '{request.namespace}'"
+                )
 
             # Create Service (not needed for Jobs or Sandboxes)
             if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
@@ -3299,7 +3345,7 @@ async def finalize_shipwright_build(
                     raise
         if not workload_exists and settings.kagenti_feature_flag_agent_sandbox:
             try:
-                kube.get_sandbox(namespace=namespace, name=name)
+                kube.get_sandbox_claim(namespace=namespace, name=name)
                 workload_exists = True
                 existing_workload_type = WORKLOAD_TYPE_SANDBOX
             except ApiException as e:
@@ -3554,7 +3600,7 @@ async def finalize_shipwright_build(
                 f"Created Job '{name}' with image '{container_image}' in namespace '{namespace}'"
             )
         elif final_workload_type == WORKLOAD_TYPE_SANDBOX:
-            workload_manifest = _build_sandbox_manifest(
+            template_manifest = _build_sandbox_template_manifest(
                 request=agent_request,
                 image=container_image,
                 shipwright_build_name=name,
@@ -3562,15 +3608,21 @@ async def finalize_shipwright_build(
             kagenti_build_labels = {
                 k: v for k, v in build_labels.items() if k.startswith(settings.kagenti_label_prefix)
             }
-            workload_manifest["metadata"]["labels"].update(kagenti_build_labels)
-            workload_manifest["spec"]["podTemplate"]["metadata"]["labels"].update(
+            template_manifest["metadata"]["labels"].update(kagenti_build_labels)
+            template_manifest["spec"]["podTemplate"]["metadata"]["labels"].update(
                 kagenti_build_labels
             )
-            kube.create_sandbox(
-                namespace=namespace,
-                body=workload_manifest,
+            kube.create_sandbox_template(namespace=namespace, body=template_manifest)
+            claim_manifest = _build_sandbox_claim_manifest(
+                request=agent_request,
+                shipwright_build_name=name,
             )
-            logger.info(f"Created Sandbox '{name}' in namespace '{namespace}' from build")
+            claim_manifest["metadata"]["labels"].update(kagenti_build_labels)
+            kube.create_sandbox_claim(namespace=namespace, body=claim_manifest)
+            logger.info(
+                f"Created SandboxTemplate + SandboxClaim '{name}' "
+                f"in namespace '{namespace}' from build"
+            )
 
         # Create Service (not needed for Jobs or Sandboxes)
         if final_workload_type not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3078,10 +3078,20 @@ async def create_agent(
                     body=template_manifest,
                 )
                 claim_manifest = _build_sandbox_claim_manifest(request=request)
-                kube.create_sandbox_claim(
-                    namespace=request.namespace,
-                    body=claim_manifest,
-                )
+                try:
+                    kube.create_sandbox_claim(
+                        namespace=request.namespace,
+                        body=claim_manifest,
+                    )
+                except Exception:
+                    try:
+                        kube.delete_sandbox_template(namespace=request.namespace, name=request.name)
+                    except Exception:
+                        logger.warning(
+                            "Failed to clean up orphaned SandboxTemplate '%s'",
+                            request.name,
+                        )
+                    raise
                 logger.info(
                     f"Created SandboxTemplate + SandboxClaim '{request.name}' "
                     f"in namespace '{request.namespace}'"
@@ -3618,7 +3628,14 @@ async def finalize_shipwright_build(
                 shipwright_build_name=name,
             )
             claim_manifest["metadata"]["labels"].update(kagenti_build_labels)
-            kube.create_sandbox_claim(namespace=namespace, body=claim_manifest)
+            try:
+                kube.create_sandbox_claim(namespace=namespace, body=claim_manifest)
+            except Exception:
+                try:
+                    kube.delete_sandbox_template(namespace=namespace, name=name)
+                except Exception:
+                    logger.warning("Failed to clean up orphaned SandboxTemplate '%s'", name)
+                raise
             logger.info(
                 f"Created SandboxTemplate + SandboxClaim '{name}' "
                 f"in namespace '{namespace}' from build"

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -488,7 +488,7 @@ def _get_job_description(job: dict) -> str:
 
 
 def _is_sandbox_ready(sandbox: dict) -> str:
-    """Check if a Sandbox CR is ready by examining its status conditions."""
+    """Check if a Sandbox or SandboxClaim is ready by examining its status conditions."""
     status = sandbox.get("status", {})
     conditions = status.get("conditions", [])
     for cond in conditions:
@@ -500,7 +500,7 @@ def _is_sandbox_ready(sandbox: dict) -> str:
 
 
 def _get_sandbox_description(sandbox: dict) -> str:
-    """Extract description from a Sandbox CR."""
+    """Extract description from a Sandbox or SandboxClaim resource."""
     metadata = sandbox.get("metadata", {})
     annotations = metadata.get("annotations", {})
     return annotations.get(KAGENTI_DESCRIPTION_ANNOTATION, "No description")

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -19,7 +19,11 @@ from kubernetes.config import ConfigException
 from app.core.constants import (
     AGENT_SANDBOX_CRD_GROUP,
     AGENT_SANDBOX_CRD_VERSION,
+    AGENT_SANDBOX_CLAIM_PLURAL,
+    AGENT_SANDBOX_EXT_GROUP,
+    AGENT_SANDBOX_EXT_VERSION,
     AGENT_SANDBOX_PLURAL,
+    AGENT_SANDBOX_TEMPLATE_PLURAL,
     ENABLED_NAMESPACE_LABEL_KEY,
     ENABLED_NAMESPACE_LABEL_VALUE,
 )
@@ -763,6 +767,86 @@ class KubernetesService:
             AGENT_SANDBOX_PLURAL,
             name,
             body,
+        )
+
+    # -------------------------------------------------------------------------
+    # SandboxTemplate Operations (extensions.agents.x-k8s.io)
+    # -------------------------------------------------------------------------
+
+    def create_sandbox_template(self, namespace: str, body: dict) -> dict:
+        """Create a SandboxTemplate custom resource."""
+        return self.create_custom_resource(
+            AGENT_SANDBOX_EXT_GROUP,
+            AGENT_SANDBOX_EXT_VERSION,
+            namespace,
+            AGENT_SANDBOX_TEMPLATE_PLURAL,
+            body,
+        )
+
+    def get_sandbox_template(self, namespace: str, name: str) -> dict:
+        """Get a SandboxTemplate custom resource by name."""
+        return self.get_custom_resource(
+            AGENT_SANDBOX_EXT_GROUP,
+            AGENT_SANDBOX_EXT_VERSION,
+            namespace,
+            AGENT_SANDBOX_TEMPLATE_PLURAL,
+            name,
+        )
+
+    def delete_sandbox_template(self, namespace: str, name: str) -> None:
+        """Delete a SandboxTemplate custom resource by name."""
+        self.delete_custom_resource(
+            AGENT_SANDBOX_EXT_GROUP,
+            AGENT_SANDBOX_EXT_VERSION,
+            namespace,
+            AGENT_SANDBOX_TEMPLATE_PLURAL,
+            name,
+        )
+
+    # -------------------------------------------------------------------------
+    # SandboxClaim Operations (extensions.agents.x-k8s.io)
+    # -------------------------------------------------------------------------
+
+    def create_sandbox_claim(self, namespace: str, body: dict) -> dict:
+        """Create a SandboxClaim custom resource."""
+        return self.create_custom_resource(
+            AGENT_SANDBOX_EXT_GROUP,
+            AGENT_SANDBOX_EXT_VERSION,
+            namespace,
+            AGENT_SANDBOX_CLAIM_PLURAL,
+            body,
+        )
+
+    def get_sandbox_claim(self, namespace: str, name: str) -> dict:
+        """Get a SandboxClaim custom resource by name."""
+        return self.get_custom_resource(
+            AGENT_SANDBOX_EXT_GROUP,
+            AGENT_SANDBOX_EXT_VERSION,
+            namespace,
+            AGENT_SANDBOX_CLAIM_PLURAL,
+            name,
+        )
+
+    def list_sandbox_claims(
+        self, namespace: str, label_selector: Optional[str] = None
+    ) -> List[dict]:
+        """List SandboxClaim custom resources in a namespace."""
+        return self.list_custom_resources(
+            AGENT_SANDBOX_EXT_GROUP,
+            AGENT_SANDBOX_EXT_VERSION,
+            namespace,
+            AGENT_SANDBOX_CLAIM_PLURAL,
+            label_selector,
+        )
+
+    def delete_sandbox_claim(self, namespace: str, name: str) -> None:
+        """Delete a SandboxClaim custom resource by name."""
+        self.delete_custom_resource(
+            AGENT_SANDBOX_EXT_GROUP,
+            AGENT_SANDBOX_EXT_VERSION,
+            namespace,
+            AGENT_SANDBOX_CLAIM_PLURAL,
+            name,
         )
 
 


### PR DESCRIPTION
## Summary

- Switch the backend from creating `Sandbox` CRs directly to following the kubernetes-sigs intended workflow: **SandboxTemplate → SandboxClaim → controller creates Sandbox → Pod**
- All router paths updated: create, list, get, delete, and finalize (Shipwright build)
- The sigs controller now owns Pod lifecycle, NetworkPolicy creation, and future warm pool support

### What changed in the router

| Path | Before | After |
|------|--------|-------|
| Create | `_build_sandbox_manifest` → `create_sandbox` | `_build_sandbox_template_manifest` + `_build_sandbox_claim_manifest` → `create_sandbox_template` + `create_sandbox_claim` |
| List | `list_sandboxes` | `list_sandbox_claims` (same `status.conditions` schema) |
| Get | `get_sandbox` | `get_sandbox_claim` |
| Delete | `delete_sandbox` | `delete_sandbox_claim` + `delete_sandbox_template` |
| Finalize check | `get_sandbox` | `get_sandbox_claim` |

## Dependencies

> **Merge #1381 first** — this PR includes the infrastructure commit (constants, service methods, Helm RBAC) plus the router rework on top.

Refs: https://github.com/kagenti/kagenti/issues/1155

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>