### PR TITLE
fix: Pin cryptography<47 across all container images for ARM64 Kind

### DIFF
--- a/deployments/openshell/agents/adk-agent-supervised/requirements.txt
+++ b/deployments/openshell/agents/adk-agent-supervised/requirements.txt
@@ -2,3 +2,5 @@
 google-adk[a2a]>=1.0.0
 litellm>=1.60.0,!=1.82.7,!=1.82.8
 uvicorn>=0.30.0
+# cryptography 47+ crashes with SIGILL on ARM64 Kind clusters
+cryptography<47

--- a/deployments/sandbox/platform_base/requirements.txt
+++ b/deployments/sandbox/platform_base/requirements.txt
@@ -9,3 +9,5 @@ starlette>=0.52.1
 sqlalchemy[asyncio]>=2.0.0
 asyncpg>=0.30.0
 psycopg[binary]>=3.1.0
+# cryptography 47+ crashes with SIGILL on ARM64 Kind clusters
+cryptography<47

--- a/kagenti/backend/pyproject.toml
+++ b/kagenti/backend/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "a2a-sdk>=0.2.0",
     "mcp>=1.0.0",
     "asyncpg>=0.30.0",
+    # cryptography 47+ crashes with SIGILL on ARM64 Kind clusters
+    "cryptography<47",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- `cryptography 47.0.0` crashes with SIGILL (illegal instruction) on ARM64 Kind clusters when importing `hazmat.bindings._rust`
- This was fixed for auth job images in a previous commit but the following were unpinned:
  - `kagenti/backend/pyproject.toml` — **causes kagenti-backend CrashLoopBackOff (exit code 132)**
  - `deployments/openshell/agents/adk-agent-supervised/requirements.txt`
  - `deployments/sandbox/platform_base/requirements.txt`
- Pin `cryptography<47` in all dependency files that build into container images

Related: kagenti/kagenti-extensions#360 (same fix for authbridge client-registration)

## Test plan

- [ ] Delete Kind cluster and redeploy — kagenti-backend pod starts successfully
- [ ] Verify `kubectl logs deploy/kagenti-backend -n kagenti-system` shows no SIGILL
- [ ] adk-agent-supervised and platform_base images build without error

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>