### PR TITLE
fix(openshell): pass gateway endpoint and TLS secrets to compute driver

### DIFF
--- a/charts/openshell/templates/statefulset.yaml
+++ b/charts/openshell/templates/statefulset.yaml
@@ -94,7 +94,10 @@ spec:
             - "--socket=/run/drivers/compute.sock"
             - "--namespace={{ include "openshell.driverNamespace" . }}"
             - "--supervisor-image={{ .Values.supervisorImage.repository }}:{{ .Values.supervisorImage.tag }}"
+            - "--gateway-endpoint=https://openshell-server.{{ .Values.tenant }}.svc:8080"
             - "--dtach-binary-path=/usr/local/bin/openshell-sandbox"
+            - "--tls-ca-secret=openshell-server-tls"
+            - "--tls-client-secret=openshell-client-tls"
           volumeMounts:
             - name: driver-sockets
               mountPath: /run/drivers

--- a/scripts/openshell/configure-cli.sh
+++ b/scripts/openshell/configure-cli.sh
@@ -151,6 +151,29 @@ else
 fi
 echo ""
 
+# ── Extract mTLS certificates ────────────────────────────────────────────────
+# The CLI requires the CA cert (for server verification) and client cert/key
+# (for mTLS handshake) in the gateway's mtls directory.
+MTLS_DIR="${HOME}/.config/openshell/gateways/${GATEWAY_NAME}/mtls"
+
+log_info "Extracting mTLS certificates from cluster"
+
+if $DRY_RUN; then
+  echo "  [dry-run] kubectl get secret openshell-server-tls -n $TENANT → $MTLS_DIR/ca.crt"
+  echo "  [dry-run] kubectl get secret openshell-client-tls -n $TENANT → $MTLS_DIR/tls.{crt,key}"
+else
+  mkdir -p "$MTLS_DIR"
+  kubectl get secret openshell-server-tls -n "$TENANT" \
+    -o jsonpath='{.data.ca\.crt}' | base64 -d > "$MTLS_DIR/ca.crt"
+  kubectl get secret openshell-client-tls -n "$TENANT" \
+    -o jsonpath='{.data.tls\.crt}' | base64 -d > "$MTLS_DIR/tls.crt"
+  kubectl get secret openshell-client-tls -n "$TENANT" \
+    -o jsonpath='{.data.tls\.key}' | base64 -d > "$MTLS_DIR/tls.key"
+  chmod 600 "$MTLS_DIR"/{ca.crt,tls.crt,tls.key}
+  log_success "mTLS certificates extracted to $MTLS_DIR"
+fi
+echo ""
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo "╔════════════════════════════════════════════════════════════════╗"
 echo "║  Done — CLI configured for tenant: $TENANT"


### PR DESCRIPTION
## Summary
- Add `--gateway-endpoint`, `--tls-ca-secret`, and `--tls-client-secret` flags to the compute driver container args in the OpenShell gateway StatefulSet

## Context

The compute driver creates Sandbox CR pod specs. For the supervisor inside the sandbox to establish a secure gRPC connection back to the gateway (policy fetch, provider env, inference bundle, SSH relay), it needs:

1. The gateway endpoint URL (`--gateway-endpoint`) → sets `OPENSHELL_ENDPOINT` on sandbox pods
2. The CA cert secret name (`--tls-ca-secret`) → mounts CA for TLS verification
3. The client cert secret name (`--tls-client-secret`) → mounts cert/key for mTLS

These secrets are already created by the existing `certificate.yaml` template. This PR wires them through to the compute driver so it can configure sandbox pods correctly.

Follows up on #1417 which deployed the gateway but didn't configure these flags, resulting in sandbox provisioning timeouts (`DependenciesNotReady: Pod is Running but not Ready`).

## Test plan
- [x] Deploy Kind cluster: `.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy`
- [x] Deploy OpenShell: `scripts/openshell/deploy-shared.sh && scripts/openshell/deploy-tenant.sh team1`
- [x] Login: `openshell gateway login` (alice/alice123)
- [x] Create provider and inference route
- [x] `openshell sandbox create --provider claude --no-auto-providers -- claude --print "hello"` returns response

🤖 Generated with [Claude Code](https://claude.com/claude-code)