### PR TITLE
chore: Bump authbridge to v0.5.0-alpha.10 and operator to v0.2.0-alpha.32

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -229,7 +229,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-alpha.30
+        tag: 0.2.0-alpha.32
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -248,11 +248,11 @@ kagenti-operator-chart:
   # Pin sidecar image tags injected by the AuthBridge webhook.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.8
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.8
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.8
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.8
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.8
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.10
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.10
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.10
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.10
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.10
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration


### PR DESCRIPTION
## Summary

- Bump authbridge-extensions images from `v0.5.0-alpha.8` to `v0.5.0-alpha.10`
- Bump kagenti-operator from `0.2.0-alpha.30` to `0.2.0-alpha.32`

## Changes included in new versions

**kagenti-extensions v0.5.0-alpha.10:**
- MCP parser plugin and body access infrastructure (#361)
- Correct ext_proc body-phase responses and enable `allow_mode_override` (#362)

**kagenti-operator v0.2.0-alpha.32:**
- Add `allow_mode_override: true` to ext_proc filters in envoy template (#323)

## Test plan

- [x] Deployed to Kind cluster with Ansible installer
- [x] Verified inbound JWT validation works (401 on audience mismatch, pass on valid token)
- [x] Verified outbound passthrough for unrouted hosts
- [x] Verified outbound token exchange when route is configured
- [x] No "Spurious response message" Envoy warnings

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>