### PR TITLE
fix(kind): honor chart values.yaml for image tags

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -999,19 +999,10 @@ fi
 # ============================================================================
 log_info "Step 8: kagenti"
 
-# Detect latest release tag for UI images (skip when building from source)
-KAGENTI_TAG="latest"
-if $WITH_UI && ! $BUILD_IMAGES; then
-  log_info "Detecting latest kagenti release tag..."
-  DETECTED_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/kagenti/kagenti.git 2>/dev/null | \
-    tail -n1 | sed 's|.*refs/tags/||; s/\^{}//' || echo "")
-  if [ -n "$DETECTED_TAG" ]; then
-    KAGENTI_TAG="$DETECTED_TAG"
-    log_success "Using tag: $KAGENTI_TAG"
-  else
-    log_warn "Could not detect latest tag — using 'latest'"
-  fi
-fi
+# Image tags come from charts/kagenti/values.yaml (pinned at release time by
+# chore(release) commits — see docs/releasing.md). The only override is below
+# in KAGENTI_FLAGS when --build-images is set, since locally-built images are
+# tagged ":latest" and loaded into Kind.
 
 # Secrets file resolution (checked in order of precedence):
 #   1. --secrets-file CLI argument
@@ -1099,11 +1090,27 @@ KAGENTI_FLAGS=(
   --set "featureFlags.agentSandbox=${WITH_AGENT_SANDBOX}"
   --set "components.phoenix.enabled=false"
   --set "components.mlflow.enabled=${WITH_MLFLOW}"
-  --set "ui.frontend.tag=${KAGENTI_TAG}"
-  --set "ui.backend.tag=${KAGENTI_TAG}"
   --set "ui.auth.enabled=$($WITH_SPIRE && echo true || echo false)"
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"
 )
+
+# When --build-images is set, the build step tags images ":latest" and loads
+# them into Kind (see list above). Override the chart's release-pinned tags
+# for exactly those images so pods use the locally-built copies instead of
+# pulling pinned tags from ghcr.io. Image selection mirrors _BUILD_IMAGES.
+if $BUILD_IMAGES; then
+  KAGENTI_FLAGS+=(--set "agentOAuthSecret.tag=latest")
+  if $WITH_BACKEND; then
+    KAGENTI_FLAGS+=(--set "ui.backend.tag=latest")
+  fi
+  if $WITH_UI; then
+    KAGENTI_FLAGS+=(--set "ui.frontend.tag=latest")
+    KAGENTI_FLAGS+=(--set "uiOAuthSecret.tag=latest")
+  fi
+  if $WITH_MLFLOW; then
+    KAGENTI_FLAGS+=(--set "mlflowOAuthSecret.tag=latest")
+  fi
+fi
 
 log_info "Installing kagenti..."
 run_cmd helm upgrade --install kagenti "$REPO_ROOT/charts/kagenti/" \


### PR DESCRIPTION
## Summary

`scripts/kind/setup-kagenti.sh` silently overrode `ui.frontend.tag` and
`ui.backend.tag` on every helm install via a `git ls-remote --tags`
hack + hardcoded `--set` flags. This defeats whatever
`charts/kagenti/values.yaml` says.

- **Historical origin (commit 02b97389):** when the bash installer
  replaced Ansible, every `tag:` in values.yaml was literal `latest`.
  Detecting the newest git tag and pinning via `--set` was the only
  way to get a deterministic install.
- **Collision (commit 11f2da29, `chore(release): pin image tags…`):**
  values.yaml now carries concrete pinned tags at release time (see
  `docs/releasing.md`). The installer's override became redundant on
  release tags, inconsistent on other branches, and a silent trap for
  anyone editing values.yaml.

Details:
- Only `ui.frontend.tag` and `ui.backend.tag` were overridden, leaving
  `uiOAuthSecret.tag`, `agentOAuthSecret.tag`, `mlflowOAuthSecret.tag`,
  and `spiffeIdp.image.tag` to follow values.yaml — so the installed
  component set was a mix of versions.
- `--build-images` was partly broken by this: it builds
  `ui-oauth-secret`, `agent-oauth-secret`, and `mlflow-oauth-secret`
  locally as `:latest` and loads them into Kind, but the installer
  only overrode `ui.*.tag`, so those oauth-secret jobs pulled release
  tags from ghcr.io instead of using the locally-built copies.

## Change

Delete the `git ls-remote` detection and the two unconditional
`--set ui.*.tag=${KAGENTI_TAG}` lines. Chart `values.yaml` becomes the
single source of truth.

`--build-images` still needs `:latest` because the build step tags
local images that way. Add a `$BUILD_IMAGES` block that sets exactly
those image tags to `latest` — mirroring the `_BUILD_IMAGES` list so
the mapping stays in sync. Also covers `uiOAuthSecret`,
`agentOAuthSecret`, and `mlflowOAuthSecret`, which the previous code
missed.

## Test plan

- [ ] `./scripts/kind/setup-kagenti.sh --with-all --skip-cluster` on a
  Kind cluster without `--build-images` → `helm get values kagenti`
  shows no `ui.frontend.tag` / `ui.backend.tag` user-supplied value;
  pods run the tag pinned in `values.yaml`.
- [ ] Same with `--build-images` → `helm get values kagenti` shows
  `ui.frontend.tag=latest`, `ui.backend.tag=latest`, and the three
  oauth-secret tags `=latest`; pods use locally-built images.
- [ ] `bash -n scripts/kind/setup-kagenti.sh` passes.

Assisted-By: Claude Code
