### PR TITLE
fix(kind): fix arm64 Kind cluster install (image arch, SPIRE OIDC, credentials)

### DIFF
--- a/.github/scripts/local-setup/kind-full-test.sh
+++ b/.github/scripts/local-setup/kind-full-test.sh
@@ -247,7 +247,7 @@ if [ "$RUN_INSTALL" = "true" ]; then
     ./.github/scripts/common/20-create-secrets.sh
 
     log_step "Running Kagenti installer..."
-    ./scripts/kind/setup-kagenti.sh --with-all --skip-cluster --cluster-name "$CLUSTER_NAME"
+    ./scripts/kind/setup-kagenti.sh --with-all --skip-cluster --build-images --cluster-name "$CLUSTER_NAME"
 
     log_step "Waiting for platform to be ready..."
     ./.github/scripts/common/40-wait-platform-ready.sh

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -838,8 +838,9 @@
 
 #
 # SPIFFE IdP setup job - creates Keycloak SPIFFE identity provider
-# Note: The SPIRE chart (v0.28.4+) now supports setKeyUse configuration natively,
-# so no ConfigMap patching is needed. The set_key_use: true config is set via Helm values.
+# Note: SPIRE chart v0.27.0 does NOT template config.set_key_use into the ConfigMap
+# despite accepting it as a Helm value. We patch the ConfigMap directly before
+# creating the job.
 - name: Run SPIFFE IdP setup job
   block:
     - name: Get kagenti-deps release values
@@ -980,6 +981,32 @@
             kind: Role
             name: kagenti-spiffe-idp-pod-reader
             apiGroup: rbac.authorization.k8s.io
+
+    - name: Patch SPIRE OIDC ConfigMap to add set_key_use
+      shell: |
+        NS="{{ charts.spire.server_namespace }}"
+        CM="spire-spiffe-oidc-discovery-provider"
+        CONF=$(kubectl get configmap "$CM" -n "$NS" -o jsonpath='{.data.oidc-discovery-provider\.conf}' 2>/dev/null)
+        if [ -z "$CONF" ]; then
+          echo "ConfigMap not found, skipping"
+          exit 0
+        fi
+        HAS_KEY=$(echo "$CONF" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('set_key_use') else 'no')" 2>/dev/null || echo "no")
+        if [ "$HAS_KEY" = "yes" ]; then
+          echo "set_key_use already present"
+          exit 0
+        fi
+        PATCHED=$(echo "$CONF" | python3 -c "import sys,json; d=json.load(sys.stdin); d['set_key_use']=True; json.dump(d,sys.stdout)")
+        kubectl get configmap "$CM" -n "$NS" -o json | \
+          python3 -c "import sys,json; cm=json.load(sys.stdin); cm['data']['oidc-discovery-provider.conf']=r'''$PATCHED'''; json.dump(cm,sys.stdout)" | \
+          kubectl replace -f -
+        kubectl rollout restart deployment/spire-spiffe-oidc-discovery-provider -n "$NS"
+        kubectl rollout status deployment/spire-spiffe-oidc-discovery-provider -n "$NS" --timeout=120s
+        echo "OIDC ConfigMap patched with set_key_use: true"
+      args:
+        executable: /bin/bash
+      changed_when: "'patched' in patch_oidc_result.stdout"
+      register: patch_oidc_result
 
     - name: Delete existing SPIFFE IdP setup job if it exists
       kubernetes.core.k8s:

--- a/kagenti/auth/agent-oauth-secret/Dockerfile
+++ b/kagenti/auth/agent-oauth-secret/Dockerfile
@@ -1,7 +1,7 @@
 # This file has been modified with the assistance of Bob
 
 # Use minimal Python base image
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/agent-oauth-secret/Dockerfile
+++ b/kagenti/auth/agent-oauth-secret/Dockerfile
@@ -1,7 +1,7 @@
 # This file has been modified with the assistance of Bob
 
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.14-slim
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
+++ b/kagenti/auth/agent-oauth-secret/agent_oauth_secret.py
@@ -334,10 +334,14 @@ class KeycloakSetup:
             )
             typer.echo(f'Created user "{username}" (id: {user_id})')
         except KeycloakPostError:
-            typer.echo(f'User "{username}" already exists')
-            # Get existing user ID for group assignment
+            typer.echo(f'User "{username}" already exists, updating password')
             users = self.keycloak_admin.get_users({"username": username})
             user_id = users[0]["id"] if users else None
+            if user_id:
+                self.keycloak_admin.set_user_password(
+                    user_id, password, temporary=False
+                )
+                typer.echo(f'Password updated for "{username}"')
 
         # Add user to mlflow groups (required by mlflow-oidc-auth)
         if user_id:

--- a/kagenti/auth/agent-oauth-secret/requirements.txt
+++ b/kagenti/auth/agent-oauth-secret/requirements.txt
@@ -1,3 +1,4 @@
 python-keycloak~=5.3.1
 kubernetes==33.1.0
 typer==0.20.0
+cryptography<47

--- a/kagenti/auth/api-oauth-secret/Dockerfile
+++ b/kagenti/auth/api-oauth-secret/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/api-oauth-secret/Dockerfile
+++ b/kagenti/auth/api-oauth-secret/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.14-slim
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/api-oauth-secret/requirements.txt
+++ b/kagenti/auth/api-oauth-secret/requirements.txt
@@ -1,2 +1,3 @@
 python-keycloak~=5.3.1
 kubernetes==33.1.0
+cryptography<47

--- a/kagenti/auth/mlflow-oauth-secret/Dockerfile
+++ b/kagenti/auth/mlflow-oauth-secret/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/mlflow-oauth-secret/Dockerfile
+++ b/kagenti/auth/mlflow-oauth-secret/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.14-slim
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/mlflow-oauth-secret/requirements.txt
+++ b/kagenti/auth/mlflow-oauth-secret/requirements.txt
@@ -1,2 +1,3 @@
 python-keycloak==5.3.1
 kubernetes==33.1.0
+cryptography<47

--- a/kagenti/auth/spiffe-idp-setup/Dockerfile
+++ b/kagenti/auth/spiffe-idp-setup/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/spiffe-idp-setup/Dockerfile
+++ b/kagenti/auth/spiffe-idp-setup/Dockerfile
@@ -1,5 +1,5 @@
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.14-slim
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/spiffe-idp-setup/requirements.txt
+++ b/kagenti/auth/spiffe-idp-setup/requirements.txt
@@ -1,3 +1,4 @@
 python-keycloak==5.3.1
 requests==2.33.0
 kubernetes==31.0.0
+cryptography<47

--- a/kagenti/auth/ui-oauth-secret/Dockerfile
+++ b/kagenti/auth/ui-oauth-secret/Dockerfile
@@ -1,7 +1,7 @@
 # This file has been modified with the assistance of Bob
 
 # Use minimal Python base image
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/ui-oauth-secret/Dockerfile
+++ b/kagenti/auth/ui-oauth-secret/Dockerfile
@@ -1,7 +1,7 @@
 # This file has been modified with the assistance of Bob
 
 # Use minimal Python base image
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.14-slim
 
 # Set work directory
 WORKDIR /app

--- a/kagenti/auth/ui-oauth-secret/requirements.txt
+++ b/kagenti/auth/ui-oauth-secret/requirements.txt
@@ -1,2 +1,3 @@
 python-keycloak==5.3.1
 kubernetes==33.1.0
+cryptography<47

--- a/kagenti/backend/Dockerfile
+++ b/kagenti/backend/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 # Stage 1: Build stage with uv
-FROM python:3.14-slim AS builder
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033 AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN uv venv /app/.venv && \
     uv pip install --no-cache -r pyproject.toml
 
 # Stage 2: Runtime stage
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033
 
 WORKDIR /app
 

--- a/kagenti/backend/Dockerfile
+++ b/kagenti/backend/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 # Stage 1: Build stage with uv
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa AS builder
+FROM python:3.14-slim AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN uv venv /app/.venv && \
     uv pip install --no-cache -r pyproject.toml
 
 # Stage 2: Runtime stage
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -981,6 +981,9 @@ if $BUILD_IMAGES && ! $DRY_RUN; then
   if $WITH_MLFLOW; then
     _BUILD_IMAGES+=("ghcr.io/kagenti/kagenti/mlflow-oauth-secret:latest|auth/mlflow-oauth-secret/Dockerfile")
   fi
+  if $WITH_SPIRE; then
+    _BUILD_IMAGES+=("ghcr.io/kagenti/kagenti/spiffe-idp-setup:latest|auth/spiffe-idp-setup/Dockerfile")
+  fi
 
   for spec in "${_BUILD_IMAGES[@]}"; do
     IFS='|' read -r img dockerfile <<< "$spec"

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -840,6 +840,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 EOF
 
+  # Build and load spiffe-idp-setup image to ensure correct arch for Kind
+  if $BUILD_IMAGES; then
+    log_info "Building spiffe-idp-setup image for Kind..."
+    $CONTAINER_ENGINE build --load \
+      -t "$SPIFFE_IDP_IMAGE" \
+      -f "$REPO_ROOT/kagenti/auth/spiffe-idp-setup/Dockerfile" \
+      "$REPO_ROOT/kagenti"
+    kind load docker-image "$SPIFFE_IDP_IMAGE" --name "$CLUSTER_NAME"
+  fi
+
   # Delete existing job (jobs are immutable)
   kubectl delete job kagenti-spiffe-idp-setup-job -n "$KAGENTI_NS" --ignore-not-found 2>/dev/null || true
 
@@ -980,9 +990,6 @@ if $BUILD_IMAGES && ! $DRY_RUN; then
   fi
   if $WITH_MLFLOW; then
     _BUILD_IMAGES+=("ghcr.io/kagenti/kagenti/mlflow-oauth-secret:latest|auth/mlflow-oauth-secret/Dockerfile")
-  fi
-  if $WITH_SPIRE; then
-    _BUILD_IMAGES+=("ghcr.io/kagenti/kagenti/spiffe-idp-setup:latest|auth/spiffe-idp-setup/Dockerfile")
   fi
 
   for spec in "${_BUILD_IMAGES[@]}"; do

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -987,6 +987,7 @@ if $BUILD_IMAGES && ! $DRY_RUN; then
   fi
   if $WITH_UI; then
     _BUILD_IMAGES+=("ghcr.io/kagenti/kagenti/ui-v2:latest|ui-v2/Dockerfile")
+    _BUILD_IMAGES+=("ghcr.io/kagenti/kagenti/ui-oauth-secret:latest|auth/ui-oauth-secret/Dockerfile")
   fi
   if $WITH_MLFLOW; then
     _BUILD_IMAGES+=("ghcr.io/kagenti/kagenti/mlflow-oauth-secret:latest|auth/mlflow-oauth-secret/Dockerfile")


### PR DESCRIPTION
## Summary

- Pin `python:3.14-slim` to multi-arch manifest digest (`sha256:5b3879b6`) replacing the amd64-only digest from PR #1238
- Cap `cryptography<47` in all auth job requirements — v47.0.0 arm64 wheels crash with SIGILL under Docker Desktop virtualization
- Build `spiffe-idp-setup` in Step 7 before job creation (was built too late in the `_BUILD_IMAGES` block)
- Add `ui-oauth-secret` to the `--build-images` list
- Pass `--build-images` in `kind-full-test.sh` to match CI behavior
- Patch SPIRE OIDC ConfigMap with `set_key_use: true` in the Ansible installer (chart v0.27.0 silently ignores the Helm value)
- Fix test user password: update password in Keycloak when user already exists so the `kagenti-test-user` secret matches the actual credential

## Root Cause

Three issues combined to break arm64 Kind installs:

1. **Image arch**: PR #1238 pinned `python:3.14-slim` to an amd64-only digest, and `cryptography` 47.0.0 ships arm64 wheels with CPU instructions unsupported by Docker Desktop — both cause SIGILL (exit 132)
2. **SPIRE OIDC**: The Ansible installer trusted the Helm value `spiffe-oidc-discovery-provider.config.set_key_use=true` but SPIRE chart v0.27.0 doesn't render it into the ConfigMap, leaving JWKS keys without the `use` field
3. **Credentials**: The `agent-oauth-secret` job skipped password update when the realm-imported user already existed, causing the secret to store a random password that didn't match Keycloak

## Test plan

- [x] Run `kind-full-test.sh --skip-cluster-destroy` on an arm64 Mac
- [x] Verify `kagenti-spiffe-idp-setup-job` and `kagenti-ui-oauth-secret-job` both succeed
- [x] Confirm UI loads at http://kagenti-ui.localtest.me:8080 with credentials from `show-services.sh`
- [x] Verify `from keycloak import KeycloakOpenIDConnection` works inside the container image

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>