### PR TITLE
fix: move Keycloak admin secret to kagenti-system and remove client-registration sidecar references

### DIFF
--- a/.github/scripts/common/87-setup-test-credentials.sh
+++ b/.github/scripts/common/87-setup-test-credentials.sh
@@ -260,8 +260,8 @@ dump_scope_timeout_diagnostics() {
         grep -E '^  [A-Z_]+:|^data:' | head -30 || echo "  (not found — reconciler will requeue forever on 'waiting for KEYCLOAK_URL/KEYCLOAK_REALM')"
 
     echo
-    echo "--- team1 keycloak-admin-secret (existence + key names, not values) ---"
-    kubectl get secret -n team1 keycloak-admin-secret \
+    echo "--- keycloak-admin-secret (now in kagenti-system, not team1) ---"
+    kubectl get secret -n kagenti-system keycloak-admin-secret \
         -o jsonpath='{"  keys: "}{.data}{"\n"}' 2>&1 | python3 -c "
 import sys, json, re
 s = sys.stdin.read().strip()
@@ -275,7 +275,7 @@ if m:
         print(s)
 else:
     print(s)
-" 2>&1 || echo "  (not found — reconciler will requeue forever on 'waiting for keycloak-admin-secret')"
+" 2>&1 || echo "  (not found — operator will be unable to register clients)"
 
     echo
     echo "--- kagenti-operator controller pod status ---"

--- a/.github/scripts/common/99-collect-logs.sh
+++ b/.github/scripts/common/99-collect-logs.sh
@@ -26,10 +26,6 @@ echo "=== Weather Service Envoy-Proxy Logs (last 50 lines) ==="
 kubectl logs -n team1 deployment/weather-service -c envoy-proxy --tail=50 || true
 
 echo ""
-echo "=== Weather Service Client-Registration Logs (last 30 lines) ==="
-kubectl logs -n team1 deployment/weather-service -c kagenti-client-registration --tail=30 || true
-
-echo ""
 echo "=== AuthBridge Unified ConfigMap ==="
 kubectl get configmap authbridge-runtime-config -n team1 -o jsonpath='{.data.config\.yaml}' || true
 

--- a/.github/scripts/hypershift/ci/85-collect-failure-info.sh
+++ b/.github/scripts/hypershift/ci/85-collect-failure-info.sh
@@ -76,10 +76,6 @@ if [ -n "${KUBECONFIG:-}" ] && [ -f "${KUBECONFIG:-}" ]; then
     oc logs -n team1 deployment/weather-service -c envoy-proxy --tail=50 2>/dev/null || echo "(not available)"
 
     echo ""
-    echo "=== Weather Service Client-Registration Logs (last 30 lines) ==="
-    oc logs -n team1 deployment/weather-service -c kagenti-client-registration --tail=30 2>/dev/null || echo "(not available)"
-
-    echo ""
     echo "=== AuthBridge Unified ConfigMap ==="
     oc get configmap authbridge-runtime-config -n team1 -o jsonpath='{.data.config\.yaml}' 2>/dev/null || echo "(not found)"
 

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -54,12 +54,13 @@ if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
 fi
 
 # Preflight: Keycloak admin credentials for setup_keycloak_weather_advanced.py / token exchange
-if ! kubectl get secret keycloak-admin-secret -n "$NAMESPACE" &>/dev/null; then
-    log_error "Secret 'keycloak-admin-secret' not found in namespace '$NAMESPACE'."
-    log_error "The installer usually creates it in agent namespaces. Re-run platform deploy or create it (AuthBridge / Keycloak docs) before AuthBridge E2E."
+# Note: keycloak-admin-secret is now in kagenti-system (operator namespace) for security
+if ! kubectl get secret keycloak-admin-secret -n kagenti-system &>/dev/null; then
+    log_error "Secret 'keycloak-admin-secret' not found in namespace 'kagenti-system'."
+    log_error "The installer creates it in the operator namespace. Re-run platform deploy or create it (AuthBridge / Keycloak docs) before AuthBridge E2E."
     exit 1
 fi
-log_info "Preflight OK: keycloak-admin-secret present in $NAMESPACE"
+log_info "Preflight OK: keycloak-admin-secret present in kagenti-system"
 
 EXT_ROOT="${KAGENTI_EXTENSIONS_ROOT:-}"
 # Trim trailing slash so path joins are never authbridge//...

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -19,6 +19,7 @@
 #   KAGENTI_EXTENSIONS_GIT_REF  Branch or tag (default: main). Pin in CI to a release tag once
 #     authbridge/demos/weather-agent is included; verify with: git ls-remote --tags URL
 #   NAMESPACE                 K8s namespace (default: team1)
+#   OPERATOR_NAMESPACE        Operator namespace where keycloak-admin-secret is located (default: kagenti-system)
 #   SKIP_DEPLOY                 If 1, only run in-cluster verify (default: 0 = full deploy)
 #   WEATHER_TOOL_ROLLOUT_TIMEOUT / WEATHER_AGENT_ROLLOUT_TIMEOUT / WEATHER_TOOL_KC_CLIENT_SEC
 #   WEATHER_ADVANCED_PRUNE_LEGACY   Passed to deploy (default: 1 here — scale down wave-90 weather)
@@ -47,6 +48,7 @@ if ! command -v git &>/dev/null; then
 fi
 
 export NAMESPACE="${NAMESPACE:-team1}"
+export OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kagenti-system}"
 
 if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
     log_error "Namespace $NAMESPACE not found. Deploy the platform first."
@@ -54,13 +56,13 @@ if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
 fi
 
 # Preflight: Keycloak admin credentials for setup_keycloak_weather_advanced.py / token exchange
-# Note: keycloak-admin-secret is now in kagenti-system (operator namespace) for security
-if ! kubectl get secret keycloak-admin-secret -n kagenti-system &>/dev/null; then
-    log_error "Secret 'keycloak-admin-secret' not found in namespace 'kagenti-system'."
+# Note: keycloak-admin-secret is now in the operator namespace for security
+if ! kubectl get secret keycloak-admin-secret -n "$OPERATOR_NAMESPACE" &>/dev/null; then
+    log_error "Secret 'keycloak-admin-secret' not found in namespace '$OPERATOR_NAMESPACE'."
     log_error "The installer creates it in the operator namespace. Re-run platform deploy or create it (AuthBridge / Keycloak docs) before AuthBridge E2E."
     exit 1
 fi
-log_info "Preflight OK: keycloak-admin-secret present in kagenti-system"
+log_info "Preflight OK: keycloak-admin-secret present in $OPERATOR_NAMESPACE"
 
 EXT_ROOT="${KAGENTI_EXTENSIONS_ROOT:-}"
 # Trim trailing slash so path joins are never authbridge//...

--- a/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
+++ b/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
@@ -271,13 +271,10 @@ data:
 EOF
 
 # --- keycloak-admin-secret ---
-log_info "Creating keycloak-admin-secret"
-KC_ADMIN_USER=$(kubectl get secret keycloak-initial-admin -n "$KC_NAMESPACE" -o go-template='{{.data.username | base64decode}}' 2>/dev/null || echo "admin")
-KC_ADMIN_PASS=$(kubectl get secret keycloak-initial-admin -n "$KC_NAMESPACE" -o go-template='{{.data.password | base64decode}}' 2>/dev/null || echo "admin")
-kubectl create secret generic keycloak-admin-secret \
-  --from-literal=KEYCLOAK_ADMIN_USERNAME="$KC_ADMIN_USER" \
-  --from-literal=KEYCLOAK_ADMIN_PASSWORD="$KC_ADMIN_PASS" \
-  -n "$TX_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+# Note: keycloak-admin-secret is now managed by the operator in kagenti-system namespace.
+# The operator reads credentials from there to register OAuth clients for workloads.
+# No longer created in agent namespaces for security reasons.
+log_info "Skipping keycloak-admin-secret creation (managed by operator in kagenti-system)"
 
 # --- Add namespace to operator's NAMESPACES2WATCH ---
 log_info "Adding $TX_NAMESPACE to operator NAMESPACES2WATCH"

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-rc.1
-digest: sha256:929d99c8d231bddfe5ca4125a74684a7795a6d0740003c4f31b5f4e578881a7c
-generated: "2026-05-07T19:50:52.294441-04:00"
+  version: 0.2.0-rc.2
+digest: sha256:10db2048c591cd7b0b0694b606320d3f0f0a9c390185bd0dba5698859d68cfdb
+generated: "2026-05-12T02:26:42.749554-04:00"

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: oci://ghcr.io/kagenti/kagenti-operator
   version: 0.2.0-rc.2
 digest: sha256:10db2048c591cd7b0b0694b606320d3f0f0a9c390185bd0dba5698859d68cfdb
-generated: "2026-05-12T02:26:42.749554-04:00"
+generated: "2026-05-12T14:32:29.275324-04:00"

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-rc.2
-digest: sha256:10db2048c591cd7b0b0694b606320d3f0f0a9c390185bd0dba5698859d68cfdb
-generated: "2026-05-12T14:32:29.275324-04:00"
+  version: 0.2.0-rc.3
+digest: sha256:64a86558be0230bee8c83880c57e5ca81389566f3bae52dcdad4fb0662edd255
+generated: "2026-05-12T15:32:56.030668-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,6 +7,6 @@ appVersion: "0.6.0-rc.1"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-rc.2
+  version: 0.2.0-rc.3
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "0.6.0-rc.1"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-rc.1
+  version: 0.2.0-rc.2
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -9,5 +9,4 @@ dependencies:
 - name: kagenti-operator-chart
   version: 0.2.0-rc.2
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  condition: components.agentOperator.enabled
-
+  condition: components.agentOperor.enabled

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -9,4 +9,4 @@ dependencies:
 - name: kagenti-operator-chart
   version: 0.2.0-rc.2
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  condition: components.agentOperor.enabled
+  condition: components.agentOperator.enabled

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -123,8 +123,7 @@ data:
   # Keycloak connection (used by operator client registration controller)
   KEYCLOAK_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
   KEYCLOAK_REALM: {{ $root.Values.keycloak.realm | quote }}
-  # KEYCLOAK_NAMESPACE: Not used by sidecars. Included for reference by Helm-hook Jobs.
-  # Sidecars get credentials from local keycloak-admin-secret (replicated by agent-oauth-secret Job).
+  # KEYCLOAK_NAMESPACE: Not used by sidecars or operator. Included for reference by Helm-hook Jobs.
   KEYCLOAK_NAMESPACE: "{{ $root.Values.keycloak.namespace }}"
   # ISSUER: Used by envoy-proxy go-processor for inbound JWT validation.
   # Optional - auto-derived from KEYCLOAK_URL + KEYCLOAK_REALM if not set.

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -113,6 +113,9 @@ data:
 #
 #  NOTE: KEYCLOAK_NAMESPACE is only used by Helm-hook Jobs (spiffe-idp-setup, agent-oauth-secret)
 #  that run at install time with cross-namespace RBAC to read from the Keycloak namespace.
+#  Legacy: Prior to kagenti-operator#321, client-registration sidecars received credentials from
+#  a per-namespace keycloak-admin-secret replicated by agent-oauth-secret Job. Now the operator
+#  controller reads keycloak-admin-secret from its own namespace (kagenti-system) for security.
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -104,35 +104,14 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ (printf "{\"auths\":{\"quay.io\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" $.Values.secrets.quayUser $.Values.secrets.quayToken (printf "%s:%s" $.Values.secrets.quayUser $.Values.secrets.quayToken | b64enc)) | b64enc }}
 ---
-{{- if not $root.Values.keycloak.adminExistingSecret }}
-# ——————————————————————————————————————————————————————————————————————————————
-#  Secret for Keycloak Admin Credentials in Namespace: {{ . }}
-#  Used by the client-registration sidecar to register agents as OAuth clients.
-# ——————————————————————————————————————————————————————————————————————————————
-apiVersion: v1
-kind: Secret
-metadata:
-  name: keycloak-admin-secret
-  namespace: {{ . }}
-  labels:
-    {{- include "kagenti.labels" $root | nindent 4 }}
-type: Opaque
-stringData:
-  KEYCLOAK_ADMIN_USERNAME: {{ $root.Values.keycloak.adminUsername | quote }}
-  KEYCLOAK_ADMIN_PASSWORD: {{ $root.Values.keycloak.adminPassword | quote }}
----
-{{- end }}
-
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for AuthBridge in Namespace: {{ . }}
-#  Consolidated config consumed by injected sidecars:
-#  - kagenti-webhook (injects CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS, JWT_AUDIENCE into client-registration)
-#  - client-registration sidecar (reads KEYCLOAK_URL, KEYCLOAK_REALM, CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS, JWT_AUDIENCE)
-#  - envoy-proxy go-processor (reads ISSUER, EXPECTED_AUDIENCE for inbound JWT validation)
+#  Consolidated config consumed by the kagenti-operator and injected sidecars:
+#  - kagenti-operator: Client registration controller (reads KEYCLOAK_URL, KEYCLOAK_REALM)
+#  - kagenti-webhook: Injects CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS, JWT_AUDIENCE
+#  - authbridge sidecars: Read ISSUER, EXPECTED_AUDIENCE for inbound JWT validation
 #
-#  NOTE: KEYCLOAK_NAMESPACE is NOT used by injected sidecars (credentials come from
-#  local keycloak-admin-secret, replicated to this namespace by agent-oauth-secret Job).
-#  KEYCLOAK_NAMESPACE is only used by Helm-hook Jobs (spiffe-idp-setup, agent-oauth-secret)
+#  NOTE: KEYCLOAK_NAMESPACE is only used by Helm-hook Jobs (spiffe-idp-setup, agent-oauth-secret)
 #  that run at install time with cross-namespace RBAC to read from the Keycloak namespace.
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: v1
@@ -141,7 +120,7 @@ metadata:
   name: authbridge-config
   namespace: {{ . }}
 data:
-  # Keycloak connection (used by client-registration sidecar)
+  # Keycloak connection (used by operator client registration controller)
   KEYCLOAK_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
   KEYCLOAK_REALM: {{ $root.Values.keycloak.realm | quote }}
   # KEYCLOAK_NAMESPACE: Not used by sidecars. Included for reference by Helm-hook Jobs.
@@ -153,7 +132,7 @@ data:
   # that appears in token "iss" claims (split-horizon DNS).
   ISSUER: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
   SPIRE_ENABLED: {{ if $root.Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
-  # Authentication configuration (used by webhook injector and client-registration)
+  # Authentication configuration (used by operator and webhook injector)
   CLIENT_AUTH_TYPE: "{{ $root.Values.authBridge.clientAuthType }}"
   SPIFFE_IDP_ALIAS: "{{ $root.Values.authBridge.spiffeIdpAlias }}"
   JWT_AUDIENCE: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
@@ -412,7 +391,7 @@ subjects:
 #  the webhook-injected AuthBridge stack can run:
 #    - proxy-init init container (NET_ADMIN/NET_RAW, root) for iptables
 #    - envoy-proxy sidecar (UID 1337)
-#    - spiffe-helper / client-registration sidecars (UID 1000)
+#    - authbridge-light / spiffe-helper sidecars (UID 1000)
 #  Agent SAs are created dynamically by the operator (name = agent name),
 #  so we use the namespace service accounts group.
 #

--- a/charts/kagenti/templates/kagenti-authbridge-scc.yaml
+++ b/charts/kagenti/templates/kagenti-authbridge-scc.yaml
@@ -5,13 +5,13 @@
 #  The kagenti-webhook injects an AuthBridge sidecar stack into agent pods:
 #    - proxy-init (init): iptables interception (needs NET_ADMIN/NET_RAW, root, non-privileged)
 #    - envoy-proxy (sidecar): Envoy for auth token injection (requests UID 1337)
+#    - authbridge-light (sidecar): OAuth token management (no hardcoded UID)
 #    - spiffe-helper (sidecar): SPIRE identity (UBI image, no hardcoded UID)
-#    - client-registration (sidecar): Keycloak registration (no hardcoded UID)
 #
 #  This SCC grants the minimum permissions needed for AuthBridge sidecars:
 #    - proxy-init needs root + NET_ADMIN/NET_RAW capabilities (not privileged mode)
 #    - envoy-proxy requests UID 1337 (for iptables exclusion coordination)
-#    - spiffe-helper and client-registration run as image-default UIDs (no override)
+#    - authbridge-light and spiffe-helper run as image-default UIDs (no override)
 #  RunAsAny is required because proxy-init needs root and envoy needs UID 1337.
 #  Bound to agent namespaces via the `groups` field below.
 # ——————————————————————————————————————————————————————————————————————————————

--- a/charts/kagenti/templates/keycloak-admin-secret-kagenti-system.yaml
+++ b/charts/kagenti/templates/keycloak-admin-secret-kagenti-system.yaml
@@ -15,18 +15,8 @@
   — returning 503 on every inbound request with "identity not yet
   configured (credentials pending)".
 
-  Sister secret still exists in each agent namespace (see
-  agent-namespaces.yaml) to unblock workloads that opt into the legacy
-  client-registration sidecar via kagenti.io/client-registration-inject=
-  true — that path doesn't read from the operator namespace.
-
   Respect adminExistingSecret: when the operator provides a pre-created
   secret, we don't overwrite it here either.
-
-  Note: a companion PR (kagenti#1422) independently reshapes this area;
-  this template is the minimal change #1507 needs to unblock operator-
-  managed client registration without waiting for #1422's broader
-  cleanup.
 */ -}}
 {{- if not .Values.keycloak.adminExistingSecret }}
 apiVersion: v1

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -246,12 +246,15 @@ kagenti-operator-chart:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
   # NOTE: The client-registration sidecar has been sunset.
+  # v0.5.0-alpha.14 includes per-plugin config support (extensions#378) and
+  # keycloak_url/keycloak_realm fields in jwt-validation (extensions#383),
+  # required for compatibility with operator v0.2.0-rc.2's synthesizePipeline output.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.1
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-rc.1
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-rc.1
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-rc.1
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.14
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.14
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.14
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.14
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -156,9 +156,10 @@ keycloak:
   adminSecretName: keycloak-initial-admin
   adminUsernameKey: username
   adminPasswordKey: password
-  # Keycloak admin credentials for agent namespaces (keycloak-admin-secret).
-  # Used by the client-registration sidecar to register agents as OAuth clients.
-  # For production, override via .secret_values.yaml or use an existing secret.
+  # Keycloak admin credentials (keycloak-admin-secret in kagenti-system namespace).
+  # Used by the kagenti-operator client registration controller to register
+  # agents as OAuth clients. For production, override via .secret_values.yaml
+  # or use an existing secret.
   adminUsername: admin
   adminPassword: admin
   # Set to an existing Secret name to skip creating keycloak-admin-secret.
@@ -212,6 +213,20 @@ spiffeIdp:
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
+#  Kagenti Webhook Configuration
+# ------------------------------------------------------------------
+# Pin sidecar image tags to the webhook chart version to prevent
+# breakage when :latest is updated by newer kagenti-extensions builds.
+# These MUST be updated together with the chart version in Chart.yaml.
+# NOTE: The client-registration sidecar has been sunset. Client registration
+# is now handled by the kagenti-operator controller.
+kagenti-webhook-chart:
+  defaults:
+    images:
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.9
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.9
+
+# ------------------------------------------------------------------
 #  Kagenti Operator Configuration (includes AuthBridge webhook)
 # ------------------------------------------------------------------
 kagenti-operator-chart:
@@ -219,7 +234,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-alpha.36
+        tag: 0.2.0-rc.1
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -227,10 +242,7 @@ kagenti-operator-chart:
       - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
       - "--config-path=/etc/kagenti/config.yaml"
       - "--feature-gates-path=/etc/kagenti/feature-gates/feature-gates.yaml"
-      # operator alpha.36 simplified the client-registration flags:
-      # --enable-operator-client-registration was removed, and this flag
-      # now controls operator-based registration directly (legacy sidecar
-      # path is gone). See kagenti-operator commit f5df832.
+      # Enable client registration controller (operator-managed, not sidecar)
       - "--enable-client-registration=true"
       resources:
         limits:
@@ -248,21 +260,13 @@ kagenti-operator-chart:
   signatureVerification:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
-  # v0.5.0-alpha.13 was the first release requiring per-plugin
-  # authbridge config (schema cutover — old top-level inbound/
-  # outbound/identity/bypass/routes blocks are rejected).
-  # v0.5.0-alpha.14 adds keycloak_url + keycloak_realm to
-  # jwt-validation so jwks_url derives from the internal URL
-  # (extensions#383); paired with operator v0.2.0-alpha.36 whose
-  # synthesizePipeline emits those fields (operator#336). Both
-  # pins must advance together.
+  # NOTE: The client-registration sidecar has been sunset.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.14
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.14
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.14
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.14
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.14
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.1
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-rc.1
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-rc.1
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-rc.1
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -242,8 +242,7 @@ kagenti-operator-chart:
       - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
       - "--config-path=/etc/kagenti/config.yaml"
       - "--feature-gates-path=/etc/kagenti/feature-gates/feature-gates.yaml"
-      # Enable client registration controller (operator-managed, not sidecar)
-      - "--enable-client-registration=true"
+      # Client registration controller is enabled by default (operator-managed)
       resources:
         limits:
           cpu: 150m

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -213,20 +213,6 @@ spiffeIdp:
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
-#  Kagenti Webhook Configuration
-# ------------------------------------------------------------------
-# Pin sidecar image tags to the webhook chart version to prevent
-# breakage when :latest is updated by newer kagenti-extensions builds.
-# These MUST be updated together with the chart version in Chart.yaml.
-# NOTE: The client-registration sidecar has been sunset. Client registration
-# is now handled by the kagenti-operator controller.
-kagenti-webhook-chart:
-  defaults:
-    images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.9
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.9
-
-# ------------------------------------------------------------------
 #  Kagenti Operator Configuration (includes AuthBridge webhook)
 # ------------------------------------------------------------------
 kagenti-operator-chart:
@@ -234,7 +220,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-rc.1
+        tag: 0.2.0-rc.2
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -220,7 +220,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-rc.2
+        tag: 0.2.0-rc.3
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -246,15 +246,15 @@ kagenti-operator-chart:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
   # NOTE: The client-registration sidecar has been sunset.
-  # v0.5.0-alpha.14 includes per-plugin config support (extensions#378) and
+  # v0.5.0-rc.2 includes per-plugin config support (extensions#378) and
   # keycloak_url/keycloak_realm fields in jwt-validation (extensions#383),
-  # required for compatibility with operator v0.2.0-rc.2's synthesizePipeline output.
+  # required for compatibility with operator v0.2.0-rc.3's synthesizePipeline output.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.14
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.14
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.14
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.14
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.2
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-rc.2
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-rc.2
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-rc.2
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/docs/components.md
+++ b/docs/components.md
@@ -446,18 +446,19 @@ Kagenti provides a unified framework for identity and authorization in agentic s
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| **[Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/client-registration)** | Automatic OAuth2/OIDC client provisioning using SPIFFE ID | `AuthBridge/client-registration` |
 | **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
 | **[SPIRE](https://spiffe.io/docs/latest/spire-about/)** | Workload identity and attestation | External |
 | **[Keycloak](https://www.keycloak.org/)** | Identity provider and access management | External |
 
-### Client Registration
+### Keycloak Client Registration (Operator-Managed)
 
-Automatically registers Kubernetes workloads as Keycloak clients at pod startup:
+Keycloak client registration is handled by the kagenti-operator's ClientRegistrationReconciler controller:
 
+- Watches for Deployments/StatefulSets labeled with `kagenti.io/type: agent` or `tool`
 - Uses **SPIFFE ID** as client identifier (e.g., `spiffe://localtest.me/ns/team/sa/my-agent`)
-- Eliminates manual client creation and secret distribution
-- Writes credentials to shared volume for application use
+- Reads Keycloak admin credentials from the operator namespace (`kagenti-system`)
+- Creates a secret in the agent namespace containing client credentials
+- Eliminates the need for admin credentials in agent namespaces
 
 ### AuthProxy
 
@@ -497,7 +498,7 @@ An Envoy-based sidecar that handles both **inbound JWT validation** and **outbou
 - **Inbound JWT Validation** — Validates token signature, expiration, and issuer using JWKS keys fetched from Keycloak. Optionally validates the audience claim. Returns HTTP 401 for missing or invalid tokens.
 - **Outbound Token Exchange** — Performs [OAuth 2.0 Token Exchange (RFC 8693)](https://datatracker.ietf.org/doc/html/rfc8693) to replace the caller's token with one scoped to the target service audience
 - **Transparent to applications** — Traffic interception via iptables; no application code changes required
-- **Configuration** — Inbound validation is configured via `ISSUER` (required) and `EXPECTED_AUDIENCE` (optional) environment variables. Outbound exchange uses `TOKEN_URL`, `CLIENT_ID`, `CLIENT_SECRET`, and `TARGET_AUDIENCE`.
+- **Configuration** — Inbound validation is configured via `ISSUER` (required) and `EXPECTED_AUDIENCE` (optional) environment variables. Outbound exchange uses `TOKEN_URL`, `CLIENT_ID`, `CLIENT_SECRET` (provided by the operator via secret), and `TARGET_AUDIENCE`.
 
 ### SPIRE (Workload Identity)
 
@@ -518,7 +519,7 @@ An Envoy-based sidecar that handles both **inbound JWT validation** and **outbou
 | Feature | Description |
 |---------|-------------|
 | **User Management** | Create and manage Kagenti users |
-| **Client Registration** | OAuth clients for agents and UI (e.g. automated Keycloak Client registration via [Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/client-registration) component) |
+| **Client Registration** | OAuth clients for agents and UI (automated registration via kagenti-operator's ClientRegistrationReconciler) |
 | **Token Exchange** | Exchange tokens between audiences ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) |
 | **SSO** | Single sign-on across Kagenti components |
 

--- a/docs/design-proposals/consolidated-compositional-agent-platform-design.md
+++ b/docs/design-proposals/consolidated-compositional-agent-platform-design.md
@@ -243,7 +243,6 @@ Webhook Intercepts Pod CREATE (pods carry controller-applied labels)
   • Injects AuthBridge sidecars:
     - proxy-init (init container — network setup)
     - spiffe-helper (identity)
-    - client-registration (IdP integration)
     - envoy-proxy (outbound token exchange)
         ↓
 Agent Pod Running with Secure Identity
@@ -764,10 +763,11 @@ This is the same approach used for Istio sidecar injection labels.
 |-----------|------|---------|
 | `proxy-init` | Init Container | Sets up iptables for traffic interception |
 | `spiffe-helper` | Sidecar | Manages SPIFFE workload identity |
-| `client-registration` | Sidecar | Registers agent with identity provider |
 | `envoy-proxy` | Sidecar | Intercepts outbound traffic, performs token exchange |
 
 > **Note: AuthBridge Sidecar Consolidation** — The current AuthBridge implementation uses multiple sidecars as listed above. The Kagenti team plans to consolidate these into fewer containers in the near term. The current multi-sidecar design reflects the initial implementation where each concern was developed independently. Consolidation will reduce per-pod resource overhead, simplify configuration propagation (fewer processes to update), and reduce pod startup latency. The architecture described in this proposal is designed to work with both the current multi-sidecar layout and the future consolidated form — the webhook injects whatever the current AuthBridge implementation requires, and the number of injected containers is an implementation detail transparent to the developer.
+> 
+> **Note: Operator-Managed Client Registration** — Keycloak client registration is now handled by the kagenti-operator controller, not by an injected sidecar. The operator's ClientRegistrationReconciler watches deployments labeled as agents or tools and automatically registers them with Keycloak using credentials from the operator namespace. This eliminates the need for admin credentials in agent namespaces and provides better security isolation.
 
 ### Controller Architecture
 
@@ -832,7 +832,7 @@ The specific mechanism for this propagation is still under discussion. The candi
 
 **Current assessment**: For the Envoy proxy sidecar (which handles outbound token exchange and traffic interception), **xDS is the leading candidate** — it is Envoy's native configuration interface and provides the low-latency updates required for security-sensitive configuration like token exchange rules and destination policies.
 
-> **Open gap: Non-Envoy sidecar configuration propagation.** The mechanism for propagating configuration to non-Envoy sidecars (spiffe-helper, client-registration) is not yet defined. These sidecars currently read configuration from environment variables and mounted ConfigMaps at startup. Dynamic reconfiguration without pod restart is an unsolved problem for these components. This gap should be tracked explicitly and addressed in a future design iteration.
+> **Open gap: Non-Envoy sidecar configuration propagation.** The mechanism for propagating configuration to non-Envoy sidecars (spiffe-helper) is not yet defined. These sidecars currently read configuration from environment variables and mounted ConfigMaps at startup. Dynamic reconfiguration without pod restart is an unsolved problem for these components. This gap should be tracked explicitly and addressed in a future design iteration.
 
 **Requirements regardless of mechanism**:
 - Configuration changes should reach running sidecars without pod restarts where possible; changes to sidecar images or init containers require a pod restart
@@ -1097,20 +1097,20 @@ Unchanged from original proposal:
 
 ### Sidecar Consolidation Plan
 
-The current AuthBridge implementation injects four containers per pod:
+The current AuthBridge implementation injects three containers per pod:
 
 | Container | Purpose | Runtime |
 |-----------|---------|---------|
 | `proxy-init` | iptables redirect setup | Init container (short-lived) |
 | `envoy-proxy` | Envoy + go-processor ext-proc (outbound token exchange, inbound JWT validation) | Go + Envoy |
 | `spiffe-helper` | SPIFFE JWT-SVID management | Go |
-| `kagenti-client-registration` | Keycloak client registration | Python |
+
+**Keycloak Client Registration** is now handled by the kagenti-operator's ClientRegistrationReconciler controller rather than an injected sidecar. This provides better security isolation by keeping Keycloak admin credentials in the operator namespace.
 
 **Planned consolidation** (tracked as a separate work item):
 
 1. **Merge spiffe-helper into go-processor**: The go-processor already reads JWT-SVIDs; spiffe-helper's role (writing SVIDs to disk) can be absorbed into the go-processor or handled via SPIRE's workload API directly.
-2. **Merge client-registration into go-processor**: Client registration is a one-time operation that writes `client-id.txt` and `client-secret.txt`. This can run as an init phase within the go-processor.
-3. **Target state**: 2 containers — `proxy-init` (init) + `envoy-proxy` (sidecar with consolidated go-processor).
+2. **Target state**: 2 containers — `proxy-init` (init) + `envoy-proxy` (sidecar with consolidated go-processor).
 
 **Benefits**: Reduced per-pod resource overhead, simplified configuration propagation (one process to update), reduced pod startup latency, fewer shared volumes.
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -263,23 +263,17 @@ grant_type=authorization_code
 }
 ```
 
-#### Stage 2: Keycloak Client Registration Flow (Secret-based)
+#### Stage 2: Keycloak Client Registration Flow (Operator-managed)
 
-![Keycloak Client Registration Flow (Secret-based) Flow](./diagrams/images/png/02-kagenti-client-registration.png)
+Keycloak client registration is now handled by the kagenti-operator's ClientRegistrationReconciler controller. The controller:
+1. Watches for Deployments/StatefulSets labeled with `kagenti.io/type: agent` or `tool`
+2. Reads Keycloak admin credentials from the `keycloak-admin-secret` in the operator namespace (`kagenti-system`)
+3. Uses the workload's SPIFFE ID as the client identifier
+4. Registers the client with Keycloak and creates a secret containing client credentials in the agent namespace
 
-*Figure 2: Keycloak Client Registration Flow (Secret-based) Flow - Shows how automatic client registration registers clients in Keycloak*
+This approach provides better security isolation by restricting Keycloak admin credentials to the operator namespace rather than replicating them to every agent namespace.
 
-[View Mermaid Source Code](./diagrams/02-kagenti-client-registration.mmd)
-
-#### Stage 3: Keycloak Client Registration Flow (Secretless with OIDC DCR)
-
-![Keycloak Client Registration Flow (Secretless with OIDC DCR) Flow](./diagrams/images/png/03-kagenti-client-registreation-final.png)
-
-*Figure 3: Keycloak Client Registration Flow (Secretless with OIDC DCR) Flow - Shows how automatic client registration registers clients in Keycloak without credentials*
-
-[View Mermaid Source Code](./diagrams/03-kagenti-client-registreation-final.mmd)
-
-#### Stage 4: Agent Token Exchange
+#### Stage 3: Agent Token Exchange
 
 ![Agent Token Exchange Flow](./diagrams/images/png/04-agent-token-exchange-flow.png)
 
@@ -311,11 +305,11 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 }
 ```
 
-#### Stage 5: Internal Tool Access with Delegated Token
+#### Stage 4: Internal Tool Access with Delegated Token
 
 ![Internal Tool Access with Delegated Token Flow](./diagrams/images/png/05-tool-access-delegated-token-flow.png)
 
-*Figure 5: Internal Tool Access Flow - Shows how agents call internal tools using delegated tokens with proper permission validation*
+*Figure 4: Internal Tool Access Flow - Shows how agents call internal tools using delegated tokens with proper permission validation*
 
 [View Mermaid Source Code](./diagrams/05-tool-access-delegated-token-flow.mmd)
 
@@ -355,11 +349,11 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 
 The **MCP Gateway** acts as an authentication proxy for all Model Context Protocol communications:
 
-#### Stage 6: Gateway Authentication Flow
+#### Stage 5: Gateway Authentication Flow
 
 ![MCP Gateway Authentication Flow](./diagrams/images/png/06-mcp-gateway-authentication-flow.png)
 
-*Figure 6: MCP Gateway Authentication Flow - Illustrates authentication flow through the MCP Gateway proxy for Model Context Protocol communications*
+*Figure 5: MCP Gateway Authentication Flow - Illustrates authentication flow through the MCP Gateway proxy for Model Context Protocol communications*
 
 [View Mermaid Source Code](./diagrams/06-mcp-gateway-authentication-flow.mmd)
 
@@ -439,11 +433,11 @@ def validate_request(request):
         raise AuthorizationError("Insufficient permissions")
 ```
 
-#### Stage 7: External API Access with Delegated Token and Vault
+#### Stage 6: External API Access with Delegated Token and Vault
 
 ![External API Access with Delegated Token and Vault Flow](./diagrams/images/png/07-tool-with-external-api-flow.png)
 
-*Figure 7: External API Access with Vault Flow - Shows how agents call internal tools using delegated tokens with proper permission validation and the Vault exchanges this token for external API key for accessing external APIs*
+*Figure 6: External API Access with Vault Flow - Shows how agents call internal tools using delegated tokens with proper permission validation and the Vault exchanges this token for external API key for accessing external APIs*
 
 [View Mermaid Source Code](./diagrams/07-tool-with-external-api-flow.mmd)
 
@@ -479,77 +473,34 @@ def validate_request(request):
 
 ### Client Registration Process
 
-#### Automatic Registration via Init Container
+#### Operator-Managed Registration
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: slack-researcher
-spec:
-  template:
-    spec:
-      initContainers:
-      - name: client-registration
-        image: ghcr.io/kagenti/client-registration:latest
-        env:
-        - name: KEYCLOAK_URL
-          value: "http://keycloak.keycloak.svc.cluster.local:8080"
-        - name: CLIENT_NAME
-          value: "slack-researcher"
-        - name: KEYCLOAK_REALM
-          value: "master"
-        volumeMounts:
-        - name: spiffe-workload-api
-          mountPath: /spiffe-workload-api
-        - name: shared-secrets
-          mountPath: /shared
-      containers:
-      - name: slack-researcher
-        image: ghcr.io/kagenti/slack-researcher:latest
-        volumeMounts:
-        - name: shared-secrets
-          mountPath: /secrets
-```
+Keycloak client registration is handled automatically by the kagenti-operator's ClientRegistrationReconciler. When you deploy an agent or tool:
 
-#### Manual Client Registration
+1. **Label the workload** with `kagenti.io/type: agent` or `kagenti.io/type: tool`
+2. **The operator watches** for these labeled workloads
+3. **The operator registers** the workload with Keycloak using:
+   - SPIFFE ID as the client identifier (e.g., `spiffe://localtest.me/ns/team/sa/slack-researcher`)
+   - Keycloak admin credentials from the `keycloak-admin-secret` in the operator namespace
+4. **The operator creates** a secret in the agent namespace containing client credentials
+
+This is fully automatic and requires no manual intervention or init containers.
+
+#### Reading Client Credentials in Application Code
+
+Applications can read the client credentials from the secret created by the operator:
 
 ```python
-from keycloak import KeycloakAdmin
-import jwt
+import os
 
-# Read SPIFFE JWT SVID
-with open("/opt/jwt_svid.token", "r") as f:
-    jwt_svid = f.read().strip()
+# Read client credentials from operator-created secret
+# Mounted at /secrets by the platform
+client_id = open("/secrets/client-id.txt").read().strip()
+client_secret = open("/secrets/client-secret.txt").read().strip()
 
-# Extract client ID from SPIFFE identity
-payload = jwt.decode(jwt_svid, options={"verify_signature": False})
-client_id = payload["sub"]  # e.g., spiffe://localtest.me/ns/team/sa/slack-researcher
-
-# Register with Keycloak
-keycloak_admin = KeycloakAdmin(
-    server_url="http://keycloak.keycloak.svc.cluster.local:8080",
-    username="admin",
-    password="admin",
-    realm_name="master"
-)
-
-client_payload = {
-    "clientId": client_id,
-    "name": "Slack Researcher Agent",
-    "standardFlowEnabled": True,
-    "directAccessGrantsEnabled": True,
-    "serviceAccountsEnabled": True,
-    "publicClient": False,
-    "attributes": {
-        "oauth2.device.authorization.grant.enabled": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "client.secret.creation.time": str(int(time.time()))
-    }
-}
-
-internal_client_id = keycloak_admin.create_client(client_payload)
-print(f"Registered client: {client_id} with internal ID: {internal_client_id}")
+# Use credentials for OAuth2 flows
+keycloak_url = os.getenv("KEYCLOAK_URL", "http://keycloak.keycloak.svc.cluster.local:8080")
+realm = os.getenv("KEYCLOAK_REALM", "master")
 ```
 
 ### Token Exchange Implementation
@@ -610,15 +561,99 @@ tool_response = requests.post(
 
 ## 🌉 AuthBridge Component
 
-AuthBridge provides platform primitives to secure AI agents by managing agent identity,
-authentication, and authorization transparently. For comprehensive documentation, see:
+The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete, hands-on implementation of Kagenti's identity and authorization patterns. It combines **Client Registration** and **AuthProxy** to demonstrate the full zero-trust authentication flow.
 
-- **[AuthBridge Documentation](./authbridge/README.md)** — Overview, architecture, and persona guides
-- **[Security Model](./authbridge/security-model.md)** — Trust model, token exchange, threat model
-- **[Deployment Guide](./authbridge/deployment-guide.md)** — Modes, configuration, troubleshooting
-- **[Demos](./authbridge/demos.md)** — Progressive hands-on walkthrough
-- **[Roadmap](./authbridge/roadmap.md)** — Vision and upcoming features
-- **[AuthBridge Source](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** — Implementation and demo code
+### What AuthBridge Demonstrates
+
+| Capability | Description |
+|------------|-------------|
+| **Automatic Workload Identity** | Pod registers itself with Keycloak using SPIFFE ID |
+| **Inbound JWT Validation** | Validates incoming token signature, expiration, and issuer via JWKS; optionally validates audience. Returns 401 for invalid tokens. |
+| **Transparent Token Exchange** | Sidecar exchanges outbound tokens for correct target audience via Keycloak |
+| **Target Service Validation** | Target validates token has correct audience |
+
+### AuthBridge Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│  1. SPIFFE Helper obtains SVID from SPIRE Agent                                 │
+│  2. Client Registration extracts SPIFFE ID and registers with Keycloak          │
+│  3. Caller gets token from Keycloak (audience: "caller's SPIFFE ID")            │
+│  4. Caller sends request to auth-target with token                              │
+│  5. Envoy intercepts; Go Processor (ext-proc) validates token signature,        │
+│     expiration, and issuer via JWKS (returns 401 if invalid), then exchanges    │
+│     token for target audience (audience: "auth-target")                         │
+│  6. Auth Target validates token and returns "authorized"                        │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+  SPIRE Agent                    Keycloak                       Auth Target
+       │                            │                               │
+       │  1. SVID                   │                               │
+       ▼                            │                               │
+  ┌─────────┐                       │                               │
+  │ SPIFFE  │  2. Register client   │                               │
+  │ Helper  │──────────────────────►│                               │
+  └─────────┘                       │                               │
+       │                            │                               │
+       ▼                            │                               │
+  ┌─────────┐  3. Get token         │                               │
+  │ Caller  │──────────────────────►│                               │
+  │         │◄──────────────────────│                               │
+  │         │   (aud: authproxy)    │                               │
+  │         │                       │                               │
+  │         │  4. Request + token   │                               │
+  │         │───────────────────────┼──────────────────────────────►│
+  └─────────┘                       │                               │
+       │                            │                               │
+       │      ┌──────────────┐      │                               │
+       └─────►│ Envoy+GoPro  │      │                               │
+              │              │  5. Exchange token                   │
+              │              │─────►│                               │
+              │              │◄─────│                               │
+              │              │   (aud: auth-target)                 │
+              │              │─────────────────────────────────────►│
+              └──────────────┘                              6. Validate & Authorize
+                                                                    │
+                                                               "authorized"
+```
+
+### AuthBridge Components
+
+| Component | Type | Purpose |
+|-----------|------|---------|
+| **SPIFFE Helper** | Container | Obtains SVID from SPIRE Agent |
+| **Envoy + Go Processor (Ext Proc)** | Sidecar | Intercepts traffic in both directions: **inbound** — validates JWT (signature, expiration, issuer, optional audience) via JWKS, returns 401 for invalid tokens; **outbound** — exchanges tokens for target audience via Keycloak |
+| **Auth Target** | Deployment | Target service that validates exchanged tokens |
+
+> **Note**: Keycloak client registration is handled by the kagenti-operator's ClientRegistrationReconciler controller, not by an AuthBridge component. The operator automatically registers agents and tools with Keycloak using credentials from the operator namespace.
+
+### Installation and Hands-On Demo
+
+The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete end-to-end example:
+
+```bash
+# Clone and deploy
+cd AuthBridge
+python setup_keycloak.py           # Configure Keycloak
+kubectl apply -f k8s/authbridge-deployment.yaml  # Deploy demo
+
+# Test
+kubectl exec -it deployment/caller -n authbridge -c caller -- sh
+TOKEN=$(curl -s ... | jq -r '.access_token')
+curl -H "Authorization: Bearer $TOKEN" http://auth-target-service:8081/test
+# Returns: "authorized"
+```
+
+For detailed installation and demo instructions please see the [AuthBridge Demo](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)
+
+### AuthBridge Documentation
+
+For complete documentation, see:
+
+- **[AuthBridge README](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** - Full demo instructions
+- **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** - Token validation and exchange proxy
+
+> **Note**: The AuthBridge demo in kagenti-extensions includes client-registration components for demonstration purposes. In production Kagenti deployments, client registration is handled by the kagenti-operator controller.
 
 ---
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -480,7 +480,9 @@ Keycloak client registration is handled automatically by the kagenti-operator's 
 1. **Label the workload** with `kagenti.io/type: agent` or `kagenti.io/type: tool`
 2. **The operator watches** for these labeled workloads
 3. **The operator registers** the workload with Keycloak using:
-   - SPIFFE ID as the client identifier (e.g., `spiffe://localtest.me/ns/team/sa/slack-researcher`)
+   - Client ID pattern depends on whether SPIFFE is enabled:
+     - **SPIFFE disabled**: `namespace/workload-name` (e.g., `team1/slack-researcher`)
+     - **SPIFFE enabled**: `spiffe://trustdomain/ns/namespace/sa/serviceaccount` (e.g., `spiffe://localtest.me/ns/team1/sa/slack-researcher-sa`)
    - Keycloak admin credentials from the `keycloak-admin-secret` in the operator namespace
 4. **The operator creates** a secret in the agent namespace containing client credentials
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -578,56 +578,61 @@ The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/ma
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────┐
-│  1. SPIFFE Helper obtains SVID from SPIRE Agent                                 │
-│  2. Client Registration extracts SPIFFE ID and registers with Keycloak          │
-│  3. Caller gets token from Keycloak (audience: "caller's SPIFFE ID")            │
-│  4. Caller sends request to auth-target with token                              │
-│  5. Envoy intercepts; Go Processor (ext-proc) validates token signature,        │
-│     expiration, and issuer via JWKS (returns 401 if invalid), then exchanges    │
-│     token for target audience (audience: "auth-target")                         │
-│  6. Auth Target validates token and returns "authorized"                        │
+│  1. Operator watches workloads with kagenti.io/type label                       │
+│  2. Operator registers client with Keycloak (using admin credentials from       │
+│     operator namespace) and creates credentials secret in agent namespace       │
+│  3. (If SPIFFE enabled) SPIFFE Helper obtains SVID from SPIRE Agent             │
+│  4. Agent gets token from Keycloak using credentials from secret                │
+│  5. Agent sends request to target with token                                    │
+│  6. Envoy+ext-proc intercepts: validates token signature, expiration, issuer    │
+│     via JWKS (returns 401 if invalid), then exchanges token for target audience │
+│  7. Target receives request with exchanged token and validates audience         │
 └─────────────────────────────────────────────────────────────────────────────────┘
 
-  SPIRE Agent                    Keycloak                       Auth Target
-       │                            │                               │
-       │  1. SVID                   │                               │
-       ▼                            │                               │
-  ┌─────────┐                       │                               │
-  │ SPIFFE  │  2. Register client   │                               │
-  │ Helper  │──────────────────────►│                               │
-  └─────────┘                       │                               │
-       │                            │                               │
-       ▼                            │                               │
-  ┌─────────┐  3. Get token         │                               │
-  │ Caller  │──────────────────────►│                               │
-  │         │◄──────────────────────│                               │
-  │         │   (aud: authproxy)    │                               │
-  │         │                       │                               │
-  │         │  4. Request + token   │                               │
-  │         │───────────────────────┼──────────────────────────────►│
-  └─────────┘                       │                               │
-       │                            │                               │
-       │      ┌──────────────┐      │                               │
-       └─────►│ Envoy+GoPro  │      │                               │
-              │              │  5. Exchange token                   │
-              │              │─────►│                               │
-              │              │◄─────│                               │
-              │              │   (aud: auth-target)                 │
-              │              │─────────────────────────────────────►│
-              └──────────────┘                              6. Validate & Authorize
-                                                                    │
-                                                               "authorized"
+  Operator                   SPIRE Agent           Keycloak              Target
+       │                         │                     │                    │
+       │ 1. Watch workload       │                     │                    │
+       │ 2. Register client      │                     │                    │
+       ├─────────────────────────┼────────────────────►│                    │
+       │                         │                     │                    │
+       │ Create credentials      │                     │                    │
+       │ secret in agent ns      │                     │                    │
+       │                         │                     │                    │
+       │              ┌─────────┐│  3. Get SVID        │                    │
+       │              │ SPIFFE  ││◄────────────────────┤                    │
+       │              │ Helper  ││                     │                    │
+       │              └─────────┘│                     │                    │
+       │                    │    │                     │                    │
+       │              ┌─────────┐│                     │                    │
+       │              │  Agent  ││  4. Get token       │                    │
+       │              │         ││────────────────────►│                    │
+       │              │         ││◄────────────────────│                    │
+       │              │         ││  (aud: agent's ID)  │                    │
+       │              │         ││                     │                    │
+       │              │         ││  5. Request + token │                    │
+       │              │         ││─────────────────────┼───────────────────►│
+       │              └─────────┘│                     │                    │
+       │                    │    │                     │                    │
+       │         ┌──────────────┐│                     │                    │
+       │         │ Envoy+ext-pr ││  6. Validate &      │                    │
+       │         │              ││     Exchange token  │                    │
+       │         │              ││────────────────────►│                    │
+       │         │              ││◄────────────────────│                    │
+       │         │              ││  (aud: target)      │                    │
+       │         │              ││─────────────────────┼───────────────────►│
+       │         └──────────────┘│                     │  7. Validate aud   │
+       │                         │                     │       "authorized" │
 ```
 
 ### AuthBridge Components
 
 | Component | Type | Purpose |
 |-----------|------|---------|
-| **SPIFFE Helper** | Container | Obtains SVID from SPIRE Agent |
+| **Kagenti Operator** | Controller | Watches for workloads with `kagenti.io/type` label, registers them as OAuth clients in Keycloak, and creates credentials secrets in agent namespaces |
+| **SPIFFE Helper** | Container | (Optional, when SPIFFE enabled) Obtains SVID from SPIRE Agent for workload identity |
 | **Envoy + Go Processor (Ext Proc)** | Sidecar | Intercepts traffic in both directions: **inbound** — validates JWT (signature, expiration, issuer, optional audience) via JWKS, returns 401 for invalid tokens; **outbound** — exchanges tokens for target audience via Keycloak |
-| **Auth Target** | Deployment | Target service that validates exchanged tokens |
 
-> **Note**: Keycloak client registration is handled by the kagenti-operator's ClientRegistrationReconciler controller, not by an AuthBridge component. The operator automatically registers agents and tools with Keycloak using credentials from the operator namespace.
+> **Note**: Client registration is fully automatic. The operator reads Keycloak admin credentials from `keycloak-admin-secret` in the operator namespace (not from agent namespaces), providing better security isolation.
 
 ### Installation and Hands-On Demo
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -634,24 +634,12 @@ The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/ma
 
 > **Note**: Client registration is fully automatic. The operator reads Keycloak admin credentials from `keycloak-admin-secret` in the operator namespace (not from agent namespaces), providing better security isolation.
 
-### Installation and Hands-On Demo
+### Hands-On Demos
 
-The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete end-to-end example:
+For step-by-step AuthBridge demos with real working examples, see:
 
-```bash
-# Clone and deploy
-cd AuthBridge
-python setup_keycloak.py           # Configure Keycloak
-kubectl apply -f k8s/authbridge-deployment.yaml  # Deploy demo
-
-# Test
-kubectl exec -it deployment/caller -n authbridge -c caller -- sh
-TOKEN=$(curl -s ... | jq -r '.access_token')
-curl -H "Authorization: Bearer $TOKEN" http://auth-target-service:8081/test
-# Returns: "authorized"
-```
-
-For detailed installation and demo instructions please see the [AuthBridge Demo](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)
+- **[AuthBridge Weather Demo](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/demos/weather-agent)** — Complete end-to-end example showing token exchange between a weather agent and weather tool
+- **[AuthBridge Documentation](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** — Component documentation and additional examples
 
 ### AuthBridge Documentation
 


### PR DESCRIPTION
## Summary

Addresses security issue in [kagenti-operator#320](https://github.com/kagenti/kagenti-operator/issues/320) by:

1. **Moving Keycloak admin credentials to kagenti-system namespace** - prevents compromised agent namespaces from gaining full Keycloak realm admin access
2. **Removing client-registration sidecar references** - the sidecar is being sunset in favor of the operator-based approach
3. **Updating documentation and comments** to reflect the new architecture

## Changes

### Security Improvement
- ✅ Create `keycloak-admin-secret` in `kagenti-system` namespace (operator namespace)
- ✅ Remove `keycloak-admin-secret` from agent namespaces (team1, team2, etc.)

### Cleanup
- ✅ Remove `clientRegistration` image references from values.yaml (sidecar sunset)
- ✅ Update comments in agent-namespaces.yaml to remove sidecar references
- ✅ Update OpenShift SCC comments
- ✅ Update Ansible deployment comments

## Impact

| Before | After |
|--------|-------|
| Admin credentials in every agent namespace | Admin credentials only in kagenti-system |
| Compromised agent namespace = realm admin access | Compromised agent namespace = no admin access |
| Client registration via sidecar | Client registration via operator controller |

## Related PRs

This PR **must be merged and deployed BEFORE** the operator PR:
- **Next:** [kagenti-operator PR](link-tbd) - updates operator controller to read from kagenti-system

## Migration Instructions

After **both** PRs are merged and deployed:

```bash
# Manually clean up old secrets from agent namespaces
kubectl delete secret keycloak-admin-secret -n team1
kubectl delete secret keycloak-admin-secret -n team2
```

## Testing

- [ ] Deploy to Kind cluster
- [ ] Verify secret exists in kagenti-system
- [ ] Verify secrets removed from agent namespaces
- [ ] Deploy test agent and verify OAuth client registration works
- [ ] Run E2E tests

## Related Issues

- Closes: kagenti-operator#320
- Long-term: #1421 (SPIFFE DCR to eliminate admin credentials entirely)

Assisted-By: Claude Code
