### PR TITLE
fix(openshell): update chart for v0.0.36-kagenti.8 gateway and supervisor

### DIFF
--- a/charts/openshell/templates/statefulset.yaml
+++ b/charts/openshell/templates/statefulset.yaml
@@ -49,6 +49,8 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            - name: OPENSHELL_BIND_ADDRESS
+              value: "0.0.0.0"
             - name: OPENSHELL_TLS_CERT
               value: "/tls/server/tls.crt"
             - name: OPENSHELL_TLS_KEY
@@ -108,7 +110,8 @@ spec:
             - "--namespace={{ include "openshell.driverNamespace" . }}"
             - "--supervisor-image={{ .Values.supervisorImage.repository }}:{{ .Values.supervisorImage.tag }}"
             - "--gateway-endpoint=https://openshell-server.{{ .Values.tenant }}.svc:8080"
-            - "--dtach-binary-path=/usr/local/bin/openshell-sandbox"
+            - "--supervisor-binary-path={{ .Values.supervisorImage.binaryPath }}"
+            - "--dtach-binary-path={{ .Values.supervisorImage.binaryPath }}"
             - "--tls-ca-secret=openshell-server-tls"
             - "--tls-client-secret=openshell-client-tls"
             {{- if .Values.sandboxImagePullPolicy }}

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -5,7 +5,7 @@ tenant: ""
 images:
   gateway:
     repository: ghcr.io/kagenti/openshell/gateway
-    tag: mvp-a9aa694
+    tag: v0.0.36-kagenti.8
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
@@ -31,7 +31,8 @@ keycloakClusterIP: ""
 # Built from kagenti/OpenShell@mvp as a multi-arch image (linux/amd64 + linux/arm64).
 supervisorImage:
   repository: ghcr.io/kagenti/openshell/supervisor
-  tag: latest
+  tag: v0.0.36-kagenti.8
+  binaryPath: /openshell-sandbox
 
 # -- Image pull policy for sandbox pods (init + agent containers).
 # Valid values: Always, IfNotPresent, Never.

--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -46,7 +46,7 @@ Choose the section that matches your target environment.
 #### Step 1: Deploy Kagenti on Kind
 
 ```bash
-scripts/kind/setup-kagenti.sh  --with-ui --with-agent-sandbox --with-spire 
+scripts/kind/setup-kagenti.sh  --with-ui --with-agent-sandbox --with-spire
 ```
 
 This deploys: Kind cluster, Istio ambient mesh, cert-manager, Keycloak, SPIRE,

--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -46,7 +46,7 @@ Choose the section that matches your target environment.
 #### Step 1: Deploy Kagenti on Kind
 
 ```bash
-scripts/kind/setup-kagenti.sh  --with-all
+scripts/kind/setup-kagenti.sh  --with-ui --with-agent-sandbox --with-spire 
 ```
 
 This deploys: Kind cluster, Istio ambient mesh, cert-manager, Keycloak, SPIRE,


### PR DESCRIPTION
## Summary

- Fix gateway bind address for v0.0.36 (defaults to `127.0.0.1`, now set to `0.0.0.0`)
- Make supervisor/dtach binary path configurable via `supervisorImage.binaryPath` (binary moved from `/usr/local/bin/openshell-sandbox` to `/openshell-sandbox` in v0.0.36)
- Pin gateway and supervisor image tags to `v0.0.36-kagenti.8`
- Fix sandbox-guide.md to use explicit flags instead of deprecated `--with-all`

## Test plan

- [x] Deployed on Kind (`kind-kagenti`) with `deploy-shared.sh` + `deploy-tenant.sh team1`
- [x] Verified `openshell status` shows Connected, Version: 0.0.36-kagenti.8
- [x] Verified sandbox create/exec/delete lifecycle works end-to-end
- [x] Verified sandbox init container copies `/openshell-sandbox` correctly

Assisted-By: Claude Code