### PR TITLE
fix: use server-side apply for Gateway API CRDs

### DIFF
--- a/scripts/openshell/deploy-shared.sh
+++ b/scripts/openshell/deploy-shared.sh
@@ -155,7 +155,7 @@ if $STEP_GATEWAY_API; then
     log_success "Experimental Gateway API CRDs already installed — skipping"
   else
     log_info "Installing Gateway API ${GATEWAY_API_VERSION} (experimental bundle)..."
-    run_cmd kubectl apply -f \
+    run_cmd kubectl apply --server-side --force-conflicts -f \
       "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml"
 
     if ! $DRY_RUN; then


### PR DESCRIPTION
## Summary
- Switch Gateway API experimental CRD installation from client-side `kubectl apply` to `--server-side --force-conflicts`
- Fixes `metadata.annotations: Too long: may not be more than 262144 bytes` error on `httproutes.gateway.networking.k8s.io`
- The HTTPRoute CRD in v1.4.0 experimental bundle exceeds the annotation size limit when using client-side apply

## Test plan
- [x] Verified `kubectl apply --server-side --force-conflicts` successfully installs all Gateway API v1.4.0 experimental CRDs on a Kind cluster
- [ ] Re-run `scripts/openshell/deploy-shared.sh` end-to-end