### PR TITLE
fix: show actual Keycloak credentials at end of Kind installer

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1250,8 +1250,19 @@ if $WITH_SPIRE; then
   echo "  Tornjak:      http://spire-tornjak-ui.${DOMAIN}:8080"
 fi
 echo ""
-echo "  Keycloak credentials:"
-echo "    kubectl get secret keycloak-initial-admin -n keycloak -o go-template='User: {{.data.username | base64decode}}  Pass: {{.data.password | base64decode}}'"
+echo "  Credentials:"
+KC_ADMIN_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
+KC_ADMIN_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
+echo "    Keycloak admin console: ${KC_ADMIN_USER} / ${KC_ADMIN_PASS}"
+if $WITH_UI; then
+  UI_USER=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+  UI_PASS=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+  if [ -n "$UI_PASS" ]; then
+    echo "    Kagenti UI login:       ${UI_USER} / ${UI_PASS}"
+  else
+    echo "    Kagenti UI login:       (pending — run show-services.sh once platform is ready)"
+  fi
+fi
 echo ""
 
 ELAPSED=$(( SECONDS - START_SECONDS ))

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1251,9 +1251,13 @@ if $WITH_SPIRE; then
 fi
 echo ""
 echo "  Credentials:"
-KC_ADMIN_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
-KC_ADMIN_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "N/A")
-echo "    Keycloak admin console: ${KC_ADMIN_USER} / ${KC_ADMIN_PASS}"
+KC_ADMIN_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null)
+KC_ADMIN_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null)
+if [ -n "$KC_ADMIN_PASS" ]; then
+  echo "    Keycloak admin console: ${KC_ADMIN_USER} / ${KC_ADMIN_PASS}"
+else
+  echo "    Keycloak admin console: (pending — secret keycloak-initial-admin not ready)"
+fi
 if $WITH_UI; then
   UI_USER=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
   UI_PASS=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- Replaces the static `kubectl get secret keycloak-initial-admin` command with actual credential reads at runtime
- Displays **Keycloak admin console** password (from `keycloak-initial-admin` secret)
- Displays **Kagenti UI login** password (from `kagenti-test-user` secret) only when `--with-ui` is enabled
- Handles the race condition where the `agent-oauth-secret` Job hasn't created the secret yet

## Context

The `agent-oauth-secret` Helm Job resets the kagenti realm `admin` user password to a random token during chart install. The old message showed `admin/admin` from the bootstrap secret which doesn't match the actual UI login credentials.

Closes #1495

## Test plan

- [x] Run `scripts/kind/setup-kagenti.sh --with-all` and verify both credentials are shown correctly
- [x] Run `scripts/kind/setup-kagenti.sh --with-istio` (no `--with-ui`) and verify UI password line is not shown
- [x] Verify the displayed UI password matches what `show-services.sh` reports

Assisted-By: Claude Code