### PR TITLE
fix(ansible): Move Jinja2 comment outside values block scalar

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1912,8 +1912,8 @@
         create_namespace: false
         wait: true
         timeout: "{{ helm_wait_timeout }}s"
+        # kagenti_latest_tag is only set on OpenShift; non-OCP installs use the chart default (latest)
         values: >-
-          {# kagenti_latest_tag is only set on OpenShift; non-OCP installs use the chart default (latest) #}
           {{ (((charts['kagenti'] | default({})).get('values')) | default({}))
             | combine(({'ui': {'frontend': {'tag': kagenti_latest_tag}, 'backend': {'tag': kagenti_latest_tag}}} if kagenti_latest_tag is defined else {}), recursive=True)
             | combine((global_values_merged | default({}) | dict2items | rejectattr('key', 'in', ['charts', 'gatewayApi', 'certManager', 'tekton', 'shipwright', 'kiali', 'secrets', 'values_files', 'create_kind_cluster', 'kind_cluster_name', 'kind_images_preload', 'container_engine', 'kind_config', 'kind_config_registry', 'preload_images_file']) | list | items2dict), recursive=True)


### PR DESCRIPTION
## Summary

- The Jinja2 comment `{# ... #}` inside the `>-` block scalar caused Ansible to render the `values` parameter as a string instead of a dict
- The `kubernetes.core.helm` module fails with: `argument 'release_values' is of type str and we were unable to convert to dict`
- Move the comment above the `values:` key as a YAML comment so the template expression evaluates cleanly to a dict

Fixes regression introduced in bab1cda7 (#1441).

## Test plan

- [ ] Re-run Ansible installer on Kind — kagenti chart installs successfully
- [ ] Verify agent namespaces and ConfigMaps are created

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>