### PR TITLE
feat(ocp): add --with-kiali, --with-builds, --with-kuadrant flags to installer

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -4,8 +4,8 @@
 # ============================================================================
 # Installs the Kagenti stack (SPIRE, cert-manager, Keycloak, operator, webhook,
 # MCP Gateway) on an OpenShift cluster. Run this BEFORE setup.sh --with-a2a.
-# Prometheus/Kiali are disabled. UI/backend installed by default (use --skip-ui to disable).
-# Shipwright disabled by default.
+# Optional layers enabled via --with-* flags (Kiali, Builds, Kuadrant).
+# UI/backend installed by default (use --skip-ui to disable).
 #
 # MLflow: provisions an MLflow instance via RHOAI's DSC mlflowoperator
 # and wires the OTEL collector to export traces to it.
@@ -15,6 +15,10 @@
 #   ./scripts/ocp/setup-kagenti.sh --kagenti-repo /path/to/kagenti  # Use local clone
 #   ./scripts/ocp/setup-kagenti.sh --kagenti-repo https://github.com/org/kagenti.git  # Clone from URL
 #   ./scripts/ocp/setup-kagenti.sh --realm nerc                 # Custom Keycloak realm (default: kagenti)
+#   ./scripts/ocp/setup-kagenti.sh --with-kiali                  # Enable Kiali + Prometheus
+#   ./scripts/ocp/setup-kagenti.sh --with-builds                # Enable Tekton + OpenShift Builds
+#   ./scripts/ocp/setup-kagenti.sh --with-kuadrant              # Enable Kuadrant (auto-enables MCP Gateway)
+#   ./scripts/ocp/setup-kagenti.sh --with-all                   # Enable all optional components
 #   ./scripts/ocp/setup-kagenti.sh --skip-ovn-patch             # Skip OVN gateway patch
 #   ./scripts/ocp/setup-kagenti.sh --skip-mcp-gateway           # Skip MCP Gateway install
 #   ./scripts/ocp/setup-kagenti.sh --skip-mlflow                # Disable Kagenti-Operator <-> MLflow integration
@@ -52,6 +56,10 @@ MCP_GATEWAY_VERSION="0.5.1"
 OPERATOR_REPO=""
 OPERATOR_IMAGE=""
 DRY_RUN=false
+WITH_KIALI=false
+WITH_BUILDS=false
+WITH_KUADRANT=false
+KUADRANT_VERSION="1.4.2"
 MLFLOW_NAMESPACE="redhat-ods-applications"
 MLFLOW_INSTANCE_NAME="mlflow"
 MLFLOW_TRACES_ENDPOINT=""
@@ -82,6 +90,10 @@ while [[ $# -gt 0 ]]; do
     --operator-repo)      OPERATOR_REPO="$2"; shift 2 ;;
     --operator-image)     OPERATOR_IMAGE="$2"; shift 2 ;;
     --mcp-gateway-version) MCP_GATEWAY_VERSION="$2"; shift 2 ;;
+    --with-kiali)         WITH_KIALI=true; shift ;;
+    --with-builds)        WITH_BUILDS=true; shift ;;
+    --with-kuadrant)      WITH_KUADRANT=true; shift ;;
+    --with-all)           WITH_KIALI=true; WITH_BUILDS=true; WITH_KUADRANT=true; shift ;;
     --dry-run)            DRY_RUN=true; shift ;;
     -h|--help)
       echo "Usage: $0 [OPTIONS]"
@@ -95,6 +107,10 @@ while [[ $# -gt 0 ]]; do
       echo "  --skip-ui                 Skip Kagenti UI and backend installation"
       echo "  --skip-mlflow             Skip MLflow integration (OTel traces + operator auto-config)"
       echo "  --show-secrets            Print Keycloak admin credentials to stdout (omitted by default for CI safety)"
+      echo "  --with-kiali              Enable Kiali + Prometheus (user workload monitoring)"
+      echo "  --with-builds             Enable Tekton + OpenShift Builds (Shipwright)"
+      echo "  --with-kuadrant           Enable Kuadrant operator (auto-enables MCP Gateway)"
+      echo "  --with-all                Enable all optional components (kiali, builds, kuadrant)"
       echo "  --operator-repo PATH      Local path to kagenti-operator repo (overrides Chart.yaml dependency)"
       echo "  --operator-image IMG:TAG  Custom operator image (e.g. quay.io/user/kagenti-operator:dev)"
       echo "  --mcp-gateway-version VER MCP Gateway chart version (default: $MCP_GATEWAY_VERSION)"
@@ -105,6 +121,12 @@ while [[ $# -gt 0 ]]; do
     *) log_error "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+# ── Flag dependencies ──────────────────────────────────────────────────────
+# Kuadrant provides AuthPolicy for MCP Gateway — don't skip it
+if $WITH_KUADRANT && $SKIP_MCP_GATEWAY; then
+  SKIP_MCP_GATEWAY=false
+fi
 
 run_cmd() {
   if $DRY_RUN; then
@@ -611,10 +633,11 @@ EOF
       -n kagenti-system \
       --set spire.trustDomain="${DOMAIN}" \
       --set "keycloak.publicUrl=${_kc_public_url}" \
-      --set components.kiali.enabled=false \
+      --set "components.kiali.enabled=${WITH_KIALI}" \
       --set components.rhoai.enabled=true \
       --set components.mlflow.enabled=false \
-      --set components.shipwright.enabled=false \
+      --set "components.tekton.enabled=${WITH_BUILDS}" \
+      --set "components.shipwright.enabled=${WITH_BUILDS}" \
       --set mlflow.auth.enabled=false \
       ${_mlflow_vals_file:+-f "$_mlflow_vals_file"} \
       --no-hooks
@@ -634,10 +657,11 @@ EOF
     -n kagenti-system --create-namespace \
     --set spire.trustDomain="${DOMAIN}" \
     --set "keycloak.publicUrl=${_kc_public_url}" \
-    --set components.kiali.enabled=false \
+    --set "components.kiali.enabled=${WITH_KIALI}" \
     --set components.rhoai.enabled=true \
     --set components.mlflow.enabled=false \
-    --set components.shipwright.enabled=false \
+    --set "components.tekton.enabled=${WITH_BUILDS}" \
+    --set "components.shipwright.enabled=${WITH_BUILDS}" \
     --set mlflow.auth.enabled=false \
     ${_mlflow_vals_file:+-f "$_mlflow_vals_file"} \
     --no-hooks
@@ -1030,6 +1054,43 @@ fi
 echo ""
 
 # ============================================================================
+# Step 5b: Install Kuadrant operator (optional, --with-kuadrant)
+# ============================================================================
+log_info "Step 5b: Kuadrant"
+
+if $WITH_KUADRANT; then
+  KUADRANT_NS="kuadrant-system"
+
+  if helm status kuadrant-operator -n "$KUADRANT_NS" &>/dev/null; then
+    log_info "Kuadrant operator already installed — skipping"
+  else
+    log_info "Installing Kuadrant operator v${KUADRANT_VERSION}..."
+    run_cmd helm upgrade --install kuadrant-operator kuadrant-operator \
+      --repo "https://kuadrant.io/helm-charts/" \
+      --version "$KUADRANT_VERSION" \
+      -n "$KUADRANT_NS" --create-namespace --wait --timeout 5m
+  fi
+
+  if ! $DRY_RUN; then
+    _wait_deployment_ready kuadrant-operator-controller-manager "$KUADRANT_NS" "Kuadrant operator"
+
+    log_info "Creating Kuadrant CR..."
+    $KUBECTL apply -f - <<EOF
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: ${KUADRANT_NS}
+EOF
+  fi
+
+  log_success "Kuadrant installed"
+else
+  log_info "Skipped (use --with-kuadrant)"
+fi
+echo ""
+
+# ============================================================================
 # Step 6: Verify Helm releases
 # ============================================================================
 log_info "Step 6: Verify Helm releases"
@@ -1059,6 +1120,9 @@ VERIFY_FAILED=false
 _verify_release kagenti-deps kagenti-system    || VERIFY_FAILED=true
 if ! $SKIP_MCP_GATEWAY; then
   _verify_release mcp-gateway mcp-system       || VERIFY_FAILED=true
+fi
+if $WITH_KUADRANT; then
+  _verify_release kuadrant-operator kuadrant-system || VERIFY_FAILED=true
 fi
 _verify_release kagenti kagenti-system         || VERIFY_FAILED=true
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1037,26 +1037,9 @@ fi
 echo ""
 
 # ============================================================================
-# Step 5: Install MCP Gateway
+# Step 5: Install Kuadrant operator (optional, --with-kuadrant)
 # ============================================================================
-log_info "Step 5: Install MCP Gateway"
-
-if $SKIP_MCP_GATEWAY; then
-  log_info "Skipped (--skip-mcp-gateway)"
-elif helm status mcp-gateway -n mcp-system &>/dev/null; then
-  log_info "MCP Gateway already installed — skipping"
-else
-  log_info "Installing MCP Gateway v${MCP_GATEWAY_VERSION}..."
-  run_cmd helm install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
-    --create-namespace --namespace mcp-system --version "$MCP_GATEWAY_VERSION"
-  log_success "MCP Gateway installed"
-fi
-echo ""
-
-# ============================================================================
-# Step 5b: Install Kuadrant operator (optional, --with-kuadrant)
-# ============================================================================
-log_info "Step 5b: Kuadrant"
+log_info "Step 5: Kuadrant"
 
 if $WITH_KUADRANT; then
   KUADRANT_NS="kuadrant-system"
@@ -1087,6 +1070,23 @@ EOF
   log_success "Kuadrant installed"
 else
   log_info "Skipped (use --with-kuadrant)"
+fi
+echo ""
+
+# ============================================================================
+# Step 5b: Install MCP Gateway
+# ============================================================================
+log_info "Step 5b: Install MCP Gateway"
+
+if $SKIP_MCP_GATEWAY; then
+  log_info "Skipped (--skip-mcp-gateway)"
+elif helm status mcp-gateway -n mcp-system &>/dev/null; then
+  log_info "MCP Gateway already installed — skipping"
+else
+  log_info "Installing MCP Gateway v${MCP_GATEWAY_VERSION}..."
+  run_cmd helm install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
+    --create-namespace --namespace mcp-system --version "$MCP_GATEWAY_VERSION"
+  log_success "MCP Gateway installed"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

- Adds composable `--with-kiali`, `--with-builds`, `--with-kuadrant`, and `--with-all` flags to the OCP installer (`scripts/ocp/setup-kagenti.sh`)
- All flags default to `false` (additive pattern matching the Kind installer)
- `--with-kuadrant` auto-enables MCP Gateway (overrides `--skip-mcp-gateway`)

## Changes

| Flag | Effect |
|------|--------|
| `--with-kiali` | Sets `components.kiali.enabled=true` in kagenti-deps chart |
| `--with-builds` | Sets `components.tekton.enabled=true` + `components.shipwright.enabled=true` |
| `--with-kuadrant` | Installs Kuadrant operator via Helm + creates Kuadrant CR |
| `--with-all` | Enables all three above |

## Test plan

- [x] `bash -n` syntax check passes
- [x] `--help` shows new flags correctly
- [x] Pre-commit hooks pass (lint, secret detection)
- [ ] `--dry-run --with-all` on OCP cluster shows correct helm flags
- [ ] `--with-kiali` on OCP enables Kiali operator + Prometheus
- [ ] `--with-builds` on OCP enables Tekton + OpenShift Builds
- [ ] `--with-kuadrant` on OCP installs Kuadrant + creates CR

Closes #1304

Assisted-By: Claude Code