### PR TITLE
fix: resolve Dockerfile hadolint warnings

### DIFF
--- a/deployments/openshell/agents/nemoclaw-hermes/Dockerfile
+++ b/deployments/openshell/agents/nemoclaw-hermes/Dockerfile
@@ -30,6 +30,7 @@ RUN pip install --no-cache-dir \
     && hermes --version
 
 # Startup script: configure + socat bridge + hermes gateway
+# hadolint ignore=SC2016
 RUN echo '#!/bin/sh' > /usr/local/bin/start-hermes.sh \
     && echo 'set -e' >> /usr/local/bin/start-hermes.sh \
     && echo 'mkdir -p "$HOME/.hermes" "$HOME/.hermes-data/memories" "$HOME/.hermes-data/logs"' >> /usr/local/bin/start-hermes.sh \

--- a/deployments/openshell/agents/nemoclaw-openclaw/Dockerfile
+++ b/deployments/openshell/agents/nemoclaw-openclaw/Dockerfile
@@ -26,6 +26,7 @@ RUN npm install -g "openclaw@${OPENCLAW_VERSION}" \
     && openclaw --version
 
 # Startup script: socat bridge + openclaw gateway
+# hadolint ignore=SC2016
 RUN echo '#!/bin/sh' > /usr/local/bin/start-openclaw.sh \
     && echo 'set -e' >> /usr/local/bin/start-openclaw.sh \
     && echo 'mkdir -p "$HOME/.openclaw" "$HOME/.openclaw-data"' >> /usr/local/bin/start-openclaw.sh \

--- a/kagenti/ui-v2/Dockerfile
+++ b/kagenti/ui-v2/Dockerfile
@@ -7,10 +7,11 @@ FROM node:25-alpine@sha256:ad82ecad30371c43f4057aaa4800a8ed88f9446553a2d21323710
 WORKDIR /app
 
 # Copy package files
-COPY ui-v2/package.json ./
+COPY ui-v2/package.json ui-v2/package-lock.json ./
 
-# Install dependencies
-RUN npm install --legacy-peer-deps
+# Install dependencies (locked via package-lock.json)
+# hadolint ignore=DL3016
+RUN npm ci --legacy-peer-deps
 
 # Copy source code
 COPY ui-v2/ .


### PR DESCRIPTION
## Summary

- **ui-v2**: Copy `package-lock.json` into build stage and switch from `npm install` to `npm ci` for deterministic builds (DL3016)
- **nemoclaw-openclaw**: Suppress SC2016 — single quotes are intentional (writing literal shell script via echo)
- **nemoclaw-hermes**: Same SC2016 suppression

## Test plan

- [ ] Hadolint CI check passes
- [ ] UI container builds successfully (npm ci with lockfile)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>