### PR TITLE
fix: bump agent-sandbox to v0.4.3

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -63,7 +63,7 @@ TEKTON_VERSION="v0.66.0"
 SHIPWRIGHT_VERSION="v0.14.0"
 MCP_GATEWAY_VERSION="0.6.0"
 KUADRANT_VERSION="1.4.2"
-AGENT_SANDBOX_VERSION="v0.3.10"
+AGENT_SANDBOX_VERSION="v0.4.3"
 
 # ── Colors & logging ────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'


### PR DESCRIPTION
## Summary

- Bumps `agent-sandbox` from v0.3.10 to v0.4.3 in `scripts/kind/setup-kagenti.sh`
- v0.4.3 includes an important fix: the Sandbox controller now clears stale `pod-name` annotations on 404, preventing pods from getting stuck in a non-running state after restarts (e.g. when the operator triggers a two-phase restart via scale 0→1)

## Test plan

- [ ] Run `./scripts/kind/setup-kagenti.sh --with-agent-sandbox` on a fresh Kind cluster
- [ ] Verify agent-sandbox controller starts with v0.4.3 image
- [ ] Deploy a Sandbox workload and confirm pod lifecycle works correctly

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>