### PR TITLE
docs: align agentic-runtime docs with tiered tests and upstream OpenShell changes

### DIFF
--- a/docs/agentic-runtime/agents/README.md
+++ b/docs/agentic-runtime/agents/README.md
@@ -141,7 +141,6 @@ Which E2E tests cover this agent:
 | test_T1_1_connectivity | 2 | 2 | 0 | 0 |
 | test_T3_1_skill_execution | 3 | 1 | 2 | 0 |
 ```
-```
 
 ## Capability Comparison Matrix
 

--- a/docs/agentic-runtime/agents/README.md
+++ b/docs/agentic-runtime/agents/README.md
@@ -138,8 +138,8 @@ Which E2E tests cover this agent:
 
 | Test File | Tests | Pass | Skip | Fail |
 |-----------|-------|------|------|------|
-| test_02_a2a_connectivity | 2 | 2 | 0 | 0 |
-| test_07_skill_execution | 3 | 1 | 2 | 0 |
+| test_T1_1_connectivity | 2 | 2 | 0 | 0 |
+| test_T3_1_skill_execution | 3 | 1 | 2 | 0 |
 ```
 ```
 

--- a/docs/agentic-runtime/agents/adk-agent.md
+++ b/docs/agentic-runtime/agents/adk-agent.md
@@ -190,11 +190,11 @@ kill %1
 
 | Test File | Tests | Pass | Skip | Notes |
 |-----------|-------|------|------|-------|
-| test_02_a2a_connectivity | 2 | 2 | 0 | Hello + agent card |
-| test_05_multiturn | 3 | 2 | 1 | Sequential + isolation pass; continuity skips |
-| test_07_skill_execution | 5 | 3 | 2 | PR review, RCA, security pass; real GH PR pass |
-| test_T1_6_credential_security | 4 | 4 | 0 | secretKeyRef, no hardcoded keys |
-| test_06_conversation_resume | 2 | 0 | 2 | Destructive-gated |
+| test_T1_1_connectivity | 2 | 2 | 0 | Hello + agent card |
+| test_T2_1_multiturn | 3 | 2 | 1 | Sequential + isolation pass; continuity skips |
+| test_T3_1_skill_execution | 5 | 3 | 2 | PR review, RCA, security pass; real GH PR pass |
+| test_T1_2_credentials | 4 | 4 | 0 | secretKeyRef, no hardcoded keys |
+| test_T2_3_session_resume | 2 | 0 | 2 | Destructive-gated |
 
 ## 11. Sandbox Deployment Models
 

--- a/docs/agentic-runtime/agents/claude-sdk-agent.md
+++ b/docs/agentic-runtime/agents/claude-sdk-agent.md
@@ -140,9 +140,9 @@ kill %1
 
 | Test File | Tests | Pass | Skip | Notes |
 |-----------|-------|------|------|-------|
-| test_02_a2a_connectivity | 2 | 2 | 0 | Hello + agent card |
-| test_05_multiturn | 3 | 2 | 1 | Sequential + isolation pass; continuity skips |
-| test_07_skill_execution | 7 | 5 | 2 | PR review, RCA, security, real GH PR, RCA logs |
+| test_T1_1_connectivity | 2 | 2 | 0 | Hello + agent card |
+| test_T2_1_multiturn | 3 | 2 | 1 | Sequential + isolation pass; continuity skips |
+| test_T3_1_skill_execution | 7 | 5 | 2 | PR review, RCA, security, real GH PR, RCA logs |
 
 ## 10. Sandbox Deployment Models
 

--- a/docs/agentic-runtime/agents/nemoclaw-hermes.md
+++ b/docs/agentic-runtime/agents/nemoclaw-hermes.md
@@ -127,10 +127,10 @@ network_policies:
 
 | Test File | Tests | Pass | Skip | Notes |
 |-----------|:---:|:---:|:---:|-------|
-| test_11_nemoclaw_smoke (platform) | 3 | 3 | 0 | Deployment, pod running, framework label |
-| test_11_nemoclaw_smoke (health) | 1 | 1 | 0 | TCP connectivity |
-| test_11_nemoclaw_smoke (inference) | 1 | 0 | 1 | Internal protocol, needs NemoClaw plugin |
-| test_11_nemoclaw_smoke (security) | 4 | 4 | 0 | AuthBridge, capabilities, escalation, secret |
+| test_T0_4_infra_nemoclaw (platform) | 3 | 3 | 0 | Deployment, pod running, framework label |
+| test_T0_4_infra_nemoclaw (health) | 1 | 1 | 0 | TCP connectivity |
+| test_T0_4_infra_nemoclaw (inference) | 1 | 0 | 1 | Internal protocol, needs NemoClaw plugin |
+| test_T0_4_infra_nemoclaw (security) | 4 | 4 | 0 | AuthBridge, capabilities, escalation, secret |
 | **Total** | **9** | **8** | **1** | |
 
 ## 9. NemoClaw Source Pinning

--- a/docs/agentic-runtime/agents/nemoclaw-openclaw.md
+++ b/docs/agentic-runtime/agents/nemoclaw-openclaw.md
@@ -127,10 +127,10 @@ network_policies:
 
 | Test File | Tests | Pass | Skip | Notes |
 |-----------|:---:|:---:|:---:|-------|
-| test_11_nemoclaw_smoke (platform) | 3 | 3 | 0 | Deployment, pod running, framework label |
-| test_11_nemoclaw_smoke (health) | 1 | 1 | 0 | HTTP gateway responds |
-| test_11_nemoclaw_smoke (inference) | 1 | 1 | 0 | Gateway interaction verified |
-| test_11_nemoclaw_smoke (security) | 4 | 4 | 0 | AuthBridge, capabilities, escalation, secret |
+| test_T0_4_infra_nemoclaw (platform) | 3 | 3 | 0 | Deployment, pod running, framework label |
+| test_T0_4_infra_nemoclaw (health) | 1 | 1 | 0 | HTTP gateway responds |
+| test_T0_4_infra_nemoclaw (inference) | 1 | 1 | 0 | Gateway interaction verified |
+| test_T0_4_infra_nemoclaw (security) | 4 | 4 | 0 | AuthBridge, capabilities, escalation, secret |
 | **Total** | **9** | **9** | **0** | **100% pass rate** |
 
 ## 9. NemoClaw Source Pinning

--- a/docs/agentic-runtime/agents/openshell-claude.md
+++ b/docs/agentic-runtime/agents/openshell-claude.md
@@ -190,7 +190,7 @@ It **cannot** use OpenAI-compatible proxies (LiteMaaS, LiteLLM, Ollama) because:
 
 ### Path to Enabling Skills (Paolo's Provider Workflow)
 
-Once TLS + ingress are configured (see [architecture alignment](../../plans/2026-04-25-architecture-alignment-review.md#4-openshell-provider-mechanism--zero-trust-credential-delivery)):
+Once TLS + ingress are configured:
 
 ```bash
 # 1. Create provider with real Anthropic key (or LiteLLM with Anthropic routing)

--- a/docs/agentic-runtime/agents/openshell-claude.md
+++ b/docs/agentic-runtime/agents/openshell-claude.md
@@ -244,9 +244,9 @@ see the `claude-*` model name and accept it.
 
 | Test File | Tests | Pass | Skip | Notes |
 |-----------|-------|------|------|-------|
-| test_04_sandbox_lifecycle | 1 | 1 | 0 | Sandbox CR created |
-| test_07_skill_execution | 3 | 0 | 3 | Needs real Anthropic key |
-| test_10_workspace_persistence | 2 | 1 | 1 | PVC write passes; sandbox creation skips |
+| test_T1_3_sandbox_lifecycle | 1 | 1 | 0 | Sandbox CR created |
+| test_T3_1_skill_execution | 3 | 0 | 3 | Needs real Anthropic key |
+| test_T1_4_workspace | 2 | 1 | 1 | PVC write passes; sandbox creation skips |
 
 ## 11. Sandbox Deployment Models
 

--- a/docs/agentic-runtime/agents/openshell-opencode.md
+++ b/docs/agentic-runtime/agents/openshell-opencode.md
@@ -247,9 +247,9 @@ opencode run -m openai/gpt-4o-mini "Review this code for security issues: ..."
 
 | Test File | Tests | Pass | Skip | Notes |
 |-----------|-------|------|------|-------|
-| test_04_sandbox_lifecycle | 1 | 1 | 0 | Sandbox CR created |
-| test_07_skill_execution | 5 | 3 | 2 | PR review, RCA, security pass; real GH PR + CLI check skip |
-| test_10_workspace_persistence | 3 | 3 | 0 | PVC write + sandbox creation pass |
+| test_T1_3_sandbox_lifecycle | 1 | 1 | 0 | Sandbox CR created |
+| test_T3_1_skill_execution | 5 | 3 | 2 | PR review, RCA, security pass; real GH PR + CLI check skip |
+| test_T1_4_workspace | 3 | 3 | 0 | PVC write + sandbox creation pass |
 
 ## 11. Sandbox Deployment Models
 

--- a/docs/agentic-runtime/agents/weather-supervised.md
+++ b/docs/agentic-runtime/agents/weather-supervised.md
@@ -180,10 +180,10 @@ ENTRYPOINT ["/usr/local/bin/openshell-sandbox", "--", ...]
 
 | Test File | Tests | Pass | Skip | Notes |
 |-----------|-------|------|------|-------|
-| test_08_supervisor_enforcement | 12 | 12 | 0 | All protection layers verified |
-| test_09_hitl_policy | 3 | 1-2 | 1 | OPA deny/allow tested |
-| test_02_a2a_connectivity | 1 | 1 | 0 | kubectl exec hello |
-| test_05_multiturn | 2 | 1 | 1 | exec-based multi-turn |
+| test_T0_3_infra_supervisor | 12 | 12 | 0 | All protection layers verified |
+| test_T4_1_hitl_network | 3 | 1-2 | 1 | OPA deny/allow tested |
+| test_T1_1_connectivity | 1 | 1 | 0 | kubectl exec hello |
+| test_T2_1_multiturn | 2 | 1 | 1 | exec-based multi-turn |
 
 ## 9. Sandbox Deployment Models
 

--- a/docs/agentic-runtime/e2e-test-matrix.md
+++ b/docs/agentic-runtime/e2e-test-matrix.md
@@ -19,7 +19,7 @@ Agent lists defined in `conftest.py`: `A2A_AGENTS`, `EXEC_AGENTS`, `CLI_AGENTS`,
 
 ## Capability Matrix (CI Kind)
 
-208 tests total. P=pass, S=skip, —=not tested.
+174 tests total. P=pass, S=skip, —=not tested.
 
 **Tier 1: Infrastructure**
 
@@ -29,8 +29,6 @@ Agent lists defined in `conftest.py`: `A2A_AGENTS`, `EXEC_AGENTS`, `CLI_AGENTS`,
 | Credentials | P | P | P | P | P | P | P |
 | Sandbox lifecycle | P | — | — | — | — | — | — |
 | Workspace | P | P | — | — | — | — | — |
-| Credential security | P | P | P | P | P | P | P |
-| Sandbox connectivity | P | — | — | — | — | — | — |
 | Resource limits | S | — | P | S | S | P | P |
 
 **Tier 2: Capabilities**
@@ -62,10 +60,49 @@ Per-model: `llama-scout-17b` + `deepseek-r1` (both 100% via LiteMaaS).
 | Capability | Weather | Others |
 |---|:---:|:---:|
 | HITL: Network egress | P | — |
-| Tenant isolation (auth) | — | S (needs Keycloak port-forward in CI) |
-| Tenant isolation (RBAC) | — | P |
-| Tenant isolation (credentials) | — | P |
 | Audit logging | — | P (Claude Code, OpenCode) |
+
+**Tier 5: Backend API (via kagenti-backend A2A proxy)**
+
+All A2A agents are tested through the backend proxy (`/api/v1/chat/{ns}/{agent}/send|stream`).
+This validates the production path — one port-forward to the backend replaces per-agent port-forwards.
+
+| Capability | Claude SDK | ADK | Weather | Claude Code | OpenCode | OpenClaw |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Health check | — | — | — | — | — | — |
+| Agent card proxy | — | — | — | — | — | — |
+| Send proxy | — | — | S | — | — | — |
+| Stream proxy | — | — | S | — | — | — |
+| Multiturn proxy | — | — | S | — | — | — |
+| Agent list | — | — | — | — | — | — |
+| Error handling | — | — | — | — | — | — |
+| Concurrent proxy | — | — | — | — | — | — |
+
+S for Weather send/stream/multiturn: no LLM capability (by design).
+Claude Code/OpenCode: CLI sandbox agents, not A2A — backend proxy N/A (use ACP instead).
+OpenClaw: gateway protocol, not A2A — backend proxy N/A (needs adapter).
+Requires `OPENSHELL_BACKEND_AVAILABLE=true`.
+
+**Tier 6: ACP Protocol (WebSocket)**
+
+Tests the ACP WebSocket endpoint (`/api/v1/acp/ws/{ns}/{agent}`) with JSON-RPC 2.0.
+Currently bridges to A2A agents; future: direct ACP for Claude Code/OpenCode sandboxes.
+
+| Capability | Claude SDK | ADK | Weather | Claude Code | OpenCode | OpenClaw |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Initialize | — | — | — | — | — | — |
+| Session new/close | — | — | — | — | — | — |
+| Prompt relay | — | — | S | — | — | — |
+| Context preserved | — | — | S | — | — | — |
+| Session list | — | — | — | — | — | — |
+| Session resume | — | — | — | — | — | — |
+| Permission gate | — | — | — | — | — | — |
+| Error handling | — | — | — | — | — | — |
+
+S for Weather: no LLM.
+Claude Code/OpenCode: future — ACP native (session/prompt → sandbox exec).
+OpenClaw: future — ACP-NemoClaw bridge.
+Requires `KAGENTI_FEATURE_FLAG_ACP=true` on the backend.
 
 ## Skip Reasons
 
@@ -94,10 +131,9 @@ Per-model: `llama-scout-17b` + `deepseek-r1` (both 100% via LiteMaaS).
 | `test_T2_1_multiturn.py` | 2 | 20 | Multiturn, context, tool calling, concurrent |
 | `test_T2_3_session_resume.py` | 2 | 7 | Session resume across restarts |
 | `test_T3_1_skill_execution.py` | 3 | 32 | Skills x 6 agents + per-model + audit |
-| `test_T1_6_credential_security.py` | 1 | 14 | Secret delivery, no hardcoded keys, K8s token leak, policy mount |
-| `test_T1_7_sandbox_connectivity.py` | 1 | 5 | Gateway health, endpoints, port-forward, kubectl exec |
 | `test_T4_1_hitl_network.py` | 4 | 3 | HITL network egress |
-| `test_T4_2_tenant_isolation.py` | 4 | 15 | JWT audience, RBAC scoping, credential isolation |
+| `test_T5_1_backend_api.py` | 5 | ~15 | Backend A2A proxy |
+| `test_T6_1_acp_protocol.py` | 6 | ~15 | ACP WebSocket protocol |
 
 ## Running Tests
 

--- a/docs/agentic-runtime/e2e-test-matrix.md
+++ b/docs/agentic-runtime/e2e-test-matrix.md
@@ -15,7 +15,7 @@
 | `nemoclaw-hermes` | TCP (internal) | LiteMaaS | Internal protocol (skip) |
 
 Agent lists defined in `conftest.py`: `A2A_AGENTS`, `EXEC_AGENTS`, `CLI_AGENTS`,
-`NEMOCLAW_AGENTS`, `SKILL_AGENTS`, `ALL_AGENTS`.
+`NEMOCLAW_AGENTS`, `ALL_AGENTS`.
 
 ## Capability Matrix (CI Kind)
 
@@ -116,6 +116,8 @@ Requires `KAGENTI_FEATURE_FLAG_ACP=true` on the backend.
 | Session resume | 5 | All | Kagenti backend session store |
 
 ## Test File Organization
+
+Test counts include parametrized instances (e.g., a test parametrized across 3 agents counts as 3).
 
 | File | Tier | Tests | What it covers |
 |---|---|:---:|---|

--- a/docs/agentic-runtime/openshell-integration.md
+++ b/docs/agentic-runtime/openshell-integration.md
@@ -261,7 +261,7 @@ graph TB
 
 ### AuthBridge Integration (Phase 3)
 
-Kagenti's [AuthBridge](../authbridge-combined-sidecar.md) and the OpenShell
+Kagenti's [AuthBridge](../authbridge/README.md) and the OpenShell
 supervisor are complementary security layers that cannot currently coexist in
 the same pod. AuthBridge provides inbound JWT validation, outbound token
 exchange, and SPIFFE identity. The supervisor provides Landlock, seccomp,
@@ -327,9 +327,9 @@ volumes:
   emptyDir: {}
 ```
 
-Helm values for configuring the supervisor image:
-- `server.supervisorImage` (default: `ghcr.io/nvidia/openshell/supervisor:latest`)
-- `server.supervisorImagePullPolicy`
+Upstream Helm values for configuring the supervisor image:
+- `supervisor.image.repository` (default: `ghcr.io/nvidia/openshell/supervisor`)
+- `supervisor.image.pullPolicy`
 
 **Note:** The supervisor binary path changed from `/usr/local/bin/openshell-sandbox`
 to `/openshell-sandbox` in the upstream image. Kagenti's chart

--- a/docs/agentic-runtime/openshell-integration.md
+++ b/docs/agentic-runtime/openshell-integration.md
@@ -366,7 +366,6 @@ model validation.
 
 | Agent | Supervisor? | OPA Enforced? | Egress |
 |-------|------------|---------------|--------|
-| weather-agent-supervised | Yes | Yes | Tier 2 |
 | weather-agent-supervised | **Yes** | **Yes** | Restricted to `*.svc.cluster.local` + LiteMaaS |
 | adk-agent-supervised | Yes | Yes (enforced) | Tier 2 |
 | claude-sdk-agent | No | No (policy mounted but not enforced) | **Open** |

--- a/docs/agentic-runtime/openshell-integration.md
+++ b/docs/agentic-runtime/openshell-integration.md
@@ -278,52 +278,69 @@ for open questions.
 
 ## 7. OpenShell RFC 0001
 
-OpenShell is being rearchitected via [RFC 0001](https://github.com/NVIDIA/OpenShell/pull/836)
-into a composable, driver-based system with four pluggable subsystems:
+OpenShell was rearchitected via [RFC 0001](https://github.com/NVIDIA/OpenShell/pull/836)
+(merged 2026-04-27) into a composable, driver-based system with four pluggable subsystems:
 
 | Subsystem | Purpose | Kagenti Mapping |
 |-----------|---------|-----------------|
-| **Compute** | Sandbox lifecycle (K8s, Podman, VM) | Kagenti as compute driver (phase 2) |
+| **Compute** | Sandbox lifecycle (K8s, Podman, VM, Docker) | Kagenti as compute driver (phase 2) |
 | **Credentials** | Secret resolution (Vault, K8s Secrets) | Delivers secrets to supervisor proxy |
 | **Control-plane identity** | User/operator auth (mTLS, OIDC) | Keycloak OIDC |
 | **Sandbox identity** | Workload identity (SPIFFE) | SPIRE |
 
-## 8. Security: Init Container Pattern (TODO)
+The RFC is now the canonical architecture reference at `rfc/0001-core-architecture.md`
+in the upstream repo. Key post-RFC changes: compute driver auto-detection
+([#1088](https://github.com/NVIDIA/OpenShell/pull/1088), `--drivers` defaults to
+empty and auto-detects K8s > Podman > Docker), and Docker compute driver
+([#888](https://github.com/NVIDIA/OpenShell/pull/888)).
 
-The PoC uses `privileged: true` on the supervised agent container because
-the OpenShell supervisor needs `CAP_SYS_ADMIN` + `CAP_NET_ADMIN` for
-network namespace creation (`unshare CLONE_NEWNET` + `mount --make-shared`).
+## 8. Supervisor Binary Delivery: Init Container Pattern
 
-**Current (PoC):** Single container with `privileged: true`. The supervisor
-applies Landlock + seccomp after startup, but there is a window before
-isolation is applied where the process has full host access.
+Upstream OpenShell now delivers the supervisor binary via an init container
+([#1154](https://github.com/NVIDIA/OpenShell/pull/1154), merged 2026-05-04),
+replacing the old `hostPath` volume mount. The supervisor image is `FROM scratch`
+and uses a `copy-self` subcommand ([#1208](https://github.com/NVIDIA/OpenShell/pull/1208),
+merged 2026-05-06) since `sh -c "cp ..."` cannot run in a scratch container.
 
-**Target (production):** Use an **init container** for the supervisor:
+**Upstream pattern (v0.0.36+):**
 
 ```yaml
 initContainers:
 - name: supervisor-init
   image: ghcr.io/nvidia/openshell/supervisor:latest
-  securityContext:
-    privileged: true   # Only init container is privileged
-  command: ["/usr/local/bin/openshell-sandbox", "--setup-only"]
-  # Sets up netns, Landlock, seccomp, then exits
+  command: ["/openshell-sandbox", "copy-self", "/opt/openshell/bin/openshell-sandbox"]
+  volumeMounts:
+  - name: supervisor-bin
+    mountPath: /opt/openshell/bin
 
 containers:
 - name: agent
   image: agent:latest
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop: [ALL]      # Agent has zero capabilities
+  command: ["/opt/openshell/bin/openshell-sandbox"]
+  volumeMounts:
+  - name: supervisor-bin
+    mountPath: /opt/openshell/bin
+    readOnly: true
+
+volumes:
+- name: supervisor-bin
+  emptyDir: {}
 ```
 
-The init container runs with elevated privileges for ~2 seconds (netns setup),
-then terminates. The agent container starts with `drop: [ALL]` and inherits
-the isolation. This eliminates the privileged window.
+Helm values for configuring the supervisor image:
+- `server.supervisorImage` (default: `ghcr.io/nvidia/openshell/supervisor:latest`)
+- `server.supervisorImagePullPolicy`
 
-**Requires:** Upstream OpenShell support for `--setup-only` mode (supervisor
-sets up isolation and exits, leaving the netns/Landlock for the next container).
+**Note:** The supervisor binary path changed from `/usr/local/bin/openshell-sandbox`
+to `/openshell-sandbox` in the upstream image. Kagenti's chart
+(`charts/openshell/values.yaml`) makes this configurable via
+`supervisorImage.binaryPath` (PR [#1513](https://github.com/kagenti/kagenti/pull/1513)).
+
+**Security model:** The PoC still uses `privileged: true` on supervised agent
+containers because the supervisor needs `CAP_SYS_ADMIN` + `CAP_NET_ADMIN` for
+network namespace creation. The init container pattern above delivers the binary
+but does not yet implement `--setup-only` mode (supervisor sets up isolation in
+init, then exits). Full privilege reduction remains a TODO.
 
 ## 9. LLM Compatibility Matrix
 
@@ -359,12 +376,16 @@ as preparation for supervisor integration. The policies are NOT enforced until t
 supervisor binary is the container entrypoint. Only `weather-agent-supervised`
 enforces egress control through the supervisor's HTTP CONNECT proxy + OPA engine.
 
-**Blocker for full enforcement:** The supervisor creates a network namespace
-that blocks `kubectl port-forward` and K8s readiness probes. A2A tests
-require port-forward to reach agents from the test runner. Solutions:
-1. Upstream: supervisor exposes agent port through the proxy (not yet supported)
-2. Workaround: run tests from inside the cluster (e.g., test runner pod)
-3. Workaround: use a sidecar that bridges the netns port to the pod network
+**Test workaround:** The supervisor's network namespace blocks `kubectl port-forward`.
+Supervised agents use a port-bridge sidecar (socat TCP forwarder `0.0.0.0:8080 →
+10.200.0.2:8080`) to expose the A2A port. This is validated on both Kind and
+HyperShift — `adk-agent-supervised` passes all skill tests through the port bridge.
+
+**Note:** Upstream removed direct gateway-to-sandbox connectivity
+([#867](https://github.com/NVIDIA/OpenShell/pull/867), merged 2026-04-21).
+`ResolveSandboxEndpoint` RPC was deleted. All SSH/exec now goes through
+supervisor-initiated gRPC relay (`RelayStream` RPC). SSH daemon moved to
+Unix socket (`/run/openshell/ssh.sock`); port 2222 is no longer used.
 
 ## 11. Phase 1 PoC Results
 
@@ -476,8 +497,8 @@ unified session management via the UI:
 | Agent Type | Backend Adapter | How it works |
 |-----------|----------------|-------------|
 | Custom A2A (weather, ADK, Claude SDK) | **A2A adapter** (already implemented) | Backend sends A2A `message/send` JSON-RPC, stores response in session DB |
-| OpenShell builtin (Claude, OpenCode) | **ExecSandbox adapter** (Phase 2) | Backend calls gateway's `ExecSandbox` gRPC to send prompts, captures stdout, stores in session DB |
-| OpenShell builtin (interactive SSH) | **Terminal adapter** (Phase 3) | Backend bridges WebSocket (xterm.js in UI) to SSH tunnel via gateway gRPC |
+| OpenShell builtin (Claude, OpenCode) | **ExecSandbox adapter** (Phase 2) | Backend calls gateway's `ExecSandbox` gRPC to send prompts, captures stdout, stores in session DB. Note: upstream moved to supervisor-initiated relay ([#867](https://github.com/NVIDIA/OpenShell/pull/867)); exec now uses `RelayStream` RPC |
+| OpenShell builtin (interactive SSH) | **Terminal adapter** (Phase 3) | Backend bridges WebSocket (xterm.js in UI) to SSH via supervisor gRPC relay (port 2222 removed; SSH uses Unix socket) |
 
 ### Session persistence architecture
 
@@ -526,7 +547,7 @@ OpenShell sandboxes through the same API used for Deployment-backed agents.
 
 | Item | Priority | Description |
 |------|----------|-------------|
-| Init container pattern | HIGH | Replace `privileged: true` with init container (see section 9) |
+| Reduce privileges | HIGH | Init container binary delivery done (section 8); `--setup-only` mode still needed to eliminate `privileged: true` on agent container |
 | Enable TLS + auth on gateway | HIGH | Remove `--disable-tls --disable-gateway-auth`, mount TLS certs |
 | Push agent images to registry | HIGH | Use Shipwright on-cluster builds for OCP (manifests in `shipwright-build.yaml`) |
 | Namespace-scoped NetworkPolicy | MEDIUM | Restrict gateway access to agent namespaces only |
@@ -535,15 +556,23 @@ OpenShell sandboxes through the same API used for Deployment-backed agents.
 | Supervisor-managed A2A port | LOW | Expose agent port through supervisor proxy for netns-compatible testing |
 | Multi-namespace support | LOW | Add RoleBindings for team2, team3, etc. |
 
-## 14. Related PRs
+## 14. Related Upstream PRs
 
-Key upstream PRs relevant to integration:
+Key upstream [NVIDIA/OpenShell](https://github.com/NVIDIA/OpenShell) PRs relevant
+to integration (as of 2026-05-08):
 
 | PR | Status | Impact |
 |----|--------|--------|
-| [#817](https://github.com/NVIDIA/OpenShell/pull/817) | Merged | K8s compute driver extraction |
-| [#836](https://github.com/NVIDIA/OpenShell/pull/836) | Open | RFC 0001 — core architecture |
-| [#858](https://github.com/NVIDIA/OpenShell/pull/858) | Open | VM compute driver (proves out-of-process driver) |
-| [#822](https://github.com/NVIDIA/OpenShell/pull/822) | Merged | L7 deny rules in policy schema |
-| [#860](https://github.com/NVIDIA/OpenShell/pull/860) | Open | Incremental policy updates |
-| [#861](https://github.com/NVIDIA/OpenShell/pull/861) | Open | Supervisor session relay |
+| [#817](https://github.com/NVIDIA/OpenShell/pull/817) | Merged (2026-04-14) | K8s compute driver extraction into `openshell-driver-kubernetes` crate |
+| [#822](https://github.com/NVIDIA/OpenShell/pull/822) | Merged (2026-04-15) | L7 deny rules in policy schema (`deny_rules` field) |
+| [#836](https://github.com/NVIDIA/OpenShell/pull/836) | Merged (2026-04-27) | RFC 0001 — canonical architecture (composable drivers) |
+| [#858](https://github.com/NVIDIA/OpenShell/pull/858) | Merged (2026-04-17) | VM compute driver (proves out-of-process driver model) |
+| [#860](https://github.com/NVIDIA/OpenShell/pull/860) | Merged (2026-04-20) | Incremental policy updates (`merge_operations`, `--add-endpoint`) |
+| [#861](https://github.com/NVIDIA/OpenShell/pull/861) | Closed | Supervisor session relay (superseded by #867) |
+| [#867](https://github.com/NVIDIA/OpenShell/pull/867) | Merged (2026-04-21) | **Supervisor-initiated gRPC relay** — removes `ResolveSandboxEndpoint`, SSH moves to Unix socket |
+| [#903](https://github.com/NVIDIA/OpenShell/pull/903) | Merged (2026-04-21) | Health endpoints on separate port 8081 (probes must target health port) |
+| [#1088](https://github.com/NVIDIA/OpenShell/pull/1088) | Merged (2026-05-01) | Compute driver auto-detection (K8s > Podman > Docker) |
+| [#1154](https://github.com/NVIDIA/OpenShell/pull/1154) | Merged (2026-05-04) | Supervisor binary via init container + `emptyDir` (replaces `hostPath`) |
+| [#1208](https://github.com/NVIDIA/OpenShell/pull/1208) | Merged (2026-05-06) | `copy-self` subcommand for scratch supervisor image |
+| [#1221](https://github.com/NVIDIA/OpenShell/pull/1221) | Merged (2026-05-07) | CLI `gateway start/stop/destroy` removed (only `gateway remove` remains) |
+| [#1237](https://github.com/NVIDIA/OpenShell/pull/1237) | Merged (2026-05-07) | Helm `nameOverride` set to `openshell` (all K8s resources renamed) |

--- a/docs/agentic-runtime/questions.md
+++ b/docs/agentic-runtime/questions.md
@@ -151,7 +151,7 @@ Two credential models exist:
 
 **Status:** TESTED (new)
 
-Our `test_09_hitl_policy.py` tests OPA egress blocking via `kubectl exec` into
+Our `test_T4_1_hitl_network.py` tests OPA egress blocking via `kubectl exec` into
 the supervised agent. Three tests: deny unauthorized, allow authorized, log denials.
 
 **Hurdle:** `curl` not available in supervised agent pod. Fixed by using python3 urllib.

--- a/docs/agentic-runtime/questions.md
+++ b/docs/agentic-runtime/questions.md
@@ -579,7 +579,7 @@ Sources: [OpenCode providers docs](https://opencode.ai/docs/providers),
 
 **Status:** OPEN (architecture decision) | **Related:** Q1.1 (tiers), Q2.3 (credential model)
 
-AuthBridge (Kagenti's [identity sidecar](../authbridge-combined-sidecar.md))
+AuthBridge (Kagenti's [identity sidecar](../authbridge/README.md))
 and the OpenShell supervisor provide complementary security layers:
 - AuthBridge: inbound JWT validation, outbound token exchange, SPIFFE identity
 - Supervisor: Landlock, seccomp, netns, OPA egress filtering, credential injection
@@ -652,8 +652,8 @@ management under Keycloak/AuthBridge.
 | Agent-to-agent communication | SPIFFE mTLS between pods | Egress policy allows target | Mutual auth + policy |
 | CI/CD agent running in sandbox | — | Seccomp blocks dangerous syscalls | Identity + process isolation |
 
-**Phase 3 tests:** See [e2e-test-matrix.md § AuthBridge Integration](e2e-test-matrix.md#authbridge-integration-tests-phase-3)
-for the planned test matrix.
+**Phase 3 tests:** AuthBridge integration tests are planned but not yet in the
+[test matrix](e2e-test-matrix.md).
 
 ### Q9.5: Which `authbridge-unified-config` ConfigMap version is required?
 

--- a/docs/agentic-runtime/sandboxing-layers.md
+++ b/docs/agentic-runtime/sandboxing-layers.md
@@ -103,7 +103,7 @@ into a composable, driver-based system with four pluggable subsystems:
 
 ## AuthBridge + Supervisor Integration (Phase 3)
 
-Kagenti's [AuthBridge](../authbridge-combined-sidecar.md) and the OpenShell
+Kagenti's [AuthBridge](../authbridge/README.md) and the OpenShell
 supervisor provide complementary security layers. In the current PoC they
 are **mutually exclusive** — supervised agents disable AuthBridge injection
 via `kagenti.io/inject: disabled`. Phase 3 resolves the architectural

--- a/docs/agentic-runtime/tests/README.md
+++ b/docs/agentic-runtime/tests/README.md
@@ -89,3 +89,5 @@ export OPENSHELL_DESTRUCTIVE_TESTS=false
 | `OPENSHELL_NEMOCLAW_ENABLED` | `false` | Enable NemoClaw tests |
 | `OPENSHELL_BACKEND_AVAILABLE` | `false` | Enable backend API tests (T5/T6) |
 | `OPENSHELL_DESTRUCTIVE_TESTS` | `false` | Enable pod restart tests |
+| `OPENSHELL_AGENT_PORT` | `8080` | Agent port for port-forwarding |
+| `OPENSHELL_LLM_PROVIDER` | `remote` | LLM provider type (`remote` or `ollama`) |

--- a/docs/agentic-runtime/tests/README.md
+++ b/docs/agentic-runtime/tests/README.md
@@ -30,6 +30,8 @@ Tests use tiered naming: `test_T{tier}_{module}_{description}.py`
 - [T1-3 Sandbox Lifecycle](T1-3-sandbox-lifecycle.md) — Sandbox CR CRUD, status observability
 - [T1-4 Workspace](T1-4-workspace.md) — PVC data persistence
 - [T1-5 Resource Limits](T1-5-resource-limits.md) — CPU/memory limits on all agents
+- T1-6 Credential Security (`test_T1_6_credential_security.py`, 5 tests) — secretKeyRef delivery, no hardcoded secrets, policy ConfigMaps
+- T1-7 Sandbox Connectivity (`test_T1_7_sandbox_connectivity.py`, 5 tests) — Gateway reachable, kubectl exec into sandboxes
 
 ### Tier 2: Conversation
 
@@ -43,6 +45,7 @@ Tests use tiered naming: `test_T{tier}_{module}_{description}.py`
 ### Tier 4: Security
 
 - [T4-1 HITL Network](T4-1-hitl-network.md) — OPA egress blocking
+- T4-2 Tenant Isolation (`test_T4_2_tenant_isolation.py`, 15 tests) — JWT audience auth, RBAC namespace scoping, credential isolation
 
 ### Tier 5: Backend API
 

--- a/docs/agentic-runtime/tests/README.md
+++ b/docs/agentic-runtime/tests/README.md
@@ -4,40 +4,53 @@
 
 ## Overview
 
-This directory contains detailed documentation for each E2E test category. Each doc explains what's being tested, shows the architecture under test with mermaid diagrams, and maps test functions to agent types.
+This directory contains detailed documentation for each E2E test category.
+Each doc explains what's being tested, shows the architecture under test with
+mermaid diagrams, and maps test functions to agent types.
+
+For current test counts, pass/skip status, and per-agent capability coverage,
+see the **[E2E Test Matrix](../e2e-test-matrix.md)** — that is the canonical
+source of truth.
 
 ## Test Categories
 
-| # | Category | Test File | Tests | Pass | Skip | Focus |
-|---|----------|-----------|-------|------|------|-------|
-| 01 | [Platform Health](01-platform-health.md) | `test_01_platform_health.py` | 7 | 7 | 0 | Gateway, operator, agent pods |
-| 02 | [A2A Connectivity](02-a2a-connectivity.md) | `test_02_a2a_connectivity.py` | 8 | 7 | 1 | JSON-RPC, agent card discovery |
-| 03 | [Credential Security](03-credential-security.md) | `test_T1_6_credential_security.py` | 15 | 15 | 0 | secretKeyRef, policy mounting |
-| 04 | [Sandbox Lifecycle](04-sandbox-lifecycle.md) | `test_04_sandbox_lifecycle.py` | 7 | 7 | 0 | Sandbox CR CRUD, status observability |
-| 05 | [Multi-Turn Conversation](05-multiturn-conversation.md) | `test_05_multiturn_conversation.py` | 12 | 9 | 3 | Sequential messages, context isolation |
-| 06 | [Conversation Resume](06-conversation-resume.md) | `test_06_conversation_resume.py` | 5 | 0 | 5 | Pod restart, PVC session restore |
-| 07 | [Skill Execution](07-skill-execution.md) | `test_07_skill_execution.py` | 27 | 18 | 9 | PR review, RCA, security review |
-| 08 | [Supervisor Enforcement](08-supervisor-enforcement.md) | `test_08_supervisor_enforcement.py` | 11 | 11 | 0 | Landlock, netns, OPA policy |
-| 09 | [HITL Policy](09-hitl-policy.md) | `test_09_hitl_policy.py` | 3 | 2 | 1 | OPA egress blocking |
-| 10 | [Workspace Persistence](10-workspace-persistence.md) | `test_10_workspace_persistence.py` | 8 | 7 | 1 | PVC data persistence |
+Tests use tiered naming: `test_T{tier}_{module}_{description}.py`
 
-**Totals:** 136 tests, 102 passed (local Kind+LLM+NemoClaw), 34 skipped (Kind, fresh cluster)
+### Tier 0: Infrastructure
 
-## Agent Type Coverage
+- [T0-1 Platform Health](T0-1-infra-platform.md) — Gateway, operator, agent pods
+- [T0-3 Supervisor Enforcement](T0-3-infra-supervisor.md) — Landlock, netns, seccomp, OPA
+- [T0-4 NemoClaw Infrastructure](T0-4-infra-nemoclaw.md) — NemoClaw health, security, connectivity
+- [T0-5 LiteLLM Infrastructure](T0-5-infra-litellm.md) — LiteLLM config, waypoint, passthrough
 
-Each test category covers ALL 7 agent types where applicable:
+### Tier 1: Basic Capabilities
 
-| Agent ID | Type | Tests Cover |
-|----------|------|-------------|
-| `weather_agent` | Custom A2A | A2A connectivity, multi-turn, security |
-| `adk_agent` | Custom A2A | Skill execution, LLM interaction |
-| `claude_sdk_agent` | Custom A2A | Skill execution, LLM interaction |
-| `weather_supervised` | Custom A2A + supervisor | Supervisor enforcement, HITL policy |
-| `openshell_claude` | Builtin sandbox | Workspace persistence, sandbox lifecycle |
-| `openshell_opencode` | Builtin sandbox | Workspace persistence, sandbox lifecycle |
-| `openshell_generic` | Builtin sandbox | Workspace persistence, sandbox lifecycle |
+- [T1-1 Connectivity](T1-1-connectivity.md) — A2A JSON-RPC, agent card discovery
+- [T1-2 Credentials](T1-2-credentials.md) — secretKeyRef, no hardcoded keys
+- [T1-3 Sandbox Lifecycle](T1-3-sandbox-lifecycle.md) — Sandbox CR CRUD, status observability
+- [T1-4 Workspace](T1-4-workspace.md) — PVC data persistence
+- [T1-5 Resource Limits](T1-5-resource-limits.md) — CPU/memory limits on all agents
 
-Unsupported combinations are explicitly skipped with documented reasons.
+### Tier 2: Conversation
+
+- [T2-1 Multi-Turn](T2-1-multiturn.md) — Sequential messages, context isolation, tool calling
+- [T2-3 Session Resume](T2-3-session-resume.md) — Session resume across pod restarts
+
+### Tier 3: Skills
+
+- [T3-1 Skill Execution](T3-1-skill-execution.md) — PR review, RCA, security review across agents and models
+
+### Tier 4: Security
+
+- [T4-1 HITL Network](T4-1-hitl-network.md) — OPA egress blocking
+
+### Tier 5: Backend API
+
+- [T5-1 Backend API](T5-1-backend-api.md) — A2A proxy through kagenti-backend
+
+### Tier 6: ACP Protocol
+
+- [T6-1 ACP Protocol](T6-1-acp-protocol.md) — ACP WebSocket JSON-RPC 2.0
 
 ## Using These Docs
 
@@ -56,7 +69,7 @@ Each test doc includes:
 uv run pytest kagenti/tests/e2e/openshell/ -v --timeout=300
 
 # Single category
-uv run pytest kagenti/tests/e2e/openshell/test_01_platform_health.py -v
+uv run pytest kagenti/tests/e2e/openshell/test_T0_1_infra_platform.py -v
 
 # With debug logging
 uv run pytest kagenti/tests/e2e/openshell/ -v --log-cli-level=INFO
@@ -65,26 +78,14 @@ uv run pytest kagenti/tests/e2e/openshell/ -v --log-cli-level=INFO
 export OPENSHELL_DESTRUCTIVE_TESTS=false
 ```
 
-## Test Status Legend
-
-- **✅** — test runs and passes
-- **⏭️** — test skips with documented reason (shown in test matrix)
-- **—** — test not applicable for this agent type
-
 ## Environment Variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `OPENSHELL_AGENT_NAMESPACE` | `team1` | Agent namespace |
-| `OPENSHELL_GATEWAY_NAMESPACE` | `openshell-system` | Gateway namespace |
+| `OPENSHELL_GATEWAY_NAMESPACE` | `team1` | Gateway namespace |
 | `OPENSHELL_LLM_AVAILABLE` | `false` | Enable LLM-dependent tests |
+| `OPENSHELL_LLM_MODELS` | — | Comma-separated model list |
+| `OPENSHELL_NEMOCLAW_ENABLED` | `false` | Enable NemoClaw tests |
+| `OPENSHELL_BACKEND_AVAILABLE` | `false` | Enable backend API tests (T5/T6) |
 | `OPENSHELL_DESTRUCTIVE_TESTS` | `false` | Enable pod restart tests |
-
-## Test File Organization
-
-Tests are organized by capability, not by agent type. This ensures:
-
-- All agents are tested for each capability
-- Gaps are explicit (skipped with reason)
-- Test structure matches architecture docs
-- Easy to add new agent types (add column to matrix)

--- a/docs/agentic-runtime/tests/T0-1-infra-platform.md
+++ b/docs/agentic-runtime/tests/T0-1-infra-platform.md
@@ -1,6 +1,6 @@
 # Platform Health
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_01_platform_health.py`
+> **Test file:** `kagenti/tests/e2e/openshell/test_T0_1_infra_platform.py`
 > **Tests:** 7 | **Pass:** 7 | **Skip:** 0 (Kind, fresh cluster)
 
 ## What This Tests

--- a/docs/agentic-runtime/tests/T0-1-infra-platform.md
+++ b/docs/agentic-runtime/tests/T0-1-infra-platform.md
@@ -1,7 +1,7 @@
 # Platform Health
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T0_1_infra_platform.py`
-> **Tests:** 7 | **Pass:** 7 | **Skip:** 0 (Kind, fresh cluster)
+> **Tests:** 7
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T0-3-infra-supervisor.md
+++ b/docs/agentic-runtime/tests/T0-3-infra-supervisor.md
@@ -1,7 +1,7 @@
 # Supervisor Enforcement
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_08_supervisor_enforcement.py`
-> **Tests:** 11 | **Pass:** 11 | **Skip:** 0 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T0_3_infra_supervisor.py`
+> **Tests:** 12 | **Pass:** 11 | **Skip:** 0 (Kind, fresh cluster)
 
 ## What This Tests
 
@@ -227,9 +227,9 @@ data:
 | Test Type | What's Tested | Limitation |
 |-----------|--------------|------------|
 | Log-based (this test) | Supervisor applied rules | Cannot verify LIVE enforcement (kubectl exec bypasses Landlock) |
-| Exec-based (test_09_hitl_policy) | OPA blocks unauthorized egress | Live enforcement via network calls |
+| Exec-based (test_T4_1_hitl_network) | OPA blocks unauthorized egress | Live enforcement via network calls |
 
-**Why log-based?** kubectl exec runs as root in the pod namespace, bypassing Landlock and seccomp. To test live enforcement, we need the agent process itself to attempt violations — which test_09_hitl_policy does via OPA proxy.
+**Why log-based?** kubectl exec runs as root in the pod namespace, bypassing Landlock and seccomp. To test live enforcement, we need the agent process itself to attempt violations — which test_T4_1_hitl_network does via OPA proxy.
 
 ## Future Expansion
 

--- a/docs/agentic-runtime/tests/T0-3-infra-supervisor.md
+++ b/docs/agentic-runtime/tests/T0-3-infra-supervisor.md
@@ -1,7 +1,7 @@
 # Supervisor Enforcement
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T0_3_infra_supervisor.py`
-> **Tests:** 12 | **Pass:** 11 | **Skip:** 0 (Kind, fresh cluster)
+> **Tests:** 12
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T0-4-infra-nemoclaw.md
+++ b/docs/agentic-runtime/tests/T0-4-infra-nemoclaw.md
@@ -1,0 +1,22 @@
+# NemoClaw Infrastructure
+
+> **Test file:** `kagenti/tests/e2e/openshell/test_T0_4_infra_nemoclaw.py`
+> **Tests:** 11
+
+## What This Tests
+
+Validates that NemoClaw agents (Hermes and OpenClaw) deployed via OpenShell are healthy, reachable, and properly secured. These agents use native APIs rather than A2A JSON-RPC -- Hermes exposes an OpenAI-compatible API on port 8642 and OpenClaw uses a gateway API on port 18789. Tests cover deployment health, health probes, basic inference smoke tests, and security posture (AuthBridge disabled, no privilege escalation, capabilities dropped, LLM keys from secrets). The entire suite is gated behind the `OPENSHELL_NEMOCLAW_ENABLED` environment variable.
+
+## Test Functions
+
+- `test_deployment_exists[agent]` -- NemoClaw agent deployment exists and has at least one available replica.
+- `test_pod_running[agent]` -- NemoClaw agent pod is in Running phase.
+- `test_framework_label[agent]` -- NemoClaw agents carry the `kagenti.io/framework=NemoClaw` label.
+- `test_hermes_health` -- Hermes gateway is reachable via TCP connect (no HTTP health endpoint).
+- `test_openclaw_health` -- OpenClaw agent responds to its gateway health endpoint with 200.
+- `test_hermes_chat_completion` -- Hermes processes an OpenAI-compatible chat completion request (skips if LLM unavailable or HTTP API not deployed).
+- `test_openclaw_gateway_interaction` -- OpenClaw gateway root returns a valid HTTP response.
+- `test_authbridge_disabled[agent]` -- NemoClaw agents have `kagenti.io/inject=disabled` to skip AuthBridge sidecar injection.
+- `test_no_privilege_escalation[agent]` -- All containers set `allowPrivilegeEscalation: false`.
+- `test_capabilities_dropped[agent]` -- All containers drop ALL Linux capabilities.
+- `test_llm_key_from_secret[agent]` -- OPENAI_API_KEY is sourced via `secretKeyRef`, not a literal env value.

--- a/docs/agentic-runtime/tests/T0-5-infra-litellm.md
+++ b/docs/agentic-runtime/tests/T0-5-infra-litellm.md
@@ -1,0 +1,22 @@
+# LiteLLM Infrastructure
+
+> **Test file:** `kagenti/tests/e2e/openshell/test_T0_5_infra_litellm.py`
+> **Tests:** 11
+
+## What This Tests
+
+Validates LiteLLM proxy configuration, security posture, Istio waypoint infrastructure, and Anthropic Messages API passthrough. Covers three areas: (1) secure config -- no plaintext API keys in ConfigMaps, secrets exist, deployment uses `secretKeyRef`, correct provider prefix (`hosted_vllm/` or `ollama/`), and Anthropic translation settings present; (2) Istio waypoint -- namespaces with `istio.io/use-waypoint` label have a matching Gateway resource and running waypoint proxy pod; (3) model routing -- LiteLLM correctly translates Anthropic Messages API requests, lists Claude model aliases, and routes requests to each configured model.
+
+## Test Functions
+
+- `test_configmap_no_plaintext_api_keys` -- LiteLLM ConfigMap uses `os.environ/VAR_NAME` references for API keys (or no `api_key` lines in Ollama mode).
+- `test_litemaas_secret_exists` -- The `litemaas-credentials` Kubernetes Secret exists and contains a non-empty `api-key`.
+- `test_litellm_deployment_uses_secret_ref` -- LiteLLM Deployment mounts `LITEMAAS_API_KEY` via `secretKeyRef` (not a literal value).
+- `test_litellm_uses_correct_provider` -- Model config uses `hosted_vllm/` or `ollama/` provider prefix, not `openai/`.
+- `test_litellm_anthropic_settings` -- Config includes `use_chat_completions_url_for_anthropic_messages` and `drop_params` for Claude Code compatibility.
+- `test_waypoint_exists_if_labeled[namespace]` -- Namespaces with `istio.io/use-waypoint` label have a matching waypoint Gateway resource.
+- `test_waypoint_pod_running` -- Waypoint proxy pod in team1 is in Running phase.
+- `test_anthropic_messages_api_returns_response` -- LiteLLM `/v1/messages` endpoint returns a valid Anthropic-format response with `type=message`.
+- `test_claude_model_alias_in_model_list` -- LiteLLM `/v1/models` lists the `claude-sonnet-4-20250514` alias.
+- `test_litellm_model_routing__responds[model]` -- Each configured model returns a valid chat completion response through LiteLLM.
+- `test_litellm_model_routing__all_models_in_list` -- All models from `OPENSHELL_LLM_MODELS` appear in the LiteLLM model list.

--- a/docs/agentic-runtime/tests/T1-1-connectivity.md
+++ b/docs/agentic-runtime/tests/T1-1-connectivity.md
@@ -1,7 +1,7 @@
 # A2A Connectivity
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T1_1_connectivity.py`
-> **Tests:** 11 | **Pass:** 7 | **Skip:** 1 (Kind, fresh cluster)
+> **Tests:** 11
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T1-1-connectivity.md
+++ b/docs/agentic-runtime/tests/T1-1-connectivity.md
@@ -1,7 +1,7 @@
 # A2A Connectivity
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_02_a2a_connectivity.py`
-> **Tests:** 8 | **Pass:** 7 | **Skip:** 1 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T1_1_connectivity.py`
+> **Tests:** 11 | **Pass:** 7 | **Skip:** 1 (Kind, fresh cluster)
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T1-2-credentials.md
+++ b/docs/agentic-runtime/tests/T1-2-credentials.md
@@ -1,7 +1,7 @@
 # Credential Security
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T1_2_credentials.py`
-> **Tests:** 9 | **Pass:** 15 | **Skip:** 0 (Kind, fresh cluster)
+> **Tests:** 9
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T1-2-credentials.md
+++ b/docs/agentic-runtime/tests/T1-2-credentials.md
@@ -1,7 +1,7 @@
 # Credential Security
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_T1_6_credential_security.py`
-> **Tests:** 15 | **Pass:** 15 | **Skip:** 0 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T1_2_credentials.py`
+> **Tests:** 9 | **Pass:** 15 | **Skip:** 0 (Kind, fresh cluster)
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T1-3-sandbox-lifecycle.md
+++ b/docs/agentic-runtime/tests/T1-3-sandbox-lifecycle.md
@@ -1,7 +1,7 @@
 # Sandbox Lifecycle
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T1_3_sandbox_lifecycle.py`
-> **Tests:** 9 | **Pass:** 7 | **Skip:** 0 (Kind, fresh cluster)
+> **Tests:** 9
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T1-3-sandbox-lifecycle.md
+++ b/docs/agentic-runtime/tests/T1-3-sandbox-lifecycle.md
@@ -1,7 +1,7 @@
 # Sandbox Lifecycle
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_04_sandbox_lifecycle.py`
-> **Tests:** 7 | **Pass:** 7 | **Skip:** 0 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T1_3_sandbox_lifecycle.py`
+> **Tests:** 9 | **Pass:** 7 | **Skip:** 0 (Kind, fresh cluster)
 
 ## What This Tests
 
@@ -141,8 +141,8 @@ In Kagenti's A2A-first model, sandbox status is observed via:
 | Proposal Requirement | Kagenti A2A Equivalent | How Tested |
 |---------------------|----------------------|-----------|
 | `openshell term` shows status | kubectl get pod/deploy/sandbox -o json | test_*_status_queryable |
-| Terminal session active | Agent A2A endpoint responds | test_02_a2a_connectivity |
-| Session reconnect | PVC-backed session restore | test_06_conversation_resume |
+| Terminal session active | Agent A2A endpoint responds | test_T1_1_connectivity |
+| Session reconnect | PVC-backed session restore | test_T2_3_session_resume |
 
 The Kagenti UI PodStatusPanel queries the same Kubernetes API these tests validate.
 

--- a/docs/agentic-runtime/tests/T1-4-workspace.md
+++ b/docs/agentic-runtime/tests/T1-4-workspace.md
@@ -1,7 +1,7 @@
 # Workspace Persistence
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T1_4_workspace.py`
-> **Tests:** 6 | **Pass:** 7 | **Skip:** 1 (Kind, fresh cluster)
+> **Tests:** 6
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T1-4-workspace.md
+++ b/docs/agentic-runtime/tests/T1-4-workspace.md
@@ -1,7 +1,7 @@
 # Workspace Persistence
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_10_workspace_persistence.py`
-> **Tests:** 8 | **Pass:** 7 | **Skip:** 1 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T1_4_workspace.py`
+> **Tests:** 6 | **Pass:** 7 | **Skip:** 1 (Kind, fresh cluster)
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T1-5-resource-limits.md
+++ b/docs/agentic-runtime/tests/T1-5-resource-limits.md
@@ -1,0 +1,15 @@
+# Resource Limits
+
+> **Test file:** `kagenti/tests/e2e/openshell/test_T1_5_resource_limits.py`
+> **Tests:** 4
+
+## What This Tests
+
+Validates that agent and sandbox pods have CPU and memory resource limits and requests configured. Checks A2A agents, NemoClaw agents, and Claude Code sandbox pods to ensure Kubernetes resource governance is in place. Tests currently skip (rather than fail) for containers that lack limits, since not all upstream agent charts set them yet.
+
+## Test Functions
+
+- `test_resource_limits__agent__has_limits[agent]` -- A2A agent deployment containers have CPU or memory `limits` set.
+- `test_resource_limits__agent__has_requests[agent]` -- A2A agent deployment containers have CPU or memory `requests` set.
+- `test_resource_limits__nemoclaw__has_limits[agent]` -- NemoClaw deployment containers have CPU or memory `limits` set (skips if NemoClaw disabled).
+- `test_resource_limits__openshell_claude__sandbox_pod_limits` -- Claude Code sandbox pod has resource limits on the sandbox container (skips if Sandbox CRD not installed).

--- a/docs/agentic-runtime/tests/T2-1-multiturn.md
+++ b/docs/agentic-runtime/tests/T2-1-multiturn.md
@@ -1,7 +1,7 @@
 # Multi-Turn Conversation
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_05_multiturn_conversation.py`
-> **Tests:** 12 | **Pass:** 9 | **Skip:** 3 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T2_1_multiturn.py`
+> **Tests:** 18 | **Pass:** 9 | **Skip:** 3 (Kind, fresh cluster)
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T2-1-multiturn.md
+++ b/docs/agentic-runtime/tests/T2-1-multiturn.md
@@ -1,7 +1,7 @@
 # Multi-Turn Conversation
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T2_1_multiturn.py`
-> **Tests:** 18 | **Pass:** 9 | **Skip:** 3 (Kind, fresh cluster)
+> **Tests:** 18
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T2-3-session-resume.md
+++ b/docs/agentic-runtime/tests/T2-3-session-resume.md
@@ -1,7 +1,7 @@
 # Conversation Resume
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T2_3_session_resume.py`
-> **Tests:** 3 | **Pass:** 0 | **Skip:** 5 (Kind, fresh cluster)
+> **Tests:** 3
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T2-3-session-resume.md
+++ b/docs/agentic-runtime/tests/T2-3-session-resume.md
@@ -1,7 +1,7 @@
 # Conversation Resume
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_06_conversation_resume.py`
-> **Tests:** 5 | **Pass:** 0 | **Skip:** 5 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T2_3_session_resume.py`
+> **Tests:** 3 | **Pass:** 0 | **Skip:** 5 (Kind, fresh cluster)
 
 ## What This Tests
 
@@ -111,7 +111,7 @@ These tests are destructive (kill pods, break port-forwards) and are disabled by
 export OPENSHELL_DESTRUCTIVE_TESTS=true
 
 # Run only conversation resume tests
-uv run pytest kagenti/tests/e2e/openshell/test_06_conversation_resume.py -v
+uv run pytest kagenti/tests/e2e/openshell/test_T2_3_session_resume.py -v
 ```
 
 Why disabled by default:

--- a/docs/agentic-runtime/tests/T3-1-skill-execution.md
+++ b/docs/agentic-runtime/tests/T3-1-skill-execution.md
@@ -1,7 +1,7 @@
 # Skill Execution
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_07_skill_execution.py`
-> **Tests:** 27 | **Pass:** 18 | **Skip:** 9 (Kind, fresh cluster)
+> **Test file:** `kagenti/tests/e2e/openshell/test_T3_1_skill_execution.py`
+> **Tests:** 12 | **Pass:** 18 | **Skip:** 9 (Kind, fresh cluster)
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T3-1-skill-execution.md
+++ b/docs/agentic-runtime/tests/T3-1-skill-execution.md
@@ -1,7 +1,7 @@
 # Skill Execution
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T3_1_skill_execution.py`
-> **Tests:** 12 | **Pass:** 18 | **Skip:** 9 (Kind, fresh cluster)
+> **Tests:** 12
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T4-1-hitl-network.md
+++ b/docs/agentic-runtime/tests/T4-1-hitl-network.md
@@ -1,7 +1,7 @@
 # HITL Policy
 
 > **Test file:** `kagenti/tests/e2e/openshell/test_T4_1_hitl_network.py`
-> **Tests:** 3 | **Pass:** 2 | **Skip:** 1 (Kind, fresh cluster)
+> **Tests:** 3
 
 ## What This Tests
 

--- a/docs/agentic-runtime/tests/T4-1-hitl-network.md
+++ b/docs/agentic-runtime/tests/T4-1-hitl-network.md
@@ -1,6 +1,6 @@
 # HITL Policy
 
-> **Test file:** `kagenti/tests/e2e/openshell/test_09_hitl_policy.py`
+> **Test file:** `kagenti/tests/e2e/openshell/test_T4_1_hitl_network.py`
 > **Tests:** 3 | **Pass:** 2 | **Skip:** 1 (Kind, fresh cluster)
 
 ## What This Tests
@@ -136,12 +136,12 @@ network_policies:
 
 | Test File | What's Tested | How |
 |-----------|--------------|-----|
-| test_08_supervisor_enforcement | Rules APPLIED | Supervisor logs show "CONFIG:APPLYING" |
-| test_09_hitl_policy | Rules ENFORCED | Agent process blocked/allowed by OPA |
+| test_T0_3_infra_supervisor | Rules APPLIED | Supervisor logs show "CONFIG:APPLYING" |
+| test_T4_1_hitl_network | Rules ENFORCED | Agent process blocked/allowed by OPA |
 
 Both are needed:
-- test_08 verifies supervisor started correctly
-- test_09 verifies supervisor actually blocks traffic
+- test_T0_3 verifies supervisor started correctly
+- test_T4_1 verifies supervisor actually blocks traffic
 
 ## Netns DNS Issue
 

--- a/docs/agentic-runtime/tests/T4-1-hitl-network.md
+++ b/docs/agentic-runtime/tests/T4-1-hitl-network.md
@@ -5,7 +5,7 @@
 
 ## What This Tests
 
-Validates that OPA policy enforcement ACTUALLY blocks unauthorized egress and allows authorized egress. This is the live enforcement complement to test_08 (which verifies rules are applied via logs).
+Validates that OPA policy enforcement ACTUALLY blocks unauthorized egress and allows authorized egress. This is the live enforcement complement to `test_T0_3_infra_supervisor` (which verifies rules are applied via logs).
 
 ## Architecture Under Test
 

--- a/docs/agentic-runtime/tests/T5-1-backend-api.md
+++ b/docs/agentic-runtime/tests/T5-1-backend-api.md
@@ -1,0 +1,22 @@
+# Backend API
+
+> **Test file:** `kagenti/tests/e2e/openshell/test_T5_1_backend_api.py`
+> **Tests:** 11
+
+## What This Tests
+
+Validates kagenti-backend as the production A2A proxy path. Instead of per-agent port-forwards, all A2A requests route through a single backend endpoint at `/api/v1/chat/{namespace}/{agent}/send|stream`. Tests cover backend health, agent card proxying, non-streaming send with session tracking, SSE streaming, multi-turn context preservation, agent listing, error handling for invalid agents/namespaces, and concurrent parallel requests across agents.
+
+## Test Functions
+
+- `test_T5_connectivity__backend_health` -- `GET /health` returns 200 with `status: healthy`.
+- `test_T5_connectivity__agent_card[agent]` -- Backend proxies the agent card for each A2A agent and returns a response with a `name` field.
+- `test_T5_send__responds[agent]` -- `POST /chat/{ns}/{agent}/send` returns a response with non-empty `content`.
+- `test_T5_send__has_session_id[agent]` -- Send response includes a non-empty `session_id` for conversation tracking.
+- `test_T5_stream__delivers_events[agent]` -- `POST /chat/{ns}/{agent}/stream` delivers SSE `data:` events.
+- `test_T5_multiturn__preserves_context[agent]` -- Two sequential sends with the same `session_id` preserve conversation context.
+- `test_T5_agent_list__shows_deployed` -- `GET /api/v1/agents?namespace={ns}` lists at least 2 deployed agents.
+- `test_T5_agent_list__has_metadata` -- Each agent in the list has a `name` field.
+- `test_T5_error__nonexistent_agent` -- Request to an unknown agent returns 404 or 503.
+- `test_T5_error__invalid_namespace` -- Request to an unknown namespace returns 404 or 503.
+- `test_T5_concurrent__parallel_requests` -- Multiple agents queried in parallel return at least one successful response.

--- a/docs/agentic-runtime/tests/T6-1-acp-protocol.md
+++ b/docs/agentic-runtime/tests/T6-1-acp-protocol.md
@@ -1,0 +1,23 @@
+# ACP Protocol
+
+> **Test file:** `kagenti/tests/e2e/openshell/test_T6_1_acp_protocol.py`
+> **Tests:** 12
+
+## What This Tests
+
+Validates the ACP (Agent Client Protocol) WebSocket endpoint at `/api/v1/acp/ws/{namespace}/{agent_name}`. Tests the full JSON-RPC 2.0 lifecycle: initialize handshake, session creation/listing/resume/close, prompt relay to A2A agents with streaming updates, multi-turn context preservation through the ACP-to-A2A bridge, permission request handling, concurrent independent sessions, and error responses for malformed JSON-RPC and unknown methods.
+
+## Test Functions
+
+- `test_T6_lifecycle__initialize` -- WebSocket connect and `initialize` handshake returns capabilities (protocolVersion or agentCapabilities).
+- `test_T6_lifecycle__session_new` -- `session/new` returns a non-empty `sessionId`.
+- `test_T6_lifecycle__session_close` -- `session/close` with a valid sessionId returns `closed: true`.
+- `test_T6_prompt__text_response[agent]` -- Send a prompt via `session/prompt` and receive streaming `session/update` events with text content.
+- `test_T6_bridge__acp_to_a2a[agent]` -- Full roundtrip: ACP client sends prompt over WebSocket, backend bridges to A2A agent, response arrives as turn_complete.
+- `test_T6_bridge__context_preserved[agent]` -- Multi-turn conversation via ACP maintains context across sequential prompts within the same session.
+- `test_T6_session__list` -- `session/list` returns all sessions created on the connection.
+- `test_T6_session__resume` -- `session/resume` with an existing sessionId returns `resumed: true`.
+- `test_T6_permission__request` -- `session/request_permission` auto-approves with `outcome: selected` and `selectedOptionId: allow_once` in PoC mode.
+- `test_T6_concurrent__sessions` -- Two independent WebSocket clients get distinct session IDs and operate without interference.
+- `test_T6_error__malformed_rpc` -- Sending invalid JSON returns a JSON-RPC parse error (code -32700).
+- `test_T6_error__unknown_method` -- Calling an unknown method returns a method-not-found error (code -32601).

--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -46,7 +46,7 @@ Choose the section that matches your target environment.
 #### Step 1: Deploy Kagenti on Kind
 
 ```bash
-scripts/kind/setup-kagenti.sh  --with-ui --with-agent-sandbox --with-spire
+.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy
 ```
 
 This deploys: Kind cluster, Istio ambient mesh, cert-manager, Keycloak, SPIRE,
@@ -55,7 +55,7 @@ and the Kagenti platform.
 #### Step 2: Deploy OpenShell Shared Infrastructure
 
 ```bash
-scripts/openshell/deploy-shared.sh
+.github/scripts/local-setup/openshell-full-test.sh --skip-test --skip-cluster-create --skip-cluster-destroy
 ```
 
 This creates:


### PR DESCRIPTION
## Summary

- Bring `docs/agentic-runtime/` and `docs/sandbox-guide.md` to main for the first time (from `docs/openshell-architecture` and related feature branches)
- Use updated `e2e-test-matrix.md` from `feat/acp-backend-t5-t6` (includes T5/T6 tiers for backend API and ACP protocol)
- Rename test docs from sequential naming (`01-10`) to tiered naming (`T0-T6`) matching actual test files
- Rewrite `tests/README.md` to point to the test matrix file instead of duplicating a stale table
- Create 5 new test category docs: NemoClaw (T0-4), LiteLLM (T0-5), resource limits (T1-5), backend API (T5-1), ACP protocol (T6-1)
- Update all upstream NVIDIA/OpenShell PR statuses — 3 marked as merged (#836 RFC 0001, #858, #860), 1 marked as closed (#861, superseded by #867)
- Add 7 new upstream PRs to tracking: #867 supervisor relay, #903 health port 8081, #1088 compute driver auto-detection, #1154 init container delivery, #1208 copy-self, #1221 CLI command removal, #1237 Helm nameOverride
- Update init container pattern to reflect upstream support (FROM scratch, copy-self subcommand, emptyDir volume)
- Document supervisor relay architecture change (ResolveSandboxEndpoint removed, SSH on Unix socket, port 2222 gone)
- Fix all old test file references across 11 documentation files

### Relationship to other PRs

| PR | Relationship |
|----|-------------|
| #1005 (`docs/openshell-architecture`) | Supersedes — this PR includes all docs from #1005 plus updates |
| #1498 (`feat/acp-backend-t5-t6`) | Uses the updated `e2e-test-matrix.md` from this PR |
| #1513 (`fix/openshell-chart-v0.0.36`) | Aligns with chart changes for v0.0.36 supervisor binary path |
| #1500 (`feat/openshell-e2e-multitenant`) | Compatible — adds multi-tenant tests (T12/T13 not in scope here) |

## Test plan

- [x] `grep -r "test_0[0-9]_" docs/` returns zero hits (all old references replaced)
- [x] `grep -r "01-platform-health\|02-a2a\|03-credential" docs/agentic-runtime/` returns zero hits
- [x] All 16 test doc files present (README + 15 tier docs)
- [x] Pre-commit hooks pass
- [ ] Review internal markdown links resolve on GitHub

Assisted-By: Claude Code