### PR TITLE
fix: add show-services.sh hint after deploy and credential setup

### DIFF
--- a/.github/scripts/common/87-setup-test-credentials.sh
+++ b/.github/scripts/common/87-setup-test-credentials.sh
@@ -277,3 +277,4 @@ fi
 log_success "Test credentials ready"
 log_info "  Test user: $TEST_USER (realm: $REALM)"
 log_info "  Service account: $E2E_CLIENT_ID"
+log_info "  Run ./.github/scripts/local-setup/show-services.sh to see login credentials"

--- a/.github/scripts/local-setup/kind-full-test.sh
+++ b/.github/scripts/local-setup/kind-full-test.sh
@@ -361,6 +361,9 @@ else
     echo "Cluster kept for debugging. To destroy later:"
     echo "  ./.github/scripts/kind/destroy-cluster.sh"
     echo ""
+    echo "To view service URLs and login credentials:"
+    echo "  ./.github/scripts/local-setup/show-services.sh"
+    echo ""
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds a log line in `87-setup-test-credentials.sh` pointing users to `show-services.sh` to find login credentials
- Adds a `show-services.sh` hint in `kind-full-test.sh` when the cluster is kept (`--skip-cluster-destroy`)

The test credential setup script resets the `admin` user password to a random value (stored in `kagenti-test-user` secret). Users who expect `admin/admin` from the realm import are surprised when login fails. These hints surface the right command to run.

## Test plan

- [ ] Run `kind-full-test.sh --skip-cluster-destroy` and verify the `show-services.sh` hint appears in the output
- [ ] Run `87-setup-test-credentials.sh` directly and verify the log line about `show-services.sh` appears

Assisted-By: Claude Code