### PR TITLE
feat: direct Sandbox creation, remove SandboxTemplate/SandboxClaim dependency

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -444,13 +444,10 @@ rules:
     resources: ["routes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   {{- if .Values.featureFlags.agentSandbox }}
-  # agent-sandbox (kubernetes-sigs) — read Sandboxes, manage Templates + Claims
+  # agent-sandbox (kubernetes-sigs) — direct Sandbox management
   - apiGroups: ["agents.x-k8s.io"]
     resources: ["sandboxes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions.agents.x-k8s.io"]
-    resources: ["sandboxtemplates", "sandboxclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete"]
   {{- end }}
   {{- if .Values.featureFlags.integrations }}
   # Integration CRDs for repository integrations

--- a/docs/superpowers/plans/2026-04-22-agent-sandbox-workload-type.md
+++ b/docs/superpowers/plans/2026-04-22-agent-sandbox-workload-type.md
@@ -1,0 +1,1077 @@
+# Agent-Sandbox Workload Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `Sandbox` (from kubernetes-sigs/agent-sandbox) as a fourth workload type alongside Deployment, StatefulSet, and Job, gated behind a new feature flag.
+
+**Architecture:** The backend creates `Sandbox` CRs via the Kubernetes CustomObjects API (same imperative pattern as the existing three workload types). A startup CRD detection check gracefully disables the feature if the agent-sandbox controller is not installed. The UI conditionally shows the Sandbox option based on the `agentSandbox` feature flag.
+
+**Tech Stack:** Python 3.11+ / FastAPI / Pydantic (backend), React / PatternFly (frontend), Helm 3 (charts), pytest (E2E)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `kagenti/backend/app/core/config.py` | Feature flag declaration |
+| `kagenti/backend/app/core/constants.py` | `WORKLOAD_TYPE_SANDBOX` constant + CRD coordinates |
+| `kagenti/backend/app/services/kubernetes.py` | Sandbox CRUD methods (create/get/list/delete/patch) |
+| `kagenti/backend/app/routers/agents.py` | Manifest builder + all dispatch points (create/list/get/delete/finalize) |
+| `kagenti/backend/app/routers/config.py` | Expose `agentSandbox` in feature flags response |
+| `kagenti/backend/app/services/reconciliation.py` | Add Sandbox to `_workload_exists` |
+| `kagenti/backend/app/main.py` | CRD detection at startup |
+| `charts/kagenti/values.yaml` | `featureFlags.agentSandbox` value |
+| `charts/kagenti/templates/ui.yaml` | Wire env var for feature flag |
+| `kagenti/ui-v2/src/types/index.ts` | Add `'sandbox'` to `WorkloadType` union |
+| `kagenti/ui-v2/src/hooks/useFeatureFlags.ts` | Add `agentSandbox` boolean |
+| `kagenti/ui-v2/src/pages/ImportAgentPage.tsx` | Sandbox option in workload dropdown |
+| `kagenti/ui-v2/src/pages/AgentCatalogPage.tsx` | Sandbox badge rendering |
+| `kagenti/ui-v2/src/pages/AgentDetailPage.tsx` | Sandbox status display |
+| `kagenti/ui-v2/src/services/api.ts` | Add `'sandbox'` to API type unions |
+| `kagenti/tests/e2e/test_agent_sandbox.py` | E2E tests for Sandbox workload type |
+
+---
+
+### Task 1: Feature flag + constants (epic 1.1)
+
+**Files:**
+- Modify: `kagenti/backend/app/core/config.py:69-71`
+- Modify: `kagenti/backend/app/core/constants.py:56-66`
+
+- [ ] **Step 1: Add feature flag to config.py**
+
+In `kagenti/backend/app/core/config.py`, add after line 71 (`kagenti_feature_flag_triggers`):
+
+```python
+    kagenti_feature_flag_agent_sandbox: bool = False
+```
+
+- [ ] **Step 2: Add constants to constants.py**
+
+In `kagenti/backend/app/core/constants.py`, add after line 59 (`WORKLOAD_TYPE_JOB = "job"`):
+
+```python
+WORKLOAD_TYPE_SANDBOX = "sandbox"
+
+# agent-sandbox CRD coordinates (kubernetes-sigs/agent-sandbox)
+AGENT_SANDBOX_CRD_GROUP = "agents.x-k8s.io"
+AGENT_SANDBOX_CRD_VERSION = "v1alpha1"
+AGENT_SANDBOX_PLURAL = "sandboxes"
+```
+
+- [ ] **Step 3: Make SUPPORTED_WORKLOAD_TYPES conditional**
+
+Replace lines 62-66 in `constants.py`:
+
+```python
+# Supported workload types
+SUPPORTED_WORKLOAD_TYPES = [
+    WORKLOAD_TYPE_DEPLOYMENT,
+    WORKLOAD_TYPE_STATEFULSET,
+    WORKLOAD_TYPE_JOB,
+]
+```
+
+with:
+
+```python
+# Supported workload types (sandbox added conditionally at startup)
+SUPPORTED_WORKLOAD_TYPES = [
+    WORKLOAD_TYPE_DEPLOYMENT,
+    WORKLOAD_TYPE_STATEFULSET,
+    WORKLOAD_TYPE_JOB,
+]
+if settings.kagenti_feature_flag_agent_sandbox:
+    SUPPORTED_WORKLOAD_TYPES.append(WORKLOAD_TYPE_SANDBOX)
+```
+
+- [ ] **Step 4: Add agentSandbox to feature flags response**
+
+In `kagenti/backend/app/routers/config.py`, update the `FeatureFlagsResponse` class (line 16-19):
+
+```python
+class FeatureFlagsResponse(BaseModel):
+    sandbox: bool
+    integrations: bool
+    triggers: bool
+    agentSandbox: bool
+```
+
+And update the endpoint (line 32-36):
+
+```python
+    return FeatureFlagsResponse(
+        sandbox=settings.kagenti_feature_flag_sandbox,
+        integrations=settings.kagenti_feature_flag_integrations,
+        triggers=settings.kagenti_feature_flag_triggers,
+        agentSandbox=settings.kagenti_feature_flag_agent_sandbox,
+    )
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kagenti/backend/app/core/config.py kagenti/backend/app/core/constants.py kagenti/backend/app/routers/config.py
+git commit -s -m "feat: add agent_sandbox feature flag and constants (epic 1155 step 1.1)"
+```
+
+---
+
+### Task 2: KubernetesService Sandbox CRUD (epic 1.2)
+
+**Files:**
+- Modify: `kagenti/backend/app/services/kubernetes.py:492-498`
+
+- [ ] **Step 1: Add Sandbox CRUD methods**
+
+In `kagenti/backend/app/services/kubernetes.py`, add a new section before the `@lru_cache` line (line 495), after the Job Operations section:
+
+```python
+    # -------------------------------------------------------------------------
+    # Sandbox Operations (agent-sandbox CRD: agents.x-k8s.io/v1alpha1)
+    # -------------------------------------------------------------------------
+
+    def create_sandbox(self, namespace: str, body: dict) -> dict:
+        """Create a Sandbox CR in the specified namespace."""
+        from app.core.constants import (
+            AGENT_SANDBOX_CRD_GROUP,
+            AGENT_SANDBOX_CRD_VERSION,
+            AGENT_SANDBOX_PLURAL,
+        )
+
+        try:
+            return self.custom_api.create_namespaced_custom_object(
+                group=AGENT_SANDBOX_CRD_GROUP,
+                version=AGENT_SANDBOX_CRD_VERSION,
+                namespace=namespace,
+                plural=AGENT_SANDBOX_PLURAL,
+                body=body,
+            )
+        except ApiException as e:
+            logger.error(f"Error creating Sandbox in {namespace}: {e}")
+            raise
+
+    def get_sandbox(self, namespace: str, name: str) -> dict:
+        """Get a Sandbox CR by name."""
+        from app.core.constants import (
+            AGENT_SANDBOX_CRD_GROUP,
+            AGENT_SANDBOX_CRD_VERSION,
+            AGENT_SANDBOX_PLURAL,
+        )
+
+        try:
+            return self.custom_api.get_namespaced_custom_object(
+                group=AGENT_SANDBOX_CRD_GROUP,
+                version=AGENT_SANDBOX_CRD_VERSION,
+                namespace=namespace,
+                plural=AGENT_SANDBOX_PLURAL,
+                name=name,
+            )
+        except ApiException as e:
+            logger.error(f"Error getting Sandbox {name} in {namespace}: {e}")
+            raise
+
+    def list_sandboxes(
+        self, namespace: str, label_selector: Optional[str] = None
+    ) -> List[dict]:
+        """List Sandbox CRs in a namespace with optional label selector."""
+        from app.core.constants import (
+            AGENT_SANDBOX_CRD_GROUP,
+            AGENT_SANDBOX_CRD_VERSION,
+            AGENT_SANDBOX_PLURAL,
+        )
+
+        try:
+            response = self.custom_api.list_namespaced_custom_object(
+                group=AGENT_SANDBOX_CRD_GROUP,
+                version=AGENT_SANDBOX_CRD_VERSION,
+                namespace=namespace,
+                plural=AGENT_SANDBOX_PLURAL,
+                label_selector=label_selector,
+            )
+            return response.get("items", [])
+        except ApiException as e:
+            logger.error(f"Error listing Sandboxes in {namespace}: {e}")
+            raise
+
+    def delete_sandbox(self, namespace: str, name: str) -> None:
+        """Delete a Sandbox CR by name."""
+        from app.core.constants import (
+            AGENT_SANDBOX_CRD_GROUP,
+            AGENT_SANDBOX_CRD_VERSION,
+            AGENT_SANDBOX_PLURAL,
+        )
+
+        try:
+            self.custom_api.delete_namespaced_custom_object(
+                group=AGENT_SANDBOX_CRD_GROUP,
+                version=AGENT_SANDBOX_CRD_VERSION,
+                namespace=namespace,
+                plural=AGENT_SANDBOX_PLURAL,
+                name=name,
+            )
+        except ApiException as e:
+            logger.error(f"Error deleting Sandbox {name} in {namespace}: {e}")
+            raise
+
+    def patch_sandbox(self, namespace: str, name: str, body: dict) -> dict:
+        """Patch a Sandbox CR with the provided body."""
+        from app.core.constants import (
+            AGENT_SANDBOX_CRD_GROUP,
+            AGENT_SANDBOX_CRD_VERSION,
+            AGENT_SANDBOX_PLURAL,
+        )
+
+        try:
+            return self.custom_api.patch_namespaced_custom_object(
+                group=AGENT_SANDBOX_CRD_GROUP,
+                version=AGENT_SANDBOX_CRD_VERSION,
+                namespace=namespace,
+                plural=AGENT_SANDBOX_PLURAL,
+                name=name,
+                body=body,
+            )
+        except ApiException as e:
+            logger.error(f"Error patching Sandbox {name} in {namespace}: {e}")
+            raise
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kagenti/backend/app/services/kubernetes.py
+git commit -s -m "feat: add Sandbox CRUD methods to KubernetesService (epic 1155 step 1.2)"
+```
+
+---
+
+### Task 3: Manifest builder (epic 1.3)
+
+**Files:**
+- Modify: `kagenti/backend/app/routers/agents.py`
+
+- [ ] **Step 1: Add WORKLOAD_TYPE_SANDBOX to imports**
+
+In `kagenti/backend/app/routers/agents.py`, add to the imports from `app.core.constants` (around line 57-59):
+
+```python
+    WORKLOAD_TYPE_SANDBOX,
+    AGENT_SANDBOX_CRD_GROUP,
+    AGENT_SANDBOX_CRD_VERSION,
+    AGENT_SANDBOX_PLURAL,
+```
+
+- [ ] **Step 2: Add _build_sandbox_manifest function**
+
+Add after `_build_job_manifest` (after line ~2400, before `create_agent`). Find the exact location by searching for the line after the closing of `_build_job_manifest`:
+
+```python
+def _build_sandbox_manifest(
+    request: "CreateAgentRequest",
+    image: str,
+    shipwright_build_name: Optional[str] = None,
+) -> dict:
+    """Build a Sandbox CR manifest for an agent (agents.x-k8s.io/v1alpha1)."""
+    env_vars = _build_env_vars(request)
+    labels = _build_common_labels(request, WORKLOAD_TYPE_SANDBOX)
+
+    annotations: Dict[str, str] = {
+        KAGENTI_DESCRIPTION_ANNOTATION: f"Agent '{request.name}' deployed from UI.",
+    }
+    if shipwright_build_name:
+        annotations["kagenti.io/shipwright-build"] = shipwright_build_name
+
+    container_port = DEFAULT_IN_CLUSTER_PORT
+    if request.servicePorts and len(request.servicePorts) > 0:
+        container_port = request.servicePorts[0].targetPort
+
+    manifest = {
+        "apiVersion": f"{AGENT_SANDBOX_CRD_GROUP}/{AGENT_SANDBOX_CRD_VERSION}",
+        "kind": "Sandbox",
+        "metadata": {
+            "name": request.name,
+            "namespace": request.namespace,
+            "labels": labels,
+            "annotations": annotations,
+        },
+        "spec": {
+            "podTemplate": {
+                "metadata": {
+                    "labels": {
+                        **labels,
+                    },
+                },
+                "spec": {
+                    "serviceAccountName": request.name,
+                    "containers": [
+                        {
+                            "name": "agent",
+                            "image": image,
+                            "imagePullPolicy": DEFAULT_IMAGE_POLICY,
+                            "resources": {
+                                "limits": DEFAULT_RESOURCE_LIMITS,
+                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                            },
+                            "env": env_vars,
+                            "ports": [
+                                {
+                                    "name": "http",
+                                    "containerPort": container_port,
+                                    "protocol": "TCP",
+                                },
+                            ],
+                            "volumeMounts": [
+                                {"name": "cache", "mountPath": "/app/.cache"},
+                                {"name": "marvin", "mountPath": "/.marvin"},
+                                {"name": "shared-data", "mountPath": "/shared"},
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {"name": "cache", "emptyDir": {}},
+                        {"name": "marvin", "emptyDir": {}},
+                        {"name": "shared-data", "emptyDir": {}},
+                    ],
+                },
+            },
+        },
+    }
+
+    if request.imagePullSecret:
+        manifest["spec"]["podTemplate"]["spec"]["imagePullSecrets"] = [
+            {"name": request.imagePullSecret}
+        ]
+
+    return manifest
+```
+
+- [ ] **Step 3: Add Sandbox status helper functions**
+
+Add near the other status helper functions (near `_is_deployment_ready`, `_is_statefulset_ready`, `_get_job_status`):
+
+```python
+def _is_sandbox_ready(sandbox: dict) -> str:
+    """Check if a Sandbox CR is ready by examining its status conditions."""
+    status = sandbox.get("status", {})
+    conditions = status.get("conditions", [])
+    for cond in conditions:
+        if cond.get("type") == "Ready":
+            if cond.get("status") == "True":
+                return "Ready"
+            return "Not Ready"
+    return "Pending"
+
+
+def _get_sandbox_description(sandbox: dict) -> str:
+    """Extract description from a Sandbox CR."""
+    metadata = sandbox.get("metadata", {})
+    annotations = metadata.get("annotations", {})
+    return annotations.get(KAGENTI_DESCRIPTION_ANNOTATION, "No description")
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kagenti/backend/app/routers/agents.py
+git commit -s -m "feat: add Sandbox manifest builder and status helpers (epic 1155 step 1.3)"
+```
+
+---
+
+### Task 4: Router integration — list, get, delete (epic 1.4a)
+
+**Files:**
+- Modify: `kagenti/backend/app/routers/agents.py`
+
+- [ ] **Step 1: Add Sandbox to list_agents**
+
+In `list_agents` (around line 566, after the Jobs query block ending at line 597), add before the legacy Agent CRD block:
+
+```python
+        # Query Sandbox CRs with agent label (when feature flag enabled)
+        if settings.kagenti_feature_flag_agent_sandbox:
+            try:
+                sandboxes = kube.list_sandboxes(
+                    namespace=namespace,
+                    label_selector=label_selector,
+                )
+
+                for sandbox in sandboxes:
+                    metadata = sandbox.get("metadata", {})
+                    name = metadata.get("name", "")
+                    if name in agent_names:
+                        logger.warning(
+                            f"Duplicate agent name '{name}' detected: Sandbox skipped because "
+                            f"another workload with the same name already exists in namespace '{namespace}'."
+                        )
+                        continue
+                    agent_names.add(name)
+                    labels = metadata.get("labels", {})
+
+                    agents.append(
+                        AgentSummary(
+                            name=name,
+                            namespace=metadata.get("namespace", namespace),
+                            description=_get_sandbox_description(sandbox),
+                            status=_is_sandbox_ready(sandbox),
+                            labels=_extract_labels(labels),
+                            workloadType=WORKLOAD_TYPE_SANDBOX,
+                            createdAt=_format_timestamp(
+                                metadata.get("creation_timestamp")
+                                or metadata.get("creationTimestamp")
+                            ),
+                        )
+                    )
+            except ApiException as e:
+                if e.status == 404:
+                    logger.debug("Sandbox CRD not installed, skipping Sandbox query")
+                elif e.status != 403:
+                    logger.warning(f"Failed to list Sandboxes in {namespace}: {e.reason}")
+```
+
+- [ ] **Step 2: Add Sandbox to get_agent**
+
+In `get_agent` (around line 692, after the Job try block), add before the 404 raise:
+
+```python
+    # If still not found, try Sandbox (when feature flag enabled)
+    if workload is None and settings.kagenti_feature_flag_agent_sandbox:
+        try:
+            workload = kube.get_sandbox(namespace=namespace, name=name)
+            workload_type = WORKLOAD_TYPE_SANDBOX
+        except ApiException as e:
+            if e.status != 404:
+                raise HTTPException(status_code=e.status, detail=str(e.reason))
+```
+
+- [ ] **Step 3: Add Sandbox status to get_agent response**
+
+In `get_agent` (around line 720-727, the ready_status if/elif chain), add before `else`:
+
+```python
+    elif workload_type == WORKLOAD_TYPE_SANDBOX:
+        ready_status = _is_sandbox_ready(workload)
+```
+
+- [ ] **Step 4: Handle Service lookup for Sandbox**
+
+In `get_agent` (around line 707), the existing code skips Service lookup for Jobs. The Sandbox controller creates its own headless Service, so we should also skip creating one but still try to look up the auto-created one. The existing logic `if workload_type != WORKLOAD_TYPE_JOB` already handles this correctly — Sandbox will look up the Service, and if the Sandbox controller hasn't created one yet, the 404 is silently ignored.
+
+No code change needed here.
+
+- [ ] **Step 5: Add Sandbox to delete_agent**
+
+In `delete_agent` (around line 818, after the Job delete block), add:
+
+```python
+    # Delete the Sandbox (if exists)
+    if settings.kagenti_feature_flag_agent_sandbox:
+        try:
+            kube.delete_sandbox(namespace=namespace, name=name)
+            messages.append(f"Sandbox '{name}' deleted")
+        except ApiException as e:
+            if e.status == 404:
+                logger.debug(f"Sandbox '{name}' not found")
+            else:
+                logger.warning(f"Failed to delete Sandbox '{name}': {e.reason}")
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kagenti/backend/app/routers/agents.py
+git commit -s -m "feat: add Sandbox to list/get/delete agent endpoints (epic 1155 step 1.4a)"
+```
+
+---
+
+### Task 5: Router integration — create + finalize (epic 1.4b)
+
+**Files:**
+- Modify: `kagenti/backend/app/routers/agents.py`
+
+- [ ] **Step 1: Add Sandbox branch to create_agent (image deploy)**
+
+In `create_agent` (around line 2466-2475, the workload type dispatch), add after the Job elif:
+
+```python
+            elif request.workloadType == WORKLOAD_TYPE_SANDBOX:
+                workload_manifest = _build_sandbox_manifest(
+                    request=request,
+                    image=request.containerImage,
+                )
+                kube.create_sandbox(
+                    namespace=request.namespace,
+                    body=workload_manifest,
+                )
+                logger.info(
+                    f"Created Sandbox '{request.name}' in namespace '{request.namespace}'"
+                )
+```
+
+- [ ] **Step 2: Handle Service creation for Sandbox**
+
+The existing code at line 2478 creates a Service when `request.workloadType != WORKLOAD_TYPE_JOB`. The Sandbox controller auto-creates a headless Service, so skip Service creation for Sandbox too. Update the condition:
+
+```python
+            if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+```
+
+- [ ] **Step 3: Handle HTTPRoute for Sandbox**
+
+The existing code at line 2489 checks `request.workloadType != WORKLOAD_TYPE_JOB` before creating an HTTPRoute. Sandbox agents can have routes. Leave this as-is — Sandbox is not excluded from HTTPRoute creation.
+
+No code change needed here.
+
+- [ ] **Step 4: Add Sandbox branch to finalize_shipwright_build**
+
+In `finalize_shipwright_build` (around line 2691-2714, the workload existence check), add a Sandbox try block after the Job check:
+
+```python
+        if not workload_exists and settings.kagenti_feature_flag_agent_sandbox:
+            try:
+                kube.get_sandbox(namespace=namespace, name=name)
+                workload_exists = True
+                existing_workload_type = WORKLOAD_TYPE_SANDBOX
+            except ApiException as e:
+                if e.status != 404:
+                    raise
+```
+
+Then in the workload creation dispatch (around line 2838-2893), add the Sandbox branch after the Job elif:
+
+```python
+        elif final_workload_type == WORKLOAD_TYPE_SANDBOX:
+            workload_manifest = _build_sandbox_manifest(
+                request=agent_request,
+                image=container_image,
+                shipwright_build_name=name,
+            )
+            kube.create_sandbox(
+                namespace=namespace,
+                body=workload_manifest,
+            )
+            logger.info(
+                f"Created Sandbox '{name}' in namespace '{namespace}' from build"
+            )
+```
+
+And update the Service skip condition (around line 2894):
+
+```python
+        if final_workload_type not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kagenti/backend/app/routers/agents.py
+git commit -s -m "feat: add Sandbox to create_agent and finalize_shipwright_build (epic 1155 step 1.4b)"
+```
+
+---
+
+### Task 6: Reconciliation (epic 1.5)
+
+**Files:**
+- Modify: `kagenti/backend/app/services/reconciliation.py:38-47`
+
+- [ ] **Step 1: Add Sandbox to _workload_exists**
+
+Replace the `_workload_exists` function:
+
+```python
+def _workload_exists(kube: KubernetesService, namespace: str, name: str) -> bool:
+    """Check if any workload (Deployment, StatefulSet, Job, or Sandbox) exists for the given name."""
+    for getter in (kube.get_deployment, kube.get_statefulset, kube.get_job):
+        try:
+            getter(namespace=namespace, name=name)
+            return True
+        except ApiException as e:
+            if e.status != 404:
+                raise
+
+    if settings.kagenti_feature_flag_agent_sandbox:
+        try:
+            kube.get_sandbox(namespace=namespace, name=name)
+            return True
+        except ApiException as e:
+            if e.status != 404:
+                raise
+
+    return False
+```
+
+- [ ] **Step 2: Add settings import**
+
+At the top of `reconciliation.py`, add:
+
+```python
+from app.core.config import settings
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kagenti/backend/app/services/reconciliation.py
+git commit -s -m "feat: add Sandbox to reconciliation workload check (epic 1155 step 1.5)"
+```
+
+---
+
+### Task 7: CRD detection at startup (epic 1.7)
+
+**Files:**
+- Modify: `kagenti/backend/app/main.py:96-117`
+
+- [ ] **Step 1: Add CRD detection in lifespan**
+
+In `main.py`, add the CRD detection inside the `lifespan` function, after the startup log lines (around line 103) and before the reconciliation block:
+
+```python
+    # Detect agent-sandbox CRD availability (when flag is enabled)
+    if settings.kagenti_feature_flag_agent_sandbox:
+        from app.core.constants import (
+            AGENT_SANDBOX_CRD_GROUP,
+            AGENT_SANDBOX_CRD_VERSION,
+            AGENT_SANDBOX_PLURAL,
+            SUPPORTED_WORKLOAD_TYPES,
+            WORKLOAD_TYPE_SANDBOX,
+        )
+        from app.services.kubernetes import get_kubernetes_service
+
+        try:
+            kube = get_kubernetes_service()
+            kube.custom_api.list_namespaced_custom_object(
+                group=AGENT_SANDBOX_CRD_GROUP,
+                version=AGENT_SANDBOX_CRD_VERSION,
+                namespace="default",
+                plural=AGENT_SANDBOX_PLURAL,
+                limit=1,
+            )
+            logger.info("agent-sandbox CRD detected — Sandbox workload type enabled")
+        except Exception:
+            logger.warning(
+                "Feature flag AGENT_SANDBOX enabled but Sandbox CRD not found "
+                "(agents.x-k8s.io/v1alpha1/sandboxes). Disabling Sandbox workload type. "
+                "Install agent-sandbox controller to enable: "
+                "https://github.com/kubernetes-sigs/agent-sandbox"
+            )
+            if WORKLOAD_TYPE_SANDBOX in SUPPORTED_WORKLOAD_TYPES:
+                SUPPORTED_WORKLOAD_TYPES.remove(WORKLOAD_TYPE_SANDBOX)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kagenti/backend/app/main.py
+git commit -s -m "feat: detect agent-sandbox CRD at startup with graceful degradation (epic 1155 step 1.7)"
+```
+
+---
+
+### Task 8: Helm chart (epic 1.1 continued)
+
+**Files:**
+- Modify: `charts/kagenti/values.yaml:7-10`
+- Modify: `charts/kagenti/templates/ui.yaml:122-123`
+
+- [ ] **Step 1: Add agentSandbox to values.yaml**
+
+In `charts/kagenti/values.yaml`, add after line 10 (`triggers: false`):
+
+```yaml
+  agentSandbox: false
+```
+
+- [ ] **Step 2: Wire env var in ui.yaml**
+
+In `charts/kagenti/templates/ui.yaml`, add after line 123 (the `KAGENTI_FEATURE_FLAG_TRIGGERS` block):
+
+```yaml
+            - name: KAGENTI_FEATURE_FLAG_AGENT_SANDBOX
+              value: "{{ .Values.featureFlags.agentSandbox }}"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add charts/kagenti/values.yaml charts/kagenti/templates/ui.yaml
+git commit -s -m "feat: add agentSandbox feature flag to Helm chart (epic 1155 step 1.1)"
+```
+
+---
+
+### Task 9: UI — types + feature flags (epic 1.8a)
+
+**Files:**
+- Modify: `kagenti/ui-v2/src/types/index.ts:9`
+- Modify: `kagenti/ui-v2/src/hooks/useFeatureFlags.ts`
+- Modify: `kagenti/ui-v2/src/services/api.ts:204`
+
+- [ ] **Step 1: Add sandbox to WorkloadType**
+
+In `kagenti/ui-v2/src/types/index.ts`, change line 9:
+
+```typescript
+export type WorkloadType = 'deployment' | 'statefulset' | 'job' | 'sandbox';
+```
+
+- [ ] **Step 2: Add agentSandbox to FeatureFlags**
+
+In `kagenti/ui-v2/src/hooks/useFeatureFlags.ts`, update the interface (line 7-11):
+
+```typescript
+export interface FeatureFlags {
+  sandbox: boolean;
+  integrations: boolean;
+  triggers: boolean;
+  agentSandbox: boolean;
+}
+```
+
+Update `DEFAULT_FLAGS` (line 13-17):
+
+```typescript
+const DEFAULT_FLAGS: FeatureFlags = {
+  sandbox: false,
+  integrations: false,
+  triggers: false,
+  agentSandbox: false,
+};
+```
+
+Update the validated block inside the `useEffect` (line 34-38):
+
+```typescript
+        const validated: FeatureFlags = {
+          sandbox: data.sandbox === true,
+          integrations: data.integrations === true,
+          triggers: data.triggers === true,
+          agentSandbox: data.agentSandbox === true,
+        };
+```
+
+- [ ] **Step 3: Add sandbox to API type unions**
+
+In `kagenti/ui-v2/src/services/api.ts`, find line 204:
+
+```typescript
+    workloadType?: 'deployment' | 'statefulset' | 'job';
+```
+
+Change to:
+
+```typescript
+    workloadType?: 'deployment' | 'statefulset' | 'job' | 'sandbox';
+```
+
+Search for any other workloadType type annotations in `api.ts` and add `'sandbox'` to each one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kagenti/ui-v2/src/types/index.ts kagenti/ui-v2/src/hooks/useFeatureFlags.ts kagenti/ui-v2/src/services/api.ts
+git commit -s -m "feat: add sandbox to UI types and feature flags (epic 1155 step 1.8a)"
+```
+
+---
+
+### Task 10: UI — ImportAgentPage dropdown (epic 1.8b)
+
+**Files:**
+- Modify: `kagenti/ui-v2/src/pages/ImportAgentPage.tsx`
+
+- [ ] **Step 1: Import useFeatureFlags**
+
+At the top of `ImportAgentPage.tsx`, add the import (if not already present):
+
+```typescript
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
+```
+
+- [ ] **Step 2: Get feature flags in component**
+
+Inside the component function, add:
+
+```typescript
+  const featureFlags = useFeatureFlags();
+```
+
+- [ ] **Step 3: Update workloadType state type**
+
+Change line 158:
+
+```typescript
+  const [workloadType, setWorkloadType] = useState<'deployment' | 'statefulset' | 'job'>('deployment');
+```
+
+to:
+
+```typescript
+  const [workloadType, setWorkloadType] = useState<'deployment' | 'statefulset' | 'job' | 'sandbox'>('deployment');
+```
+
+- [ ] **Step 4: Update onChange handler type**
+
+Change line 944:
+
+```typescript
+                  onChange={(_e, value) => setWorkloadType(value as 'deployment' | 'statefulset' | 'job')}
+```
+
+to:
+
+```typescript
+                  onChange={(_e, value) => setWorkloadType(value as 'deployment' | 'statefulset' | 'job' | 'sandbox')}
+```
+
+- [ ] **Step 5: Add Sandbox option to dropdown**
+
+After line 949 (`<FormSelectOption value="job" label="Job" />`), add:
+
+```tsx
+                  {featureFlags.agentSandbox && (
+                    <FormSelectOption value="sandbox" label="Sandbox (agent-sandbox)" />
+                  )}
+```
+
+- [ ] **Step 6: Add Sandbox helper text**
+
+After line 956 (the job helper text), add:
+
+```tsx
+                      {workloadType === 'sandbox' && 'For agents requiring stable identity, persistent storage, and lifecycle management (pause/resume). Requires agent-sandbox controller.'}
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+git commit -s -m "feat: add Sandbox option to agent workload type dropdown (epic 1155 step 1.8b)"
+```
+
+---
+
+### Task 11: UI — AgentCatalogPage + AgentDetailPage (epic 1.8c)
+
+**Files:**
+- Modify: `kagenti/ui-v2/src/pages/AgentCatalogPage.tsx:121-131`
+- Modify: `kagenti/ui-v2/src/pages/AgentDetailPage.tsx`
+
+- [ ] **Step 1: Add sandbox badge color to AgentCatalogPage**
+
+In `AgentCatalogPage.tsx`, update `renderWorkloadType` (line 121-131):
+
+```typescript
+  const renderWorkloadType = (workloadType: string | undefined) => {
+    const type = workloadType || 'deployment';
+    const label = type.charAt(0).toUpperCase() + type.slice(1);
+    let color: 'grey' | 'orange' | 'gold' | 'purple' = 'grey';
+    if (type === 'job') {
+      color = 'orange';
+    } else if (type === 'statefulset') {
+      color = 'gold';
+    } else if (type === 'sandbox') {
+      color = 'purple';
+    }
+    return <Label color={color} isCompact>{label}</Label>;
+  };
+```
+
+- [ ] **Step 2: Add sandbox to AgentDetailPage status badge**
+
+In `AgentDetailPage.tsx`, find the workloadType label rendering (line 428):
+
+```tsx
+                          <Label color={workloadType === 'job' ? 'orange' : workloadType === 'statefulset' ? 'gold' : 'grey'} isCompact>
+```
+
+Change to:
+
+```tsx
+                          <Label color={workloadType === 'job' ? 'orange' : workloadType === 'statefulset' ? 'gold' : workloadType === 'sandbox' ? 'purple' : 'grey'} isCompact>
+```
+
+- [ ] **Step 3: Add sandbox to AgentDetailPage kind mapping**
+
+In `AgentDetailPage.tsx`, find the apiVersion/kind mapping (line 999-1000):
+
+```typescript
+                      apiVersion: agent.workloadType === 'statefulset' ? 'apps/v1' : agent.workloadType === 'job' ? 'batch/v1' : 'apps/v1',
+                      kind: agent.workloadType === 'statefulset' ? 'StatefulSet' : agent.workloadType === 'job' ? 'Job' : 'Deployment',
+```
+
+Change to:
+
+```typescript
+                      apiVersion: agent.workloadType === 'sandbox' ? 'agents.x-k8s.io/v1alpha1' : agent.workloadType === 'statefulset' ? 'apps/v1' : agent.workloadType === 'job' ? 'batch/v1' : 'apps/v1',
+                      kind: agent.workloadType === 'sandbox' ? 'Sandbox' : agent.workloadType === 'statefulset' ? 'StatefulSet' : agent.workloadType === 'job' ? 'Job' : 'Deployment',
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kagenti/ui-v2/src/pages/AgentCatalogPage.tsx kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+git commit -s -m "feat: add Sandbox display to agent catalog and detail pages (epic 1155 step 1.8c)"
+```
+
+---
+
+### Task 12: E2E tests (epic 1.9)
+
+**Files:**
+- Create: `kagenti/tests/e2e/test_agent_sandbox.py`
+
+- [ ] **Step 1: Create E2E test file**
+
+Create `kagenti/tests/e2e/test_agent_sandbox.py`:
+
+```python
+"""
+E2E tests for agent-sandbox (Sandbox) workload type.
+
+Requires:
+- agent-sandbox controller installed in the cluster
+- KAGENTI_FEATURE_FLAG_AGENT_SANDBOX=true
+- Feature: agent_sandbox enabled in test config
+"""
+
+import logging
+
+import httpx
+import pytest
+from kubernetes.client import ApiException
+
+logger = logging.getLogger(__name__)
+
+SANDBOX_GROUP = "agents.x-k8s.io"
+SANDBOX_VERSION = "v1alpha1"
+SANDBOX_PLURAL = "sandboxes"
+TEST_NAMESPACE = "team1"
+TEST_AGENT_NAME = "sandbox-e2e-test"
+TEST_IMAGE = "ghcr.io/kagenti/examples/echo-agent:v0.0.1"
+
+
+@pytest.mark.requires_features(["agent_sandbox"])
+class TestAgentSandboxWorkloadType:
+    """Test Sandbox as a fourth workload type in Kagenti."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, http_client):
+        self.client = http_client
+
+    async def _get_auth_token(self) -> str:
+        """Get auth token from Keycloak (reuses existing conftest patterns)."""
+        # This will be populated based on the cluster's auth setup
+        # For Kind clusters without auth, return empty string
+        return ""
+
+    async def _api_headers(self) -> dict:
+        """Build API request headers."""
+        token = await self._get_auth_token()
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    @pytest.mark.asyncio
+    async def test_feature_flag_exposed(self):
+        """Verify agentSandbox flag is returned by /api/v1/config/features."""
+        headers = await self._api_headers()
+        resp = await self.client.get(
+            "http://localhost:8080/api/v1/config/features",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "agentSandbox" in data
+
+    @pytest.mark.asyncio
+    async def test_create_sandbox_agent(self):
+        """Create an agent with workloadType=sandbox."""
+        headers = await self._api_headers()
+        payload = {
+            "name": TEST_AGENT_NAME,
+            "namespace": TEST_NAMESPACE,
+            "protocol": "a2a",
+            "framework": "LangGraph",
+            "workloadType": "sandbox",
+            "deploymentMethod": "image",
+            "containerImage": TEST_IMAGE,
+            "authBridgeEnabled": True,
+        }
+        resp = await self.client.post(
+            "http://localhost:8080/api/v1/agents/create",
+            json=payload,
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_includes_sandbox_agent(self):
+        """Verify the sandbox agent appears in the agent list."""
+        headers = await self._api_headers()
+        resp = await self.client.get(
+            f"http://localhost:8080/api/v1/agents/{TEST_NAMESPACE}",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [a["name"] for a in data["items"]]
+        assert TEST_AGENT_NAME in names
+        sandbox_agent = next(a for a in data["items"] if a["name"] == TEST_AGENT_NAME)
+        assert sandbox_agent["workloadType"] == "sandbox"
+
+    @pytest.mark.asyncio
+    async def test_get_sandbox_agent_detail(self):
+        """Verify get agent returns Sandbox details."""
+        headers = await self._api_headers()
+        resp = await self.client.get(
+            f"http://localhost:8080/api/v1/agents/{TEST_NAMESPACE}/{TEST_AGENT_NAME}",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["workloadType"] == "sandbox"
+        assert data["metadata"]["labels"]["kagenti.io/type"] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_delete_sandbox_agent(self):
+        """Delete the sandbox agent and verify cleanup."""
+        headers = await self._api_headers()
+        resp = await self.client.delete(
+            f"http://localhost:8080/api/v1/agents/{TEST_NAMESPACE}/{TEST_AGENT_NAME}",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert "Sandbox" in data["message"]
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add kagenti/tests/e2e/test_agent_sandbox.py
+git commit -s -m "feat: add E2E tests for Sandbox workload type (epic 1155 step 1.9)"
+```
+
+---
+
+## Epic coverage matrix
+
+| Epic step | Task | Status |
+|-----------|------|--------|
+| 1.1 Feature flag + constants | Task 1, Task 8 | Covered |
+| 1.2 KubernetesService CRUD | Task 2 | Covered |
+| 1.3 Manifest builder | Task 3 | Covered |
+| 1.4 Router integration | Task 4, Task 5 | Covered |
+| 1.5 Reconciliation | Task 6 | Covered |
+| 1.6 Operator compatibility | N/A (verification only, no code changes — webhook injection works via labels) | Covered by design |
+| 1.7 CRD detection | Task 7 | Covered |
+| 1.8 UI changes | Task 9, Task 10, Task 11 | Covered |
+| 1.9 E2E tests | Task 12 | Covered |

--- a/docs/superpowers/specs/2026-04-21-agent-sandbox-workload-type-design.md
+++ b/docs/superpowers/specs/2026-04-21-agent-sandbox-workload-type-design.md
@@ -1,0 +1,189 @@
+# Agent-Sandbox as Fourth Workload Type — Design Spec
+
+**Epic:** [#1155](https://github.com/kagenti/kagenti/issues/1155)
+**Scope:** Phase 1 only (Sandbox CRD as a workload type, imperative creation)
+**Feature flag:** `kagenti_feature_flag_agent_sandbox` (new, separate from existing `sandbox` flag)
+
+## Problem
+
+Kagenti supports three workload types (Deployment, StatefulSet, Job) for agent deployment. The kubernetes-sigs/agent-sandbox project provides a Kubernetes-native abstraction purpose-built for AI agent runtimes — offering stable identity, persistent storage, lifecycle management (pause/resume/expire), and optional VM-level isolation. Adding Sandbox as a fourth workload type gives users access to these capabilities through the existing Kagenti UI.
+
+## Architecture
+
+The backend creates `Sandbox` CRs directly via the Kubernetes API (same imperative pattern as Deployment/StatefulSet/Job). The agent-sandbox controller is an **external prerequisite** — not bundled in the Kagenti Helm chart. The feature flag gates all Sandbox-related code paths so clusters without agent-sandbox installed continue to work unchanged.
+
+The kagenti-webhook already injects AuthBridge sidecars at Pod CREATE time based on `kagenti.io/type: agent` labels. Since the Sandbox controller creates Pods from the Sandbox `podTemplate`, webhook injection works automatically — no webhook changes needed.
+
+### CRD coordinates
+
+- **Group:** `agents.x-k8s.io`
+- **Version:** `v1alpha1`
+- **Plural:** `sandboxes`
+- **Kind:** `Sandbox`
+
+## Components Changed
+
+### 1. Feature flag + constants
+
+**`kagenti/backend/app/core/config.py`**
+- Add `kagenti_feature_flag_agent_sandbox: bool = False`
+
+**`kagenti/backend/app/core/constants.py`**
+- Add `WORKLOAD_TYPE_SANDBOX = "sandbox"`
+- Add to `SUPPORTED_WORKLOAD_TYPES` list (conditionally, when flag is enabled)
+- Add agent-sandbox CRD constants: `AGENT_SANDBOX_CRD_GROUP`, `AGENT_SANDBOX_CRD_VERSION`, `AGENT_SANDBOX_PLURAL`
+
+**`kagenti/backend/app/routers/config.py`**
+- Add `agentSandbox: bool` to `FeatureFlagsResponse`
+
+### 2. KubernetesService — Sandbox CRUD
+
+**`kagenti/backend/app/services/kubernetes.py`**
+- Add `create_sandbox(namespace, body)` — uses `custom_api.create_namespaced_custom_object`
+- Add `get_sandbox(namespace, name)` — uses `custom_api.get_namespaced_custom_object`
+- Add `list_sandboxes(namespace, label_selector)` — uses `custom_api.list_namespaced_custom_object`
+- Add `delete_sandbox(namespace, name)` — uses `custom_api.delete_namespaced_custom_object`
+- Add `patch_sandbox(namespace, name, body)` — uses `custom_api.patch_namespaced_custom_object`
+
+All methods use the existing `custom_api` property (no new API client needed).
+
+### 3. Manifest builder
+
+**`kagenti/backend/app/routers/agents.py`**
+
+New function `_build_sandbox_manifest(request, image)` returns a Sandbox CR dict:
+
+```yaml
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: <request.name>
+  namespace: <request.namespace>
+  labels:
+    kagenti.io/type: agent          # triggers webhook injection
+    kagenti.io/workload-type: sandbox
+    app.kubernetes.io/name: <name>
+    app.kubernetes.io/managed-by: kagenti-ui
+    # ... standard kagenti labels
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        kagenti.io/type: agent      # required for webhook pod matching
+    spec:
+      serviceAccountName: <name>
+      containers:
+      - name: agent
+        image: <image>
+        ports:
+        - containerPort: 8000
+        env: [...]                  # same env vars as Deployment
+        resources: {limits, requests}
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+```
+
+Optional fields (when provided in request):
+- `runtimeClassName` for Kata/gVisor isolation
+- `volumeClaimTemplates` for persistent `/workspace`
+
+### 4. Router integration (agents.py)
+
+12 switch points in `agents.py` need Sandbox branches, all guarded by feature flag check:
+
+| Endpoint | Change |
+|----------|--------|
+| `CreateAgentRequest.validate_workload_type` | Accept "sandbox" when flag enabled |
+| `list_agents` | Add fourth query: `kube.list_sandboxes()` |
+| `get_agent` | Add fourth try: `kube.get_sandbox()` |
+| `create_agent` (image deploy) | Add `elif WORKLOAD_TYPE_SANDBOX` branch |
+| `create_agent` (source deploy) | Add Sandbox path in `finalize_shipwright_build` |
+| `delete_agent` | Add Sandbox deletion |
+| Service creation | Sandbox manages its own headless Service — skip `_build_service_manifest` |
+| HTTPRoute | Support creating routes for Sandbox agents |
+
+**Validation gating:** The `validate_workload_type` validator on `CreateAgentRequest` checks against `SUPPORTED_WORKLOAD_TYPES`. The Sandbox type must only be accepted when the feature flag is enabled. Options:
+- **Option A:** Make `SUPPORTED_WORKLOAD_TYPES` dynamic (read flag at import time) — simple but requires restart to change
+- **Option B:** Override validation in the endpoint to check the flag — more explicit
+
+**Choice:** Option A. Feature flags already require restart to change (they're read from env vars at startup). `SUPPORTED_WORKLOAD_TYPES` will conditionally include `"sandbox"` based on `settings.kagenti_feature_flag_agent_sandbox`.
+
+### 5. Status extraction
+
+Sandbox status differs from Deployment/StatefulSet/Job. The Sandbox CR has:
+- `.status.conditions` — array of conditions (Ready, PodReady, etc.)
+- `.status.serviceFQDN` — auto-created headless Service FQDN
+
+New helper functions:
+- `_get_sandbox_description(sandbox)` — extract description from annotations
+- `_is_sandbox_ready(sandbox)` — check conditions for Ready=True
+- `_get_sandbox_status(sandbox)` — return status string
+
+### 6. Reconciliation
+
+**`kagenti/backend/app/services/reconciliation.py`**
+- Update `_workload_exists()` to check Sandbox CRs (fourth try after Job)
+
+### 7. CRD detection + graceful degradation
+
+At startup (in `main.py` lifespan), check if the `sandboxes.agents.x-k8s.io` CRD is installed:
+- If flag enabled AND CRD exists: enable Sandbox workload type
+- If flag enabled AND CRD missing: log warning, set `SUPPORTED_WORKLOAD_TYPES` to exclude sandbox
+- If flag disabled: no detection needed
+
+### 8. UI changes
+
+**`kagenti/ui-v2/src/types/index.ts`**
+- Add `'sandbox'` to `WorkloadType` union
+
+**`kagenti/ui-v2/src/hooks/useFeatureFlags.ts`**
+- Add `agentSandbox: boolean` to `FeatureFlags` interface
+
+**`kagenti/ui-v2/src/pages/ImportAgentPage.tsx`**
+- Add "Sandbox" option to workload type dropdown (shown when `agentSandbox` flag is true)
+- Description: "For agents requiring stable identity, persistent storage, and lifecycle management (pause/resume). Requires agent-sandbox controller."
+
+**`kagenti/ui-v2/src/pages/AgentDetailPage.tsx`**
+- Handle `workloadType === 'sandbox'` in status display
+- Show Sandbox-specific fields (serviceFQDN, conditions)
+
+**`kagenti/ui-v2/src/pages/AgentCatalogPage.tsx`**
+- Render sandbox workload type badge (purple label)
+
+**`kagenti/ui-v2/src/services/api.ts`**
+- Add `'sandbox'` to workload type unions in API interfaces
+
+### 9. Helm chart
+
+**`charts/kagenti/values.yaml`**
+- Add `featureFlags.agentSandbox: false`
+
+**`charts/kagenti/templates/backend-deployment.yaml`** (or equivalent)
+- Wire `KAGENTI_FEATURE_FLAG_AGENT_SANDBOX` env var from values
+
+### 10. E2E tests
+
+**`kagenti/tests/e2e/test_agent_sandbox.py`**
+- Marker: `@pytest.mark.requires_features(["agent_sandbox"])`
+- Tests: create, list, get, delete agent with `workloadType=sandbox`
+- Verify: pod running, kagenti labels present, AuthBridge sidecars injected (if webhook installed)
+
+CI installs agent-sandbox controller in Kind cluster before running these tests.
+
+## What is NOT in scope (Phase 2)
+
+- SandboxTemplate / SandboxClaim / WarmPool management
+- Template/Claim separation (admin vs user)
+- Warm pool pre-warming and utilization metrics
+- AgentRuntime CR alignment (#862)
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Feature flag | New `agent_sandbox`, not reusing `sandbox` | Existing `sandbox` controls interactive session UI |
+| CRD detection | Startup check | Fail-fast with clear log message |
+| Service creation | Skip for Sandbox | Sandbox controller auto-creates headless Service |
+| Workload type validation | Conditional at import time | Matches existing startup-time flag pattern |
+| Deployment model | External prerequisite | Loose coupling; admin controls agent-sandbox version |

--- a/docs/superpowers/specs/2026-04-30-adr-sandbox-direct-vs-claim.md
+++ b/docs/superpowers/specs/2026-04-30-adr-sandbox-direct-vs-claim.md
@@ -1,0 +1,214 @@
+# ADR: Direct Sandbox Creation vs SandboxTemplate + SandboxClaim
+
+**Status:** Proposed
+**Date:** 2026-04-30
+**Epic:** [#1155](https://github.com/kagenti/kagenti/issues/1155)
+**Context:** [Agent-Sandbox Upstream Issues](2026-04-30-agent-sandbox-upstream-issues.md),
+[Workload Type Design Spec](2026-04-21-agent-sandbox-workload-type-design.md)
+
+## Decision
+
+The kagenti backend should create `Sandbox` CRs directly, bypassing
+`SandboxTemplate` and `SandboxClaim`. This applies to both Phase 1 and the
+default path going forward, with SandboxClaim support deferred to a future
+phase if demand materializes.
+
+## Context
+
+The agent-sandbox project has three CRD layers:
+
+```
+SandboxTemplate          (extensions.agents.x-k8s.io/v1alpha1)
+    └── SandboxClaim     (extensions.agents.x-k8s.io/v1alpha1)
+        └── Sandbox      (agents.x-k8s.io/v1alpha1)
+            ├── Pod
+            ├── Service  (headless)
+            └── PVCs     (from volumeClaimTemplates)
+```
+
+The **core layer** (Sandbox) is self-contained: it manages pods, services, PVCs,
+scaling, and expiry. The **extensions layer** (SandboxTemplate + SandboxClaim)
+adds network policy management, warm pool adoption, env var injection policies,
+and secure defaults.
+
+The question is whether kagenti should target the Sandbox API directly or go
+through the claim-based abstraction.
+
+## Options Evaluated
+
+### Option A: Direct Sandbox Creation (Recommended)
+
+The backend builds a `Sandbox` CR manifest (same pattern as Deployment /
+StatefulSet) and creates it via the Kubernetes API. No SandboxTemplate or
+SandboxClaim objects are created.
+
+### Option B: SandboxTemplate + SandboxClaim (Current epic scope)
+
+The backend creates a SandboxTemplate per agent template, then a SandboxClaim
+per agent instance. The SandboxClaim controller creates the Sandbox.
+
+### Option C: Hybrid (SandboxClaim for creation, operator manages Sandbox)
+
+Use SandboxClaim to create Sandboxes (getting secure defaults and network
+policy), but have the operator reconcile against the resulting Sandbox CR.
+
+## Analysis
+
+### What Sandbox alone provides
+
+| Capability | Direct Sandbox |
+|---|---|
+| Pod lifecycle (create, delete, scale 0/1) | Yes |
+| Headless Service (auto-created, same name) | Yes |
+| PVC lifecycle (`volumeClaimTemplates`) | **Yes** — fully handled by Sandbox controller |
+| Shutdown/expiry (`shutdownTime`, `shutdownPolicy`) | Yes |
+| Replicas (0 or 1, with scale subresource) | Yes |
+
+**Storage is fully available without the claim layer.** The Sandbox controller
+creates PVCs from `spec.volumeClaimTemplates`, names them
+`<template>-<sandbox>`, sets owner references for garbage collection, and
+mounts them into the pod. Neither SandboxTemplate nor SandboxClaim participate
+in PVC management. In fact, the SandboxClaim controller only copies
+`podTemplate` from the SandboxTemplate — it does not propagate
+`volumeClaimTemplates`.
+
+### What SandboxTemplate + SandboxClaim adds
+
+| Capability | Kagenti equivalent | Gap? |
+|---|---|---|
+| **NetworkPolicy (secure defaults)** — ingress from sandbox-router only, egress to public internet, blocks RFC1918/metadata server, overrides DNS to 8.8.8.8 | Istio ambient mesh (mTLS between all pods), AuthBridge envoy-proxy (OAuth2 enforcement on every request), per-namespace network policies | **No gap.** Kagenti's mesh-level isolation is stronger than the template-scoped NetworkPolicy. |
+| **Warm pool adoption** — pre-provisioned pods for fast cold-start | Not implemented | **Gap, but not needed for Phase 1.** Cold-start is acceptable for initial release. |
+| **Env var injection policy** — template controls whether claims can inject/override env vars | Backend controls env vars directly, webhook injects sidecar config | **No gap.** Simpler model — the backend is the single source of truth. |
+| **Secure defaults** — `automountServiceAccountToken: false`, DNS override to public resolvers | Backend sets `automountServiceAccountToken: false` in manifest builder. DNS handled by mesh. | **No gap.** Backend applies these directly. |
+| **Ownership cascade** — Claim → Sandbox → Pod/Service/PVC | Backend manages lifecycle. Sandbox → Pod/Service/PVC cascade still works. | **No gap.** The Sandbox-level cascade is sufficient. |
+| **Additional pod metadata validation** — blocks restricted label domains on claims | Backend controls all labels. Webhook validates at pod CREATE time. | **No gap.** |
+
+### Operator compatibility
+
+This is the decisive factor. The kagenti-operator's AgentRuntime controller
+reconciles against the **workload object** specified in `spec.targetRef`. With
+the claim-based flow:
+
+```
+AgentRuntime (targetRef: Sandbox) ──reconciles──▶ Sandbox
+                                                     ▲
+                                          owned by   │
+                                                     │
+                                              SandboxClaim
+```
+
+The operator writes labels, annotations, and config-hash to the Sandbox's
+`spec.podTemplate`. The SandboxClaim controller also writes to the Sandbox
+(claim-uid label, template-ref-hash label, pod-name annotation during warm pool
+adoption). This creates **three concurrent writers** on the same object:
+
+1. **kagenti-operator** — writes config-hash, kagenti labels
+2. **Sandbox controller** — writes pod-name annotation, reconciles pod metadata
+3. **SandboxClaim controller** — writes claim-uid, template-ref-hash, pod-name (adoption)
+
+The `agents.x-k8s.io/pod-name` annotation race condition
+([documented here](2026-04-30-agent-sandbox-upstream-issues.md#issue-2-sandbox-controller-stuck-loop-after-pod-deletion))
+is already problematic with two writers. Adding a third writer (SandboxClaim)
+widens the race window.
+
+With direct Sandbox creation:
+
+```
+AgentRuntime (targetRef: Sandbox) ──reconciles──▶ Sandbox
+```
+
+Only two writers (operator + Sandbox controller). The race window is narrower
+and the ownership model is unambiguous — the backend creates the Sandbox, the
+operator configures it.
+
+### Pod rollout problem
+
+Neither approach fixes the upstream pod rollout issue
+([kubernetes-sigs/agent-sandbox#581](https://github.com/kubernetes-sigs/agent-sandbox/issues/581)).
+The Sandbox controller does not recreate pods when `spec.podTemplate` changes,
+regardless of whether the Sandbox was created by a SandboxClaim or directly.
+
+The operator's scale 0→1 workaround works the same way in both approaches. The
+claim layer adds no value for rollout handling.
+
+### Complexity comparison
+
+| Aspect | Direct Sandbox | SandboxClaim |
+|---|---|---|
+| CRDs the backend must manage | 1 (Sandbox) | 3 (SandboxTemplate, SandboxClaim, Sandbox) |
+| Objects created per agent | 1 | 2-3 |
+| Operator targetRef target | Sandbox (direct) | Sandbox (indirect, owned by claim) |
+| Concurrent writers on Sandbox | 2 | 3 |
+| Backend code | Mirror Deployment pattern | New claim lifecycle code |
+| Cleanup on delete | Delete Sandbox (cascades) | Delete SandboxClaim (cascades) |
+| `volumeClaimTemplates` | Set directly on Sandbox | **Not propagated** by SandboxClaim controller |
+| Feature-flag scope | Sandbox CRD only | Sandbox CRD + extensions CRDs |
+
+## Decision Rationale
+
+1. **Every capability SandboxTemplate/SandboxClaim provides is already covered
+   by kagenti's platform layer** (Istio ambient, AuthBridge, webhook injection,
+   operator config management). The claim layer would be redundant
+   infrastructure.
+
+2. **Storage lifecycle (`volumeClaimTemplates`) works better with direct
+   creation.** The SandboxClaim controller does not propagate volume claim
+   templates from the SandboxTemplate — it only copies `podTemplate`. Direct
+   Sandbox creation gives the backend full control over PVC configuration.
+
+3. **Fewer concurrent writers reduces the pod-name annotation race window.**
+   The operator's restart mechanism (scale 0→1 with annotation clearing)
+   competes with the Sandbox controller. Adding the SandboxClaim controller as
+   a third writer makes the race harder to reason about and harder to fix.
+
+4. **Simpler operational model.** One CRD type to manage, one object per agent,
+   clear ownership. The backend creates it, the operator configures it, the
+   Sandbox controller runs it.
+
+5. **Warm pool is the only genuinely lost capability**, and it is explicitly
+   out of scope for Phase 1. If warm pool support is needed later, it can be
+   added as an optional optimization — the backend creates a SandboxClaim
+   instead of a Sandbox when a warm pool is configured.
+
+## Consequences
+
+### Positive
+
+- Backend code follows the established Deployment/StatefulSet pattern — no new
+  abstraction layer to learn or maintain.
+- Operator has a clean reconciliation target with predictable ownership.
+- Full control over `volumeClaimTemplates` for persistent agent storage.
+- Fewer moving parts to debug when things go wrong (one controller, not three).
+- No dependency on the extensions CRDs — clusters only need the core Sandbox
+  CRD installed.
+
+### Negative
+
+- No shared NetworkPolicy per template. Kagenti's mesh provides equivalent
+  isolation, but clusters without Istio would need to manage NetworkPolicies
+  separately.
+- No warm pool adoption. Cold-start time for Sandbox agents equals pod creation
+  time (typically 5-15s with sidecar injection). This is acceptable for Phase 1
+  but may need revisiting for latency-sensitive use cases.
+- The backend must explicitly set secure defaults (`automountServiceAccountToken:
+  false`, resource limits, non-root security context) that the SandboxClaim
+  path would apply automatically. The current manifest builder already does
+  this.
+
+### Migration path
+
+If SandboxClaim support is needed later:
+
+1. Add a "pool" field to the agent creation request.
+2. When a pool is specified, create a SandboxClaim instead of a Sandbox.
+3. The operator's `targetRef` still points to the resulting Sandbox CR — no
+   operator changes needed.
+4. The direct creation path remains the default for agents without a pool.
+
+## References
+
+- [Agent-Sandbox Upstream Issues](2026-04-30-agent-sandbox-upstream-issues.md)
+- [Agent-Sandbox Workload Type Design](2026-04-21-agent-sandbox-workload-type-design.md)
+- [kubernetes-sigs/agent-sandbox#581](https://github.com/kubernetes-sigs/agent-sandbox/issues/581) — Pod rollout
+- [kagenti-operator#316](https://github.com/kagenti/kagenti-operator/pull/316) — Operator Sandbox support PR
+- [Epic #1155](https://github.com/kagenti/kagenti/issues/1155) — Sandbox workload type

--- a/docs/superpowers/specs/2026-04-30-agent-sandbox-upstream-issues.md
+++ b/docs/superpowers/specs/2026-04-30-agent-sandbox-upstream-issues.md
@@ -1,0 +1,261 @@
+# Agent-Sandbox Upstream Issues — Operator Integration Findings
+
+**Epic:** [#1155](https://github.com/kagenti/kagenti/issues/1155)
+**Component:** kagenti-operator AgentRuntime controller + agents.x-k8s.io Sandbox controller
+**Discovered:** 2026-04-29, during live testing of operator PR [kagenti-operator#316](https://github.com/kagenti/kagenti-operator/pull/316)
+
+## Context
+
+The kagenti-operator's AgentRuntime controller manages workload configuration (labels,
+annotations, config-hash) for Deployment, StatefulSet, and now Sandbox targets. When
+configuration changes (e.g., a namespace-level ConfigMap is updated), the operator
+recomputes a config-hash and applies it to the workload's pod template. For Deployments
+and StatefulSets, the annotation change triggers a rolling update automatically. Sandbox
+has no such mechanism.
+
+## Issue 1: Sandbox Pods Do Not Roll Out on PodTemplate Changes
+
+**Upstream issue:** [kubernetes-sigs/agent-sandbox#581](https://github.com/kubernetes-sigs/agent-sandbox/issues/581)
+
+### Behavior
+
+When the kagenti-operator updates `spec.podTemplate.metadata.annotations` on a Sandbox
+CR (e.g., writing a new `kagenti.io/config-hash`), the Sandbox controller does not
+terminate and recreate the running pod. The existing pod continues running with stale
+configuration indefinitely.
+
+This differs from Deployment and StatefulSet, where a change to
+`spec.template.metadata.annotations` triggers a rolling update.
+
+### Root cause
+
+The Sandbox controller's `reconcilePod` method (`sandbox_controller.go:480`) checks
+whether a pod exists by reading the `agents.x-k8s.io/pod-name` annotation. If the named
+pod exists and is running, the controller considers reconciliation complete — it does not
+compare the pod's spec against the current `spec.podTemplate`.
+
+### Impact
+
+Any configuration change that the kagenti-operator applies to the Sandbox (new config-hash
+from ConfigMap changes, label updates, annotation changes) has no effect on the running
+pod until the pod is externally deleted or the Sandbox is scaled down and back up.
+
+### Our workaround
+
+The operator's `restartSandbox` method performs an explicit scale 0 → 1 cycle:
+
+1. Patch `spec.replicas` to 0 (with `retry.RetryOnConflict`)
+2. Clear the `agents.x-k8s.io/pod-name` annotation (see Issue 2)
+3. Patch `spec.replicas` to 1 (with `retry.RetryOnConflict`)
+
+This forces the Sandbox controller to delete the existing pod and create a new one from
+the updated `spec.podTemplate`.
+
+---
+
+## Issue 2: Sandbox Controller Stuck Loop After Pod Deletion
+
+### Behavior
+
+After the operator scales a Sandbox to 0 replicas (deleting the pod) and then scales back
+to 1, the Sandbox controller enters a persistent error loop:
+
+```
+error: "pod in annotation get failed: Pod \"weather-service-1000\" not found"
+```
+
+The controller retries with exponential backoff (1s, 2s, 4s, 10s, 20s, 40s...) and does
+**not** self-recover. The error loop continues indefinitely until the stale
+`agents.x-k8s.io/pod-name` annotation is manually cleared.
+
+### Root cause
+
+The Sandbox controller tracks its adopted pod via the `agents.x-k8s.io/pod-name`
+annotation on the Sandbox CR. When reconciling, the controller:
+
+1. Reads `agents.x-k8s.io/pod-name` from the Sandbox metadata
+2. Attempts `GET pod/<name>` in the same namespace
+3. If the pod is not found, returns an error — **it does not clear the annotation or
+   attempt to create a new pod**
+
+The controller assumes the annotation always points to a valid pod. There is no fallback
+path for the case where the annotated pod has been deleted externally (by a scale-down,
+manual deletion, or eviction).
+
+### Reproduction
+
+```bash
+# Start with a healthy Sandbox (replicas=1, pod running)
+kubectl get sandbox weather-service-1000 -n team1
+# Pod is "weather-service-1000", annotation is set
+
+# Scale to 0 — pod is deleted
+kubectl patch sandbox weather-service-1000 -n team1 \
+  --type merge -p '{"spec":{"replicas":0}}'
+
+# Scale back to 1 — controller should create a new pod
+kubectl patch sandbox weather-service-1000 -n team1 \
+  --type merge -p '{"spec":{"replicas":1}}'
+
+# Controller logs show repeated errors:
+# "pod in annotation get failed: Pod \"weather-service-1000\" not found"
+# No new pod is created.
+
+# Fix: clear the stale annotation
+kubectl annotate sandbox weather-service-1000 -n team1 \
+  agents.x-k8s.io/pod-name-
+
+# Controller immediately creates a new pod.
+```
+
+### Race condition with our workaround
+
+Our `restartSandbox` method attempts to clear the `agents.x-k8s.io/pod-name` annotation
+between the scale-down and scale-up operations. However, the Sandbox controller runs
+concurrently and may re-read the annotation from its informer cache or re-set it during
+its own reconciliation loop before our clear takes effect.
+
+The observed sequence:
+
+```
+T0: Operator patches replicas=0
+T1: Sandbox controller deletes the pod, starts reconciling
+T2: Operator clears agents.x-k8s.io/pod-name annotation
+T3: Sandbox controller's concurrent reconcile re-reads the Sandbox object,
+    sees replicas=0, does nothing — but the informer-cached version still
+    has the annotation
+T4: Operator patches replicas=1
+T5: Sandbox controller reconciles, reads the stale annotation from its
+    own update (or from T3's cached read), tries GET pod → fails
+T6: Error loop begins
+```
+
+Even with `retry.RetryOnConflict`, our annotation-clearing update may succeed on the API
+server but lose the race to the Sandbox controller's next write.
+
+### Impact
+
+The Sandbox pod is not recreated after a config-driven restart. The AgentRuntime shows
+`Active` with `configuredPods: 1` (because the Sandbox's `spec.replicas` is 1), but no
+actual pod exists. The Sandbox controller logs errors continuously.
+
+Manual intervention (clearing the annotation) resolves the issue immediately — the
+controller then creates a fresh pod within seconds.
+
+### Possible upstream fixes
+
+1. **Annotation-clearing on pod-not-found:** When the controller sees that the annotated
+   pod doesn't exist, it should clear the annotation and fall through to the pod creation
+   path rather than returning an error.
+
+2. **Owner reference based discovery:** Instead of (or in addition to) the annotation, the
+   controller could discover its pod via `ownerReferences`, which is already set on pods
+   created by the Sandbox controller. This is resilient to annotation races.
+
+3. **Pod template drift detection:** The controller should compare the running pod's
+   labels/annotations against `spec.podTemplate` and recreate when they diverge. This
+   would fix Issue 1 entirely.
+
+### Possible kagenti-operator workarounds
+
+1. **Poll-and-clear loop:** After scale-down, poll the Sandbox annotation in a loop and
+   keep clearing it until the pod-name annotation is absent for a stable period, then
+   scale up. Adds complexity and latency but is deterministic.
+
+2. **Two-phase restart across reconcile cycles:** On config-hash change, scale to 0 in the
+   current reconcile. On the next reconcile (triggered by the Sandbox watch), detect
+   `replicas=0` with a "restart pending" annotation, clear the pod-name annotation, and
+   scale to 1. This separates the scale-down and annotation-clear into different
+   reconciliation windows, reducing the race window.
+
+3. **Accept transient delay:** Keep the current implementation. In clusters where the
+   Sandbox controller eventually backs off enough (the retry intervals grow: 1s, 2s, 4s,
+   10s, 20s, 40s), the operator's annotation clear may win a subsequent retry. Testing
+   showed this does **not** reliably self-heal — the controller re-reads its own stale
+   state on each retry.
+
+**Current recommendation:** Option 2 (two-phase restart) is the most robust within the
+operator's control. It should be filed as a follow-up after the initial PR merges with the
+current implementation and a documented known limitation.
+
+## Issue 3: SandboxClaim Controller Overwrites Operator Config on Sandbox
+
+### Behavior
+
+When a `SandboxClaim` exists for a Sandbox, the SandboxClaim controller copies the
+entire `spec.podTemplate` from the `SandboxTemplate` to the `Sandbox` on every
+reconciliation. Any annotations or labels the kagenti-operator writes to
+`spec.podTemplate.metadata` (e.g., `kagenti.io/config-hash`) are overwritten within
+seconds, triggering a continuous reconcile loop:
+
+```
+Operator writes config-hash → SandboxClaim controller detects change →
+  copies podTemplate from template (wiping config-hash) →
+  Operator detects config-hash missing → writes it again → loop
+```
+
+### Root cause
+
+This is **designed behavior**, not a bug. The SandboxClaim controller's purpose is to
+keep the Sandbox's `spec.podTemplate` in sync with the SandboxTemplate. It performs a
+full replacement of `podTemplate`, not a merge. Any fields added by external controllers
+are lost on each reconciliation cycle.
+
+### Impact
+
+The kagenti-operator cannot persist any configuration on `spec.podTemplate` when a
+SandboxClaim owns the Sandbox. This means:
+
+1. `kagenti.io/config-hash` annotation is repeatedly wiped — the operator loops forever
+   trying to reapply it.
+2. Any kagenti-managed labels on `spec.podTemplate.metadata.labels` are wiped.
+3. The two-phase restart mechanism cannot function because Phase 1 (scale to 0) triggers
+   SandboxClaim reconciliation which may reset `spec.replicas` or other fields.
+
+### Reproduction
+
+```bash
+# Create AgentRuntime pointing to a Sandbox owned by a SandboxClaim
+# Observe operator logs: continuous "Applying config to workload" messages
+kubectl logs deployment/kagenti-controller-manager -n kagenti-system --tail=20
+# Verify config-hash is never persisted:
+kubectl get sandbox weather-service-5000 -n team1 \
+  -o jsonpath='{.spec.podTemplate.metadata.annotations}'
+# Returns null — annotation is wiped every time
+```
+
+### Possible workarounds
+
+1. **Store config-hash on Sandbox CR `metadata.annotations`** (not podTemplate) — the
+   SandboxClaim controller doesn't overwrite CR-level metadata. However, any labels or
+   annotations the operator needs on the actual *pod* must go through `spec.podTemplate`,
+   which is still overwritten.
+
+2. **Write operator config to the SandboxTemplate** — changes propagate down through the
+   claim. But config-hash is per-instance (computed from namespace-specific ConfigMaps),
+   not per-template. This would require one SandboxTemplate per agent instance, defeating
+   the template's purpose.
+
+3. **Upstream change**: Modify the SandboxClaim controller to merge `podTemplate` fields
+   instead of replacing them. This is an upstream behavioral change we don't control.
+
+### Resolution
+
+**Bypass SandboxClaim entirely.** The kagenti backend creates `Sandbox` CRs directly
+(no SandboxTemplate, no SandboxClaim). This eliminates the third writer and gives the
+operator full control over `spec.podTemplate`. See
+[ADR: Direct Sandbox Creation vs SandboxClaim](2026-04-30-adr-sandbox-direct-vs-claim.md).
+
+Verified on live cluster: after removing the SandboxClaim (and its ownerReference on the
+Sandbox), the operator's config-hash persists cleanly and the two-phase restart works
+end-to-end without reconcile loops.
+
+---
+
+## Test Environment
+
+- Kind cluster, single node
+- agent-sandbox controller: `v0.3.10` (controller-runtime v0.23.3), upgraded to
+  local build with commit `9c6264c` (Issue 2 self-healing fix)
+- kagenti-operator: branch `feat/sandbox-workload-support` (two-phase restart)
+- Sandbox CRD: `agents.x-k8s.io/v1alpha1`

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -76,11 +76,6 @@ AGENT_SANDBOX_CRD_GROUP = "agents.x-k8s.io"
 AGENT_SANDBOX_CRD_VERSION = "v1alpha1"
 AGENT_SANDBOX_PLURAL = "sandboxes"
 
-# agent-sandbox extensions (SandboxTemplate, SandboxClaim)
-AGENT_SANDBOX_EXT_GROUP = "extensions.agents.x-k8s.io"
-AGENT_SANDBOX_EXT_VERSION = "v1alpha1"
-AGENT_SANDBOX_TEMPLATE_PLURAL = "sandboxtemplates"
-AGENT_SANDBOX_CLAIM_PLURAL = "sandboxclaims"
 
 # Supported workload types (sandbox added conditionally at startup)
 _BASE_WORKLOAD_TYPES = (

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3036,7 +3036,6 @@ async def create_agent(
                 sandbox_manifest = _build_sandbox_manifest(
                     request=request,
                     image=request.containerImage,
-                    shipwright_build_name=shipwright_build_name,
                 )
                 kube.create_sandbox(
                     namespace=request.namespace,

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -63,8 +63,6 @@ from app.core.constants import (
     WORKLOAD_TYPE_SANDBOX,
     AGENT_SANDBOX_CRD_GROUP,
     AGENT_SANDBOX_CRD_VERSION,
-    AGENT_SANDBOX_EXT_GROUP,
-    AGENT_SANDBOX_EXT_VERSION,
     SUPPORTED_WORKLOAD_TYPES,
     # Migration constants (Phase 4)
     MIGRATION_SOURCE_ANNOTATION,
@@ -488,7 +486,7 @@ def _get_job_description(job: dict) -> str:
 
 
 def _is_sandbox_ready(sandbox: dict) -> str:
-    """Check if a Sandbox or SandboxClaim is ready by examining its status conditions."""
+    """Check if a Sandbox is ready by examining its status conditions."""
     status = sandbox.get("status", {})
     conditions = status.get("conditions", [])
     for cond in conditions:
@@ -500,7 +498,7 @@ def _is_sandbox_ready(sandbox: dict) -> str:
 
 
 def _get_sandbox_description(sandbox: dict) -> str:
-    """Extract description from a Sandbox or SandboxClaim resource."""
+    """Extract description from a Sandbox resource."""
     metadata = sandbox.get("metadata", {})
     annotations = metadata.get("annotations", {})
     return annotations.get(KAGENTI_DESCRIPTION_ANNOTATION, "No description")
@@ -656,19 +654,19 @@ async def list_agents(
                 )
             )
 
-        # Query SandboxClaims with agent label (feature-flagged)
+        # Query Sandboxes with agent label (feature-flagged)
         if settings.kagenti_feature_flag_agent_sandbox:
             try:
-                claims = kube.list_sandbox_claims(
+                sandboxes = kube.list_sandboxes(
                     namespace=namespace,
                     label_selector=label_selector,
                 )
-                for claim in claims:
-                    metadata = claim.get("metadata", {})
+                for sandbox in sandboxes:
+                    metadata = sandbox.get("metadata", {})
                     name = metadata.get("name", "")
                     if name in agent_names:
                         logger.warning(
-                            f"Duplicate agent name '{name}' detected: SandboxClaim skipped "
+                            f"Duplicate agent name '{name}' detected: Sandbox skipped "
                             f"because a workload with the same name already exists in "
                             f"namespace '{namespace}'. This may indicate a configuration issue."
                         )
@@ -680,8 +678,8 @@ async def list_agents(
                         AgentSummary(
                             name=name,
                             namespace=metadata.get("namespace", namespace),
-                            description=_get_sandbox_description(claim),
-                            status=_is_sandbox_ready(claim),
+                            description=_get_sandbox_description(sandbox),
+                            status=_is_sandbox_ready(sandbox),
                             labels=_extract_labels(labels),
                             workloadType=WORKLOAD_TYPE_SANDBOX,
                             createdAt=_format_timestamp(
@@ -692,11 +690,11 @@ async def list_agents(
                     )
             except ApiException as e:
                 if e.status == 404:
-                    logger.debug("SandboxClaim CRD not installed")
+                    logger.debug("Sandbox CRD not installed")
                 elif e.status == 403:
-                    logger.debug("SandboxClaim RBAC: insufficient permissions")
+                    logger.debug("Sandbox RBAC: insufficient permissions")
                 else:
-                    logger.warning(f"Failed to list SandboxClaims: {e.reason}")
+                    logger.warning(f"Failed to list Sandboxes: {e.reason}")
 
         # Backward compatibility: Also list legacy Agent CRDs (during migration period)
         if settings.enable_legacy_agent_crd:
@@ -800,10 +798,10 @@ async def get_agent(
             if e.status != 404:
                 raise HTTPException(status_code=e.status, detail=str(e.reason))
 
-    # If still not found, try SandboxClaim (feature-flagged)
+    # If still not found, try Sandbox (feature-flagged)
     if workload is None and settings.kagenti_feature_flag_agent_sandbox:
         try:
-            workload = kube.get_sandbox_claim(namespace=namespace, name=name)
+            workload = kube.get_sandbox(namespace=namespace, name=name)
             workload_type = WORKLOAD_TYPE_SANDBOX
         except ApiException as e:
             if e.status != 404:
@@ -935,24 +933,16 @@ async def delete_agent(
         else:
             logger.warning("Failed to delete Job '%s': %s", safe_name, e.reason)
 
-    # Delete the SandboxClaim + SandboxTemplate (if exists)
+    # Delete the Sandbox (if exists)
     if settings.kagenti_feature_flag_agent_sandbox:
         try:
-            kube.delete_sandbox_claim(namespace=namespace, name=name)
-            messages.append(f"SandboxClaim '{name}' deleted")
+            kube.delete_sandbox(namespace=namespace, name=name)
+            messages.append(f"Sandbox '{name}' deleted")
         except ApiException as e:
             if e.status == 404:
-                logger.debug("SandboxClaim '%s' not found (may be other workload type)", safe_name)
+                logger.debug("Sandbox '%s' not found (may be other workload type)", safe_name)
             else:
-                logger.warning("Failed to delete SandboxClaim '%s': %s", safe_name, e.reason)
-        try:
-            kube.delete_sandbox_template(namespace=namespace, name=name)
-            messages.append(f"SandboxTemplate '{name}' deleted")
-        except ApiException as e:
-            if e.status == 404:
-                logger.debug("SandboxTemplate '%s' not found", safe_name)
-            else:
-                logger.warning("Failed to delete SandboxTemplate '%s': %s", safe_name, e.reason)
+                logger.warning("Failed to delete Sandbox '%s': %s", safe_name, e.reason)
 
     # Delete the Service
     try:
@@ -2845,12 +2835,12 @@ def _build_job_manifest(
     return manifest
 
 
-def _build_sandbox_template_manifest(
+def _build_sandbox_manifest(
     request: "CreateAgentRequest",
     image: str,
     shipwright_build_name: Optional[str] = None,
 ) -> dict:
-    """Build a SandboxTemplate manifest (extensions.agents.x-k8s.io/v1alpha1)."""
+    """Build a Sandbox manifest (agents.x-k8s.io/v1alpha1) for direct creation."""
     env_vars = _build_env_vars(request)
     labels = _build_common_labels(request, WORKLOAD_TYPE_SANDBOX)
 
@@ -2865,8 +2855,8 @@ def _build_sandbox_template_manifest(
         container_port = request.servicePorts[0].targetPort
 
     manifest = {
-        "apiVersion": f"{AGENT_SANDBOX_EXT_GROUP}/{AGENT_SANDBOX_EXT_VERSION}",
-        "kind": "SandboxTemplate",
+        "apiVersion": f"{AGENT_SANDBOX_CRD_GROUP}/{AGENT_SANDBOX_CRD_VERSION}",
+        "kind": "Sandbox",
         "metadata": {
             "name": request.name,
             "namespace": request.namespace,
@@ -2874,6 +2864,7 @@ def _build_sandbox_template_manifest(
             "annotations": annotations,
         },
         "spec": {
+            "replicas": 1,
             "podTemplate": {
                 "metadata": {
                     "labels": {
@@ -2882,6 +2873,7 @@ def _build_sandbox_template_manifest(
                     "annotations": _build_common_annotations(request),
                 },
                 "spec": {
+                    "automountServiceAccountToken": False,
                     "serviceAccountName": request.name,
                     "containers": [
                         {
@@ -2923,34 +2915,6 @@ def _build_sandbox_template_manifest(
         ]
 
     return manifest
-
-
-def _build_sandbox_claim_manifest(
-    request: "CreateAgentRequest",
-    shipwright_build_name: Optional[str] = None,
-) -> dict:
-    """Build a SandboxClaim manifest (extensions.agents.x-k8s.io/v1alpha1)."""
-    labels = _build_common_labels(request, WORKLOAD_TYPE_SANDBOX)
-
-    annotations: Dict[str, str] = {
-        KAGENTI_DESCRIPTION_ANNOTATION: f"Agent '{request.name}' deployed from UI.",
-    }
-    if shipwright_build_name:
-        annotations["kagenti.io/shipwright-build"] = shipwright_build_name
-
-    return {
-        "apiVersion": f"{AGENT_SANDBOX_EXT_GROUP}/{AGENT_SANDBOX_EXT_VERSION}",
-        "kind": "SandboxClaim",
-        "metadata": {
-            "name": request.name,
-            "namespace": request.namespace,
-            "labels": labels,
-            "annotations": annotations,
-        },
-        "spec": {
-            "sandboxTemplateRef": {"name": request.name},
-        },
-    }
 
 
 @router.post(
@@ -3069,33 +3033,16 @@ async def create_agent(
                 )
                 logger.info(f"Created Job '{request.name}' in namespace '{request.namespace}'")
             elif request.workloadType == WORKLOAD_TYPE_SANDBOX:
-                template_manifest = _build_sandbox_template_manifest(
+                sandbox_manifest = _build_sandbox_manifest(
                     request=request,
                     image=request.containerImage,
+                    shipwright_build_name=shipwright_build_name,
                 )
-                kube.create_sandbox_template(
+                kube.create_sandbox(
                     namespace=request.namespace,
-                    body=template_manifest,
+                    body=sandbox_manifest,
                 )
-                claim_manifest = _build_sandbox_claim_manifest(request=request)
-                try:
-                    kube.create_sandbox_claim(
-                        namespace=request.namespace,
-                        body=claim_manifest,
-                    )
-                except Exception:
-                    try:
-                        kube.delete_sandbox_template(namespace=request.namespace, name=request.name)
-                    except Exception:
-                        logger.warning(
-                            "Failed to clean up orphaned SandboxTemplate '%s'",
-                            request.name,
-                        )
-                    raise
-                logger.info(
-                    f"Created SandboxTemplate + SandboxClaim '{request.name}' "
-                    f"in namespace '{request.namespace}'"
-                )
+                logger.info(f"Created Sandbox '{request.name}' in namespace '{request.namespace}'")
 
             # Create Service (not needed for Jobs or Sandboxes)
             if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
@@ -3360,7 +3307,7 @@ async def finalize_shipwright_build(
                     raise
         if not workload_exists and settings.kagenti_feature_flag_agent_sandbox:
             try:
-                kube.get_sandbox_claim(namespace=namespace, name=name)
+                kube.get_sandbox(namespace=namespace, name=name)
                 workload_exists = True
                 existing_workload_type = WORKLOAD_TYPE_SANDBOX
             except ApiException as e:
@@ -3615,7 +3562,7 @@ async def finalize_shipwright_build(
                 f"Created Job '{name}' with image '{container_image}' in namespace '{namespace}'"
             )
         elif final_workload_type == WORKLOAD_TYPE_SANDBOX:
-            template_manifest = _build_sandbox_template_manifest(
+            sandbox_manifest = _build_sandbox_manifest(
                 request=agent_request,
                 image=container_image,
                 shipwright_build_name=name,
@@ -3623,28 +3570,12 @@ async def finalize_shipwright_build(
             kagenti_build_labels = {
                 k: v for k, v in build_labels.items() if k.startswith(settings.kagenti_label_prefix)
             }
-            template_manifest["metadata"]["labels"].update(kagenti_build_labels)
-            template_manifest["spec"]["podTemplate"]["metadata"]["labels"].update(
+            sandbox_manifest["metadata"]["labels"].update(kagenti_build_labels)
+            sandbox_manifest["spec"]["podTemplate"]["metadata"]["labels"].update(
                 kagenti_build_labels
             )
-            kube.create_sandbox_template(namespace=namespace, body=template_manifest)
-            claim_manifest = _build_sandbox_claim_manifest(
-                request=agent_request,
-                shipwright_build_name=name,
-            )
-            claim_manifest["metadata"]["labels"].update(kagenti_build_labels)
-            try:
-                kube.create_sandbox_claim(namespace=namespace, body=claim_manifest)
-            except Exception:
-                try:
-                    kube.delete_sandbox_template(namespace=namespace, name=name)
-                except Exception:
-                    logger.warning("Failed to clean up orphaned SandboxTemplate '%s'", name)
-                raise
-            logger.info(
-                f"Created SandboxTemplate + SandboxClaim '{name}' "
-                f"in namespace '{namespace}' from build"
-            )
+            kube.create_sandbox(namespace=namespace, body=sandbox_manifest)
+            logger.info(f"Created Sandbox '{name}' in namespace '{namespace}' from build")
 
         # Create Service (not needed for Jobs or Sandboxes)
         if final_workload_type not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -19,11 +19,7 @@ from kubernetes.config import ConfigException
 from app.core.constants import (
     AGENT_SANDBOX_CRD_GROUP,
     AGENT_SANDBOX_CRD_VERSION,
-    AGENT_SANDBOX_CLAIM_PLURAL,
-    AGENT_SANDBOX_EXT_GROUP,
-    AGENT_SANDBOX_EXT_VERSION,
     AGENT_SANDBOX_PLURAL,
-    AGENT_SANDBOX_TEMPLATE_PLURAL,
     ENABLED_NAMESPACE_LABEL_KEY,
     ENABLED_NAMESPACE_LABEL_VALUE,
 )
@@ -790,86 +786,6 @@ class KubernetesService:
             AGENT_SANDBOX_PLURAL,
             name,
             body,
-        )
-
-    # -------------------------------------------------------------------------
-    # SandboxTemplate Operations (extensions.agents.x-k8s.io)
-    # -------------------------------------------------------------------------
-
-    def create_sandbox_template(self, namespace: str, body: dict) -> dict:
-        """Create a SandboxTemplate custom resource."""
-        return self.create_custom_resource(
-            AGENT_SANDBOX_EXT_GROUP,
-            AGENT_SANDBOX_EXT_VERSION,
-            namespace,
-            AGENT_SANDBOX_TEMPLATE_PLURAL,
-            body,
-        )
-
-    def get_sandbox_template(self, namespace: str, name: str) -> dict:
-        """Get a SandboxTemplate custom resource by name."""
-        return self.get_custom_resource(
-            AGENT_SANDBOX_EXT_GROUP,
-            AGENT_SANDBOX_EXT_VERSION,
-            namespace,
-            AGENT_SANDBOX_TEMPLATE_PLURAL,
-            name,
-        )
-
-    def delete_sandbox_template(self, namespace: str, name: str) -> None:
-        """Delete a SandboxTemplate custom resource by name."""
-        self.delete_custom_resource(
-            AGENT_SANDBOX_EXT_GROUP,
-            AGENT_SANDBOX_EXT_VERSION,
-            namespace,
-            AGENT_SANDBOX_TEMPLATE_PLURAL,
-            name,
-        )
-
-    # -------------------------------------------------------------------------
-    # SandboxClaim Operations (extensions.agents.x-k8s.io)
-    # -------------------------------------------------------------------------
-
-    def create_sandbox_claim(self, namespace: str, body: dict) -> dict:
-        """Create a SandboxClaim custom resource."""
-        return self.create_custom_resource(
-            AGENT_SANDBOX_EXT_GROUP,
-            AGENT_SANDBOX_EXT_VERSION,
-            namespace,
-            AGENT_SANDBOX_CLAIM_PLURAL,
-            body,
-        )
-
-    def get_sandbox_claim(self, namespace: str, name: str) -> dict:
-        """Get a SandboxClaim custom resource by name."""
-        return self.get_custom_resource(
-            AGENT_SANDBOX_EXT_GROUP,
-            AGENT_SANDBOX_EXT_VERSION,
-            namespace,
-            AGENT_SANDBOX_CLAIM_PLURAL,
-            name,
-        )
-
-    def list_sandbox_claims(
-        self, namespace: str, label_selector: Optional[str] = None
-    ) -> List[dict]:
-        """List SandboxClaim custom resources in a namespace."""
-        return self.list_custom_resources(
-            AGENT_SANDBOX_EXT_GROUP,
-            AGENT_SANDBOX_EXT_VERSION,
-            namespace,
-            AGENT_SANDBOX_CLAIM_PLURAL,
-            label_selector,
-        )
-
-    def delete_sandbox_claim(self, namespace: str, name: str) -> None:
-        """Delete a SandboxClaim custom resource by name."""
-        self.delete_custom_resource(
-            AGENT_SANDBOX_EXT_GROUP,
-            AGENT_SANDBOX_EXT_VERSION,
-            namespace,
-            AGENT_SANDBOX_CLAIM_PLURAL,
-            name,
         )
 
 


### PR DESCRIPTION
## Summary

- Replace the `SandboxTemplate` + `SandboxClaim` creation path with direct `Sandbox` CR creation (`agents.x-k8s.io/v1alpha1`)
- Remove all `extensions.agents.x-k8s.io` dependencies (SandboxTemplate/SandboxClaim methods, constants, RBAC)
- Update list/get/delete agent paths to query Sandbox CRs directly
- Add ADR and upstream issues documentation

## Why the rollback from SandboxTemplate/SandboxClaim

Live testing on a Kind cluster revealed that the SandboxClaim controller overwrites the entire `spec.podTemplate` on the Sandbox CR on every reconciliation cycle. This is by design — the SandboxClaim controller keeps the Sandbox in sync with its SandboxTemplate.

The consequence is that the kagenti-operator cannot persist any configuration (labels, annotations, config-hash) on `spec.podTemplate` when a SandboxClaim owns the Sandbox. The operator writes the config-hash, the SandboxClaim controller immediately wipes it, the operator re-writes it — creating an infinite reconcile loop with three concurrent writers on the same object.

Direct Sandbox creation eliminates this problem:
- Two writers only (operator + Sandbox controller) instead of three
- Operator config-hash persists cleanly
- Two-phase restart (scale 0→1) works without interference
- All capabilities the claim layer provided (NetworkPolicy, secure defaults, env var policy) are already covered by kagenti's platform layer (Istio ambient, AuthBridge, webhook injection)

See `docs/superpowers/specs/2026-04-30-adr-sandbox-direct-vs-claim.md` for the full decision record.

## Test plan

- [ ] Deploy to Kind with `kagenti_feature_flag_agent_sandbox=true`
- [ ] Create agent with workloadType=sandbox from UI → verify `kubectl get sandbox` shows CR (no SandboxTemplate/SandboxClaim)
- [ ] Verify pod runs with correct labels and operator config-hash
- [ ] Delete agent from UI → verify Sandbox CR removed
- [ ] Modify ConfigMap → verify operator restarts pod via scale 0→1

Epic: #1155

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>