### PR TITLE
docs: Add Skills documentation and update architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,52 +42,53 @@ The goal of Kagenti is to provide a pluggable agentic platform blueprint. Key fu
 Under each of these pillars are logical components that support the workload runtime.
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                                    KAGENTI PLATFORM                                 │
-├─────────────────────────────────────────────────────────────────────────────────────┤
-│                                                                                     │
-│  ┌───────────────────────────────────────────────────────────────────────────────┐  │
-│  │                              KAGENTI UI*                                      │  │
-│  │      (Dashboard: Deploy, Test, Monitor Agents & Tools + Backend API)          │  │
-│  └───────────────────────────────────────────────────────────────────────────────┘  │
-│                                        │                                            │
-│                                        ▼                                            │
-│  ┌───────────────────────────────────────────────────────────────────────────────┐  │
-│  │                          WORKLOAD RUNTIME                                     │  │
-│  │      ┌─────────────────────────────┐    ┌─────────────────────────────┐       │  │
-│  │      │          AGENTS             │    │           TOOLS             │       │  │
-│  │      │  (A2A - LangGraph, CrewAI   │    │   (MCP Protocol Servers)    │       │  │
-│  │      │   Marvin, Autogen, etc.)    │    │                             │       │  │
-│  │      └─────────────────────────────┘    └─────────────────────────────┘       │  │
-│  └───────────────────────────────────────────────────────────────────────────────┘  │
-│                                        │                                            │
-├────────────────────────────────────────┼────────────────────────────────────────────┤
-│                                PLATFORM PILLARS                                     │
-│                                        │                                            │
-│  ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐ ┌────────────────┐  │
-│  │    LIFECYCLE     │ │    NETWORKING    │ │     SECURITY     │ │  OBSERVABILITY │  │
-│  │  ORCHESTRATION   │ │                  │ │                  │ │                │  │
-│  ├──────────────────┤ ├──────────────────┤ ├──────────────────┤ ├────────────────┤  │
-│  │                  │ │                  │ │                  │ │                │  │
-│  │   Agents/Tools   │ │   Tool Routing   │ │  Identity & Auth │ │    Tracing     │  │
-│  │   Lifecycle &    │ │    & Policy      │ │   (AuthBridge*)  │ │(MLflow,Langflow│  │
-│  │   Discovery      │ │  (MCP Gateway)   │ │                  │ │ Phoenix)       │  │
-│  │ (k8s workloads,  │ │                  │ │                  │ │                │  │
-│  │ labels,          │ ├──────────────────┤ ├──────────────────┤ ├────────────────┤  │
-│  │  AgentCard CRD*) │ │                  │ │                  │ │                │  │
-│  │                  │ │  Service Mesh    │ │    OAuth/OIDC    │ │   Network      │  │
-│  │                  │ │ (Istio/Ambient)  │ │    (Keycloak)    │ │ Visualization  │  │
-│  │                  │ │                  │ │                  │ │   (Kiali)      │  │
-│  │   Container      │ ├──────────────────┤ ├──────────────────┤ │                │  │
-│  │     Builds       │ │                  │ │                  │ │                │  │
-│  │  (Shipwright)    │ │ Ingress/Routing  │ │ Workload Identity│ │                │  │
-│  │                  │ │ (Gateway API)    │ │ (SPIFFE/SPIRE)   │ │                │  │
-│  │                  │ │                  │ │                  │ │                │  │
-│  └──────────────────┘ └──────────────────┘ └──────────────────┘ └────────────────┘  │
-│                                                                                     │
-├─────────────────────────────────────────────────────────────────────────────────────┤
-│                               KUBERNETES / OPENSHIFT                                │
-└─────────────────────────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                                         KAGENTI PLATFORM                                │
+├─────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────────────────────┐  │
+│  │                                  KAGENTI UI*                                      │  │
+│  │          (Dashboard: Deploy, Test, Monitor Agents & Tools + Backend API)          │  │
+│  └───────────────────────────────────────────────────────────────────────────────────┘  │
+│                                                 │                                       │
+│                                                 ▼                                       │
+│  ┌───────────────────────────────────────────────────────────────────────────────────┐  │
+│  │                                    WORKLOAD RUNTIME                               │  │
+│  │   ┌──────────────────────┐    ┌──────────────────────┐    ┌───────────────────┐   │  │
+│  │   │       AGENTS         │    │        TOOLS         │    │      SKILLS       │   │  │
+│  │   │  (A2A - LangGraph,   │    │  (MCP Protocol       │    │    (Reusable      │   │  │
+│  │   │   CrewAI, Marvin,    │    │   Servers)           │    │   capabilities)   │   │  │
+│  │   │   Autogen, etc.)     │    │                      │    │                   │   │  │
+│  │   └──────────────────────┘    └──────────────────────┘    └───────────────────┘   │  │
+│  └───────────────────────────────────────────────────────────────────────────────────┘  │
+│                                                 │                                       │
+├─────────────────────────────────────────────────┼───────────────────────────────────────┤
+│                                        PLATFORM PILLARS                                 │
+│                                                 │                                       │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  ┌────────────────┐   │
+│  │    LIFECYCLE     │  │    NETWORKING    │  │     SECURITY     │  │  OBSERVABILITY │   │
+│  │  ORCHESTRATION   │  │                  │  │                  │  │                │   │
+│  ├──────────────────┤  ├──────────────────┤  ├──────────────────┤  ├────────────────┤   │
+│  │                  │  │                  │  │                  │  │                │   │
+│  │   Agents/Tools   │  │   Tool Routing   │  │  Identity & Auth │  │    Tracing     │   │
+│  │   Lifecycle &    │  │    & Policy      │  │   (AuthBridge*)  │  │(MLflow,Langflow│   │
+│  │   Discovery      │  │  (MCP Gateway)   │  │                  │  │ Phoenix)       │   │
+│  │ (k8s workloads,  │  │                  │  │                  │  │                │   │
+│  │ labels,          │  ├──────────────────┤  ├──────────────────┤  ├────────────────┤   │
+│  │  AgentCard CRD*) │  │                  │  │                  │  │                │   │
+│  │                  │  │  Service Mesh    │  │    OAuth/OIDC    │  │   Network      │   │
+│  │                  │  │ (Istio/Ambient)  │  │    (Keycloak)    │  │ Visualization  │   │
+│  │                  │  │                  │  │                  │  │   (Kiali)      │   │
+│  │   Container      │  ├──────────────────┤  ├──────────────────┤  │                │   │
+│  │     Builds       │  │                  │  │                  │  │                │   │
+│  │  (Shipwright)    │  │ Ingress/Routing  │  │ Workload Identity│  │                │   │
+│  │                  │  │ (Gateway API)    │  │ (SPIFFE/SPIRE)   │  │                │   │
+│  │                  │  │                  │  │                  │  │                │   │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘  └────────────────┘   │
+│                                                                                         │
+├─────────────────────────────────────────────────────────────────────────────────────────┤
+│                                 KUBERNETES / OPENSHIFT                                  │
+└─────────────────────────────────────────────────────────────────────────────────────────┘
 * = Built by Kagenti
 ```
 
@@ -165,6 +166,7 @@ To learn how to deploy agents and MCP tools, follow the **[Weather Agent Demo](h
 | **Demos & Tutorials** | [Demo Documentation](./docs/demos/README.md) |
 | **Import Your Own Agent** | [New Agent Guide](./docs/new-agent.md) |
 | **Import Your Own Tool** | [New Tool Guide](./docs/new-tool.md) |
+| **Skills Configuration & Usage** | [Skills Guide](./docs/skills.md) |
 | **Architecture Details** | [Technical Details](./docs/tech-details.md) |
 | **Identity, Security, and Auth Bridge** | [Identity and Auth Bridge](./docs/identity-guide.md) |
 | **Developer Guide** | [Contributing](./docs/dev-guide.md) |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,144 @@
+# Skills
+
+## Overview
+
+**Skills** are reusable capabilities managed by the Kagenti framework that expand what agents can accomplish. They encapsulate domain expertise for high-value activities such as decision support, operational analysis, compliance checks, and workflow automation. By combining structured knowledge with executable logic, skills enable agents to perform and execute operations in a consistent, context-aware manner—applying provided knowledge directly to real tasks without rebuilding logic each time.
+
+Skills are a key component of the Kagenti workload runtime, working alongside Agents and Tools in the platform architecture. While agents provide the reasoning and orchestration layer, and tools offer specific integrations, skills deliver specialized domain knowledge and workflows that can be invoked on-demand.
+
+## Enabling Skills
+
+Skills are currently a feature flag in Kagenti and must be explicitly enabled before use. The method for enabling skills depends on your deployment approach:
+
+### Using Kind and OpenShift Setup Script
+
+When using the `scripts/kind/setup-kagenti.sh` script, skills can be enabled by setting the environment variable before running the script:
+
+```bash
+# Enable skills with the setup script
+export KAGENTI_FEATURE_FLAG_SKILLS=true
+./scripts/kind/setup-kagenti.sh --with-backend --with-ui
+```
+
+**Note**: The `--with-backend` and `--with-ui` flags are required to deploy the Kagenti backend and UI components where the skills feature is used.
+
+### Using Ansible Installer
+
+When using the Ansible installer, enable skills by modifying your values file (e.g., `deployments/envs/.secret_values.yaml` or a custom values file):
+
+```yaml
+charts:
+  kagenti:
+    values:
+      featureFlags:
+        skills: true
+```
+
+Then run the installer:
+
+```bash
+cd deployments/ansible
+./run-install.sh
+```
+
+### Using Helm
+
+When installing or upgrading Kagenti with Helm, enable skills by setting the feature flag in your values:
+
+```bash
+# Using --set flag
+helm upgrade --install kagenti ./charts/kagenti/ \
+  -n kagenti-system --create-namespace \
+  --set featureFlags.skills=true
+
+
+### Verifying Skills Are Enabled
+
+After enabling the feature flag and restarting/upgrading your deployment:
+
+1. **Check the UI**: Navigate to the Kagenti UI at `http://kagenti-ui.localtest.me:8080` (or your configured domain)
+2. **Look for Skills Section**: The Skills management interface should now be visible in the navigation menu
+3. **Verify Backend**: Check the backend logs to confirm skills routes are registered:
+   ```bash
+   kubectl logs -n kagenti-system -l app=kagenti-backend | grep "skills routes registered"
+   ```
+
+Once enabled, the Skills management interface will be accessible through the UI, allowing you to configure and deploy skills for your agents.
+
+## Key Features
+
+- **Reusable Capabilities**: Pre-built expertise for common development and operational tasks
+- **Framework Integration**: Seamlessly integrated into the Kagenti platform
+- **UI Configuration**: Easy setup and management through the Kagenti UI
+- **Agent Enhancement**: Extend agent capabilities without custom code
+
+## Common Use Cases
+
+Skills are designed to handle specialized tasks that combine domain knowledge with executable business logic:
+
+- **API Orchestration**: Coordinate multi-step API workflows based on business rules (e.g., validate customer data, call payment gateway, update inventory, send notifications)
+- **Decision Automation**: Execute conditional logic for approval workflows, routing decisions, or resource allocation based on predefined criteria
+- **Data Pipeline Execution**: Orchestrate data transformations, validations, and integrations across multiple systems with error handling and retry logic
+- **Compliance Enforcement**: Apply regulatory rules and policies through executable checks, automated remediation, and audit trail generation
+- **Event-Driven Actions**: React to system events with context-aware business logic (e.g., trigger escalations, initiate rollbacks, adjust configurations)
+- **Integration Workflows**: Execute multi-service operations with knowledge of when to call specific APIs, handle authentication, manage state, and coordinate responses
+
+## Configuring Skills
+
+### Prerequisites
+
+Before configuring skills, ensure you have:
+
+1. A running Kagenti installation (see [Installation Guide](./install.md))
+2. Access to the Kagenti UI
+3. Appropriate permissions to manage skills
+
+### Accessing Skills in the UI
+
+1. **Navigate to the Kagenti UI**
+   ```bash
+   open http://kagenti-ui.localtest.me:8080
+   ```
+
+2. **Login** with your credentials (use `show-services.sh` to retrieve credentials if needed)
+
+3. **Access the Skills Section**
+   - From the main dashboard, navigate to the Skills management interface
+   - Here you can view available skills, their status, and configuration options
+
+### Skill Invocation
+
+Agents can discover and invoke skills through the platform's skill registry:
+
+```python
+# Example: Agent invoking a code review skill
+skill_result = await agent.invoke_skill(
+    skill_name="code-review",
+    parameters={
+        "repository": "kagenti/kagenti",
+        "pull_request": 123,
+        "review_depth": "comprehensive"
+    }
+)
+```
+
+### Skill Discovery
+
+Agents can query available skills:
+
+```python
+# List available skills
+available_skills = await agent.list_skills()
+
+# Get skill details
+skill_info = await agent.get_skill_info("code-review")
+```
+
+
+### Troubleshooting and Additional Help
+
+For additional support:
+
+- Check the [Troubleshooting Guide](./troubleshooting.md)
+- Review [Component Details](./components.md)
+

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-**Skills** are reusable capabilities managed by the Kagenti framework that expand what agents can accomplish. They encapsulate domain expertise for high-value activities such as decision support, operational analysis, compliance checks, and workflow automation. By combining structured knowledge with executable logic, skills enable agents to perform and execute operations in a consistent, context-aware manner—applying provided knowledge directly to real tasks without rebuilding logic each time.
+**Skills** in Kagenti are reusable capabilities stored as Kubernetes ConfigMaps and managed through the platform's REST API. They encapsulate domain expertise and workflows that agents can access on-demand. Skills are stored with the label `kagenti.io/type=skill` and can include multiple files (code, documentation, configuration) that define their behavior.
 
-Skills are a key component of the Kagenti workload runtime, working alongside Agents and Tools in the platform architecture. While agents provide the reasoning and orchestration layer, and tools offer specific integrations, skills deliver specialized domain knowledge and workflows that can be invoked on-demand.
+Skills are a key component of the Kagenti workload runtime, working alongside Agents and Tools in the platform architecture. While agents provide the reasoning and orchestration layer, and tools offer specific integrations, skills deliver specialized domain knowledge stored as ConfigMaps that can be retrieved and used by agents.
 
 ## Enabling Skills
 
@@ -50,7 +50,7 @@ When installing or upgrading Kagenti with Helm, enable skills by setting the fea
 helm upgrade --install kagenti ./charts/kagenti/ \
   -n kagenti-system --create-namespace \
   --set featureFlags.skills=true
-
+```
 
 ### Verifying Skills Are Enabled
 
@@ -65,25 +65,93 @@ After enabling the feature flag and restarting/upgrading your deployment:
 
 Once enabled, the Skills management interface will be accessible through the UI, allowing you to configure and deploy skills for your agents.
 
-## Key Features
+## Accessing Skills via REST API
 
-- **Reusable Capabilities**: Pre-built expertise for common development and operational tasks
-- **Framework Integration**: Seamlessly integrated into the Kagenti platform
-- **UI Configuration**: Easy setup and management through the Kagenti UI
-- **Agent Enhancement**: Extend agent capabilities without custom code
+Skills are managed through the Kagenti backend REST API. All endpoints require authentication.
 
-## Common Use Cases
+### List Skills
 
-Skills are designed to handle specialized tasks that combine domain knowledge with executable business logic:
+List all skills in a namespace:
 
-- **API Orchestration**: Coordinate multi-step API workflows based on business rules (e.g., validate customer data, call payment gateway, update inventory, send notifications)
-- **Decision Automation**: Execute conditional logic for approval workflows, routing decisions, or resource allocation based on predefined criteria
-- **Data Pipeline Execution**: Orchestrate data transformations, validations, and integrations across multiple systems with error handling and retry logic
-- **Compliance Enforcement**: Apply regulatory rules and policies through executable checks, automated remediation, and audit trail generation
-- **Event-Driven Actions**: React to system events with context-aware business logic (e.g., trigger escalations, initiate rollbacks, adjust configurations)
-- **Integration Workflows**: Execute multi-service operations with knowledge of when to call specific APIs, handle authentication, manage state, and coordinate responses
+```bash
+# List all skills
+curl -X GET "http://kagenti-backend/api/skills?namespace=kagenti-system" \
+  -H "Authorization: Bearer $TOKEN"
 
-## Configuring Skills
+# Search skills by keyword
+curl -X GET "http://kagenti-backend/api/skills?namespace=kagenti-system&q=code-review" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Get Skill Details
+
+Retrieve detailed information about a specific skill, including all files:
+
+```bash
+curl -X GET "http://kagenti-backend/api/skills/kagenti-system/code-review" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Create a Skill
+
+Create a new skill from files:
+
+```bash
+curl -X POST "http://kagenti-backend/api/skills" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "code-review",
+    "namespace": "kagenti-system",
+    "description": "Automated code review skill",
+    "category": "development",
+    "files": {
+      "SKILL.md": "# Code Review Skill\n\nThis skill performs automated code reviews...",
+      "scripts/review.py": "# Python code for review logic..."
+    }
+  }'
+```
+
+**Note**: `SKILL.md` is mandatory and must be included in the files dictionary.
+
+### Delete a Skill
+
+Remove a skill from the cluster:
+
+```bash
+curl -X DELETE "http://kagenti-backend/api/skills/kagenti-system/code-review" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## Using Skills in Python
+
+Agents can interact with skills using standard HTTP libraries:
+
+```python
+import httpx
+
+# List available skills
+async with httpx.AsyncClient() as client:
+    response = await client.get(
+        "http://kagenti-backend/api/skills",
+        params={"namespace": "kagenti-system"},
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    skills = response.json()["items"]
+
+# Get skill details
+async with httpx.AsyncClient() as client:
+    response = await client.get(
+        "http://kagenti-backend/api/skills/kagenti-system/code-review",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    skill_detail = response.json()
+    # Access skill files
+    for file in skill_detail["files"]:
+        print(f"File: {file['path']}, Size: {file['size']}")
+```
+
+## Configuring Skills via UI
 
 ### Prerequisites
 
@@ -91,7 +159,7 @@ Before configuring skills, ensure you have:
 
 1. A running Kagenti installation (see [Installation Guide](./install.md))
 2. Access to the Kagenti UI
-3. Appropriate permissions to manage skills
+3. Appropriate permissions to manage skills (ROLE_OPERATOR for create/delete, ROLE_VIEWER for read)
 
 ### Accessing Skills in the UI
 
@@ -105,35 +173,7 @@ Before configuring skills, ensure you have:
 3. **Access the Skills Section**
    - From the main dashboard, navigate to the Skills management interface
    - Here you can view available skills, their status, and configuration options
-
-### Skill Invocation
-
-Agents can discover and invoke skills through the platform's skill registry:
-
-```python
-# Example: Agent invoking a code review skill
-skill_result = await agent.invoke_skill(
-    skill_name="code-review",
-    parameters={
-        "repository": "kagenti/kagenti",
-        "pull_request": 123,
-        "review_depth": "comprehensive"
-    }
-)
-```
-
-### Skill Discovery
-
-Agents can query available skills:
-
-```python
-# List available skills
-available_skills = await agent.list_skills()
-
-# Get skill details
-skill_info = await agent.get_skill_info("code-review")
-```
-
+   - Skills are displayed with their category, description, and usage count
 
 ### Troubleshooting and Additional Help
 
@@ -141,4 +181,4 @@ For additional support:
 
 - Check the [Troubleshooting Guide](./troubleshooting.md)
 - Review [Component Details](./components.md)
-
+- See the backend implementation: `kagenti/backend/app/routers/skills.py`


### PR DESCRIPTION
Closes #1437

## Summary
This PR adds comprehensive Skills documentation to the Kagenti platform and updates the architecture diagram to reflect Skills as a core workload runtime component.

## Changes Made
- **New Documentation**: Created  with detailed skills documentation covering:
  - Overview and purpose of skills in the platform
  - Configuration and usage examples
  - Integration patterns with agents
  - Best practices and guidelines
  
- **Architecture Update**: Updated the README.md architecture diagram to include Skills as a third component in the workload runtime alongside Agents and Tools

- **Documentation Navigation**: Added Skills Guide link to the documentation table in README.md for easy access

## Design Decisions
- Positioned Skills as a peer component to Agents and Tools in the workload runtime layer
- Structured documentation to be accessible for both new users and experienced developers
- Maintained consistency with existing documentation style and format

## Testing
- Verified markdown formatting renders correctly
- Confirmed all internal links work properly
- Validated architecture diagram ASCII art displays correctly

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>