### PR TITLE
fix: Use oc delete for HyperShift cluster cleanup instead of ansible

### DIFF
--- a/.github/scripts/hypershift/cleanup-stale-clusters.sh
+++ b/.github/scripts/hypershift/cleanup-stale-clusters.sh
@@ -156,6 +156,8 @@ NOW_EPOCH=$(date +%s)
 STALE_COUNT=0
 PROTECTED_COUNT=0
 OK_COUNT=0
+DELETED_COUNT=0
+FAILED_COUNT=0
 
 for CLUSTER_NAME in $CLUSTERS; do
     # Pattern filtering
@@ -229,12 +231,15 @@ for CLUSTER_NAME in $CLUSTERS; do
             echo "       Would delete (use --apply to execute)"
         else
             echo "       Deleting cluster..."
-            # Extract cluster suffix from full name
-            CLUSTER_SUFFIX="${CLUSTER_NAME##*-}"
-            "$REPO_ROOT/.github/scripts/local-setup/hypershift-full-test.sh" \
-                --include-cluster-destroy "$CLUSTER_SUFFIX" 2>&1 | tee "/tmp/cleanup-${CLUSTER_NAME}.log" || {
-                    log_error "Failed to delete $CLUSTER_NAME (see /tmp/cleanup-${CLUSTER_NAME}.log)"
-                }
+            # Use direct oc delete for reliable cleanup in CI and local environments
+            # The HostedCluster deletion triggers cascading cleanup of AWS resources
+            if oc delete hostedcluster "$CLUSTER_NAME" -n clusters 2>&1 | tee "/tmp/cleanup-${CLUSTER_NAME}.log"; then
+                log_success "Successfully deleted $CLUSTER_NAME"
+                DELETED_COUNT=$((DELETED_COUNT + 1))
+            else
+                log_error "Failed to delete $CLUSTER_NAME (see /tmp/cleanup-${CLUSTER_NAME}.log)"
+                FAILED_COUNT=$((FAILED_COUNT + 1))
+            fi
         fi
         echo ""
         STALE_COUNT=$((STALE_COUNT + 1))
@@ -265,8 +270,16 @@ if [ "$DRY_RUN" = "true" ] && [ "$STALE_COUNT" -gt 0 ]; then
     echo "This was a DRY-RUN. No clusters were deleted."
     echo "To actually delete stale clusters, run with --apply flag."
     echo ""
-elif [ "$STALE_COUNT" -gt 0 ]; then
-    log_success "Deleted $STALE_COUNT stale cluster(s)"
+elif [ "$DRY_RUN" = "false" ]; then
+    if [ "$DELETED_COUNT" -gt 0 ]; then
+        log_success "Successfully deleted $DELETED_COUNT cluster(s)"
+    fi
+    if [ "$FAILED_COUNT" -gt 0 ]; then
+        log_error "Failed to delete $FAILED_COUNT cluster(s)"
+    fi
+    if [ "$STALE_COUNT" -eq 0 ]; then
+        log_success "No stale clusters found"
+    fi
 else
     log_success "No stale clusters found"
 fi


### PR DESCRIPTION
  ## Problem                                                                                                                                                                                                                                                    
   
  The automated cleanup workflow (`.github/workflows/cleanup-stale-hypershift-clusters.yaml`) was detecting stale HyperShift clusters correctly but **failing to delete them** in CI.                                                                           
                  
  **Root cause:** The cleanup script called `hypershift-full-test.sh` which requires `hypershift-automation` (ansible playbooks). This dependency is not available in GitHub Actions runners, causing all deletions to fail with:                               
  Error: hypershift-automation not found
                                                                                                                                                                                                                                                                
  Additionally, the script reported "✓ Deleted X cluster(s)" even when deletions failed, making failures invisible.
                                                                                                                                                                                                                                                                
  ## Solution     
                                                                                                                                                                                                                                                                
  Replace ansible-based deletion with direct `oc delete hostedcluster` command:                                                                                                                                                                                 
  - Works in both CI and local environments (no external dependencies)
  - HostedCluster deletion triggers cascading cleanup of AWS resources                                                                                                                                                                                          
  - Add accurate deletion tracking with `DELETED_COUNT` and `FAILED_COUNT`                                                                                                                                                                                      
  - Fix misleading success messages when deletions fail                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                
  ## Testing                                                                                                                                                                                                                                                    
                  
  Created test cluster with auto-cleanup labels:                                                                                                                                                                                                                
  ```bash
  oc label hostedcluster kagenti-hypershift-ci-ztest \                                                                                                                                                                                                          
    kagenti.io/auto-cleanup=enabled \                                                                                                                                                                                                                           
    kagenti.io/ttl-hours=0
                                                                                                                                                                                                                                                                
  Verified:       
  - ✅ Workflow detects stale cluster                                                                                                                                                                                                                           
  - ✅ Script successfully deletes cluster with oc delete                                                                                                                                                                                                       
  - ✅ Accurate reporting of deletion results
                                                                                                                                                                                                                                                                
  Impact          
                                                                                                                                                                                                                                                                
  The automated cleanup workflow will now actually delete stale clusters every 3 hours instead of just reporting them.                                                                                                                                          
  ```