### PR TITLE
chore: Bump authbridge sidecar images to v0.5.0-alpha.9

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -248,11 +248,11 @@ kagenti-operator-chart:
   # Pin sidecar image tags injected by the AuthBridge webhook.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.8
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.8
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.8
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.8
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.8
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.9
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.9
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.9
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.9
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.9
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration


### PR DESCRIPTION
## Summary

- Bump all authbridge sidecar images from `v0.5.0-alpha.8` to `v0.5.0-alpha.9`
- New in v0.5.0-alpha.9 (kagenti-extensions#361):
  - MCP parser plugin (`mcp-parser`) — parses JSON-RPC bodies for tool/resource/prompt metadata
  - Body access infrastructure — `NeedsBody()` introspection, ext_proc `ModeOverride` body buffering
  - Body size enforcement (1MB) across all listener modes
  - PR review fixes (doc comments, protocol comments, README improvements)

## Test plan

- [ ] Deploy Kind cluster — authbridge pods start with new image
- [ ] Existing jwt-validation + token-exchange pipeline works (no regression)
- [ ] Optionally patch `authbridge-runtime-config` to add mcp-parser, verify logs

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>