### PR TITLE
fix(chat): place A2A contextId on message object, not params

### DIFF
--- a/kagenti/backend/app/routers/chat.py
+++ b/kagenti/backend/app/routers/chat.py
@@ -159,17 +159,16 @@ async def send_message(
 
     # Build A2A message payload. When the frontend supplied a session_id
     # (subsequent turns of the same conversation), forward it as
-    # params.contextId so the agent joins the existing A2A task chain
+    # message.contextId so the agent joins the existing A2A task chain
     # instead of spinning up a fresh context per message.
-    params: dict = {
-        "message": {
-            "role": "user",
-            "parts": [{"kind": "text", "text": request.message}],
-            "messageId": uuid4().hex,
-        },
+    message: dict = {
+        "role": "user",
+        "parts": [{"kind": "text", "text": request.message}],
+        "messageId": uuid4().hex,
     }
     if request.session_id:
-        params["contextId"] = request.session_id
+        message["contextId"] = request.session_id
+    params: dict = {"message": message}
 
     message_payload = {
         "jsonrpc": "2.0",
@@ -503,17 +502,16 @@ async def stream_message(
     if authorization:
         headers["Authorization"] = authorization
 
-    # See /send handler: forward the client's session_id as params.contextId
+    # See /send handler: forward the client's session_id as message.contextId
     # so multi-turn conversations stay in one A2A context.
-    stream_params: dict = {
-        "message": {
-            "role": "user",
-            "parts": [{"kind": "text", "text": request.message}],
-            "messageId": uuid4().hex,
-        },
+    stream_message: dict = {
+        "role": "user",
+        "parts": [{"kind": "text", "text": request.message}],
+        "messageId": uuid4().hex,
     }
     if request.session_id:
-        stream_params["contextId"] = request.session_id
+        stream_message["contextId"] = request.session_id
+    stream_params: dict = {"message": stream_message}
 
     message_payload = {
         "jsonrpc": "2.0",


### PR DESCRIPTION
The A2A spec defines contextId as a field on the Message object that
groups related Messages and Tasks into one conversation. Some A2A SDKs
ignore contextId when placed on the JSON-RPC params envelope and mint a
fresh contextId on every request, breaking multi-turn continuity even
when the client correctly forwards the prior session_id.

Move contextId from params.contextId to params.message.contextId on both
the send and stream handlers so subsequent turns join the existing A2A
context chain instead of starting a new one.