### PR TITLE
fix(ui): make observability dashboard cards consistent size

### DIFF
--- a/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
+++ b/kagenti/ui-v2/src/pages/ObservabilityPage.tsx
@@ -53,7 +53,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           {title}
         </span>
       </CardTitle>
-      <CardBody>
+      <CardBody style={{ minHeight: '120px' }}>
         <Text component="p">{description}</Text>
         {isLoading ? (
           <Skeleton width="80%" style={{ marginTop: '8px' }} />
@@ -124,7 +124,7 @@ export const ObservabilityPage: React.FC = () => {
 
         <Grid hasGutter>
           {tracesUrl && (
-            <GridItem md={6}>
+            <GridItem md={6} lg={4}>
               <DashboardCard
                 title="Tracing & Performance"
                 description="Access detailed trace data for debugging and performance analysis. Monitor LLM calls, latency, and token usage with Phoenix/OpenTelemetry."
@@ -136,7 +136,7 @@ export const ObservabilityPage: React.FC = () => {
             </GridItem>
           )}
 
-          <GridItem md={tracesUrl ? 6 : 12}>
+          <GridItem md={6} lg={4}>
             <DashboardCard
               title="Network Traffic"
               description="Visualize service interactions, traffic flow, and service mesh health with Kiali. Monitor Istio metrics and network policies."
@@ -148,7 +148,7 @@ export const ObservabilityPage: React.FC = () => {
           </GridItem>
 
           {mlflowUrl && (
-            <GridItem md={6}>
+            <GridItem md={6} lg={4}>
               <DashboardCard
                 title="MLflow"
                 description="Track experiments, model runs, and LLM traces with MLflow."


### PR DESCRIPTION
## Summary

- Use uniform grid spans (`md={6} lg={4}`) for all observability dashboard cards instead of conditional full-width for the Network Traffic card
- Add `minHeight: 120px` to `CardBody` so cards with shorter descriptions maintain equal height

Fixes #1510

## Test plan

- [ ] Open the Observability page with all dashboards configured — verify all three cards render at equal size
- [ ] Remove `tracesUrl` or `mlflowUrl` from config — verify remaining cards still render at consistent sizes
- [ ] Test at various viewport widths — cards should be responsive (single column on small, 2-col on medium, 3-col on large)

Assisted-By: Claude Code