### PR TITLE
Bug fix: Force CRD apply in case helm missed applying new CRDs

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1112,16 +1112,16 @@ run_cmd helm upgrade --install kagenti "$REPO_ROOT/charts/kagenti/" \
   "${KAGENTI_FLAGS[@]}"
 
 # Helm upgrade can miss additional CRDs, install them now
-NEW_TMP_DIR=$(mktemp -d)
-trap "rm -rf ${NEW_TMP_DIR}" EXIT
+CRD_TMP_DIR=$(mktemp -d)
+trap "rm -rf ${CRD_TMP_DIR}" EXIT
 log_info "Ensuring kagenti CRDs are updated"
 OPERATOR_TGZ_MATCHES=( "$REPO_ROOT"/charts/kagenti/charts/kagenti-operator-chart-*.tgz )
 if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]]; then
   log_error "Expected exactly one kagenti-operator-chart-*.tgz in $REPO_ROOT/charts/kagenti/charts/, found ${#OPERATOR_TGZ_MATCHES[@]}: ${OPERATOR_TGZ_MATCHES[*]}"
   exit 1
 fi
-run_cmd tar -C "${NEW_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
-run_cmd kubectl apply -f "${NEW_TMP_DIR}/kagenti-operator-chart/crds/"
+run_cmd tar -C "${CRD_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
+run_cmd kubectl apply -f "${CRD_TMP_DIR}/kagenti-operator-chart/crds/"
 
 log_success "kagenti installed"
 echo ""

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1121,7 +1121,7 @@ if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]];
   exit 1
 fi
 run_cmd tar -C "${CRD_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
-run_cmd kubectl apply -f "${CRD_TMP_DIR}/kagenti-operator-chart/crds/"
+run_cmd kubectl apply --server-side --force-conflicts -f "${CRD_TMP_DIR}/kagenti-operator-chart/crds/"
 
 log_success "kagenti installed"
 echo ""

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1111,6 +1111,18 @@ run_cmd helm upgrade --install kagenti "$REPO_ROOT/charts/kagenti/" \
   "${SECRETS_FLAGS[@]+"${SECRETS_FLAGS[@]}"}" \
   "${KAGENTI_FLAGS[@]}"
 
+# Helm upgrade can miss additional CRDs, install them now
+NEW_TMP_DIR=$(mktemp -d)
+trap "rm -rf ${NEW_TMP_DIR}" EXIT
+log_info "Ensuring kagenti CRDs are updated"
+OPERATOR_TGZ_MATCHES=( "$REPO_ROOT"/charts/kagenti/charts/kagenti-operator-chart-*.tgz )
+if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]]; then
+  log_error "Expected exactly one kagenti-operator-chart-*.tgz in $REPO_ROOT/charts/kagenti/charts/, found ${#OPERATOR_TGZ_MATCHES[@]}: ${OPERATOR_TGZ_MATCHES[*]}"
+  exit 1
+fi
+run_cmd tar -C "${NEW_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
+run_cmd kubectl apply -f "${NEW_TMP_DIR}/kagenti-operator-chart/crds/"
+
 log_success "kagenti installed"
 echo ""
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1044,17 +1044,14 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set "keycloak.realm=${KC_REALM}" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)"
 
-# Helm upgrade can miss additional CRDs, install them now
-CRD_SRC_DIR="$KAGENTI_REPO/charts/kagenti/charts/kagenti-operator-chart/crds"
-if [ ! -d "$CRD_SRC_DIR" ]; then
-  OPERATOR_TGZ_MATCHES=( "$KAGENTI_REPO"/charts/kagenti/charts/kagenti-operator-chart-*.tgz )
-  if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]]; then
-    log_error "..."
-    exit 1
-  fi
-  run_cmd tar -C "${CRD_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
-  CRD_SRC_DIR="${CRD_TMP_DIR}/kagenti-operator-chart/crds"
-fi
+# Helm upgrade can miss additional CRDs, install them now.
+# There are three ways this script is configured with chart location
+# - No --kagenti-repo given: always clone fresh from upstream main
+# - --kagenti-repo is GitHub/git URL (cloned into cache)
+# - Local path provided — "use as-is"
+# In all three cases, KAGENTI_CACHE_DIR should point to downloaded Kagenti source
+KAGENTI_CACHE_DIR="${HOME}/.cache/kagenti"
+CRD_SRC_DIR="$KAGENTI_CACHE_DIR/charts/kagenti/charts/kagenti-operator-chart/crds"
 run_cmd kubectl apply --server-side --force-conflicts -f "${CRD_SRC_DIR}/"
 
 log_success "Kagenti installed"

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1044,6 +1044,18 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set "keycloak.realm=${KC_REALM}" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)"
 
+# Helm upgrade can miss additional CRDs, install them now
+NEW_TMP_DIR=$(mktemp -d)
+trap "rm -rf ${NEW_TMP_DIR}" EXIT
+log_info "Ensuring kagenti CRDs are updated"
+OPERATOR_TGZ_MATCHES=( "$KAGENTI_REPO"/charts/kagenti/charts/kagenti-operator-chart-*.tgz )
+if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]]; then
+  log_error "Expected exactly one kagenti-operator-chart-*.tgz in $KAGENTI_REPO/charts/kagenti/charts/, found ${#OPERATOR_TGZ_MATCHES[@]}: ${OPERATOR_TGZ_MATCHES[*]}"
+  exit 1
+fi
+run_cmd tar -C "${NEW_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
+run_cmd kubectl apply -f "${NEW_TMP_DIR}/kagenti-operator-chart/crds/"
+
 log_success "Kagenti installed"
 
 # Grant otel-collector SA MLflow RBAC in agent namespaces (created by kagenti chart above)

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1045,16 +1045,16 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)"
 
 # Helm upgrade can miss additional CRDs, install them now
-NEW_TMP_DIR=$(mktemp -d)
-trap "rm -rf ${NEW_TMP_DIR}" EXIT
+CRD_TMP_DIR=$(mktemp -d)
 log_info "Ensuring kagenti CRDs are updated"
 OPERATOR_TGZ_MATCHES=( "$KAGENTI_REPO"/charts/kagenti/charts/kagenti-operator-chart-*.tgz )
 if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]]; then
   log_error "Expected exactly one kagenti-operator-chart-*.tgz in $KAGENTI_REPO/charts/kagenti/charts/, found ${#OPERATOR_TGZ_MATCHES[@]}: ${OPERATOR_TGZ_MATCHES[*]}"
   exit 1
 fi
-run_cmd tar -C "${NEW_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
-run_cmd kubectl apply -f "${NEW_TMP_DIR}/kagenti-operator-chart/crds/"
+run_cmd tar -C "${CRD_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
+run_cmd kubectl apply -f "${CRD_TMP_DIR}/kagenti-operator-chart/crds/"
+rm -rf ${CRD_TMP_DIR}
 
 log_success "Kagenti installed"
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1045,16 +1045,17 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)"
 
 # Helm upgrade can miss additional CRDs, install them now
-CRD_TMP_DIR=$(mktemp -d)
-log_info "Ensuring kagenti CRDs are updated"
-OPERATOR_TGZ_MATCHES=( "$KAGENTI_REPO"/charts/kagenti/charts/kagenti-operator-chart-*.tgz )
-if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]]; then
-  log_error "Expected exactly one kagenti-operator-chart-*.tgz in $KAGENTI_REPO/charts/kagenti/charts/, found ${#OPERATOR_TGZ_MATCHES[@]}: ${OPERATOR_TGZ_MATCHES[*]}"
-  exit 1
+CRD_SRC_DIR="$KAGENTI_REPO/charts/kagenti/charts/kagenti-operator-chart/crds"
+if [ ! -d "$CRD_SRC_DIR" ]; then
+  OPERATOR_TGZ_MATCHES=( "$KAGENTI_REPO"/charts/kagenti/charts/kagenti-operator-chart-*.tgz )
+  if [[ ${#OPERATOR_TGZ_MATCHES[@]} -ne 1 || ! -f "${OPERATOR_TGZ_MATCHES[0]}" ]]; then
+    log_error "..."
+    exit 1
+  fi
+  run_cmd tar -C "${CRD_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
+  CRD_SRC_DIR="${CRD_TMP_DIR}/kagenti-operator-chart/crds"
 fi
-run_cmd tar -C "${CRD_TMP_DIR}" -xzf "${OPERATOR_TGZ_MATCHES[0]}" kagenti-operator-chart/crds
-run_cmd kubectl apply -f "${CRD_TMP_DIR}/kagenti-operator-chart/crds/"
-rm -rf ${CRD_TMP_DIR}
+run_cmd kubectl apply --server-side --force-conflicts -f "${CRD_SRC_DIR}/"
 
 log_success "Kagenti installed"
 


### PR DESCRIPTION
## Summary

Resolves #1335

## (Optional) Testing Instructions

First, install a back-level version of Kagenti by editing _charts/kagenti/Chart.yaml_ and setting the Kagenti operator version to 0.22:

```YAML
dependencies:
- name: kagenti-operator-chart
  version: 0.2.0-alpha.22
```

Then, install Kagenti: `scripts/kind/setup-kagenti.sh --with-istio --with-spire --with-ui --with-backend`

Verify that only one CRD is returned by `oc get crd | grep agent` (the agentruntimes CRD was not used by alpha 0.22)

```
agentcards.agent.kagenti.dev                   2026-05-07T18:04:34Z
```

Then, replace the kagenti-operator-chart in _charts/kagenti/Chart.yaml_ setting the version to `0.2.0-rc.1` and re-install Kagenti: `scripts/kind/setup-kagenti.sh --with-istio --with-spire --with-ui --with-backend`

Verify that only two CRDs are returned by `oc get crd | grep agent`

```
agentcards.agent.kagenti.dev                   2026-05-07T18:04:34Z
agentruntimes.agent.kagenti.dev                2026-05-08T12:01:26Z
```


Fixes #

#1335