### PR TITLE
fix: add --with-all flag to README quick start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cp deployments/envs/secret_values.yaml.example deployments/envs/.secret_values.y
 # Edit deployments/envs/.secret_values.yaml with your values
 
 # Deploy to Kind cluster
-scripts/kind/setup-kagenti.sh
+scripts/kind/setup-kagenti.sh --with-all
 ```
 
 > **Tip:** To find the latest stable version from the command line:


### PR DESCRIPTION
## Summary

- Adds `--with-all` to the README quick start `setup-kagenti.sh` command so new users get the full platform deployed, not just core components.

## Test plan

- [ ] Verify `scripts/kind/setup-kagenti.sh --with-all` is a valid command (confirmed in script)

Assisted-By: Claude Code