### PR TITLE
fix: Use destroy-cluster.sh for stale cleanup instead of relying on finalizers

### DIFF
--- a/.github/scripts/hypershift/cleanup-stale-clusters.sh
+++ b/.github/scripts/hypershift/cleanup-stale-clusters.sh
@@ -231,9 +231,8 @@ for CLUSTER_NAME in $CLUSTERS; do
             echo "       Would delete (use --apply to execute)"
         else
             echo "       Deleting cluster..."
-            # Use direct oc delete for reliable cleanup in CI and local environments
-            # The HostedCluster deletion triggers cascading cleanup of AWS resources
-            if oc delete hostedcluster "$CLUSTER_NAME" -n clusters 2>&1 | tee "/tmp/cleanup-${CLUSTER_NAME}.log"; then
+            # Use destroy-cluster.sh which handles ansible cleanup and stuck finalizers
+            if "$SCRIPT_DIR/destroy-cluster.sh" "$CLUSTER_NAME" 2>&1 | tee "/tmp/cleanup-${CLUSTER_NAME}.log"; then
                 log_success "Successfully deleted $CLUSTER_NAME"
                 DELETED_COUNT=$((DELETED_COUNT + 1))
             else


### PR DESCRIPTION
  Automated stale cluster cleanup was using oc delete hostedcluster which relies on HyperShift  
  finalizers to clean AWS resources. These finalizers frequently hang/fail, leaving orphaned
  VPCs, EIPs, OIDC providers, and Route53 zones.                                                
                  
  Solution

  Use destroy-cluster.sh instead, which handles ansible-based AWS cleanup and stuck finalizers  
  automatically.
                                                                                                
  Changes         

  - Replace oc delete with $SCRIPT_DIR/destroy-cluster.sh call                                  
  - Remove batch AWS verification section (no longer needed)
                                                                                                
  Testing         

  ✅ Syntax validated
  ✅ Dry-run tested successfully
  ✅ Uses same proven approach as cleanup-zombies.sh and CI cleanup scripts
                                                                                                
  Restores custom cleanup approach that was removed in 9875fc8e.  finalizer     
  issues require custom cleanup until newer HyperShift versions.