### PR TITLE
feat(authbridge): Cut over Helm chart + backend to per-plugin config

### DIFF
--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -346,31 +346,30 @@ metadata:
   labels:
     {{- include "kagenti.labels" $root | nindent 4 }}
 data:
+  # Per-plugin config. Plugin-level defaults (audience_file,
+  # bypass_paths, identity file paths, etc.) are applied by the
+  # authbridge binary itself — see
+  # authbridge/authlib/plugins/CONVENTIONS.md in kagenti-extensions.
   config.yaml: |
     mode: envoy-sidecar
-    inbound:
-      issuer: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
-    outbound:
-      keycloak_url: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
-      keycloak_realm: {{ $root.Values.keycloak.realm | quote }}
-      default_policy: "passthrough"
-    identity:
-      # Map Helm clientAuthType to authbridge identity.type:
-      #   "client-secret"  → "client-secret" (traditional)
-      #   "federated-jwt"  → "spiffe" (SPIFFE JWT-SVID authentication)
-      type: {{ eq $root.Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" $root.Values.authBridge.clientAuthType | quote }}
-      client_id_file: "/shared/client-id.txt"
-      client_secret_file: "/shared/client-secret.txt"
-      credential_wait_timeout: {{ $root.Values.authBridge.credentialWaitTimeout | quote }}
-{{- if eq $root.Values.authBridge.clientAuthType "federated-jwt" }}
-      jwt_svid_path: "/opt/jwt_svid.token"
-{{- end }}
-    bypass:
-      inbound_paths:
-        - "/.well-known/*"
-        - "/healthz"
-        - "/readyz"
-        - "/livez"
+    pipeline:
+      inbound:
+        plugins:
+          - name: jwt-validation
+            config:
+              issuer: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
+      outbound:
+        plugins:
+          - name: token-exchange
+            config:
+              keycloak_url: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
+              keycloak_realm: {{ $root.Values.keycloak.realm | quote }}
+              default_policy: "passthrough"
+              identity:
+                # Map Helm clientAuthType to authbridge identity.type:
+                #   "client-secret"  → "client-secret" (traditional)
+                #   "federated-jwt"  → "spiffe" (SPIFFE JWT-SVID authentication)
+                type: {{ eq $root.Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" $root.Values.authBridge.clientAuthType | quote }}
 ---
 {{- if $.Values.openshift }}
 # ——————————————————————————————————————————————————————————————————————————————

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -357,7 +357,19 @@ data:
         plugins:
           - name: jwt-validation
             config:
+              # `issuer` carries the PUBLIC Keycloak URL because that is what
+              # Keycloak stamps into the `iss` claim of issued tokens (must
+              # match bit-for-bit for validation to pass).
               issuer: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
+              # `keycloak_url` + `keycloak_realm` let jwt-validation derive
+              # `jwks_url` from the INTERNAL Keycloak URL — the sidecar
+              # actually fetches JWKS from inside the cluster, and the
+              # public hostname (in `issuer`) typically resolves to
+              # 127.0.0.1 via the localtest.me wildcard. Mirrors the pair
+              # already passed to token-exchange below. See
+              # kagenti-extensions#383.
+              keycloak_url: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
+              keycloak_realm: {{ $root.Values.keycloak.realm | quote }}
       outbound:
         plugins:
           - name: token-exchange

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -49,7 +49,18 @@ data:
         plugins:
           - name: jwt-validation
             config:
+              # `issuer` carries the PUBLIC Keycloak URL because that is what
+              # Keycloak stamps into the `iss` claim of issued tokens (must
+              # match bit-for-bit for validation to pass).
               issuer: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+              # `keycloak_url` + `keycloak_realm` let jwt-validation derive
+              # `jwks_url` from the INTERNAL Keycloak URL — the sidecar
+              # fetches JWKS from inside the cluster, and the public
+              # hostname in `issuer` isn't reachable from inside the pod.
+              # Mirrors the pair already passed to token-exchange below.
+              # See kagenti-extensions#383.
+              keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
+              keycloak_realm: {{ .Values.keycloak.realm | quote }}
       outbound:
         plugins:
           - name: token-exchange

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -38,28 +38,27 @@ metadata:
   labels:
     {{- include "kagenti.labels" . | nindent 4 }}
 data:
+  # Per-plugin config. Plugin-level defaults (audience_file,
+  # bypass_paths, identity file paths, etc.) are applied by the
+  # authbridge binary itself — see
+  # authbridge/authlib/plugins/CONVENTIONS.md in kagenti-extensions.
   config.yaml: |
     mode: envoy-sidecar
-    inbound:
-      issuer: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
-    outbound:
-      keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
-      keycloak_realm: {{ .Values.keycloak.realm | quote }}
-      default_policy: "passthrough"
-    identity:
-      type: {{ eq .Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" .Values.authBridge.clientAuthType | quote }}
-      client_id_file: "/shared/client-id.txt"
-      client_secret_file: "/shared/client-secret.txt"
-      credential_wait_timeout: {{ .Values.authBridge.credentialWaitTimeout | quote }}
-{{- if eq .Values.authBridge.clientAuthType "federated-jwt" }}
-      jwt_svid_path: "/opt/jwt_svid.token"
-{{- end }}
-    bypass:
-      inbound_paths:
-        - "/.well-known/*"
-        - "/healthz"
-        - "/readyz"
-        - "/livez"
+    pipeline:
+      inbound:
+        plugins:
+          - name: jwt-validation
+            config:
+              issuer: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+      outbound:
+        plugins:
+          - name: token-exchange
+            config:
+              keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
+              keycloak_realm: {{ .Values.keycloak.realm | quote }}
+              default_policy: "passthrough"
+              identity:
+                type: {{ eq .Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" .Values.authBridge.clientAuthType | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kagenti/templates/keycloak-admin-secret-kagenti-system.yaml
+++ b/charts/kagenti/templates/keycloak-admin-secret-kagenti-system.yaml
@@ -1,0 +1,43 @@
+{{- /*
+  keycloak-admin-secret in the operator's namespace (Release.Namespace,
+  typically kagenti-system).
+
+  Required by kagenti-operator's ClientRegistrationReconciler since
+  kagenti-operator PR #321 (commit f5df832): the reconciler now reads
+  admin credentials from the OPERATOR namespace (not from each agent
+  namespace) to tighten the security boundary — compromising a single
+  agent namespace should not expose realm-admin credentials.
+
+  Without this secret in Release.Namespace, operator 0.2.0-alpha.36+
+  logs "waiting for keycloak-admin-secret" forever, no Keycloak client
+  gets registered for the workload, no credentials Secret is written,
+  and the envoy-proxy sidecar polls /shared/client-id.txt indefinitely
+  — returning 503 on every inbound request with "identity not yet
+  configured (credentials pending)".
+
+  Sister secret still exists in each agent namespace (see
+  agent-namespaces.yaml) to unblock workloads that opt into the legacy
+  client-registration sidecar via kagenti.io/client-registration-inject=
+  true — that path doesn't read from the operator namespace.
+
+  Respect adminExistingSecret: when the operator provides a pre-created
+  secret, we don't overwrite it here either.
+
+  Note: a companion PR (kagenti#1422) independently reshapes this area;
+  this template is the minimal change #1507 needs to unblock operator-
+  managed client registration without waiting for #1422's broader
+  cleanup.
+*/ -}}
+{{- if not .Values.keycloak.adminExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-admin-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  KEYCLOAK_ADMIN_USERNAME: {{ .Values.keycloak.adminUsername | quote }}
+  KEYCLOAK_ADMIN_PASSWORD: {{ .Values.keycloak.adminPassword | quote }}
+{{- end }}

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -232,7 +232,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-alpha.35
+        tag: 0.2.0-alpha.36
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -240,8 +240,11 @@ kagenti-operator-chart:
       - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
       - "--config-path=/etc/kagenti/config.yaml"
       - "--feature-gates-path=/etc/kagenti/feature-gates/feature-gates.yaml"
-      - "--enable-client-registration=false"
-      - "--enable-operator-client-registration=true"
+      # operator alpha.36 simplified the client-registration flags:
+      # --enable-operator-client-registration was removed, and this flag
+      # now controls operator-based registration directly (legacy sidecar
+      # path is gone). See kagenti-operator commit f5df832.
+      - "--enable-client-registration=true"
       resources:
         limits:
           cpu: 150m
@@ -258,18 +261,21 @@ kagenti-operator-chart:
   signatureVerification:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
-  # v0.5.0-alpha.13 is the first release that requires per-plugin
+  # v0.5.0-alpha.13 was the first release requiring per-plugin
   # authbridge config (schema cutover — old top-level inbound/
-  # outbound/identity/bypass/routes blocks are rejected). Paired
-  # with kagenti-operator v0.2.0-alpha.35 above; both must bump
-  # together.
+  # outbound/identity/bypass/routes blocks are rejected).
+  # v0.5.0-alpha.14 adds keycloak_url + keycloak_realm to
+  # jwt-validation so jwks_url derives from the internal URL
+  # (extensions#383); paired with operator v0.2.0-alpha.36 whose
+  # synthesizePipeline emits those fields (operator#336). Both
+  # pins must advance together.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.13
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.13
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.13
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.13
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.13
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.14
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.14
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.14
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.14
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.14
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -258,18 +258,18 @@ kagenti-operator-chart:
   signatureVerification:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
-  # v0.5.0-alpha.12 is the first release that requires per-plugin
+  # v0.5.0-alpha.13 is the first release that requires per-plugin
   # authbridge config (schema cutover — old top-level inbound/
   # outbound/identity/bypass/routes blocks are rejected). Paired
   # with kagenti-operator v0.2.0-alpha.35 above; both must bump
   # together.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.12
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.12
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.12
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.12
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.12
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.13
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.13
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.13
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.13
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.13
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -232,7 +232,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-rc.1
+        tag: 0.2.0-alpha.35
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -258,13 +258,18 @@ kagenti-operator-chart:
   signatureVerification:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
+  # v0.5.0-alpha.12 is the first release that requires per-plugin
+  # authbridge config (schema cutover — old top-level inbound/
+  # outbound/identity/bypass/routes blocks are rejected). Paired
+  # with kagenti-operator v0.2.0-alpha.35 above; both must bump
+  # together.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.1
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-rc.1
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-rc.1
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-rc.1
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-rc.1
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.12
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.12
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.12
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.12
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.12
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2019,6 +2019,11 @@ def _build_authbridge_runtime_yaml(
     source-of-truth in one place.
     """
     identity_type = "spiffe" if spire_enabled else "client-secret"
+    # jwt-validation receives keycloak_url + keycloak_realm so it can
+    # derive jwks_url from the INTERNAL keycloak URL rather than the
+    # public `issuer`. Required for split-horizon deployments where
+    # `issuer` isn't reachable from inside the pod. See
+    # kagenti-extensions#383.
     config = {
         "mode": "envoy-sidecar",
         "pipeline": {
@@ -2026,7 +2031,11 @@ def _build_authbridge_runtime_yaml(
                 "plugins": [
                     {
                         "name": "jwt-validation",
-                        "config": {"issuer": issuer},
+                        "config": {
+                            "issuer": issuer,
+                            "keycloak_url": keycloak_url,
+                            "keycloak_realm": realm,
+                        },
                     }
                 ]
             },

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2852,7 +2852,18 @@ def _build_sandbox_manifest(
     shipwright_build_name: Optional[str] = None,
 ) -> dict:
     """Build a Sandbox manifest (agents.x-k8s.io/v1alpha1) for direct creation."""
-    env_vars = _build_env_vars(request)
+    # Sandbox controller creates a headless Service with no port translation,
+    # so the container must listen on the same port clients connect to (the
+    # external service port, which is also baked into AGENT_ENDPOINT). For
+    # other workload types the Service port-translates to targetPort, so the
+    # split is fine there.
+    service_port = (
+        request.servicePorts[0].port if request.servicePorts else DEFAULT_OFF_CLUSTER_PORT
+    )
+    env_vars = [
+        {"name": "PORT", "value": str(service_port)} if ev.get("name") == "PORT" else ev
+        for ev in _build_env_vars(request)
+    ]
     labels = _build_common_labels(request, WORKLOAD_TYPE_SANDBOX)
 
     annotations: Dict[str, str] = {
@@ -2861,9 +2872,7 @@ def _build_sandbox_manifest(
     if shipwright_build_name:
         annotations["kagenti.io/shipwright-build"] = shipwright_build_name
 
-    container_port = DEFAULT_IN_CLUSTER_PORT
-    if request.servicePorts and len(request.servicePorts) > 0:
-        container_port = request.servicePorts[0].targetPort
+    container_port = service_port
 
     manifest = {
         "apiVersion": f"{AGENT_SANDBOX_CRD_GROUP}/{AGENT_SANDBOX_CRD_VERSION}",

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2008,32 +2008,43 @@ def _build_authbridge_runtime_yaml(
     merging in mode and listener addresses at injection time. The Helm chart
     creates an equivalent ConfigMap for pre-declared namespaces
     (see charts/kagenti/templates/agent-namespaces.yaml).
+
+    Emits the per-plugin schema: every plugin-specific setting lives under
+    its own `config:` block inside pipeline.inbound.plugins[] or
+    pipeline.outbound.plugins[]. Plugin-level defaults (audience_file,
+    bypass_paths, identity file paths) are intentionally omitted — the
+    authbridge binary applies them from its own convention layer
+    (see authbridge/authlib/plugins/CONVENTIONS.md). Leaving them out
+    here keeps the backend-generated ConfigMap minimal and the schema
+    source-of-truth in one place.
     """
     identity_type = "spiffe" if spire_enabled else "client-secret"
     config = {
         "mode": "envoy-sidecar",
-        "inbound": {"issuer": issuer},
-        "outbound": {
-            "keycloak_url": keycloak_url,
-            "keycloak_realm": realm,
-            "default_policy": "passthrough",
-        },
-        "identity": {
-            "type": identity_type,
-            "client_id_file": "/shared/client-id.txt",
-            "client_secret_file": "/shared/client-secret.txt",
-        },
-        "bypass": {
-            "inbound_paths": [
-                "/.well-known/*",
-                "/healthz",
-                "/readyz",
-                "/livez",
-            ]
+        "pipeline": {
+            "inbound": {
+                "plugins": [
+                    {
+                        "name": "jwt-validation",
+                        "config": {"issuer": issuer},
+                    }
+                ]
+            },
+            "outbound": {
+                "plugins": [
+                    {
+                        "name": "token-exchange",
+                        "config": {
+                            "keycloak_url": keycloak_url,
+                            "keycloak_realm": realm,
+                            "default_policy": "passthrough",
+                            "identity": {"type": identity_type},
+                        },
+                    }
+                ]
+            },
         },
     }
-    if spire_enabled:
-        config["identity"]["jwt_svid_path"] = "/opt/jwt_svid.token"
 
     return yaml.dump(config, default_flow_style=False)
 

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -20,9 +20,7 @@ def _plugin_config(cfg, direction, name):
     for entry in plugins:
         if entry["name"] == name:
             return entry["config"]
-    raise AssertionError(
-        f"plugin {name!r} not found under pipeline.{direction}.plugins"
-    )
+    raise AssertionError(f"plugin {name!r} not found under pipeline.{direction}.plugins")
 
 
 def test_build_authbridge_runtime_yaml_client_secret():

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -1,9 +1,28 @@
 # Copyright 2025 IBM Corp.
 # Licensed under the Apache License, Version 2.0
 
-"""Tests for _build_authbridge_runtime_yaml helper."""
+"""Tests for _build_authbridge_runtime_yaml helper.
+
+Emits the per-plugin schema authbridge expects — every plugin-
+specific setting lives inside its own plugin entry under
+pipeline.inbound.plugins[] or pipeline.outbound.plugins[].
+Plugin-level defaults (audience_file, bypass_paths, identity
+file paths) are applied by the authbridge binary itself; this
+helper deliberately omits them.
+"""
 
 import yaml
+
+
+def _plugin_config(cfg, direction, name):
+    """Navigate pipeline.<direction>.plugins[<name>].config."""
+    plugins = cfg["pipeline"][direction]["plugins"]
+    for entry in plugins:
+        if entry["name"] == name:
+            return entry["config"]
+    raise AssertionError(
+        f"plugin {name!r} not found under pipeline.{direction}.plugins"
+    )
 
 
 def test_build_authbridge_runtime_yaml_client_secret():
@@ -19,22 +38,26 @@ def test_build_authbridge_runtime_yaml_client_secret():
     cfg = yaml.safe_load(result)
 
     assert cfg["mode"] == "envoy-sidecar"
-    assert cfg["inbound"]["issuer"] == "http://keycloak.example.com/realms/kagenti"
-    assert cfg["outbound"]["keycloak_url"] == "http://keycloak:8080"
-    assert cfg["outbound"]["keycloak_realm"] == "kagenti"
-    assert cfg["outbound"]["default_policy"] == "passthrough"
-    assert cfg["identity"]["type"] == "client-secret"
-    assert cfg["identity"]["client_id_file"] == "/shared/client-id.txt"
-    assert cfg["identity"]["client_secret_file"] == "/shared/client-secret.txt"
-    assert "jwt_svid_path" not in cfg["identity"]
-    bypass_paths = cfg["bypass"]["inbound_paths"]
-    assert len(bypass_paths) == 4
-    assert "/.well-known/*" in bypass_paths
-    assert "/healthz" in bypass_paths
+
+    jwt = _plugin_config(cfg, "inbound", "jwt-validation")
+    assert jwt["issuer"] == "http://keycloak.example.com/realms/kagenti"
+
+    tok = _plugin_config(cfg, "outbound", "token-exchange")
+    assert tok["keycloak_url"] == "http://keycloak:8080"
+    assert tok["keycloak_realm"] == "kagenti"
+    assert tok["default_policy"] == "passthrough"
+    assert tok["identity"]["type"] == "client-secret"
+
+    # Plugin defaults are applied by the authbridge binary, not
+    # emitted here. Asserting absence keeps the contract honest.
+    assert "bypass_paths" not in jwt
+    assert "audience_file" not in jwt
+    assert "client_id_file" not in tok["identity"]
+    assert "client_secret_file" not in tok["identity"]
 
 
 def test_build_authbridge_runtime_yaml_spire_enabled():
-    """SPIRE-enabled config maps to spiffe identity with jwt_svid_path."""
+    """SPIRE-enabled config maps to spiffe identity."""
     from app.routers.agents import _build_authbridge_runtime_yaml
 
     result = _build_authbridge_runtime_yaml(
@@ -45,6 +68,8 @@ def test_build_authbridge_runtime_yaml_spire_enabled():
     )
     cfg = yaml.safe_load(result)
 
-    assert cfg["identity"]["type"] == "spiffe"
-    assert cfg["identity"]["jwt_svid_path"] == "/opt/jwt_svid.token"
-    assert cfg["identity"]["client_id_file"] == "/shared/client-id.txt"
+    tok = _plugin_config(cfg, "outbound", "token-exchange")
+    assert tok["identity"]["type"] == "spiffe"
+    # jwt_svid_path is not emitted — the plugin applies
+    # /opt/jwt_svid.token as its default when identity.type is spiffe.
+    assert "jwt_svid_path" not in tok["identity"]

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -39,6 +39,13 @@ def test_build_authbridge_runtime_yaml_client_secret():
 
     jwt = _plugin_config(cfg, "inbound", "jwt-validation")
     assert jwt["issuer"] == "http://keycloak.example.com/realms/kagenti"
+    # keycloak_url + keycloak_realm let jwt-validation derive jwks_url
+    # from the INTERNAL keycloak URL (see kagenti-extensions#383).
+    # Pinning the full jwks_url was the pre-plugin-fix workaround; the
+    # two hints are the supported contract now.
+    assert jwt["keycloak_url"] == "http://keycloak:8080"
+    assert jwt["keycloak_realm"] == "kagenti"
+    assert "jwks_url" not in jwt
 
     tok = _plugin_config(cfg, "outbound", "token-exchange")
     assert tok["keycloak_url"] == "http://keycloak:8080"


### PR DESCRIPTION
## Summary

Completes the three-PR authbridge per-plugin-config cutover started in
[kagenti/kagenti-extensions#378](https://github.com/kagenti/kagenti-extensions/pull/378)
and continued in
[kagenti/kagenti-operator#335](https://github.com/kagenti/kagenti-operator/pull/335).
This PR flips the kagenti Helm chart and backend ConfigMap generator
onto the per-plugin schema and pins the paired authbridge
(`v0.5.0-alpha.12`) + kagenti-operator (`v0.2.0-alpha.35`) image
tags.

## Schema rewrite

The chart previously emitted `authbridge-runtime-config` with the
top-level `inbound:` / `outbound:` / `identity:` / `bypass:` blocks.
Authbridge `v0.5.0-alpha.12` rejects that shape (empty-pipeline guard
— kagenti-extensions#378's open-proxy mitigation). This PR emits
`pipeline.inbound.plugins[]` + `pipeline.outbound.plugins[]` with one
entry each (`jwt-validation`, `token-exchange`).

Plugin-level defaults (`audience_file`, `bypass_paths`, identity file
paths) are applied by the authbridge binary from its own convention
layer and are **not** emitted by the chart. See
[authbridge/authlib/plugins/CONVENTIONS.md](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/authlib/plugins/CONVENTIONS.md).

### Files

- `charts/kagenti/templates/authbridge-template-configmaps.yaml` —
  the release-namespace template the operator propagates to agent
  namespaces that didn't come from the Helm chart.
- `charts/kagenti/templates/agent-namespaces.yaml` — the
  per-agent-namespace copy written directly at install time.
- `kagenti/backend/app/routers/agents.py` —
  `_build_authbridge_runtime_yaml`, used when the API creates an
  agent namespace through the UI.
- `kagenti/backend/tests/test_authbridge_runtime_config.py` —
  assertions walk `pipeline.<direction>.plugins[<name>].config` via
  a small `_plugin_config` helper. Also asserts the absence of
  fields that the plugin now defaults on its own (`bypass_paths`,
  `audience_file`, identity file paths) so the chart→authbridge
  contract stays honest over time.

## Image pins (atomic cutover)

`charts/kagenti/values.yaml`:

| Pin | Before | After |
|---|---|---|
| `kagenti-operator-chart.controllerManager.container.image.tag` | `0.2.0-alpha.34` | `0.2.0-alpha.35` |
| `kagenti-operator-chart.defaults.images.envoyProxy` | `authbridge-envoy:v0.5.0-alpha.10` | `authbridge-envoy:v0.5.0-alpha.12` |
| `kagenti-operator-chart.defaults.images.authbridgeLight` | `v0.5.0-alpha.10` | `v0.5.0-alpha.12` |
| `kagenti-operator-chart.defaults.images.proxyInit` | `v0.5.0-alpha.10` | `v0.5.0-alpha.12` |
| `kagenti-operator-chart.defaults.images.spiffeHelper` | `v0.5.0-alpha.10` | `v0.5.0-alpha.12` |
| `kagenti-operator-chart.defaults.images.clientRegistration` | `v0.5.0-alpha.10` | `v0.5.0-alpha.12` |

`v0.5.0-alpha.12` is the first authbridge-extensions release
requiring the new schema. `v0.2.0-alpha.35` is the first
kagenti-operator release whose webhook emits it. Both must bump
together — this PR is the atomic flip.

`kagenti-webhook-chart` (`v0.4.0-alpha.9`) is left alone; that chart
belongs to the legacy `envoy-with-processor` deployment path and
doesn't touch authbridge's YAML schema.

## Test plan

- [x] `helm template charts/kagenti/` renders both ConfigMap
  templates without errors; output parses as valid YAML and matches
  the new schema.
- [x] Direct verification of `_build_authbridge_runtime_yaml`'s output
  shape for `spire_enabled=True` and `False`.
- [ ] Python tests (`pytest kagenti/backend/tests/test_authbridge_runtime_config.py`)
  — pending CI (local env missing the backend's deps; existing
  backend tests have the same issue without a venv).
- [ ] Local kind-cluster smoke test with all three merged images.
  Pre-merge gate.

## Rollout story

Once this merges:

1. Helm chart 0.1.3 (or whatever version bump accompanies the
   cutover) points at the paired images.
2. Fresh installs pick up the new shape automatically.
3. Upgrading installs need `helm upgrade`; the operator's per-agent
   ConfigMap replicates the new shape on the next pod admission
   after an agent rollout.
4. Operators with custom `authbridge-runtime-config` ConfigMaps in
   their agent namespaces (bypassing the Helm chart) need to
   migrate those manually — the chart's release-namespace template
   stays as the reference shape.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
