### PR TITLE
🐛 Guard MLflow RBAC grant with --skip-mlflow flag

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -948,7 +948,9 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
 log_success "Kagenti installed"
 
 # Grant otel-collector SA MLflow RBAC in agent namespaces (created by kagenti chart above)
-_mlflow_grant_otel_rbac
+if ! $SKIP_MLFLOW; then
+  _mlflow_grant_otel_rbac
+fi
 echo ""
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Guard the unconditional `_mlflow_grant_otel_rbac()` call in `setup-kagenti.sh` with `$SKIP_MLFLOW`, aligning it with the rest of the script's MLflow skip logic
- Fixes HyperShift CI failures on clusters without RHOAI/MLflow where the ClusterRole `mlflow-operator-mlflow-integration` does not exist

Fixes #1388

## Details

`setup-kagenti.sh` already supports `--skip-mlflow` and correctly:
1. Skips MLflow provisioning at Step 2.5 when RHOAI is absent
2. Sets `kagenti-operator-chart.mlflow.enable=false` in the Helm install

But the `_mlflow_grant_otel_rbac` call at line 951 was not guarded, causing a hard failure:
```
✓ Kagenti installed
✗ ClusterRole 'mlflow-operator-mlflow-integration' not found
```

## Test plan

- [ ] HyperShift CI passes on a cluster without RHOAI (the `_mlflow_grant_otel_rbac` call is skipped)
- [ ] HyperShift CI passes on a cluster with RHOAI (the RBAC grant still runs)
- [ ] `shellcheck scripts/ocp/setup-kagenti.sh` passes

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>