### PR TITLE
docs: update Quick Start install command to use specific flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cp deployments/envs/secret_values.yaml.example deployments/envs/.secret_values.y
 # Edit deployments/envs/.secret_values.yaml with your values
 
 # Deploy to Kind cluster
-scripts/kind/setup-kagenti.sh --with-all
+scripts/kind/setup-kagenti.sh --with-ui --with-spire --with-agent-sandbox --with-builds
 ```
 
 > **Tip:** To find the latest stable version from the command line:
@@ -136,7 +136,7 @@ scripts/kind/setup-kagenti.sh --with-all
 > git tag --list 'v*' --sort=-v:refname | grep -v -E '(alpha|rc)' | head -1
 > ```
 
-For more detailed installation instructions including OpenShift refer to [Installation Guide](./docs/install.md).
+For all available installer options and detailed instructions (including OpenShift), refer to the [Installation Guide](./docs/install.md).
 
 ### Access the UI
 


### PR DESCRIPTION
## Summary

- Replace `--with-all` with targeted flags (`--with-ui --with-spire --with-agent-sandbox --with-builds`) for a lighter default install
- Update doc pointer to mention all available installer options

## Why

`--with-all` installs everything (MLflow, Kiali, etc.) which is heavy and slow for most users getting started. The targeted flags install the core platform with the most common features.

Assisted-By: Claude Code