### PR TITLE
fix(e2e): fix HyperShift E2E test failures across multiple layers

### DIFF
--- a/.github/scripts/hypershift/ci/80-run-e2e-tests.sh
+++ b/.github/scripts/hypershift/ci/80-run-e2e-tests.sh
@@ -23,6 +23,11 @@ uv sync --extra test
 # Use hypershift-full-test.sh with whitelist mode (--include-test)
 # hypershift-full-test.sh handles AGENT_URL detection from route and calls 90-run-e2e-tests.sh
 # Note: CLUSTER_SUFFIX is set by the workflow (e.g., pr594), don't override it
+#
+# Use CI-specific config that disables features not installed on ephemeral clusters
+# (RHOAI, MLflow, Shipwright, Kiali) so tests are correctly skipped.
+export KAGENTI_CONFIG_FILE="deployments/envs/ocp_ci_values.yaml"
+
 exec "$REPO_ROOT/.github/scripts/local-setup/hypershift-full-test.sh" \
     --include-test \
     --env ocp

--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -655,7 +655,7 @@ oc get nodes
 ./.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
 
 export AGENT_URL="https://\$(oc get route -n team1 weather-service -o jsonpath='{.spec.host}')"
-export KAGENTI_CONFIG_FILE=deployments/envs/ocp_values.yaml
+export KAGENTI_CONFIG_FILE=deployments/envs/ocp_ci_values.yaml
 ./.github/scripts/kagenti-operator/90-run-e2e-tests.sh
 
 # ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/.github/scripts/kagenti-operator/41-wait-crds.sh
+++ b/.github/scripts/kagenti-operator/41-wait-crds.sh
@@ -10,13 +10,29 @@ log_step "41" "Waiting for Kagenti Operator CRDs"
 # NOTE: agents.agent.kagenti.dev is NOT required for E2E tests since we now
 # deploy agents using standard Kubernetes Deployments + Services directly.
 # Only keeping CRDs that are still actively used in CI.
-CRDS=(
-    "mcpserverregistrations.mcp.kagenti.com"
-    "mcpvirtualservers.mcp.kagenti.com"
-    "mcpgatewayextensions.mcp.kagenti.com"
+#
+# MCP gateway v0.6.0 renamed the CRD group from mcp.kuadrant.io to
+# mcp.kagenti.com. Kind CI still uses the old version; HyperShift uses the new.
+# Detect which domain is present, then wait for those CRDs.
+MCP_RESOURCES=(
+    "mcpserverregistrations"
+    "mcpvirtualservers"
+    "mcpgatewayextensions"
 )
 
-for crd in "${CRDS[@]}"; do
+# Detect which MCP CRD domain is installed (quick check, no wait)
+if kubectl get crd "mcpserverregistrations.mcp.kagenti.com" &>/dev/null; then
+    MCP_DOMAIN="mcp.kagenti.com"
+elif kubectl get crd "mcpserverregistrations.mcp.kuadrant.io" &>/dev/null; then
+    MCP_DOMAIN="mcp.kuadrant.io"
+else
+    # Neither exists yet — default to new domain and let wait_for_crd handle the timeout
+    MCP_DOMAIN="mcp.kagenti.com"
+fi
+log_info "MCP CRD domain: $MCP_DOMAIN"
+
+for resource in "${MCP_RESOURCES[@]}"; do
+    crd="${resource}.${MCP_DOMAIN}"
     log_info "Waiting for CRD: $crd"
     wait_for_crd "$crd" || {
         log_error "CRD $crd not found"

--- a/.github/scripts/kagenti-operator/41-wait-crds.sh
+++ b/.github/scripts/kagenti-operator/41-wait-crds.sh
@@ -11,9 +11,9 @@ log_step "41" "Waiting for Kagenti Operator CRDs"
 # deploy agents using standard Kubernetes Deployments + Services directly.
 # Only keeping CRDs that are still actively used in CI.
 CRDS=(
-    "mcpserverregistrations.mcp.kuadrant.io"
-    "mcpvirtualservers.mcp.kuadrant.io"
-    "mcpgatewayextensions.mcp.kuadrant.io"
+    "mcpserverregistrations.mcp.kagenti.com"
+    "mcpvirtualservers.mcp.kagenti.com"
+    "mcpgatewayextensions.mcp.kagenti.com"
 )
 
 for crd in "${CRDS[@]}"; do

--- a/.github/scripts/kagenti-operator/41-wait-crds.sh
+++ b/.github/scripts/kagenti-operator/41-wait-crds.sh
@@ -20,14 +20,23 @@ MCP_RESOURCES=(
     "mcpgatewayextensions"
 )
 
-# Detect which MCP CRD domain is installed (quick check, no wait)
-if kubectl get crd "mcpserverregistrations.mcp.kagenti.com" &>/dev/null; then
+# Detect which MCP CRD domain is installed.
+# Retry up to 60s since operators may still be registering CRDs.
+MCP_DOMAIN=""
+for i in $(seq 1 12); do
+    if kubectl get crd "mcpserverregistrations.mcp.kagenti.com" &>/dev/null; then
+        MCP_DOMAIN="mcp.kagenti.com"
+        break
+    elif kubectl get crd "mcpserverregistrations.mcp.kuadrant.io" &>/dev/null; then
+        MCP_DOMAIN="mcp.kuadrant.io"
+        break
+    fi
+    log_info "MCP CRDs not yet available, retrying ($i/12)..."
+    sleep 5
+done
+if [ -z "$MCP_DOMAIN" ]; then
     MCP_DOMAIN="mcp.kagenti.com"
-elif kubectl get crd "mcpserverregistrations.mcp.kuadrant.io" &>/dev/null; then
-    MCP_DOMAIN="mcp.kuadrant.io"
-else
-    # Neither exists yet — default to new domain and let wait_for_crd handle the timeout
-    MCP_DOMAIN="mcp.kagenti.com"
+    log_info "Defaulting to $MCP_DOMAIN (neither domain detected after 60s)"
 fi
 log_info "MCP CRD domain: $MCP_DOMAIN"
 

--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -97,11 +97,32 @@ log_info "Creating Deployment and Service..."
 # Create ServiceAccount (required by webhook for correct SPIFFE ID derivation)
 kubectl create serviceaccount weather-service -n team1 --dry-run=client -o yaml | kubectl apply -f -
 
-# Apply Deployment manifest (OCP internal registry only when Shipwright built the image)
+# Apply Deployment manifest
 if [ "$SHIPWRIGHT_BUILD" = "true" ]; then
+    # Shipwright built the image into the internal registry — use OCP manifest
     kubectl apply -f "$REPO_ROOT/kagenti/examples/agents/weather_service_deployment_ocp.yaml"
 else
+    # Use ghcr.io image (Kind manifest)
     kubectl apply -f "$REPO_ROOT/kagenti/examples/agents/weather_service_deployment.yaml"
+
+    # On OpenShift without Shipwright, patch LLM config to use external endpoint
+    # (Kind manifest points to dockerhost:11434 which doesn't exist on OCP)
+    if [ "$IS_OPENSHIFT" = "true" ]; then
+        log_info "Patching LLM config for OpenShift (no local Ollama)..."
+        kubectl set env deployment/weather-service -n team1 \
+            LLM_API_BASE="https://litellm-prod.apps.maas.redhatworkshops.io/v1" \
+            LLM_MODEL="llama-scout-17b" \
+            LLM_API_KEY- OPENAI_API_KEY- 2>/dev/null || true
+        # Set API keys from secret if it exists
+        if kubectl get secret openai-secret -n team1 &>/dev/null; then
+            kubectl patch deployment weather-service -n team1 --type=json -p '[
+                {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"LLM_API_KEY","valueFrom":{"secretKeyRef":{"name":"openai-secret","key":"apikey"}}}},
+                {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"OPENAI_API_KEY","valueFrom":{"secretKeyRef":{"name":"openai-secret","key":"apikey"}}}}
+            ]' || true
+        else
+            log_warn "openai-secret not found in team1 — LLM calls will fail without API key"
+        fi
+    fi
 fi
 
 # Apply Service manifest

--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -15,7 +15,9 @@ log_step "74" "Deploying weather-service agent"
 # On Kind, the deployment manifest references ghcr.io directly — no build needed.
 # ============================================================================
 
-if [ "$IS_OPENSHIFT" = "true" ]; then
+SHIPWRIGHT_BUILD=false
+if [ "$IS_OPENSHIFT" = "true" ] && kubectl get crd builds.shipwright.io &>/dev/null; then
+    SHIPWRIGHT_BUILD=true
     log_info "Using OpenShift Shipwright files with internal registry"
 
     # Clean up previous Build to avoid conflicts
@@ -82,7 +84,7 @@ if [ "$IS_OPENSHIFT" = "true" ]; then
 
     log_success "BuildRun completed successfully"
 else
-    log_info "Using ghcr.io image for Kind — skipping Shipwright build"
+    log_info "Shipwright not available — using ghcr.io image"
 fi
 
 # ============================================================================
@@ -95,8 +97,8 @@ log_info "Creating Deployment and Service..."
 # Create ServiceAccount (required by webhook for correct SPIFFE ID derivation)
 kubectl create serviceaccount weather-service -n team1 --dry-run=client -o yaml | kubectl apply -f -
 
-# Apply Deployment manifest (use OCP-specific file with correct registry on OpenShift)
-if [ "$IS_OPENSHIFT" = "true" ]; then
+# Apply Deployment manifest (OCP internal registry only when Shipwright built the image)
+if [ "$SHIPWRIGHT_BUILD" = "true" ]; then
     kubectl apply -f "$REPO_ROOT/kagenti/examples/agents/weather_service_deployment_ocp.yaml"
 else
     kubectl apply -f "$REPO_ROOT/kagenti/examples/agents/weather_service_deployment.yaml"

--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -370,7 +370,7 @@ jobs:
         run: bash .github/scripts/hypershift/ci/80-run-e2e-tests.sh
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-          KAGENTI_CONFIG_FILE: deployments/envs/ocp_values.yaml
+          KAGENTI_CONFIG_FILE: deployments/envs/ocp_ci_values.yaml
 
       - name: Run UI E2E tests
         if: success()

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -203,7 +203,7 @@ jobs:
         run: bash .github/scripts/hypershift/ci/80-run-e2e-tests.sh
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
-          KAGENTI_CONFIG_FILE: deployments/envs/ocp_values.yaml
+          KAGENTI_CONFIG_FILE: deployments/envs/ocp_ci_values.yaml
 
       - name: Run UI E2E tests
         if: success()

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -19,6 +19,8 @@ metadata:
     istio.io/dataplane-mode: ambient
     istio.io/use-waypoint: waypoint
     shared-gateway-access: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   {{- include "kagenti.labels" $root | nindent 4 }}
 ---
 # ——————————————————————————————————————————————————————————————————————————————

--- a/deployments/ansible/cleanup-install.sh
+++ b/deployments/ansible/cleanup-install.sh
@@ -32,8 +32,9 @@ for ns in "${TEAM_NAMESPACES[@]}"; do
     # Delete Agent CRs (kagenti-operator)
     kubectl delete agents.agent.kagenti.dev --all -n "$ns" --ignore-not-found 2>/dev/null || true
     kubectl delete agentcards.agent.kagenti.dev --all -n "$ns" --ignore-not-found 2>/dev/null || true
-    # Delete MCP Gateway CRs
+    # Delete MCP Gateway CRs (handle both old and new CRD domain)
     kubectl delete mcpserverregistrations.mcp.kagenti.com --all -n "$ns" --ignore-not-found 2>/dev/null || true
+    kubectl delete mcpserverregistrations.mcp.kuadrant.io --all -n "$ns" --ignore-not-found 2>/dev/null || true
   fi
 done
 echo ""

--- a/deployments/ansible/cleanup-install.sh
+++ b/deployments/ansible/cleanup-install.sh
@@ -33,7 +33,7 @@ for ns in "${TEAM_NAMESPACES[@]}"; do
     kubectl delete agents.agent.kagenti.dev --all -n "$ns" --ignore-not-found 2>/dev/null || true
     kubectl delete agentcards.agent.kagenti.dev --all -n "$ns" --ignore-not-found 2>/dev/null || true
     # Delete MCP Gateway CRs
-    kubectl delete mcpserverregistrations.mcp.kuadrant.io --all -n "$ns" --ignore-not-found 2>/dev/null || true
+    kubectl delete mcpserverregistrations.mcp.kagenti.com --all -n "$ns" --ignore-not-found 2>/dev/null || true
   fi
 done
 echo ""

--- a/deployments/envs/ocp_ci_values.yaml
+++ b/deployments/envs/ocp_ci_values.yaml
@@ -1,0 +1,98 @@
+# Kagenti CI configuration for HyperShift ephemeral clusters
+# Based on ocp_values.yaml but disables components not installed on CI clusters:
+#   - RHOAI (requires separate operator install + entitlement)
+#   - MLflow (depends on RHOAI MLflow operator)
+#   - Shipwright (requires OpenShift Builds operator)
+#   - Kiali (not installed on ephemeral clusters)
+#
+# This config is used by KAGENTI_CONFIG_FILE in E2E tests to correctly
+# skip tests for features that are not present on the cluster.
+
+create_kind_cluster: false
+
+charts:
+  kagenti-deps:
+    enabled: true
+    values:
+      openshift: true
+      components:
+        mcpInspector:
+          enabled: true
+        istio:
+          enabled: true
+        kiali:
+          enabled: false
+        keycloak:
+          enabled: true
+        otel:
+          enabled: true
+        phoenix:
+          enabled: false
+        mlflow:
+          enabled: false
+        spire:
+          enabled: true
+        tekton:
+          enabled: true
+        shipwright:
+          enabled: false
+        certManager:
+          enabled: true
+        rhoai:
+          enabled: false
+        gatewayApi:
+          enabled: false
+      mlflow:
+        auth:
+          enabled: false
+
+  kagenti:
+    enabled: true
+    values:
+      openshift: true
+      featureFlags:
+        sandbox: true
+        integrations: true
+        triggers: true
+      components:
+        agentNamespaces:
+          enabled: true
+        platformOperator:
+          enabled: true
+        platformWebhook:
+          enabled: true
+        ui:
+          enabled: true
+        mcpGateway:
+          enabled: true
+        istio:
+          enabled: false
+        phoenix:
+          enabled: false
+      mlflow:
+        auth:
+          enabled: false
+      ui:
+        auth:
+          enabled: true
+        backend:
+          defaultRegistryUrl: "image-registry.openshift-image-registry.svc:5000"
+      uiOAuthSecret:
+        useServiceAccountCA: true
+      keycloak:
+        url: http://keycloak-service.keycloak:8080
+      agentNamespaces:
+        - team1
+        - team2
+
+  mcpGateway:
+    enabled: true
+
+  kuadrant:
+    enabled: true
+
+  spire:
+    enabled: false
+
+rhoai:
+  enabled: false

--- a/kagenti/tests/e2e/common/test_platform_health.py
+++ b/kagenti/tests/e2e/common/test_platform_health.py
@@ -42,26 +42,49 @@ def _is_job_pod(pod) -> bool:
     return False
 
 
+KAGENTI_NAMESPACES = {
+    "kagenti-system",
+    "kagenti-webhook-system",
+    "keycloak",
+    "team1",
+    "team2",
+    "mcp-system",
+    "spire-mgmt",
+    "zero-trust-workload-identity-manager",
+    "spire-system",
+    "gateway-system",
+    "istio-system",
+    "istio-cni",
+    "istio-ztunnel",
+    "cert-manager",
+}
+
+
+def _in_kagenti_namespace(namespace: str) -> bool:
+    return namespace in KAGENTI_NAMESPACES
+
+
 class TestPlatformHealth:
     """Test overall platform health checks."""
 
     @pytest.mark.critical
     def test_no_failed_pods(self, k8s_client):
         """
-        Verify there are no failed pods in the cluster.
+        Verify there are no failed pods in Kagenti-managed namespaces.
 
         Checks that all pods are in Running or Succeeded phase.
         Excludes Job pods since they can fail and be retried (expected behavior).
+        Scoped to Kagenti namespaces to avoid false positives from
+        unrelated system pods on OpenShift.
         """
-        # Get all pods across all namespaces
         pods = k8s_client.list_pod_for_all_namespaces(watch=False)
 
-        # Find pods that are not in Running or Succeeded state
-        # Exclude Job pods - they can fail during retries which is normal
         failed_pods = [
             f"{pod.metadata.namespace}/{pod.metadata.name} ({pod.status.phase})"
             for pod in pods.items
-            if pod.status.phase not in ["Running", "Succeeded"] and not _is_job_pod(pod)
+            if _in_kagenti_namespace(pod.metadata.namespace)
+            and pod.status.phase not in ["Running", "Succeeded"]
+            and not _is_job_pod(pod)
         ]
 
         assert len(failed_pods) == 0, (
@@ -71,7 +94,7 @@ class TestPlatformHealth:
     @pytest.mark.critical
     def test_no_crashlooping_pods(self, k8s_client):
         """
-        Verify there are no crashlooping pods.
+        Verify there are no crashlooping pods in Kagenti-managed namespaces.
 
         Checks that no pods are currently in a CrashLoopBackOff state
         or have recently restarted (within the last 5 minutes).
@@ -87,14 +110,15 @@ class TestPlatformHealth:
         recent_restart_threshold = timedelta(minutes=5)
 
         for pod in pods.items:
+            if not _in_kagenti_namespace(pod.metadata.namespace):
+                continue
+
             # Skip Job pods — they restart on failure by design
             if _is_job_pod(pod):
                 continue
 
-            # Check if pod is in CrashLoopBackOff state
             if pod.status.container_statuses:
                 for container in pod.status.container_statuses:
-                    # Check for CrashLoopBackOff state
                     if container.state and container.state.waiting:
                         if container.state.waiting.reason == "CrashLoopBackOff":
                             crashlooping_pods.append(
@@ -104,7 +128,6 @@ class TestPlatformHealth:
                             )
                             continue
 
-                    # Check for recent restarts (not just total count)
                     if (
                         container.restart_count > 0
                         and container.state
@@ -113,7 +136,6 @@ class TestPlatformHealth:
                         started_at = container.state.running.started_at
                         if started_at:
                             time_since_start = now - started_at
-                            # If pod restarted recently (within 5 min) and has multiple restarts, flag it
                             if (
                                 time_since_start < recent_restart_threshold
                                 and container.restart_count > 2
@@ -132,7 +154,7 @@ class TestPlatformHealth:
     @pytest.mark.critical
     def test_all_jobs_completed(self, k8s_batch_client):
         """
-        Verify that all Jobs in the cluster have completed successfully.
+        Verify that all Jobs in Kagenti-managed namespaces have completed.
 
         Checks that every Job has at least one successful completion
         (status.succeeded >= 1). Jobs that are still actively running
@@ -140,33 +162,31 @@ class TestPlatformHealth:
         allowed to fail since they run during install and may encounter
         transient Keycloak availability issues.
         """
-        # Helm hook jobs that may fail due to timing/ordering — not app failures
         HELM_HOOK_JOBS = {
             "kagenti-agent-oauth-secret-job",
             "kagenti-ui-oauth-secret-job",
         }
 
-        # Get all jobs across all namespaces
         jobs = k8s_batch_client.list_job_for_all_namespaces(watch=False)
 
         failed_jobs = []
         for job in jobs.items:
             namespace = job.metadata.namespace
+            if not _in_kagenti_namespace(namespace):
+                continue
+
             job_name = job.metadata.name
 
             succeeded = job.status.succeeded or 0
             failed = job.status.failed or 0
             active = job.status.active or 0
 
-            # Skip jobs that are still running
             if active > 0:
                 continue
 
-            # Skip known Helm hook jobs that may fail transiently
             if job_name in HELM_HOOK_JOBS:
                 continue
 
-            # Job is not running - check if it succeeded
             if succeeded < 1:
                 failed_jobs.append(
                     f"{namespace}/{job_name} (succeeded={succeeded}, failed={failed})"

--- a/kagenti/tests/e2e/common/test_shipwright_build.py
+++ b/kagenti/tests/e2e/common/test_shipwright_build.py
@@ -164,7 +164,7 @@ class TestShipwrightAvailability:
 class TestShipwrightBuildLifecycle:
     """Test Shipwright Build and BuildRun lifecycle."""
 
-    @pytest.mark.requires_features(["tekton"])  # Shipwright requires Tekton
+    @pytest.mark.requires_features(["shipwright"])
     def test_create_build(self, k8s_custom_client, shipwright_available, cleanup_build):
         """Verify a Shipwright Build can be created."""
         if not shipwright_available:
@@ -214,7 +214,7 @@ class TestShipwrightBuildLifecycle:
         assert created is not None
         assert created["metadata"]["name"] == TEST_BUILD_NAME
 
-    @pytest.mark.requires_features(["tekton"])
+    @pytest.mark.requires_features(["shipwright"])
     def test_create_buildrun(
         self, k8s_custom_client, shipwright_available, cleanup_build
     ):
@@ -290,7 +290,7 @@ class TestShipwrightBuildLifecycle:
         assert created["metadata"]["name"].startswith(f"{TEST_BUILD_NAME}-run-")
         assert created["spec"]["build"]["name"] == TEST_BUILD_NAME
 
-    @pytest.mark.requires_features(["tekton"])
+    @pytest.mark.requires_features(["shipwright"])
     def test_buildrun_status_progression(
         self, k8s_custom_client, shipwright_available, cleanup_build
     ):
@@ -393,7 +393,7 @@ class TestShipwrightBuildLifecycle:
 class TestBuildAnnotations:
     """Test agent configuration storage in Build annotations."""
 
-    @pytest.mark.requires_features(["tekton"])
+    @pytest.mark.requires_features(["shipwright"])
     def test_agent_config_in_annotations(
         self, k8s_custom_client, shipwright_available, cleanup_build
     ):

--- a/kagenti/tests/e2e/common/test_shipwright_tool_build.py
+++ b/kagenti/tests/e2e/common/test_shipwright_tool_build.py
@@ -176,6 +176,7 @@ def cleanup_tool_build(k8s_custom_client):
         pass
 
 
+@pytest.mark.requires_features(["shipwright"])
 class TestToolShipwrightBuildIntegration:
     """Integration tests for tool Shipwright build workflow."""
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -536,6 +536,21 @@ _apply_operand_crs() {
   done
   log_success "ZTWIM CRDs available"
 
+  # Wait for Sail Operator CRDs — Istio/ztunnel/CNI operands depend on this.
+  log_info "Waiting for Sail Operator CRDs..."
+  tries=0
+  while ! $KUBECTL get crd istios.sailoperator.io &>/dev/null; do
+    tries=$((tries + 1))
+    if [ $tries -ge 120 ]; then
+      log_error "Sail Operator CRDs not found after 10m — check operator subscription"
+      $KUBECTL get subscription -n openshift-operators 2>/dev/null || true
+      $KUBECTL get csv -n openshift-operators 2>/dev/null | grep -i sail || true
+      return 1
+    fi
+    sleep 5
+  done
+  log_success "Sail Operator CRDs available"
+
   log_info "Applying operand CRs..."
   helm get hooks kagenti-deps -n kagenti-system 2>/dev/null | python3 -c "
 import sys

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -520,6 +520,22 @@ _apply_operand_crs() {
   done
   log_success "Keycloak CRD available"
 
+  # Wait for ZTWIM operator CRDs — the Subscription was just created and
+  # OLM needs time to install the operator CSV which registers the CRDs.
+  log_info "Waiting for ZTWIM (SPIRE) CRDs..."
+  tries=0
+  while ! $KUBECTL get crd spiffecsidrivers.operator.openshift.io &>/dev/null; do
+    tries=$((tries + 1))
+    if [ $tries -ge 120 ]; then
+      log_error "ZTWIM CRDs not found after 10m — check operator subscription"
+      $KUBECTL get subscription -n zero-trust-workload-identity-manager 2>/dev/null || true
+      $KUBECTL get csv -n zero-trust-workload-identity-manager 2>/dev/null || true
+      return 1
+    fi
+    sleep 5
+  done
+  log_success "ZTWIM CRDs available"
+
   log_info "Applying operand CRs..."
   helm get hooks kagenti-deps -n kagenti-system 2>/dev/null | python3 -c "
 import sys

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -397,6 +397,7 @@ for ns in v.get('agentNamespaces', ['team1', 'team2']):
 log_info "Step 2.5: MLflow DSC preflight + provisioning"
 if ! $KUBECTL get crd datascienceclusters.datasciencecluster.opendatahub.io &>/dev/null; then
   log_warn "RHOAI not installed (DataScienceCluster CRD not found) — skipping MLflow provisioning"
+  SKIP_MLFLOW=true
 else
   _mlflow_check_dsc
   _mlflow_create_cr


### PR DESCRIPTION
## Summary

Fix a cascade of E2E test failures on HyperShift (OCP 4.20) ephemeral CI clusters. Each fix exposed the next layer of pre-existing issues that were masked by earlier failures.

## Changes

### 1. Skip MLflow RBAC when RHOAI is absent
Set `SKIP_MLFLOW=true` when the RHOAI CRD is not detected in `setup-kagenti.sh`, so the downstream `_mlflow_grant_otel_rbac` call and Helm `mlflow.enable` value are both consistently skipped.

### 2. Handle MCP CRD domain migration
The MCP gateway v0.6.0 renamed CRDs from `mcp.kuadrant.io` to `mcp.kagenti.com`. Kind CI still uses the old version; HyperShift uses the new. Updated `41-wait-crds.sh` to detect which domain is present with a 60s retry loop instead of a single instant check.

### 3. Add privileged PSA labels to agent namespaces
SPIFFE CSI volumes require `pod-security.kubernetes.io/enforce: privileged` on agent namespaces. Added the label to `agent-namespaces.yaml`.

### 4. Wait for ZTWIM CRDs before applying SPIRE operands
`_apply_operand_crs()` was applying SPIRE operand CRs (SpiffeCSIDriver, SpireServer, etc.) before the ZTWIM operator had registered its CRDs. The errors were silently swallowed by `|| true`. Added a wait loop for `spiffecsidrivers.operator.openshift.io` (up to 10 min).

### 5. Create CI-specific config and fix LLM endpoint
- Created `ocp_ci_values.yaml` that disables features not installed on ephemeral clusters (RHOAI, MLflow, Shipwright, Kiali) so tests are correctly skipped via `@pytest.mark.requires_features`.
- Patched weather agent LLM config on OpenShift when Shipwright is unavailable — the Kind manifest points to `dockerhost:11434` (local Ollama) which doesn't exist on OCP.

### 6. Scope health checks and fix test markers
- Scoped `test_no_failed_pods`, `test_no_crashlooping_pods`, and `test_all_jobs_completed` to Kagenti-managed namespaces only. On OpenShift, scanning all namespaces causes false positives from unrelated system pods.
- Changed Shipwright test markers from `requires_features(["tekton"])` to `requires_features(["shipwright"])`.
- Added missing `requires_features` marker to `TestToolShipwrightBuildIntegration`.
- Updated both HyperShift workflow files to use `ocp_ci_values.yaml`.

## Test plan

- [ ] E2E HyperShift passes on cluster without RHOAI/MLflow/Shipwright
- [ ] Deploy & Test (Kind) continues to pass
- [ ] RHOAI/MLflow/Shipwright/Kiali tests are skipped (not failed) on CI
- [ ] Platform health checks don't flag OpenShift system pods
- [ ] Weather agent can reach LLM endpoint on OpenShift

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>