### PR TITLE
feat(helm): expose AuthBridge credential wait timeout

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -161,6 +161,7 @@ data:
   # for inbound JWT "aud" claim validation. Must match the audience mapper value
   # configured in Keycloak (kagenti-platform-audience scope).
   EXPECTED_AUDIENCE: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
+  CREDENTIAL_WAIT_TIMEOUT: {{ $root.Values.authBridge.credentialWaitTimeout | quote }}
 ---
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for Envoy in Namespace: {{ . }}
@@ -360,6 +361,7 @@ data:
       type: {{ eq $root.Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" $root.Values.authBridge.clientAuthType | quote }}
       client_id_file: "/shared/client-id.txt"
       client_secret_file: "/shared/client-secret.txt"
+      credential_wait_timeout: {{ $root.Values.authBridge.credentialWaitTimeout | quote }}
 {{- if eq $root.Values.authBridge.clientAuthType "federated-jwt" }}
       jwt_svid_path: "/opt/jwt_svid.token"
 {{- end }}

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -28,6 +28,7 @@ data:
   SPIFFE_IDP_ALIAS: "{{ .Values.authBridge.spiffeIdpAlias }}"
   JWT_AUDIENCE: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
   EXPECTED_AUDIENCE: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+  CREDENTIAL_WAIT_TIMEOUT: {{ .Values.authBridge.credentialWaitTimeout | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -49,6 +50,7 @@ data:
       type: {{ eq .Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" .Values.authBridge.clientAuthType | quote }}
       client_id_file: "/shared/client-id.txt"
       client_secret_file: "/shared/client-secret.txt"
+      credential_wait_timeout: {{ .Values.authBridge.credentialWaitTimeout | quote }}
 {{- if eq .Values.authBridge.clientAuthType "federated-jwt" }}
       jwt_svid_path: "/opt/jwt_svid.token"
 {{- end }}

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -198,6 +198,8 @@ authBridge:
   clientAuthType: "client-secret"
   # SPIFFE_IDP_ALIAS: Keycloak SPIFFE identity provider alias (only used with federated-jwt)
   spiffeIdpAlias: "spire-spiffe"
+  # How long AuthBridge fast-polls for credential files before switching to backoff
+  credentialWaitTimeout: "120s"
 
 # ------------------------------------------------------------------
 #  SPIFFE Identity Provider Setup Job Configuration


### PR DESCRIPTION
## Summary

- Add `authBridge.credentialWaitTimeout` Helm value (default `"120s"`)
- Expose `CREDENTIAL_WAIT_TIMEOUT` in authbridge-config ConfigMap (both agent namespaces and template)
- Add `credential_wait_timeout` to authbridge-runtime-config YAML identity section

## Context

Companion to kagenti/kagenti-extensions#375 which makes AuthBridge credential provisioning robust by polling continuously with exponential backoff instead of giving up after 60s. This Helm change exposes the configurable initial timeout so operators can tune it per environment.

## Test plan

- [x] `helm template` renders correctly (verified locally)
- [x] Pre-commit hooks pass
- [ ] Deploy to Kind and verify ConfigMap propagates to agent namespaces

Relates-to: #1480

Assisted-By: Claude Code