### PR TITLE
fix(ansible): Fix Helm values parsing and pin cryptography<47 for ARM64

### DIFF
--- a/deployments/ansible/roles/kagenti_installer/tasks/main.yml
+++ b/deployments/ansible/roles/kagenti_installer/tasks/main.yml
@@ -1912,8 +1912,8 @@
         create_namespace: false
         wait: true
         timeout: "{{ helm_wait_timeout }}s"
+        # kagenti_latest_tag is only set on OpenShift; non-OCP installs use the chart default (latest)
         values: >-
-          {# kagenti_latest_tag is only set on OpenShift; non-OCP installs use the chart default (latest) #}
           {{ (((charts['kagenti'] | default({})).get('values')) | default({}))
             | combine(({'ui': {'frontend': {'tag': kagenti_latest_tag}, 'backend': {'tag': kagenti_latest_tag}}} if kagenti_latest_tag is defined else {}), recursive=True)
             | combine((global_values_merged | default({}) | dict2items | rejectattr('key', 'in', ['charts', 'gatewayApi', 'certManager', 'tekton', 'shipwright', 'kiali', 'secrets', 'values_files', 'create_kind_cluster', 'kind_cluster_name', 'kind_images_preload', 'container_engine', 'kind_config', 'kind_config_registry', 'preload_images_file']) | list | items2dict), recursive=True)

--- a/deployments/openshell/agents/adk-agent-supervised/requirements.txt
+++ b/deployments/openshell/agents/adk-agent-supervised/requirements.txt
@@ -2,3 +2,5 @@
 google-adk[a2a]>=1.0.0
 litellm>=1.60.0,!=1.82.7,!=1.82.8
 uvicorn>=0.30.0
+# cryptography 47+ crashes with SIGILL on ARM64 Kind clusters
+cryptography<47

--- a/deployments/sandbox/platform_base/requirements.txt
+++ b/deployments/sandbox/platform_base/requirements.txt
@@ -9,3 +9,5 @@ starlette>=0.52.1
 sqlalchemy[asyncio]>=2.0.0
 asyncpg>=0.30.0
 psycopg[binary]>=3.1.0
+# cryptography 47+ crashes with SIGILL on ARM64 Kind clusters
+cryptography<47

--- a/kagenti/backend/pyproject.toml
+++ b/kagenti/backend/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "a2a-sdk>=0.2.0",
     "mcp>=1.0.0",
     "asyncpg>=0.30.0",
+    # cryptography 47+ crashes with SIGILL on ARM64 Kind clusters
+    "cryptography<47",
 ]
 
 [project.optional-dependencies]

--- a/kagenti/backend/uv.lock
+++ b/kagenti/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -686,6 +686,7 @@ source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },
     { name = "asyncpg" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "kubernetes" },
@@ -711,6 +712,7 @@ dev = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "cryptography", specifier = "<47" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary

- **Helm values parsing:** The Jinja2 comment `{# ... #}` inside the `>-` block scalar caused Ansible to render the `values` parameter as a string instead of a dict, breaking `kubernetes.core.helm` with: `argument 'release_values' is of type str and we were unable to convert to dict`. Moved to a YAML comment above the key.
- **cryptography SIGILL:** `cryptography 47.0.0` crashes with SIGILL (exit code 132) on ARM64 Kind clusters when importing `hazmat.bindings._rust`. Pinned `cryptography<47` in all unpinned container image dependencies:
  - `kagenti/backend/pyproject.toml` (causes kagenti-backend CrashLoopBackOff)
  - `deployments/openshell/agents/adk-agent-supervised/requirements.txt`
  - `deployments/sandbox/platform_base/requirements.txt`

Fixes regression from bab1cda7 (#1441).
Related: kagenti/kagenti-extensions#360 (same cryptography fix for authbridge).

## Test plan

- [ ] Delete Kind cluster and redeploy — Ansible installer completes without `release_values` error
- [ ] kagenti-backend pod starts successfully (no exit code 132)
- [ ] Agent images build and run without SIGILL

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>