### PR TITLE
chore: Bump authbridge sidecar images to v0.5.0-alpha.8

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -248,11 +248,11 @@ kagenti-operator-chart:
   # Pin sidecar image tags injected by the AuthBridge webhook.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.5
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.5
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.5
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.5
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.5
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.8
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.8
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.8
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.8
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.8
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1768,7 +1768,7 @@
 #
 #  Install kagenti
 #
-- name: Compute latest kagenti tag
+- name: Compute latest kagenti tag (OpenShift only)
   block:
     - name: Lookup latest tag from remote git
       shell: |
@@ -1779,7 +1779,9 @@
     - name: Set kagenti_latest_tag fact
       set_fact:
         kagenti_latest_tag: "{{ kagenti_latest_tag_cmd.stdout }}"
-  when: charts.kagenti.enabled | default(false)
+  when:
+    - charts.kagenti.enabled | default(false)
+    - enable_openshift | default(false)
 
 - name: Run helm dependency update for kagenti when chart is local and dependency_update requested
   command: helm dependency update "{{ (charts['kagenti'] | default({})).get('chart','') }}"
@@ -1911,8 +1913,9 @@
         wait: true
         timeout: "{{ helm_wait_timeout }}s"
         values: >-
+          {# kagenti_latest_tag is only set on OpenShift; non-OCP installs use the chart default (latest) #}
           {{ (((charts['kagenti'] | default({})).get('values')) | default({}))
-            | combine({'ui': {'frontend': {'tag': kagenti_latest_tag}, 'backend': {'tag': kagenti_latest_tag}}}, recursive=True)
+            | combine(({'ui': {'frontend': {'tag': kagenti_latest_tag}, 'backend': {'tag': kagenti_latest_tag}}} if kagenti_latest_tag is defined else {}), recursive=True)
             | combine((global_values_merged | default({}) | dict2items | rejectattr('key', 'in', ['charts', 'gatewayApi', 'certManager', 'tekton', 'shipwright', 'kiali', 'secrets', 'values_files', 'create_kind_cluster', 'kind_cluster_name', 'kind_images_preload', 'container_engine', 'kind_config', 'kind_config_registry', 'preload_images_file']) | list | items2dict), recursive=True)
             | combine((((secret_values.get('charts', {}) | default({})).get('kagenti', {}) ).get('values', {})) , recursive=True)
             | combine((secret_values.get('global', {}) | default({})), recursive=True)


### PR DESCRIPTION
## Summary
- Bumps kagenti-operator-chart pinned authbridge sidecar images from `v0.5.0-alpha.5` to `v0.5.0-alpha.8`
- v0.5.0-alpha.8 includes the pipeline architecture refactor (PR kagenti/kagenti-extensions#358, #359) and the cryptography ARM64 SIGILL fix (#360)
- Fixes Ansible installer unconditionally overriding UI/backend image tags with `git ls-remote` result, preventing Kind/dev installs from picking up recently merged fixes without cutting a release tag. The tag override now only applies to OpenShift deployments. (Fixes #1442)

## Test plan
- [x] Verified authbridge v0.5.0-alpha.8 end-to-end in Kind cluster with weather-agent demo
- [ ] Verify Kind install uses `:latest` images after this change (no longer pinned to old tag)
- [ ] CI passes

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>