### PR TITLE
fix(ui): Retry streaming chat on 401 with force-refreshed token

### DIFF
--- a/kagenti/ui-v2/src/components/AgentChat.tsx
+++ b/kagenti/ui-v2/src/components/AgentChat.tsx
@@ -89,7 +89,7 @@ export const AgentChat: React.FC<AgentChatProps> = ({ namespace, name }) => {
   const [showAgentCard, setShowAgentCard] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-  const { getToken, user } = useAuth();
+  const { getToken, forceRefreshToken, user } = useAuth();
   const currentUsername = user?.username || 'you';
 
   // Fetch agent card to check capabilities
@@ -147,7 +147,7 @@ export const AgentChat: React.FC<AgentChatProps> = ({ namespace, name }) => {
 
       try {
         // Get auth token if available
-        const token = await getToken();
+        let token = await getToken();
         const headers: Record<string, string> = {
           'Content-Type': 'application/json',
         };
@@ -158,18 +158,32 @@ export const AgentChat: React.FC<AgentChatProps> = ({ namespace, name }) => {
         const controller = new AbortController();
         abortControllerRef.current = controller;
 
-        const response = await fetch(
-          `/api/v1/chat/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/stream`,
-          {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({
-              message: messageToSend,
-              session_id: sessionId,
-            }),
-            signal: controller.signal,
+        const streamUrl = `/api/v1/chat/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/stream`;
+        const streamBody = JSON.stringify({
+          message: messageToSend,
+          session_id: sessionId,
+        });
+
+        let response = await fetch(streamUrl, {
+          method: 'POST',
+          headers,
+          body: streamBody,
+          signal: controller.signal,
+        });
+
+        // On 401, force-refresh token and retry once (scope may have been added after login)
+        if (response.status === 401) {
+          token = await forceRefreshToken();
+          if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+            response = await fetch(streamUrl, {
+              method: 'POST',
+              headers,
+              body: streamBody,
+              signal: controller.signal,
+            });
           }
-        );
+        }
 
         if (!response.ok) {
           throw new Error(`HTTP error: ${response.status}`);

--- a/kagenti/ui-v2/src/components/AgentChat.tsx
+++ b/kagenti/ui-v2/src/components/AgentChat.tsx
@@ -173,6 +173,7 @@ export const AgentChat: React.FC<AgentChatProps> = ({ namespace, name }) => {
 
         // On 401, force-refresh token and retry once (scope may have been added after login)
         if (response.status === 401) {
+          await response.body?.cancel();
           token = await forceRefreshToken();
           if (token) {
             headers['Authorization'] = `Bearer ${token}`;
@@ -330,21 +331,26 @@ export const AgentChat: React.FC<AgentChatProps> = ({ namespace, name }) => {
 
   const handleHitlResponse = async (_taskId: string, action: 'approve' | 'deny') => {
     try {
-      const token = await getToken();
+      let token = await getToken();
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       if (token) {
         headers['Authorization'] = `Bearer ${token}`;
       }
 
       const message = action === 'approve' ? 'Approved' : 'Denied';
-      await fetch(
-        `/api/v1/chat/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/stream`,
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({ message, session_id: sessionId }),
+      const hitlUrl = `/api/v1/chat/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/stream`;
+      const hitlBody = JSON.stringify({ message, session_id: sessionId });
+
+      let response = await fetch(hitlUrl, { method: 'POST', headers, body: hitlBody });
+
+      if (response.status === 401) {
+        await response.body?.cancel();
+        token = await forceRefreshToken();
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`;
+          response = await fetch(hitlUrl, { method: 'POST', headers, body: hitlBody });
         }
-      );
+      }
     } catch (error) {
       console.error(`[AgentChat] Failed to send HITL ${action}:`, error);
     }

--- a/kagenti/ui-v2/src/contexts/AuthContext.tsx
+++ b/kagenti/ui-v2/src/contexts/AuthContext.tsx
@@ -47,6 +47,7 @@ export interface AuthContextType {
   login: () => void;
   logout: () => void;
   getToken: () => Promise<string | null>;
+  forceRefreshToken: () => Promise<string | null>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -394,8 +395,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       login,
       logout,
       getToken,
+      forceRefreshToken,
     }),
-    [isAuthenticated, isLoading, isEnabled, user, token, error, login, logout, getToken]
+    [isAuthenticated, isLoading, isEnabled, user, token, error, login, logout, getToken, forceRefreshToken]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
## Summary

- Adds 401 retry with force-refresh to the streaming chat path in AgentChat
- Exposes `forceRefreshToken` from AuthContext for component-level use

## Root cause

When a user creates a new agent, client-registration adds the agent's audience scope to Keycloak as a default scope. But the user's existing token was issued before the scope existed, so it lacks the `aud` claim. The non-streaming chat path already handles this via `apiFetch`'s 401 retry logic (issue #1009), but the streaming path used raw `fetch()` without any retry — resulting in a persistent 401 that required a full re-login to resolve.

## Changes

- **AuthContext.tsx**: Added `forceRefreshToken` to the exported `AuthContextType` interface and context value
- **AgentChat.tsx**: On 401 from the streaming endpoint, force-refreshes the token and retries the request once

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] No new lint errors introduced (pre-existing only)
- [ ] Manual: create agent → immediately chat → should auto-recover without re-login

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>