### PR TITLE
Feat: Render UI version in the UI's title bar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,6 +117,8 @@ jobs:
           file: ${{ matrix.image_config.context }}/${{ matrix.image_config.dockerfile }}
           load: true
           tags: ${{ matrix.image_config.name }}:smoke-test
+          build-args: |
+            RELEASE_TAG=${{ github.ref_name }}
 
       - name: Run smoke test for ${{ matrix.image_config.name }}
         if: matrix.image_config.smoke_cmd

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,6 +133,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_retry.outputs.tags || steps.meta.outputs.tags }}
           labels: ${{ steps.meta_retry.outputs.labels || steps.meta.outputs.labels }}
+          build-args: |
+            RELEASE_TAG=${{ github.ref_name }}
 
   package-charts:
     # Package and push Helm charts once, after all images are built.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 KIND_CLUSTER_NAME := kagenti
 # Generate unique tag using git commit hash (short) or timestamp if not in git repo
 TAG := $(shell git rev-parse --short HEAD 2>/dev/null | xargs -I {} sh -c 'echo "{}-$$(date +%s)"' || date +%s)
-RELEASE_TAG := $(shell git describe --tags --abbrev=0)
+RELEASE_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "unknown")
 
 # Agent OAuth Secret
 AGENT_OAUTH_SECRET_IMAGE := agent-oauth-secret

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ lint:
 KIND_CLUSTER_NAME := kagenti
 # Generate unique tag using git commit hash (short) or timestamp if not in git repo
 TAG := $(shell git rev-parse --short HEAD 2>/dev/null | xargs -I {} sh -c 'echo "{}-$$(date +%s)"' || date +%s)
+RELEASE_TAG := $(shell git describe --tags --abbrev=0)
 
 # Agent OAuth Secret
 AGENT_OAUTH_SECRET_IMAGE := agent-oauth-secret
@@ -72,7 +73,7 @@ build-load-ui-frontend:
 		echo "Info: Podman backend detected. Using --load flag for build."; \
 	fi
 	@echo ""
-	docker build -t $(UI_FRONTEND_REPO):$(UI_FRONTEND_TAG) -f $(UI_FRONTEND_DIR)/Dockerfile $(DOCKER_BUILD_CONTEXT) $(DOCKER_BUILD_FLAGS)
+	docker build -t $(UI_FRONTEND_REPO):$(UI_FRONTEND_TAG) -f $(UI_FRONTEND_DIR)/Dockerfile $(DOCKER_BUILD_CONTEXT) $(DOCKER_BUILD_FLAGS) --build-arg RELEASE_TAG=$(RELEASE_TAG)
 	@echo ""
 	@echo "Loading frontend image into kind cluster $(KIND_CLUSTER_NAME)..."
 	kind load docker-image $(UI_FRONTEND_REPO):$(UI_FRONTEND_TAG) --name $(KIND_CLUSTER_NAME)

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -16,7 +16,7 @@ RUN npm install --legacy-peer-deps
 COPY ui-v2/ .
 
 ARG RELEASE_TAG=unknown
-RUN sed -i -r 's/"version": (.*)/"version": "'${RELEASE_TAG}'",/' package.json
+RUN sed -i -r 's/^\ \ "version": (.*)/"version": "'${RELEASE_TAG}'",/' package.json
 
 # Build the application
 RUN npm run build

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -15,9 +15,8 @@ RUN npm install --legacy-peer-deps
 # Copy source code
 COPY ui-v2/ .
 
-# Make the NPM version of the package the same as the GitHub tag
-RUN LATEST_TAG=$(git describe --tags --abbrev=0|| echo "unknown") && \
-  sed -i -r 's/"version": (.*)/"version": "'${LATEST_TAG}'",/' package.json
+ARG RELEASE_TAG=unknown
+RUN sed -i -r 's/"version": (.*)/"version": "'${RELEASE_TAG}'",/' package.json
 
 # Build the application
 RUN npm run build

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -16,7 +16,7 @@ RUN npm install --legacy-peer-deps
 COPY ui-v2/ .
 
 ARG RELEASE_TAG=unknown
-RUN sed -i -r 's/^\ \ "version": (.*)/"version": "'${RELEASE_TAG}'",/' package.json
+RUN sed -i -r 's/^\ \ "version": (.*)/  "version": "'${RELEASE_TAG}'",/' package.json
 
 # Build the application
 RUN npm run build

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -15,6 +15,10 @@ RUN npm install --legacy-peer-deps
 # Copy source code
 COPY ui-v2/ .
 
+# Make the NPM version of the package the same as the GitHub tag
+RUN LATEST_TAG=$(git describe --tags --abbrev=0|| echo "unknown") && \
+  sed -i -r 's/"version": (.*)/"version": "'${LATEST_TAG}'",/' package.json
+
 # Build the application
 RUN npm run build
 

--- a/kagenti/ui-v2/src/components/AppLayout.tsx
+++ b/kagenti/ui-v2/src/components/AppLayout.tsx
@@ -237,7 +237,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, features }) => {
           </svg>
           Kagenti
         </MastheadBrand>
-        <span style={{ fontSize: '0.75rem', color: 'white', marginLeft: '0.5rem' }}>
+        <span className="kagenti-brand-version">
           {packageJson.version}
         </span>
       </MastheadMain>

--- a/kagenti/ui-v2/src/components/AppLayout.tsx
+++ b/kagenti/ui-v2/src/components/AppLayout.tsx
@@ -48,6 +48,7 @@ import {
 import { useAuth, useTheme } from '@/contexts';
 import type { ThemeMode } from '@/contexts';
 import type { FeatureFlags } from '@/hooks/useFeatureFlags';
+import packageJson from '../../package.json';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -236,6 +237,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, features }) => {
           </svg>
           Kagenti
         </MastheadBrand>
+        <span style={{ fontSize: '0.75rem', color: 'white', marginLeft: '0.5rem' }}>
+          v{packageJson.version}
+        </span>
       </MastheadMain>
       <MastheadContent>
         <Toolbar isFullHeight isStatic>

--- a/kagenti/ui-v2/src/components/AppLayout.tsx
+++ b/kagenti/ui-v2/src/components/AppLayout.tsx
@@ -238,7 +238,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, features }) => {
           Kagenti
         </MastheadBrand>
         <span style={{ fontSize: '0.75rem', color: 'white', marginLeft: '0.5rem' }}>
-          v{packageJson.version}
+          {packageJson.version}
         </span>
       </MastheadMain>
       <MastheadContent>

--- a/kagenti/ui-v2/src/styles/global.css
+++ b/kagenti/ui-v2/src/styles/global.css
@@ -541,6 +541,12 @@ body {
   height: 36px;
 }
 
+.kagenti-brand-version {
+  font-size: 0.75rem;
+  color: #ffffff;
+  margin-left: 0.5rem;
+}
+
 /* Content area */
 .kagenti-content {
   flex: 1;


### PR DESCRIPTION
## Summary

Resolves #1305

## (Optional) Testing Instructions

If you have a running Kagenti and K8s API access:

```bash
make build-load-ui-frontend
UI_TAG=$(docker images | grep kagenti-ui-v2 | tail -n 1 | awk 'END {print $2}')
echo UI_TAG is $UI_TAG
oc -n kagenti-system set image deployment/kagenti-ui frontend=ghcr.io/kagenti/kagenti-ui-v2:${UI_TAG}
kubectl -n kagenti-system rollout status deployment kagenti-ui
```

cc @webchang 

Getting the version from the _project.json_ file is typical.  In this implementation we calculate it while building the container image.  Kiali does something similar when a new release is made on GitHub.  That approach is an alternative.  (See https://github.com/kiali/kiali/blob/master/.github/workflows/bump-release-version.yml#L102 )