### PR TITLE
fix: use HTTP for SPIFFE bundle endpoint on Kind clusters

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1170,7 +1170,7 @@
                       - name: SPIFFE_TRUST_DOMAIN
                         value: "spiffe://{{ kagenti_deps_values.domain }}"
                       - name: SPIFFE_BUNDLE_ENDPOINT
-                        value: "https://spire-spiffe-oidc-discovery-provider.{{ charts.spire.server_namespace }}.svc.cluster.local/keys"
+                        value: "{{ 'https' if (enable_openshift | default(false)) else 'http' }}://spire-spiffe-oidc-discovery-provider.{{ charts.spire.server_namespace }}.svc.cluster.local/keys"
                       - name: SPIFFE_IDP_ALIAS
                         value: "{{ (kagenti_deps_values.authBridge | default({})).spiffeIdpAlias | default('spire-spiffe') }}"
                       - name: SPIFFE_TLS_VERIFY


### PR DESCRIPTION
## Summary

- PR #1322 changed the Ansible installer's `SPIFFE_BUNDLE_ENDPOINT` from `http://` to `https://`, which is correct for OpenShift (port 443/HTTPS) but breaks Kind clusters where the SPIRE OIDC discovery provider service only exposes port 80 (HTTP)
- Makes the URL scheme conditional using the existing `enable_openshift` flag, matching the pattern already used for `SPIFFE_TLS_VERIFY`
- On OpenShift: `https://` + `SPIFFE_TLS_VERIFY=false`
- On Kind: `http://` + `SPIFFE_TLS_VERIFY=true` (irrelevant for HTTP)

## Root Cause

The `spire-spiffe-oidc-discovery-provider` service is configured differently per platform:
- **OpenShift**: exposes port 443 (HTTPS via Route/Ingress TLS termination)
- **Kind**: exposes port 80 → nginx sidecar on 8080 (plain HTTP, no TLS)

After PR #1322, the Ansible installer always uses `https://`, causing the job to fail on Kind with `BackoffLimitExceeded` after 10 retries.

## Test plan

- [ ] Deploy Kind cluster using Ansible installer, verify `kagenti-spiffe-idp-setup-job` completes successfully
- [ ] Verify no regression on OpenShift deployments (HTTPS still used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)