### PR TITLE
fix: update weather agent injection label

### DIFF
--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -29,7 +29,7 @@ spec:
         kagenti.io/type: agent
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
-        kagenti.io/client-registration-inject: "true"
+        kagenti.io/inject: "enabled"
         app.kubernetes.io/name: weather-service
     spec:
       serviceAccountName: weather-service

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -29,7 +29,6 @@ spec:
         kagenti.io/type: agent
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
-        kagenti.io/inject: "enabled"
         app.kubernetes.io/name: weather-service
     spec:
       serviceAccountName: weather-service

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -28,7 +28,7 @@ spec:
         kagenti.io/type: agent
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
-        kagenti.io/client-registration-inject: "true"
+        kagenti.io/inject: "enabled"
         app.kubernetes.io/name: weather-service
     spec:
       serviceAccountName: weather-service

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -28,7 +28,6 @@ spec:
         kagenti.io/type: agent
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
-        kagenti.io/inject: "enabled"
         app.kubernetes.io/name: weather-service
     spec:
       serviceAccountName: weather-service


### PR DESCRIPTION
Replace `kagenti.io/client-registration-inject: "true"` with `kagenti.io/inject: "enabled"` in weather agent manifests.

The AuthBridge webhook now requires the `kagenti.io/inject: enabled` label to inject sidecars. The old label is no longer recognized.

Fixes #1403