### PR TITLE
fix(ui): Propagate agent 401 as HTTP 401 for transparent token refresh

### DIFF
--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -301,9 +301,7 @@ async def _stream_from_response(
                 detail = response.text[:500]
             except Exception:
                 detail = str(response.status_code)
-            logger.error(
-                "Agent error: %d: %s", response.status_code, detail.replace("\n", " ")
-            )
+            logger.error("Agent error: %d: %s", response.status_code, detail.replace("\n", " "))
             payload = {"error": f"Agent error: {response.status_code}", "session_id": session_id}
             yield f"data: {json.dumps(payload)}\n\n"
             return
@@ -424,9 +422,7 @@ async def _stream_from_response(
                         logger.warning("Unknown result structure: keys=%s", list(result.keys()))
 
                 except json.JSONDecodeError as e:
-                    logger.warning(
-                        "Failed to parse SSE data: %.200s, error: %s", data, e
-                    )
+                    logger.warning("Failed to parse SSE data: %.200s, error: %s", data, e)
                     continue
 
     except httpx.RequestError as e:
@@ -493,7 +489,7 @@ async def stream_message(
         },
     }
 
-    logger.info("Starting A2A stream to %s with session_id=%s", agent_url, session_id)
+    logger.debug("Starting A2A stream to %s with session_id=%s", agent_url, session_id)
 
     client = httpx.AsyncClient(timeout=120.0)
     try:

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -301,8 +301,11 @@ async def _stream_from_response(
                 detail = response.text[:500]
             except Exception:
                 detail = str(response.status_code)
-            logger.error(f"Agent error: {response.status_code}: {detail}")
-            yield f"data: {json.dumps({'error': f'Agent error: {response.status_code}', 'session_id': session_id})}\n\n"
+            logger.error(
+                "Agent error: %d: %s", response.status_code, detail.replace("\n", " ")
+            )
+            payload = {"error": f"Agent error: {response.status_code}", "session_id": session_id}
+            yield f"data: {json.dumps(payload)}\n\n"
             return
 
         logger.debug("Connected to agent, status=%d", response.status_code)
@@ -418,10 +421,12 @@ async def _stream_from_response(
                         yield f"data: {json.dumps(payload)}\n\n"
 
                     else:
-                        logger.warning(f"Unknown result structure: keys={list(result.keys())}")
+                        logger.warning("Unknown result structure: keys=%s", list(result.keys()))
 
                 except json.JSONDecodeError as e:
-                    logger.warning(f"Failed to parse SSE data: {data[:200]}, error: {e}")
+                    logger.warning(
+                        "Failed to parse SSE data: %.200s, error: %s", data, e
+                    )
                     continue
 
     except httpx.RequestError as e:
@@ -488,7 +493,7 @@ async def stream_message(
         },
     }
 
-    logger.info(f"Starting A2A stream to {agent_url} with session_id={session_id}")
+    logger.info("Starting A2A stream to %s with session_id=%s", agent_url, session_id)
 
     client = httpx.AsyncClient(timeout=120.0)
     try:
@@ -498,7 +503,8 @@ async def stream_message(
         )
     except httpx.RequestError as e:
         await client.aclose()
-        raise HTTPException(status_code=503, detail=f"Cannot connect to agent: {e}")
+        logger.error("Cannot connect to agent at %s: %s", agent_url, e)
+        raise HTTPException(status_code=503, detail="Cannot connect to agent")
 
     if response.status_code == 401:
         await response.aclose()

--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -282,221 +282,148 @@ def _extract_text_from_parts(parts: list) -> str:
     return content
 
 
-async def _stream_a2a_response(
-    agent_url: str,
-    message: str,
+async def _stream_from_response(
+    client: httpx.AsyncClient,
+    response: httpx.Response,
     session_id: str,
-    authorization: Optional[str] = None,
     username: Optional[str] = None,
 ):
-    """Generator for streaming A2A responses with event metadata."""
+    """Stream SSE events from an already-connected agent response.
+
+    Owns closing both the response and client when done.
+    """
     import json
 
-    # Build A2A streaming message payload
-    message_payload = {
-        "jsonrpc": "2.0",
-        "id": str(uuid4()),
-        "method": "message/stream",
-        "params": {
-            "message": {
-                "role": "user",
-                "parts": [{"kind": "text", "text": message}],
-                "messageId": uuid4().hex,
-            },
-        },
-    }
-
-    logger.info(f"Starting A2A stream to {agent_url} with session_id={session_id}")
-    logger.debug(f"Message payload: {json.dumps(message_payload, indent=2)}")
-
-    # Prepare headers with optional Authorization
-    headers = {
-        "Content-Type": "application/json",
-        "Accept": "text/event-stream",
-    }
-    if authorization:
-        headers["Authorization"] = authorization
-        logger.info("Forwarding Authorization header to agent")
-
     try:
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            async with client.stream(
-                "POST",
-                agent_url,
-                json=message_payload,
-                headers=headers,
-            ) as response:
-                response.raise_for_status()
-                logger.debug("Connected to agent, status=%d", response.status_code)
+        if response.status_code >= 400:
+            try:
+                await response.aread()
+                detail = response.text[:500]
+            except Exception:
+                detail = str(response.status_code)
+            logger.error(f"Agent error: {response.status_code}: {detail}")
+            yield f"data: {json.dumps({'error': f'Agent error: {response.status_code}', 'session_id': session_id})}\n\n"
+            return
 
-                # Resolve sidecar manager once before the loop (not per-chunk)
-                _sidecar_mgr = None
-                if getattr(settings, "kagenti_feature_flag_sidecars", False):
-                    try:
-                        from app.services.sidecar_manager import get_sidecar_manager
+        logger.debug("Connected to agent, status=%d", response.status_code)
 
-                        _sidecar_mgr = get_sidecar_manager()
-                    except ImportError:
-                        pass
+        _sidecar_mgr = None
+        if getattr(settings, "kagenti_feature_flag_sidecars", False):
+            try:
+                from app.services.sidecar_manager import get_sidecar_manager
 
-                async for line in response.aiter_lines():
-                    if not line:
+                _sidecar_mgr = get_sidecar_manager()
+            except ImportError:
+                pass
+
+        async for line in response.aiter_lines():
+            if not line:
+                continue
+
+            if line.startswith("data: "):
+                data = line[6:]
+                if data == "[DONE]":
+                    done_payload = {"done": True, "session_id": session_id}
+                    if username:
+                        done_payload["username"] = username
+                    yield f"data: {json.dumps(done_payload)}\n\n"
+                    break
+
+                try:
+                    chunk = json.loads(data)
+
+                    if _sidecar_mgr is not None:
+                        try:
+                            _sidecar_mgr.fan_out_event(session_id, chunk)
+                        except Exception:
+                            logger.debug("Sidecar fan-out failed", exc_info=True)
+
+                    if "result" not in chunk:
                         continue
 
-                    # Parse SSE format
-                    if line.startswith("data: "):
-                        data = line[6:]
-                        if data == "[DONE]":
-                            done_payload = {"done": True, "session_id": session_id}
-                            if username:
-                                done_payload["username"] = username
-                            yield f"data: {json.dumps(done_payload)}\n\n"
-                            break
+                    result = chunk["result"]
+                    payload = {"session_id": session_id}
+                    if username:
+                        payload["username"] = username
 
-                        try:
-                            chunk = json.loads(data)
+                    if "artifact" in result:
+                        artifact = result.get("artifact", {})
+                        parts = artifact.get("parts", [])
+                        content = _extract_text_from_parts(parts)
+                        payload["event"] = {
+                            "type": "artifact",
+                            "taskId": result.get("taskId", ""),
+                            "name": artifact.get("name"),
+                            "index": artifact.get("index"),
+                        }
+                        if content:
+                            payload["content"] = content
+                        yield f"data: {json.dumps(payload)}\n\n"
 
-                            # Fan out event to sidecars (resolved once above)
-                            if _sidecar_mgr is not None:
-                                try:
-                                    _sidecar_mgr.fan_out_event(session_id, chunk)
-                                except Exception:
-                                    logger.debug("Sidecar fan-out failed", exc_info=True)
+                    elif "status" in result and "taskId" in result:
+                        status = result["status"]
+                        is_final = result.get("final", False)
+                        state = status.get("state", "UNKNOWN")
 
-                            if "result" not in chunk:
-                                continue
+                        status_message = ""
+                        if "message" in status and status["message"]:
+                            parts = status["message"].get("parts", [])
+                            status_message = _extract_text_from_parts(parts)
 
-                            result = chunk["result"]
-                            payload = {"session_id": session_id}
-                            if username:
-                                payload["username"] = username
+                        event_type = "status"
+                        if state == "INPUT_REQUIRED":
+                            event_type = "hitl_request"
 
-                            # TaskArtifactUpdateEvent
-                            if "artifact" in result:
-                                logger.debug("Processing TaskArtifactUpdateEvent")
-                                artifact = result.get("artifact", {})
-                                parts = artifact.get("parts", [])
+                        payload["event"] = {
+                            "type": event_type,
+                            "taskId": result.get("taskId", ""),
+                            "state": state,
+                            "final": is_final,
+                            "message": status_message if status_message else None,
+                        }
+                        if is_final or state in ["COMPLETED", "FAILED"]:
+                            if status_message:
+                                payload["content"] = status_message
+                        yield f"data: {json.dumps(payload)}\n\n"
+
+                    elif "id" in result and "status" in result:
+                        task_status = result["status"]
+                        state = task_status.get("state", "UNKNOWN")
+                        payload["event"] = {
+                            "type": "status",
+                            "taskId": result.get("id", ""),
+                            "state": state,
+                            "final": state in ["COMPLETED", "FAILED"],
+                        }
+                        if state in ["COMPLETED", "FAILED"]:
+                            if "message" in task_status and task_status["message"]:
+                                parts = task_status["message"].get("parts", [])
                                 content = _extract_text_from_parts(parts)
-
-                                payload["event"] = {
-                                    "type": "artifact",
-                                    "taskId": result.get("taskId", ""),
-                                    "name": artifact.get("name"),
-                                    "index": artifact.get("index"),
-                                }
                                 if content:
                                     payload["content"] = content
+                        yield f"data: {json.dumps(payload)}\n\n"
 
-                                logger.debug("Yielding artifact event")
-                                yield f"data: {json.dumps(payload)}\n\n"
+                    elif "parts" in result:
+                        content = _extract_text_from_parts(result["parts"])
+                        message_id = result.get("messageId", "")
+                        payload["event"] = {
+                            "type": "status",
+                            "taskId": message_id,
+                            "state": "WORKING",
+                            "final": False,
+                            "message": content if content else None,
+                        }
+                        if content:
+                            payload["content"] = content
+                        yield f"data: {json.dumps(payload)}\n\n"
 
-                            # TaskStatusUpdateEvent
-                            elif "status" in result and "taskId" in result:
-                                status = result["status"]
-                                is_final = result.get("final", False)
-                                state = status.get("state", "UNKNOWN")
+                    else:
+                        logger.warning(f"Unknown result structure: keys={list(result.keys())}")
 
-                                logger.debug(
-                                    "TaskStatusUpdateEvent: state=%s final=%s", state, is_final
-                                )
+                except json.JSONDecodeError as e:
+                    logger.warning(f"Failed to parse SSE data: {data[:200]}, error: {e}")
+                    continue
 
-                                # Extract status message text if present
-                                status_message = ""
-                                if "message" in status and status["message"]:
-                                    parts = status["message"].get("parts", [])
-                                    status_message = _extract_text_from_parts(parts)
-
-                                # Detect HITL (Human-in-the-Loop) requests
-                                event_type = "status"
-                                if state == "INPUT_REQUIRED":
-                                    event_type = "hitl_request"
-                                    logger.info("HITL request detected")
-
-                                payload["event"] = {
-                                    "type": event_type,
-                                    "taskId": result.get("taskId", ""),
-                                    "state": state,
-                                    "final": is_final,
-                                    "message": status_message if status_message else None,
-                                }
-
-                                # For final states, also include content for backward compatibility
-                                if is_final or state in ["COMPLETED", "FAILED"]:
-                                    if status_message:
-                                        payload["content"] = status_message
-
-                                logger.info(
-                                    f"Yielding status event: state={state}, final={is_final}"
-                                )
-                                yield f"data: {json.dumps(payload)}\n\n"
-
-                            # Task object (initial task response)
-                            elif "id" in result and "status" in result:
-                                task_status = result["status"]
-                                state = task_status.get("state", "UNKNOWN")
-
-                                logger.info(
-                                    f"Processing Task object: id={result.get('id')}, state={state}"
-                                )
-
-                                payload["event"] = {
-                                    "type": "status",
-                                    "taskId": result.get("id", ""),
-                                    "state": state,
-                                    "final": state in ["COMPLETED", "FAILED"],
-                                }
-
-                                # Extract message content for final states
-                                if state in ["COMPLETED", "FAILED"]:
-                                    if "message" in task_status and task_status["message"]:
-                                        parts = task_status["message"].get("parts", [])
-                                        content = _extract_text_from_parts(parts)
-                                        if content:
-                                            payload["content"] = content
-
-                                logger.info(f"Yielding task event: state={state}")
-                                yield f"data: {json.dumps(payload)}\n\n"
-
-                            # Direct message (A2AMessage)
-                            elif "parts" in result:
-                                logger.info("Processing direct message (A2AMessage) with parts")
-                                content = _extract_text_from_parts(result["parts"])
-                                message_id = result.get("messageId", "")
-
-                                # Create an event for visibility in the events panel
-                                payload["event"] = {
-                                    "type": "status",
-                                    "taskId": message_id,
-                                    "state": "WORKING",
-                                    "final": False,
-                                    "message": content if content else None,
-                                }
-                                if content:
-                                    payload["content"] = content
-
-                                logger.info(
-                                    f"Yielding direct message event: messageId={message_id}"
-                                )
-                                yield f"data: {json.dumps(payload)}\n\n"
-
-                            else:
-                                logger.warning(
-                                    f"Unknown result structure: keys={list(result.keys())}"
-                                )
-
-                        except json.JSONDecodeError as e:
-                            logger.warning(f"Failed to parse SSE data: {data[:200]}, error: {e}")
-                            continue
-
-    except httpx.HTTPStatusError as e:
-        error_msg = f"Agent error: {e.response.status_code}"
-        try:
-            await e.response.aread()
-            detail = e.response.text[:500]
-        except Exception:
-            detail = str(e)
-        logger.error(f"{error_msg}: {detail}")
-        yield f"data: {json.dumps({'error': error_msg, 'session_id': session_id})}\n\n"
     except httpx.RequestError as e:
         error_msg = f"Connection error: {str(e)}"
         logger.error(error_msg)
@@ -505,6 +432,9 @@ async def _stream_a2a_response(
         error_msg = f"Unexpected error: {str(e)}"
         logger.error(error_msg, exc_info=True)
         yield f"data: {json.dumps({'error': error_msg, 'session_id': session_id})}\n\n"
+    finally:
+        await response.aclose()
+        await client.aclose()
 
 
 @router.post("/{namespace}/{name}/stream", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
@@ -524,6 +454,9 @@ async def stream_message(
 
     Forwards the Authorization header from the client to the agent for
     authenticated requests.
+
+    Returns HTTP 401 directly when the agent rejects the token, enabling
+    the frontend to trigger token refresh and retry transparently.
     """
     agent_url = resolve_agent_url(name, namespace, kube)
     session_id = request.session_id or uuid4().hex
@@ -531,8 +464,49 @@ async def stream_message(
     # Extract Authorization header if present
     authorization = http_request.headers.get("Authorization")
 
+    # Pre-flight: open the streaming connection and check for auth errors
+    # before committing to the StreamingResponse (which locks HTTP 200).
+    # This allows the frontend to see a real HTTP 401 and trigger token
+    # refresh (e.g., when a new agent's audience scope was added after login).
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    }
+    if authorization:
+        headers["Authorization"] = authorization
+
+    message_payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid4()),
+        "method": "message/stream",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": request.message}],
+                "messageId": uuid4().hex,
+            },
+        },
+    }
+
+    logger.info(f"Starting A2A stream to {agent_url} with session_id={session_id}")
+
+    client = httpx.AsyncClient(timeout=120.0)
+    try:
+        response = await client.send(
+            client.build_request("POST", agent_url, json=message_payload, headers=headers),
+            stream=True,
+        )
+    except httpx.RequestError as e:
+        await client.aclose()
+        raise HTTPException(status_code=503, detail=f"Cannot connect to agent: {e}")
+
+    if response.status_code == 401:
+        await response.aclose()
+        await client.aclose()
+        raise HTTPException(status_code=401, detail="Agent rejected token (audience mismatch)")
+
     return StreamingResponse(
-        _stream_a2a_response(agent_url, request.message, session_id, authorization, user.username),
+        _stream_from_response(client, response, session_id, user.username),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/kagenti/backend/tests/test_chat_stream_401.py
+++ b/kagenti/backend/tests/test_chat_stream_401.py
@@ -8,7 +8,7 @@ Verifies that when an agent rejects a request with 401 (audience mismatch),
 the backend returns HTTP 401 to the frontend so the UI can trigger token refresh.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -17,7 +17,7 @@ from fastapi.testclient import TestClient
 
 @pytest.fixture
 def app():
-    """Create FastAPI app with mocked auth dependencies."""
+    """Create FastAPI app with mocked Kubernetes dependencies."""
     with (
         patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "fake"}, clear=False),
         patch("app.services.kubernetes.kubernetes.config.load_incluster_config"),
@@ -26,11 +26,15 @@ def app():
     ):
         from app.main import app as fastapi_app
 
-        return fastapi_app
+        yield fastapi_app
+        fastapi_app.dependency_overrides.clear()
 
 
 @pytest.fixture
 def client(app):
+    from app.services.kubernetes import get_kubernetes_service
+
+    app.dependency_overrides[get_kubernetes_service] = lambda: MagicMock()
     return TestClient(app)
 
 
@@ -50,7 +54,6 @@ def mock_auth(app):
     app.dependency_overrides[get_required_user] = lambda: user
     app.dependency_overrides[require_roles("kagenti-operator")] = lambda: None
     yield user
-    app.dependency_overrides.clear()
 
 
 @pytest.fixture

--- a/kagenti/backend/tests/test_chat_stream_401.py
+++ b/kagenti/backend/tests/test_chat_stream_401.py
@@ -1,0 +1,102 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for chat streaming 401 propagation.
+
+Verifies that when an agent rejects a request with 401 (audience mismatch),
+the backend returns HTTP 401 to the frontend so the UI can trigger token refresh.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app():
+    """Create FastAPI app with mocked auth dependencies."""
+    with patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "fake"}, clear=False):
+        with patch("app.services.kubernetes.kubernetes.config.load_incluster_config"):
+            with patch("app.services.kubernetes.kubernetes.client.ApiClient"):
+                from app.main import app as fastapi_app
+
+                return fastapi_app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_auth(app):
+    """Override auth dependencies to skip token validation."""
+    from app.core.auth import TokenData, get_required_user, require_roles
+
+    user = TokenData(
+        sub="test-user",
+        username="alice",
+        email="alice@example.com",
+        roles=["kagenti-operator"],
+        raw_token={},
+    )
+
+    app.dependency_overrides[get_required_user] = lambda: user
+    app.dependency_overrides[require_roles("kagenti-operator")] = lambda: None
+    yield user
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_resolve_agent_url():
+    with patch(
+        "app.routers.chat.resolve_agent_url",
+        return_value="http://weather-agent.team1.svc:8080",
+    ):
+        yield
+
+
+class TestStreamMessage401:
+    """Test that agent 401 responses are propagated as HTTP 401."""
+
+    def test_agent_401_returns_http_401(
+        self, client, mock_auth, mock_resolve_agent_url
+    ):
+        """When agent returns 401, backend should return HTTP 401 (not 200 with SSE error)."""
+        mock_response = httpx.Response(
+            status_code=401,
+            request=httpx.Request("POST", "http://weather-agent.team1.svc:8080"),
+        )
+
+        async def mock_send(self, request, *, stream=False, **kwargs):
+            return mock_response
+
+        with patch.object(httpx.AsyncClient, "send", mock_send):
+            response = client.post(
+                "/api/v1/chat/team1/weather-agent/stream",
+                json={"message": "hello", "session_id": "test123"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+
+        assert response.status_code == 401
+        assert "audience" in response.json().get("detail", "").lower()
+
+    def test_agent_503_on_connection_error(
+        self, client, mock_auth, mock_resolve_agent_url
+    ):
+        """When agent is unreachable, backend should return HTTP 503."""
+
+        async def mock_send(self, request, *, stream=False, **kwargs):
+            raise httpx.ConnectError("Connection refused")
+
+        with patch.object(httpx.AsyncClient, "send", mock_send):
+            response = client.post(
+                "/api/v1/chat/team1/weather-agent/stream",
+                json={"message": "hello", "session_id": "test123"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+
+        assert response.status_code == 503

--- a/kagenti/backend/tests/test_chat_stream_401.py
+++ b/kagenti/backend/tests/test_chat_stream_401.py
@@ -8,22 +8,25 @@ Verifies that when an agent rejects a request with 401 (audience mismatch),
 the backend returns HTTP 401 to the frontend so the UI can trigger token refresh.
 """
 
-import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-import httpx
+from unittest.mock import patch
 
+import httpx
+import pytest
 from fastapi.testclient import TestClient
 
 
 @pytest.fixture
 def app():
     """Create FastAPI app with mocked auth dependencies."""
-    with patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "fake"}, clear=False):
-        with patch("app.services.kubernetes.kubernetes.config.load_incluster_config"):
-            with patch("app.services.kubernetes.kubernetes.client.ApiClient"):
-                from app.main import app as fastapi_app
+    with (
+        patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "fake"}, clear=False),
+        patch("app.services.kubernetes.kubernetes.config.load_incluster_config"),
+        patch("app.services.kubernetes.kubernetes.config.load_kube_config"),
+        patch("app.services.kubernetes.kubernetes.client.ApiClient"),
+    ):
+        from app.main import app as fastapi_app
 
-                return fastapi_app
+        return fastapi_app
 
 
 @pytest.fixture
@@ -62,9 +65,7 @@ def mock_resolve_agent_url():
 class TestStreamMessage401:
     """Test that agent 401 responses are propagated as HTTP 401."""
 
-    def test_agent_401_returns_http_401(
-        self, client, mock_auth, mock_resolve_agent_url
-    ):
+    def test_agent_401_returns_http_401(self, client, mock_auth, mock_resolve_agent_url):
         """When agent returns 401, backend should return HTTP 401 (not 200 with SSE error)."""
         mock_response = httpx.Response(
             status_code=401,
@@ -84,9 +85,7 @@ class TestStreamMessage401:
         assert response.status_code == 401
         assert "audience" in response.json().get("detail", "").lower()
 
-    def test_agent_503_on_connection_error(
-        self, client, mock_auth, mock_resolve_agent_url
-    ):
+    def test_agent_503_on_connection_error(self, client, mock_auth, mock_resolve_agent_url):
         """When agent is unreachable, backend should return HTTP 503."""
 
         async def mock_send(self, request, *, stream=False, **kwargs):


### PR DESCRIPTION
## Summary

- Streaming chat endpoint now returns HTTP 401 (instead of HTTP 200 + SSE error) when the agent rejects a token due to audience mismatch
- This enables the existing frontend retry logic (PR #1430) to fire correctly: force-refresh the token, which picks up the new agent's audience scope from Keycloak, then retry transparently
- Removes dead `_stream_a2a_response` function replaced by `_stream_from_response` (owns an already-opened connection)

## Problem

When a user deploys a new agent:
1. `client-registration` creates an audience scope in Keycloak with the agent's SPIFFE ID
2. The user's existing token (issued before the scope existed) lacks the agent's audience
3. AuthBridge rejects with 401
4. Backend caught this as `HTTPStatusError`, yielded `data: {"error": "Agent error: 401"}` inside an HTTP 200 stream
5. Frontend retry logic checks `response.status === 401` but sees 200 — never retries

## Fix

Open the agent connection in the endpoint function **before** committing to `StreamingResponse`. If the agent returns 401, raise `HTTPException(401)` directly. The frontend's existing `forceRefreshToken()` fires, gets a new token with the correct audience, and retries — all transparent to the user.

## Test plan

- [x] New unit tests: `test_chat_stream_401.py` (agent 401 → HTTP 401, connection error → HTTP 503)
- [x] Existing test suite passes (256 tests)
- [ ] Manual: deploy weather-agent on fresh cluster, verify first chat attempt succeeds without re-login

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>