### PR TITLE
feat: use kaniko-insecure-push for OpenShift Internal Registry

### DIFF
--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -33,6 +33,42 @@ class Settings(BaseSettings):
 
         return os.getenv("KUBERNETES_SERVICE_HOST") is not None
 
+    @property
+    def is_openshift(self) -> bool:
+        """
+        Detect if running on OpenShift platform.
+
+        Checks for the presence of route.openshift.io API group.
+        Returns False if not in cluster or detection fails.
+        """
+        if not self.is_running_in_cluster:
+            return False
+
+        try:
+            from kubernetes import client, config
+
+            # Load config if not already loaded
+            try:
+                config.load_incluster_config()
+            except config.ConfigException:
+                return False
+
+            # Check for OpenShift-specific API group
+            apis_api = client.ApisApi()
+            api_list = apis_api.get_api_versions()
+
+            # api_list.groups is a list of V1APIGroup objects
+            # Type ignore needed due to dynamic kubernetes client response types
+            if hasattr(api_list, "groups") and api_list.groups:  # type: ignore[union-attr]
+                for group in api_list.groups:  # type: ignore[union-attr]
+                    if hasattr(group, "name") and group.name == "route.openshift.io":  # type: ignore[union-attr]
+                        return True
+
+            return False
+        except Exception:
+            # If detection fails, assume not OpenShift
+            return False
+
     # CORS settings (domain-based origin added dynamically via validator)
     cors_origins: List[str] = [
         "http://localhost:3000",
@@ -54,11 +90,35 @@ class Settings(BaseSettings):
     agentruntimes_plural: str = "agentruntimes"
 
     # Shipwright build settings
-    shipwright_default_strategy: str = "buildah-insecure-push"  # Default for dev
     shipwright_default_timeout: str = "15m"
 
+    @property
+    def shipwright_default_strategy(self) -> str:
+        """
+        Get the default Shipwright build strategy based on platform.
+
+        Returns:
+            - "kaniko-insecure-push" for OpenShift clusters
+            - "buildah-insecure-push" for other Kubernetes clusters (Kind, etc.)
+        """
+        if self.is_openshift:
+            return "kaniko-insecure-push"
+        return "buildah-insecure-push"
+
     # Default registry for source-based builds (override via DEFAULT_REGISTRY_URL env var)
-    default_registry_url: str = "registry.cr-system.svc.cluster.local:5000"
+    # Using Field with alias to allow environment variable override while providing property-based default
+    default_registry_url: str = ""
+
+    @model_validator(mode="after")
+    def _set_default_registry_url(self) -> "Settings":
+        """Set default registry URL based on platform if not explicitly provided."""
+        if not self.default_registry_url:
+            # Auto-detect based on platform
+            if self.is_openshift:
+                self.default_registry_url = "image-registry.openshift-image-registry.svc:5000"
+            else:
+                self.default_registry_url = "registry.cr-system.svc.cluster.local:5000"
+        return self
 
     # Build reconciliation settings
     build_reconciliation_interval: int = 30  # seconds between reconciliation scans

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -134,12 +134,21 @@ export const ImportAgentPage: React.FC = () => {
 
   // Update registry secret default when registry type changes
   React.useEffect(() => {
-    if (registryType !== 'local') {
+    if (registryType === 'openshift') {
+      // OpenShift uses service account tokens, no secret needed
+      setRegistrySecret('');
+      setRegistryNamespace(namespace);
+      // Use kaniko strategy for OpenShift
+      setBuildStrategy('kaniko-insecure-push');
+    } else if (registryType !== 'local') {
       setRegistrySecret(`${registryType}-registry-secret`);
+      // Use buildah for other registries
+      setBuildStrategy('buildah-insecure-push');
     } else {
       setRegistrySecret('');
+      setBuildStrategy('buildah-insecure-push');
     }
-  }, [registryType]);
+  }, [registryType, namespace]);
 
   // Shipwright build configuration (always enabled for source builds)
   const [buildStrategy, setBuildStrategy] = useState('buildah-insecure-push');

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -67,6 +67,7 @@ const TOOL_EXAMPLES = [
 
 const REGISTRY_OPTIONS = [
   { value: 'local', label: 'Local Registry (In-Cluster)', url: 'registry.cr-system.svc.cluster.local:5000' },
+  { value: 'openshift', label: 'OpenShift Internal Registry', url: 'image-registry.openshift-image-registry.svc:5000' },
   { value: 'quay', label: 'Quay.io', url: 'quay.io' },
   { value: 'dockerhub', label: 'Docker Hub', url: 'docker.io' },
   { value: 'github', label: 'GitHub Container Registry', url: 'ghcr.io' },
@@ -110,12 +111,21 @@ export const ImportToolPage: React.FC = () => {
 
   // Update registry secret default when registry type changes
   React.useEffect(() => {
-    if (registryType !== 'local') {
+    if (registryType === 'openshift') {
+      // OpenShift uses service account tokens, no secret needed
+      setRegistrySecret('');
+      setRegistryNamespace(namespace);
+      // Use kaniko strategy for OpenShift
+      setBuildStrategy('kaniko-insecure-push');
+    } else if (registryType !== 'local') {
       setRegistrySecret(`${registryType}-registry-secret`);
+      // Use buildah for other registries
+      setBuildStrategy('buildah-insecure-push');
     } else {
       setRegistrySecret('');
+      setBuildStrategy('buildah-insecure-push');
     }
-  }, [registryType]);
+  }, [registryType, namespace]);
 
   // Shipwright build configuration
   const [buildStrategy, setBuildStrategy] = useState('buildah-insecure-push');

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -970,6 +970,86 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set "keycloak.realm=${KC_REALM}" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)"
 
+
+# ============================================================================
+# Step 4.5: Install kaniko-insecure-push ClusterBuildStrategy
+# ============================================================================
+log_info "Step 4.5: Install kaniko-insecure-push ClusterBuildStrategy"
+
+# Install kaniko-insecure-push strategy for OpenShift internal registry
+log_info "Installing kaniko-insecure-push ClusterBuildStrategy for OpenShift..."
+run_cmd $KUBECTL apply -f - <<'STRATEGY_EOF'
+apiVersion: shipwright.io/v1beta1
+kind: ClusterBuildStrategy
+metadata:
+  name: kaniko-insecure-push
+  annotations:
+    description: "Kaniko-based build strategy for OpenShift with insecure registry support"
+spec:
+  parameters:
+    - name: dockerfile
+      description: Path to the Dockerfile
+      type: string
+      default: Dockerfile
+  steps:
+    - name: prepare-auth
+      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      command:
+        - /bin/sh
+      args:
+        - -c
+        - |
+          set -e
+          TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          mkdir -p /kaniko/.docker
+          cat > /kaniko/.docker/config.json <<EOC
+          {
+            "auths": {
+              "image-registry.openshift-image-registry.svc:5000": {
+                "auth": "$(echo -n "serviceaccount:${TOKEN}" | base64 -w 0)"
+              }
+            }
+          }
+          EOC
+          cat /kaniko/.docker/config.json
+      volumeMounts:
+        - mountPath: /kaniko/.docker
+          name: docker-config
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor:v1.23.2
+      workingDir: $(params.shp-source-root)
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(params.dockerfile)
+        - --context=$(params.shp-source-context)
+        - --destination=$(params.shp-output-image)
+        - --skip-tls-verify
+        - --insecure-pull
+        - --insecure-registry=image-registry.openshift-image-registry.svc:5000
+      env:
+        - name: DOCKER_CONFIG
+          value: /kaniko/.docker
+      securityContext:
+        capabilities:
+          add:
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - SETGID
+            - SETUID
+            - SETFCAP
+        runAsUser: 0
+      volumeMounts:
+        - mountPath: /kaniko/.docker
+          name: docker-config
+  volumes:
+    - name: docker-config
+      emptyDir: {}
+STRATEGY_EOF
+
+log_success "kaniko-insecure-push ClusterBuildStrategy installed"
+echo ""
 log_success "Kagenti installed"
 
 # Grant otel-collector SA MLflow RBAC in agent namespaces (created by kagenti chart above)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

- This change allows installing Agents/Tools from source using OpenShift internal registry
- When Selecting `OpenShift Internal Registry` in the dropdown:
    - the `Registry Namespace/Organization` field's value will be set to the value under `Agent Configuration > Namespace` by default.
    - the `Registry Secret Name` field will be cleared to None as service accounts already have internal registry access. 
    - the `Build Configuration (Advanced) > Build Strategy` will be set to `kaniko-insecure-push`
 - `scripts/ocp/setup-kagenti.sh` will install the `kaniko-insecure-push` `ClusterBuildStrategy` for Shipwright. The Ansible installer is not modified.

## Related issue(s)

## (Optional) Testing Instructions

0. `scripts/ocp/setup-kagenti.sh`
1. Login to Kagenti UI
2. Import Agent/Tool
3. Select `Build from Source`
4. Select Container Registry as `OpenShift Internal Registry`
5. Create Agent/Tool

Fixes https://github.com/kagenti/kagenti/issues/1193
