### PR TITLE
Feature: Initial implementation of AuthBridge UI tab

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -195,14 +195,6 @@ data:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
         filter_chains:
-        - filter_chain_match:
-            destination_port: 9093
-          filters:
-          - name: envoy.filters.network.tcp_proxy
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-              stat_prefix: outbound_passthrough_9093
-              cluster: original_destination
         # TLS passthrough: forward HTTPS traffic as-is via TCP proxy
         - filter_chain_match:
             transport_protocol: tls
@@ -260,6 +252,15 @@ data:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
         filter_chains:
+        # AuthBridge config and stats passthrough
+        - filter_chain_match:
+            destination_port: 9093
+          filters:
+          - name: envoy.filters.network.tcp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              stat_prefix: outbound_passthrough_9093
+              cluster: original_destination
         - filters:
           - name: envoy.filters.network.http_connection_manager
             typed_config:

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -134,6 +134,8 @@ spec:
               value: "{{ .Values.featureFlags.agentSandbox }}"
             - name: KAGENTI_FEATURE_FLAG_SKILLS
               value: "{{ .Values.featureFlags.skills }}"
+            - name: KAGENTI_FEATURE_FLAG_AUTHBRIDGE_API
+              value: "{{ .Values.featureFlags.authbridgeAPI }}"
             - name: KEYCLOAK_URL
               value: {{ .Values.keycloak.url | quote }}
             - name: KEYCLOAK_PUBLIC_URL

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -12,6 +12,7 @@ featureFlags:
   triggers: false
   agentSandbox: false
   skills: false
+  authbridgeAPI: false
 
 # ------------------------------------------------------------------
 #  Control Panel: Enable or disable components here

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -212,14 +212,6 @@ static_resources:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     filter_chains:
     - filter_chain_match:
-        destination_port: 9093
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          stat_prefix: outbound_passthrough_9093
-          cluster: original_destination
-    - filter_chain_match:
         transport_protocol: tls
       filters:
       - name: envoy.filters.network.tcp_proxy
@@ -274,6 +266,15 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
     filter_chains:
+    # AuthBridge config and stats passthrough
+    - filter_chain_match:
+        destination_port: 9093
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: outbound_passthrough_9093
+          cluster: original_destination
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -21,6 +21,7 @@ class FeatureFlagsResponse(BaseModel):
     triggers: bool = Field(description="Event-driven trigger system")
     agentSandbox: bool = Field(description="agent-sandbox (k8s-sigs) as a workload type")
     skills: bool = Field(description="Skill management system (CRUD + catalog UI)")
+    authbridgeAPI: bool = Field(description="AuthBridge statistics (API and UI)")
 
 
 router = APIRouter(prefix="/config", tags=["config"])
@@ -38,6 +39,7 @@ async def get_feature_flags() -> FeatureFlagsResponse:
         triggers=settings.kagenti_feature_flag_triggers,
         agentSandbox=settings.kagenti_feature_flag_agent_sandbox,
         skills=settings.kagenti_feature_flag_skills,
+        authbridgeAPI=settings.kagenti_feature_flag_authbridge_api,
     )
 
 

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -11,6 +11,8 @@ export interface FeatureFlags {
   /** agent-sandbox (kubernetes-sigs) as a fourth workload type. */
   agentSandbox: boolean;
   skills: boolean;
+  /** AuthBridge statistics */
+  authbridgeAPI: boolean;
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -19,6 +21,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   triggers: false,
   agentSandbox: false,
   skills: false,
+  authbridgeAPI: false,
 };
 
 let cachedFlags: FeatureFlags | null = null;
@@ -38,7 +41,8 @@ export function useFeatureFlags(): FeatureFlags {
           triggers: data.triggers === true,
           agentSandbox: data.agentSandbox === true,
           skills: data.skills === true,
-        };
+          authbridgeAPI: data.authbridgeAPI === true,
+          };
         cachedFlags = validated;
         setFlags(validated);
       })

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -1029,14 +1029,16 @@ export const AgentDetailPage: React.FC = () => {
                       <Spinner size="md" aria-label="Loading AuthBridge config" />
                     ) : authBridgeConfig ? (
                       <DescriptionList isCompact>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Enabled</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <Label color={authBridgeConfig.AuthBridge ? 'green' : 'red'} isCompact>
-                              {authBridgeConfig.AuthBridge ? 'Yes' : 'No'}
-                            </Label>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
+                        {authBridgeConfig.AuthBridge != null && !authBridgeConfig.AuthBridge && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Enabled</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              <Label color={authBridgeConfig.AuthBridge ? 'green' : 'red'} isCompact>
+                                {authBridgeConfig.AuthBridge ? 'Yes' : 'No'}
+                              </Label>
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
                         <DescriptionListGroup>
                           <DescriptionListTerm>Mode</DescriptionListTerm>
                           <DescriptionListDescription>
@@ -1080,54 +1082,18 @@ export const AgentDetailPage: React.FC = () => {
                           </DescriptionListDescription>
                         </DescriptionListGroup>
                         <DescriptionListGroup>
-                          <DescriptionListTerm>Listener Ext-Proc Address</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.ext_proc_addr || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Listener Ext-Authz Address</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.ext_authz_addr || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Listener Forward Proxy</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.forward_proxy_addr || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Listener Reverse Proxy</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.reverse_proxy_addr || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
                           <DescriptionListTerm>Bypass Inbound Paths</DescriptionListTerm>
                           <DescriptionListDescription>
-                            {authBridgeConfig.bypass?.inbound_paths?.length > 0 ? (
+                            {(authBridgeConfig.bypass?.inbound_paths?.length ?? 0) > 0 ? (
                               <LabelGroup>
-                                {authBridgeConfig.bypass.inbound_paths.map((path) => (
+                                {authBridgeConfig.bypass?.inbound_paths?.map((path) => (
                                   <Label key={path} isCompact>{path}</Label>
                                 ))}
                               </LabelGroup>
                             ) : '-'}
                           </DescriptionListDescription>
                         </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Routes File</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.routes?.file || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Stats Address</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.stats?.address || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        {authBridgeConfig.routes?.rules?.length > 0 && (
+                        {(authBridgeConfig.routes?.rules?.length ?? 0) > 0 && (
                           <DescriptionListGroup>
                             <DescriptionListTerm>Routes</DescriptionListTerm>
                             <DescriptionListDescription>
@@ -1141,7 +1107,7 @@ export const AgentDetailPage: React.FC = () => {
                                   </Tr>
                                 </Thead>
                                 <Tbody>
-                                  {authBridgeConfig.routes.rules.map((route, idx) => (
+                                  {authBridgeConfig.routes?.rules?.map((route, idx) => (
                                     <Tr key={idx}>
                                       <Td dataLabel="Host">{route.host}</Td>
                                       <Td dataLabel="Action">{route.action || '-'}</Td>
@@ -1175,7 +1141,7 @@ export const AgentDetailPage: React.FC = () => {
                       <Spinner size="md" aria-label="Loading AuthBridge status" />
                     ) : authBridgeStats ? (
                       <DescriptionList isCompact>
-                        {authBridgeStats.AuthBridge != null && (
+                        {authBridgeStats.AuthBridge != null && !authBridgeStats.AuthBridge && (
                           <DescriptionListGroup>
                             <DescriptionListTerm>Enabled</DescriptionListTerm>
                             <DescriptionListDescription>
@@ -1195,7 +1161,7 @@ export const AgentDetailPage: React.FC = () => {
                                     <Label key={key} isCompact color="green">{key}: {val}</Label>
                                   ))}
                                 </LabelGroup>
-                              ) : '0'}
+                              ) : 'None'}
                             </DescriptionListDescription>
                           </DescriptionListGroup>
                         )}
@@ -1209,7 +1175,7 @@ export const AgentDetailPage: React.FC = () => {
                                     <Label key={key} isCompact color="red">{key}: {val}</Label>
                                   ))}
                                 </LabelGroup>
-                              ) : '0'}
+                              ) : 'None'}
                             </DescriptionListDescription>
                           </DescriptionListGroup>
                         )}
@@ -1223,7 +1189,7 @@ export const AgentDetailPage: React.FC = () => {
                                     <Label key={key} isCompact color="green">{key}: {val}</Label>
                                   ))}
                                 </LabelGroup>
-                              ) : '0'}
+                              ) : 'None'}
                             </DescriptionListDescription>
                           </DescriptionListGroup>
                         )}
@@ -1237,7 +1203,7 @@ export const AgentDetailPage: React.FC = () => {
                                     <Label key={key} isCompact color="red">{key}: {val}</Label>
                                   ))}
                                 </LabelGroup>
-                              ) : '0'}
+                              ) : 'None'}
                             </DescriptionListDescription>
                           </DescriptionListGroup>
                         )}
@@ -1251,7 +1217,7 @@ export const AgentDetailPage: React.FC = () => {
                                     <Label key={key} isCompact color="blue">{key}: {val}</Label>
                                   ))}
                                 </LabelGroup>
-                              ) : '0'}
+                              ) : 'None'}
                             </DescriptionListDescription>
                           </DescriptionListGroup>
                         )}

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -208,6 +208,7 @@ export const AgentDetailPage: React.FC = () => {
   });
 
   // Fetch AuthBridge config and status
+  // AuthBridge queries are suppressed until the agent is loaded and confirmed to have the sidecar
   const hasAuthBridge = agent?.metadata?.labels?.['kagenti.io/inject'] === 'enabled';
 
   const { data: authBridgeConfig, isLoading: isAuthBridgeConfigLoading } = useQuery({
@@ -1021,7 +1022,7 @@ export const AgentDetailPage: React.FC = () => {
             </Card>
           </Tab>
 
-          <Tab eventKey={4} title={<TabTitleText>AuthBridge</TabTitleText>}>
+          {hasAuthBridge && <Tab eventKey={4} title={<TabTitleText>AuthBridge</TabTitleText>}>
             <Grid hasGutter style={{ marginTop: '16px' }}>
               <GridItem md={6}>
                 <Card>
@@ -1235,7 +1236,7 @@ export const AgentDetailPage: React.FC = () => {
                 </Card>
               </GridItem>
             </Grid>
-          </Tab>
+          </Tab>}
         </Tabs>
       </PageSection>
 

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -208,16 +208,18 @@ export const AgentDetailPage: React.FC = () => {
   });
 
   // Fetch AuthBridge config and status
+  const hasAuthBridge = agent?.metadata?.labels?.['kagenti.io/inject'] === 'enabled';
+
   const { data: authBridgeConfig, isLoading: isAuthBridgeConfigLoading } = useQuery({
     queryKey: ['authbridge-config', namespace, name],
     queryFn: () => authBridgeService.getConfig(namespace!, name!),
-    enabled: !!namespace && !!name,
+    enabled: !!namespace && !!name && hasAuthBridge,
   });
 
   const { data: authBridgeStats, isLoading: isAuthBridgeStatsLoading } = useQuery({
     queryKey: ['authbridge-status', namespace, name],
     queryFn: () => authBridgeService.getStatus(namespace!, name!),
-    enabled: !!namespace && !!name,
+    enabled: !!namespace && !!name && hasAuthBridge,
   });
 
   if (isLoading) {
@@ -1029,100 +1031,101 @@ export const AgentDetailPage: React.FC = () => {
                       <Spinner size="md" aria-label="Loading AuthBridge config" />
                     ) : authBridgeConfig ? (
                       <DescriptionList isCompact>
-                        {authBridgeConfig.AuthBridge != null && !authBridgeConfig.AuthBridge && (
+                        {authBridgeConfig.AuthBridge != null && !authBridgeConfig.AuthBridge ? (
                           <DescriptionListGroup>
                             <DescriptionListTerm>Enabled</DescriptionListTerm>
                             <DescriptionListDescription>
-                              <Label color={authBridgeConfig.AuthBridge ? 'green' : 'red'} isCompact>
-                                {authBridgeConfig.AuthBridge ? 'Yes' : 'No'}
-                              </Label>
+                              <Label color="red" isCompact>No</Label>
                             </DescriptionListDescription>
                           </DescriptionListGroup>
-                        )}
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Mode</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <Label isCompact color="blue">{authBridgeConfig.mode}</Label>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Inbound JWKS URL</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.inbound?.jwks_url || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Inbound Issuer</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            {authBridgeConfig.inbound?.issuer || '-'}
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Outbound Token URL</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.outbound?.token_url || '-'}</code>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Outbound Default Policy</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            {authBridgeConfig.outbound?.default_policy || '-'}
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Identity Type</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            <Label isCompact>{authBridgeConfig.identity?.type || '-'}</Label>
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Identity Client ID</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            {authBridgeConfig.identity?.client_id || '-'}
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        <DescriptionListGroup>
-                          <DescriptionListTerm>Bypass Inbound Paths</DescriptionListTerm>
-                          <DescriptionListDescription>
-                            {(authBridgeConfig.bypass?.inbound_paths?.length ?? 0) > 0 ? (
-                              <LabelGroup>
-                                {authBridgeConfig.bypass?.inbound_paths?.map((path) => (
-                                  <Label key={path} isCompact>{path}</Label>
-                                ))}
-                              </LabelGroup>
-                            ) : '-'}
-                          </DescriptionListDescription>
-                        </DescriptionListGroup>
-                        {(authBridgeConfig.routes?.rules?.length ?? 0) > 0 && (
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>Routes</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              <Table aria-label="AuthBridge routes" variant="compact">
-                                <Thead>
-                                  <Tr>
-                                    <Th>Host</Th>
-                                    <Th>Action</Th>
-                                    <Th>Target Audience</Th>
-                                    <Th>Passthrough</Th>
-                                  </Tr>
-                                </Thead>
-                                <Tbody>
-                                  {authBridgeConfig.routes?.rules?.map((route, idx) => (
-                                    <Tr key={idx}>
-                                      <Td dataLabel="Host">{route.host}</Td>
-                                      <Td dataLabel="Action">{route.action || '-'}</Td>
-                                      <Td dataLabel="Target Audience">{route.target_audience || '-'}</Td>
-                                      <Td dataLabel="Passthrough">
-                                        <Label isCompact color={route.passthrough ? 'green' : 'gold'}>
-                                          {route.passthrough ? 'Yes' : 'No'}
-                                        </Label>
-                                      </Td>
-                                    </Tr>
-                                  ))}
-                                </Tbody>
-                              </Table>
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
+                        ) : (
+                          <>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Mode</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                <Label isCompact color="blue">{authBridgeConfig.mode}</Label>
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Inbound JWKS URL</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.inbound?.jwks_url || '-'}</code>
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Inbound Issuer</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                {authBridgeConfig.inbound?.issuer || '-'}
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Outbound Token URL</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.outbound?.token_url || '-'}</code>
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Outbound Default Policy</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                {authBridgeConfig.outbound?.default_policy || '-'}
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Identity Type</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                <Label isCompact>{authBridgeConfig.identity?.type || '-'}</Label>
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Identity Client ID</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                {authBridgeConfig.identity?.client_id || '-'}
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                              <DescriptionListTerm>Bypass Inbound Paths</DescriptionListTerm>
+                              <DescriptionListDescription>
+                                {(authBridgeConfig.bypass?.inbound_paths?.length ?? 0) > 0 ? (
+                                  <LabelGroup>
+                                    {authBridgeConfig.bypass?.inbound_paths?.map((path) => (
+                                      <Label key={path} isCompact>{path}</Label>
+                                    ))}
+                                  </LabelGroup>
+                                ) : '-'}
+                              </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            {(authBridgeConfig.routes?.rules?.length ?? 0) > 0 && (
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Routes</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  <Table aria-label="AuthBridge routes" variant="compact">
+                                    <Thead>
+                                      <Tr>
+                                        <Th>Host</Th>
+                                        <Th>Action</Th>
+                                        <Th>Target Audience</Th>
+                                        <Th>Passthrough</Th>
+                                      </Tr>
+                                    </Thead>
+                                    <Tbody>
+                                      {authBridgeConfig.routes?.rules?.map((route, idx) => (
+                                        <Tr key={idx}>
+                                          <Td dataLabel="Host">{route.host}</Td>
+                                          <Td dataLabel="Action">{route.action || '-'}</Td>
+                                          <Td dataLabel="Target Audience">{route.target_audience || '-'}</Td>
+                                          <Td dataLabel="Passthrough">
+                                            <Label isCompact color={route.passthrough ? 'green' : 'gold'}>
+                                              {route.passthrough ? 'Yes' : 'No'}
+                                            </Label>
+                                          </Td>
+                                        </Tr>
+                                      ))}
+                                    </Tbody>
+                                  </Table>
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            )}
+                          </>
                         )}
                       </DescriptionList>
                     ) : (
@@ -1141,85 +1144,86 @@ export const AgentDetailPage: React.FC = () => {
                       <Spinner size="md" aria-label="Loading AuthBridge status" />
                     ) : authBridgeStats ? (
                       <DescriptionList isCompact>
-                        {authBridgeStats.AuthBridge != null && !authBridgeStats.AuthBridge && (
+                        {authBridgeStats.AuthBridge != null && !authBridgeStats.AuthBridge ? (
                           <DescriptionListGroup>
                             <DescriptionListTerm>Enabled</DescriptionListTerm>
                             <DescriptionListDescription>
-                              <Label color={authBridgeStats.AuthBridge ? 'green' : 'red'} isCompact>
-                                {authBridgeStats.AuthBridge ? 'Yes' : 'No'}
-                              </Label>
+                              <Label color="red" isCompact>No</Label>
                             </DescriptionListDescription>
                           </DescriptionListGroup>
-                        )}
-                        {authBridgeStats.inbound_approvals != null && (
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>Inbound Approvals</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {Object.keys(authBridgeStats.inbound_approvals).length > 0 ? (
-                                <LabelGroup>
-                                  {Object.entries(authBridgeStats.inbound_approvals).map(([key, val]) => (
-                                    <Label key={key} isCompact color="green">{key}: {val}</Label>
-                                  ))}
-                                </LabelGroup>
-                              ) : 'None'}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                        )}
-                        {authBridgeStats.inbound_denials != null && (
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>Inbound Denials</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {Object.keys(authBridgeStats.inbound_denials).length > 0 ? (
-                                <LabelGroup>
-                                  {Object.entries(authBridgeStats.inbound_denials).map(([key, val]) => (
-                                    <Label key={key} isCompact color="red">{key}: {val}</Label>
-                                  ))}
-                                </LabelGroup>
-                              ) : 'None'}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                        )}
-                        {authBridgeStats.outbound_approvals != null && (
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>Outbound Approvals</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {Object.keys(authBridgeStats.outbound_approvals).length > 0 ? (
-                                <LabelGroup>
-                                  {Object.entries(authBridgeStats.outbound_approvals).map(([key, val]) => (
-                                    <Label key={key} isCompact color="green">{key}: {val}</Label>
-                                  ))}
-                                </LabelGroup>
-                              ) : 'None'}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                        )}
-                        {authBridgeStats.outbound_denials != null && (
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>Outbound Denials</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {Object.keys(authBridgeStats.outbound_denials).length > 0 ? (
-                                <LabelGroup>
-                                  {Object.entries(authBridgeStats.outbound_denials).map(([key, val]) => (
-                                    <Label key={key} isCompact color="red">{key}: {val}</Label>
-                                  ))}
-                                </LabelGroup>
-                              ) : 'None'}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                        )}
-                        {authBridgeStats.outbound_replace_tokens != null && (
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>Outbound Token Replacements</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {Object.keys(authBridgeStats.outbound_replace_tokens).length > 0 ? (
-                                <LabelGroup>
-                                  {Object.entries(authBridgeStats.outbound_replace_tokens).map(([key, val]) => (
-                                    <Label key={key} isCompact color="blue">{key}: {val}</Label>
-                                  ))}
-                                </LabelGroup>
-                              ) : 'None'}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
+                        ) : (
+                          <>
+                            {authBridgeStats.inbound_approvals != null && (
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Inbound Approvals</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {Object.keys(authBridgeStats.inbound_approvals).length > 0 ? (
+                                    <LabelGroup>
+                                      {Object.entries(authBridgeStats.inbound_approvals).map(([key, val]) => (
+                                        <Label key={key} isCompact color="green">{key}: {val}</Label>
+                                      ))}
+                                    </LabelGroup>
+                                  ) : 'None'}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            )}
+                            {authBridgeStats.inbound_denials != null && (
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Inbound Denials</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {Object.keys(authBridgeStats.inbound_denials).length > 0 ? (
+                                    <LabelGroup>
+                                      {Object.entries(authBridgeStats.inbound_denials).map(([key, val]) => (
+                                        <Label key={key} isCompact color="red">{key}: {val}</Label>
+                                      ))}
+                                    </LabelGroup>
+                                  ) : 'None'}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            )}
+                            {authBridgeStats.outbound_approvals != null && (
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Outbound Approvals</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {Object.keys(authBridgeStats.outbound_approvals).length > 0 ? (
+                                    <LabelGroup>
+                                      {Object.entries(authBridgeStats.outbound_approvals).map(([key, val]) => (
+                                        <Label key={key} isCompact color="green">{key}: {val}</Label>
+                                      ))}
+                                    </LabelGroup>
+                                  ) : 'None'}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            )}
+                            {authBridgeStats.outbound_denials != null && (
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Outbound Denials</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {Object.keys(authBridgeStats.outbound_denials).length > 0 ? (
+                                    <LabelGroup>
+                                      {Object.entries(authBridgeStats.outbound_denials).map(([key, val]) => (
+                                        <Label key={key} isCompact color="red">{key}: {val}</Label>
+                                      ))}
+                                    </LabelGroup>
+                                  ) : 'None'}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            )}
+                            {authBridgeStats.outbound_replace_tokens != null && (
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>Outbound Token Replacements</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  {Object.keys(authBridgeStats.outbound_replace_tokens).length > 0 ? (
+                                    <LabelGroup>
+                                      {Object.entries(authBridgeStats.outbound_replace_tokens).map(([key, val]) => (
+                                        <Label key={key} isCompact color="blue">{key}: {val}</Label>
+                                      ))}
+                                    </LabelGroup>
+                                  ) : 'None'}
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            )}
+                          </>
                         )}
                       </DescriptionList>
                     ) : (

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -68,7 +68,7 @@ import {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import yaml from 'js-yaml';
 
-import { agentService, chatService, configService, shipwrightService, ShipwrightBuildInfo } from '@/services/api';
+import { agentService, authBridgeService, chatService, configService, shipwrightService, ShipwrightBuildInfo } from '@/services/api';
 import { AgentChat } from '@/components/AgentChat';
 
 interface StatusCondition {
@@ -205,6 +205,19 @@ export const AgentDetailPage: React.FC = () => {
   const { data: dashboardConfig } = useQuery({
     queryKey: ['dashboards'],
     queryFn: () => configService.getDashboards(),
+  });
+
+  // Fetch AuthBridge config and status
+  const { data: authBridgeConfig, isLoading: isAuthBridgeConfigLoading } = useQuery({
+    queryKey: ['authbridge-config', namespace, name],
+    queryFn: () => authBridgeService.getConfig(namespace!, name!),
+    enabled: !!namespace && !!name,
+  });
+
+  const { data: authBridgeStats, isLoading: isAuthBridgeStatsLoading } = useQuery({
+    queryKey: ['authbridge-status', namespace, name],
+    queryFn: () => authBridgeService.getStatus(namespace!, name!),
+    enabled: !!namespace && !!name,
   });
 
   if (isLoading) {
@@ -1004,6 +1017,254 @@ export const AgentDetailPage: React.FC = () => {
                 </pre>
               </CardBody>
             </Card>
+          </Tab>
+
+          <Tab eventKey={4} title={<TabTitleText>AuthBridge</TabTitleText>}>
+            <Grid hasGutter style={{ marginTop: '16px' }}>
+              <GridItem md={6}>
+                <Card>
+                  <CardTitle>Config</CardTitle>
+                  <CardBody>
+                    {isAuthBridgeConfigLoading ? (
+                      <Spinner size="md" aria-label="Loading AuthBridge config" />
+                    ) : authBridgeConfig ? (
+                      <DescriptionList isCompact>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Enabled</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <Label color={authBridgeConfig.AuthBridge ? 'green' : 'red'} isCompact>
+                              {authBridgeConfig.AuthBridge ? 'Yes' : 'No'}
+                            </Label>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Mode</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <Label isCompact color="blue">{authBridgeConfig.mode}</Label>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Inbound JWKS URL</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.inbound?.jwks_url || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Inbound Issuer</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            {authBridgeConfig.inbound?.issuer || '-'}
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Outbound Token URL</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.outbound?.token_url || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Outbound Default Policy</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            {authBridgeConfig.outbound?.default_policy || '-'}
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Identity Type</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <Label isCompact>{authBridgeConfig.identity?.type || '-'}</Label>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Identity Client ID</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            {authBridgeConfig.identity?.client_id || '-'}
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Listener Ext-Proc Address</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.ext_proc_addr || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Listener Ext-Authz Address</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.ext_authz_addr || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Listener Forward Proxy</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.forward_proxy_addr || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Listener Reverse Proxy</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.listener?.reverse_proxy_addr || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Bypass Inbound Paths</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            {authBridgeConfig.bypass?.inbound_paths?.length > 0 ? (
+                              <LabelGroup>
+                                {authBridgeConfig.bypass.inbound_paths.map((path) => (
+                                  <Label key={path} isCompact>{path}</Label>
+                                ))}
+                              </LabelGroup>
+                            ) : '-'}
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Routes File</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.routes?.file || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Stats Address</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <code style={{ fontSize: '0.85em' }}>{authBridgeConfig.stats?.address || '-'}</code>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        {authBridgeConfig.routes?.rules?.length > 0 && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Routes</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              <Table aria-label="AuthBridge routes" variant="compact">
+                                <Thead>
+                                  <Tr>
+                                    <Th>Host</Th>
+                                    <Th>Action</Th>
+                                    <Th>Target Audience</Th>
+                                    <Th>Passthrough</Th>
+                                  </Tr>
+                                </Thead>
+                                <Tbody>
+                                  {authBridgeConfig.routes.rules.map((route, idx) => (
+                                    <Tr key={idx}>
+                                      <Td dataLabel="Host">{route.host}</Td>
+                                      <Td dataLabel="Action">{route.action || '-'}</Td>
+                                      <Td dataLabel="Target Audience">{route.target_audience || '-'}</Td>
+                                      <Td dataLabel="Passthrough">
+                                        <Label isCompact color={route.passthrough ? 'green' : 'gold'}>
+                                          {route.passthrough ? 'Yes' : 'No'}
+                                        </Label>
+                                      </Td>
+                                    </Tr>
+                                  ))}
+                                </Tbody>
+                              </Table>
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                      </DescriptionList>
+                    ) : (
+                      <EmptyState>
+                        <EmptyStateHeader titleText="No configuration available" headingLevel="h4" />
+                      </EmptyState>
+                    )}
+                  </CardBody>
+                </Card>
+              </GridItem>
+              <GridItem md={6}>
+                <Card>
+                  <CardTitle>Status</CardTitle>
+                  <CardBody>
+                    {isAuthBridgeStatsLoading ? (
+                      <Spinner size="md" aria-label="Loading AuthBridge status" />
+                    ) : authBridgeStats ? (
+                      <DescriptionList isCompact>
+                        {authBridgeStats.AuthBridge != null && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Enabled</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              <Label color={authBridgeStats.AuthBridge ? 'green' : 'red'} isCompact>
+                                {authBridgeStats.AuthBridge ? 'Yes' : 'No'}
+                              </Label>
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {authBridgeStats.inbound_approvals != null && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Inbound Approvals</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {Object.keys(authBridgeStats.inbound_approvals).length > 0 ? (
+                                <LabelGroup>
+                                  {Object.entries(authBridgeStats.inbound_approvals).map(([key, val]) => (
+                                    <Label key={key} isCompact color="green">{key}: {val}</Label>
+                                  ))}
+                                </LabelGroup>
+                              ) : '0'}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {authBridgeStats.inbound_denials != null && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Inbound Denials</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {Object.keys(authBridgeStats.inbound_denials).length > 0 ? (
+                                <LabelGroup>
+                                  {Object.entries(authBridgeStats.inbound_denials).map(([key, val]) => (
+                                    <Label key={key} isCompact color="red">{key}: {val}</Label>
+                                  ))}
+                                </LabelGroup>
+                              ) : '0'}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {authBridgeStats.outbound_approvals != null && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Outbound Approvals</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {Object.keys(authBridgeStats.outbound_approvals).length > 0 ? (
+                                <LabelGroup>
+                                  {Object.entries(authBridgeStats.outbound_approvals).map(([key, val]) => (
+                                    <Label key={key} isCompact color="green">{key}: {val}</Label>
+                                  ))}
+                                </LabelGroup>
+                              ) : '0'}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {authBridgeStats.outbound_denials != null && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Outbound Denials</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {Object.keys(authBridgeStats.outbound_denials).length > 0 ? (
+                                <LabelGroup>
+                                  {Object.entries(authBridgeStats.outbound_denials).map(([key, val]) => (
+                                    <Label key={key} isCompact color="red">{key}: {val}</Label>
+                                  ))}
+                                </LabelGroup>
+                              ) : '0'}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {authBridgeStats.outbound_replace_tokens != null && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Outbound Token Replacements</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {Object.keys(authBridgeStats.outbound_replace_tokens).length > 0 ? (
+                                <LabelGroup>
+                                  {Object.entries(authBridgeStats.outbound_replace_tokens).map(([key, val]) => (
+                                    <Label key={key} isCompact color="blue">{key}: {val}</Label>
+                                  ))}
+                                </LabelGroup>
+                              ) : '0'}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                      </DescriptionList>
+                    ) : (
+                      <EmptyState>
+                        <EmptyStateHeader titleText="No status available" headingLevel="h4" />
+                      </EmptyState>
+                    )}
+                  </CardBody>
+                </Card>
+              </GridItem>
+            </Grid>
           </Tab>
         </Tabs>
       </PageSection>

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -70,6 +70,7 @@ import yaml from 'js-yaml';
 
 import { agentService, authBridgeService, chatService, configService, shipwrightService, ShipwrightBuildInfo } from '@/services/api';
 import { AgentChat } from '@/components/AgentChat';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 
 interface StatusCondition {
   type: string;
@@ -107,6 +108,7 @@ export const AgentDetailPage: React.FC = () => {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const features = useFeatureFlags();
   const [activeTab, setActiveTab] = React.useState<string | number>(0);
   const [isAgentCardExpanded, setIsAgentCardExpanded] = React.useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
@@ -214,13 +216,13 @@ export const AgentDetailPage: React.FC = () => {
   const { data: authBridgeConfig, isLoading: isAuthBridgeConfigLoading } = useQuery({
     queryKey: ['authbridge-config', namespace, name],
     queryFn: () => authBridgeService.getConfig(namespace!, name!),
-    enabled: !!namespace && !!name && hasAuthBridge,
+    enabled: !!namespace && !!name && hasAuthBridge && features.authbridgeAPI,
   });
 
   const { data: authBridgeStats, isLoading: isAuthBridgeStatsLoading } = useQuery({
     queryKey: ['authbridge-status', namespace, name],
     queryFn: () => authBridgeService.getStatus(namespace!, name!),
-    enabled: !!namespace && !!name && hasAuthBridge,
+    enabled: !!namespace && !!name && hasAuthBridge && features.authbridgeAPI,
   });
 
   if (isLoading) {
@@ -1022,7 +1024,7 @@ export const AgentDetailPage: React.FC = () => {
             </Card>
           </Tab>
 
-          {hasAuthBridge && <Tab eventKey={4} title={<TabTitleText>AuthBridge</TabTitleText>}>
+          {hasAuthBridge && features.authbridgeAPI && <Tab eventKey={4} title={<TabTitleText>AuthBridge</TabTitleText>}>
             <Grid hasGutter style={{ marginTop: '16px' }}>
               <GridItem md={6}>
                 <Card>

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -26,6 +26,8 @@ import type {
   SkillFile,
   CreateSkillRequest,
   CreateSkillResponse,
+  AuthBridgeConfig,
+  AuthBridgeStats,
 } from '@/types';
 
 // API configuration
@@ -1500,6 +1502,16 @@ export const skillService = {
         method: 'DELETE',
       }
     );
+  },
+};
+
+export const authBridgeService = {
+  async getConfig(namespace: string, name: string): Promise<AuthBridgeConfig> {
+    return apiFetch(`/agents/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/identity-config`);
+  },
+
+  async getStatus(namespace: string, name: string): Promise<AuthBridgeStats> {
+    return apiFetch(`/agents/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/identity-status`);
   },
 };
 

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -452,15 +452,15 @@ export interface CreateSkillResponse {
 
 // AuthBridge types
 export interface AuthBridgeConfig {
-  AuthBridge: boolean
-  mode: string;
-	inbound: InboundConfig;
-	outbound: OutboundConfig;
-	identity: IdentityConfig;
-	listener: ListenerConfig;
-	bypass:   BypassConfig;
-	routes:   RoutesConfig;
-	stats:    StatsConfig;
+  AuthBridge: boolean | null
+  mode: string | null;
+	inbound: InboundConfig | null;
+	outbound: OutboundConfig | null;
+	identity: IdentityConfig | null;
+	listener: ListenerConfig | null;
+	bypass:   BypassConfig | null;
+	routes:   RoutesConfig | null;
+	stats:    StatsConfig | null;
 }
 
 export interface InboundConfig {

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -454,44 +454,44 @@ export interface CreateSkillResponse {
 export interface AuthBridgeConfig {
   AuthBridge: boolean | null
   mode: string | null;
-	inbound: InboundConfig | null;
-	outbound: OutboundConfig | null;
-	identity: IdentityConfig | null;
-	listener: ListenerConfig | null;
-	bypass:   BypassConfig | null;
-	routes:   RoutesConfig | null;
-	stats:    StatsConfig | null;
+  inbound: InboundConfig | null;
+  outbound: OutboundConfig | null;
+  identity: IdentityConfig | null;
+  listener: ListenerConfig | null;
+  bypass:   BypassConfig | null;
+  routes:   RoutesConfig | null;
+  stats:    StatsConfig | null;
 }
 
 export interface InboundConfig {
   jwks_url: string;
-	issuer:  string;
+  issuer:  string;
 }
 
 export interface OutboundConfig {
-	token_url:      string;
-	keycloak_url:   string;
-	keycloak_realm: string;
-	default_policy: string;
+  token_url:      string;
+  keycloak_url:   string;
+  keycloak_realm: string;
+  default_policy: string;
 }
 
 export interface IdentityConfig {
-	type:             string; // "spiffe", "client-secret", "k8s-sa"
-	client_id:         string;
-	client_secret:     string;
-	client_id_file:     string;
-	client_secret_file: string;
-	socket_path:       string;
-	jwt_svid_path:      string;
-	jwt_audience:      string[];
+  type:             string; // "spiffe", "client-secret", "k8s-sa"
+  client_id:         string;
+  client_secret:     string;
+  client_id_file:     string;
+  client_secret_file: string;
+  socket_path:       string;
+  jwt_svid_path:      string;
+  jwt_audience:      string[];
 }
 
 export interface ListenerConfig {
-	ext_proc_addr:         string;
-	ext_authz_addr:        string;
-	forward_proxy_addr:    string;
-	reverse_proxy_addr:    string;
-	reverse_proxy_backend: string;
+  ext_proc_addr:         string;
+  ext_authz_addr:        string;
+  forward_proxy_addr:    string;
+  reverse_proxy_addr:    string;
+  reverse_proxy_backend: string;
 }
 
 export interface BypassConfig {
@@ -499,21 +499,21 @@ export interface BypassConfig {
 }
 
 export interface RoutesConfig {
-	file:  string; // path to routes YAML file
-	rules: RouteConfig[]
+  file:  string; // path to routes YAML file
+  rules: RouteConfig[]
 }
 
 export interface RouteConfig {
-	host:           string;
-	target_audience: string;
-	token_scopes:    string;
-	token_url:       string;
-	passthrough:    boolean;
-	action:         string;
+  host:           string;
+  target_audience: string;
+  token_scopes:    string;
+  token_url:       string;
+  passthrough:    boolean;
+  action:         string;
 }
 
 export interface StatsConfig {
-	address: string; // for example, ":9093"
+  address: string; // for example, ":9093"
 }
 
 export interface AuthBridgeStats {

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -449,3 +449,78 @@ export interface CreateSkillResponse {
   namespace: string;
   message: string;
 }
+
+// AuthBridge types
+export interface AuthBridgeConfig {
+  AuthBridge: boolean
+  mode: string;
+	inbound: InboundConfig;
+	outbound: OutboundConfig;
+	identity: IdentityConfig;
+	listener: ListenerConfig;
+	bypass:   BypassConfig;
+	routes:   RoutesConfig;
+	stats:    StatsConfig;
+}
+
+export interface InboundConfig {
+  jwks_url: string;
+	issuer:  string;
+}
+
+export interface OutboundConfig {
+	token_url:      string;
+	keycloak_url:   string;
+	keycloak_realm: string;
+	default_policy: string;
+}
+
+export interface IdentityConfig {
+	type:             string; // "spiffe", "client-secret", "k8s-sa"
+	client_id:         string;
+	client_secret:     string;
+	client_id_file:     string;
+	client_secret_file: string;
+	socket_path:       string;
+	jwt_svid_path:      string;
+	jwt_audience:      string[];
+}
+
+export interface ListenerConfig {
+	ext_proc_addr:         string;
+	ext_authz_addr:        string;
+	forward_proxy_addr:    string;
+	reverse_proxy_addr:    string;
+	reverse_proxy_backend: string;
+}
+
+export interface BypassConfig {
+  inbound_paths: string[];
+}
+
+export interface RoutesConfig {
+	file:  string; // path to routes YAML file
+	rules: RouteConfig[]
+}
+
+export interface RouteConfig {
+	host:           string;
+	target_audience: string;
+	token_scopes:    string;
+	token_url:       string;
+	passthrough:    boolean;
+	action:         string;
+}
+
+export interface StatsConfig {
+	address: string; // for example, ":9093"
+}
+
+export interface AuthBridgeStats {
+  AuthBridge: boolean | null;
+  inbound_approvals: Record<string, number> | null;
+  inbound_denials: Record<string, number> | null;
+  outbound_approvals: Record<string, number> | null;
+  outbound_denials: Record<string, number> | null;
+  outbound_replace_tokens: Record<string, number> | null;
+}


### PR DESCRIPTION
## Summary

A new "AuthBridge" tab for agents.

<img width="1684" height="1642" alt="authbridge-ui" src="https://github.com/user-attachments/assets/2f72ce02-c6b3-41e9-a411-d340787d0310" />

## Related issue(s)

Resolves #1310

## (Optional) Testing Instructions

First, we need to configure the new backend

```bash
make build-load-ui-backend
BACKEND_TAG=$(docker images | grep kagenti-backend | tail -n 1 | awk 'END {print $2}')
echo BACKEND_TAG is $BACKEND_TAG
oc -n kagenti-system set image deployment/kagenti-backend backend=ghcr.io/kagenti/kagenti-backend:${BACKEND_TAG}
oc -n kagenti-system set env deployment/kagenti-backend KAGENTI_FEATURE_FLAG_AUTHBRIDGE_API=TRUE
kubectl -n kagenti-system rollout status deployment kagenti-backend
```

Next, we need to configure the new sidecars:

```bash
podman build -f authbridge/cmd/authbridge/Dockerfile -t authbridge-envoy:local authbridge/
kind load docker-image authbridge-envoy:local --name kagenti
kubectl -n kagenti-system get configmap kagenti-platform-config -o json \
 | jq '.data |= with_entries(.value |= gsub("ghcr.io/kagenti/kagenti-extensions/authbridge:latest"; "authbridge-envoy:local"))' \
 | kubectl apply -f -
```

Next, we need to tell the webhook to use the new configuration

```
oc -n kagenti-system rollout restart deployment/kagenti-controller-manager
oc -n kagenti-system rollout status deployment/kagenti-controller-manager
oc -n team1 delete cm envoy-config
```

At this point, deploy the weather agent.

Next we need to build and deploy the new UI

```bash
kubectl -n kagenti-system patch deployment kagenti-ui --type=json --patch='[{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "IfNotPresent"}]'

make build-load-ui-frontend &&
  UI_TAG=$(docker images | grep kagenti-ui-v2 | tail -n 1 | awk 'END {print $2}') &&
  echo UI_TAG is $UI_TAG &&
  oc -n kagenti-system set image deployment/kagenti-ui frontend=ghcr.io/kagenti/kagenti-ui-v2:${UI_TAG} &&
  kubectl -n kagenti-system rollout status deployment kagenti-ui
```
