### PR TITLE
Fix: Bump preload image tags

### DIFF
--- a/deployments/ansible/kind/preload-images.txt
+++ b/deployments/ansible/kind/preload-images.txt
@@ -9,8 +9,8 @@ docker.io/istio/install-cni:1.28.0-distroless
 docker.io/istio/pilot:1.28.0-distroless
 docker.io/istio/proxyv2:1.28.0-distroless
 docker.io/istio/ztunnel:1.28.0
-docker.io/nginx/nginx-prometheus-exporter:1.4.2
-docker.io/nginxinc/nginx-unprivileged:1.29.1-alpine
+docker.io/nginx/nginx-prometheus-exporter:1.5.1
+docker.io/nginxinc/nginx-unprivileged:1.29.5-alpine
 docker.io/prom/prometheus:v3.5.0
 otel/opentelemetry-collector-contrib:0.122.1
 quay.io/containers/buildah:v1.37.5

--- a/scripts/kind/preload-images.txt
+++ b/scripts/kind/preload-images.txt
@@ -4,7 +4,7 @@ docker.io/istio/proxyv2:1.28.0-distroless
 docker.io/istio/ztunnel:1.28.0
 docker.io/kindest/kindnetd:v20251212-v0.29.0-alpha-105-g20ccfc88
 docker.io/kindest/local-path-provisioner:v20251212-v0.29.0-alpha-105-g20ccfc88
-docker.io/nginx/nginx-prometheus-exporter:1.4.2
-docker.io/nginxinc/nginx-unprivileged:1.29.1-alpine
+docker.io/nginx/nginx-prometheus-exporter:1.5.1
+docker.io/nginxinc/nginx-unprivileged:1.29.5-alpine
 docker.io/prom/prometheus:v3.5.0
 otel/opentelemetry-collector-contrib:0.122.1


### PR DESCRIPTION
## Summary

Resolves #1451

Some change, perhaps in some helm chart, broke our `--preload` feature by defaulting to different images.

Do we need to change our CI to test the `--preload` flag?