### PR TITLE
fix(helm): Add allow_mode_override to envoy ext_proc filters

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -240,6 +240,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP
@@ -295,6 +296,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -126,6 +126,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP
@@ -178,6 +179,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
                     response_header_mode: SKIP


### PR DESCRIPTION
## Summary
- Adds allow_mode_override: true to all 4 ext_proc filter blocks in the Helm chart envoy config templates
- Without this, the ext_proc server cannot dynamically request body buffering, preventing body-aware plugins (mcp-parser, a2a-parser) from receiving request bodies
- Mirrors the fix already applied to the operator template in kagenti-operator#323

## Files changed
- charts/kagenti/templates/authbridge-template-configmaps.yaml - outbound + inbound ext_proc filters
- charts/kagenti/templates/agent-namespaces.yaml - outbound + inbound ext_proc filters

## Test plan
- [x] helm lint charts/kagenti/ passes
- [ ] Deploy to Kind cluster, verify allow_mode_override: true appears in envoy-config ConfigMap
- [ ] Send MCP request through weather-agent, verify mcp-parser logs tools/call with parsed tool name

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>