### PR TITLE
fix(backend): use correct port fallback for in-cluster agent resolution

### DIFF
--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -336,7 +336,10 @@ def lookup_service_port(
 
 def resolve_agent_url(name: str, namespace: str, kube: KubernetesService) -> str:
     """Resolve agent URL by looking up actual Service port."""
-    port = lookup_service_port(name, namespace, kube, DEFAULT_OFF_CLUSTER_PORT)
+    fallback = (
+        DEFAULT_IN_CLUSTER_PORT if settings.is_running_in_cluster else DEFAULT_OFF_CLUSTER_PORT
+    )
+    port = lookup_service_port(name, namespace, kube, fallback)
     return get_agent_url(name, namespace, port)
 
 

--- a/kagenti/backend/tests/test_routes.py
+++ b/kagenti/backend/tests/test_routes.py
@@ -63,8 +63,8 @@ class TestResolveAgentUrl:
         assert url == "http://my-agent.team1.svc.cluster.local:8080"
 
     @patch("app.utils.routes.settings")
-    def test_service_not_found(self, mock_settings, kubernetes_service):
-        """Missing Service falls back to default port."""
+    def test_service_not_found_in_cluster(self, mock_settings, kubernetes_service):
+        """Missing Service in-cluster falls back to in-cluster port (8000)."""
         mock_settings.is_running_in_cluster = True
         kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
             status=404, reason="Not Found"
@@ -73,11 +73,25 @@ class TestResolveAgentUrl:
         from app.utils.routes import resolve_agent_url
 
         url = resolve_agent_url("my-agent", "team1", kubernetes_service)
-        assert url == "http://my-agent.team1.svc.cluster.local:8080"
+        assert url == "http://my-agent.team1.svc.cluster.local:8000"
 
     @patch("app.utils.routes.settings")
-    def test_service_no_ports(self, mock_settings, kubernetes_service):
-        """Service with empty ports list falls back to default port."""
+    def test_service_not_found_off_cluster(self, mock_settings, kubernetes_service):
+        """Missing Service off-cluster falls back to off-cluster port (8080)."""
+        mock_settings.is_running_in_cluster = False
+        mock_settings.domain_name = "localtest.me"
+        kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+
+        from app.utils.routes import resolve_agent_url
+
+        url = resolve_agent_url("my-agent", "team1", kubernetes_service)
+        assert url == "http://my-agent.team1.localtest.me:8080"
+
+    @patch("app.utils.routes.settings")
+    def test_service_no_ports_in_cluster(self, mock_settings, kubernetes_service):
+        """Service with empty ports list in-cluster falls back to 8000."""
         mock_settings.is_running_in_cluster = True
         mock_result = MagicMock()
         mock_result.to_dict.return_value = {"spec": {"ports": []}}
@@ -86,7 +100,21 @@ class TestResolveAgentUrl:
         from app.utils.routes import resolve_agent_url
 
         url = resolve_agent_url("my-agent", "team1", kubernetes_service)
-        assert url == "http://my-agent.team1.svc.cluster.local:8080"
+        assert url == "http://my-agent.team1.svc.cluster.local:8000"
+
+    @patch("app.utils.routes.settings")
+    def test_service_no_ports_off_cluster(self, mock_settings, kubernetes_service):
+        """Service with empty ports list off-cluster falls back to 8080."""
+        mock_settings.is_running_in_cluster = False
+        mock_settings.domain_name = "localtest.me"
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"spec": {"ports": []}}
+        kubernetes_service._core_api.read_namespaced_service.return_value = mock_result
+
+        from app.utils.routes import resolve_agent_url
+
+        url = resolve_agent_url("my-agent", "team1", kubernetes_service)
+        assert url == "http://my-agent.team1.localtest.me:8080"
 
     @patch("app.utils.routes.settings")
     def test_off_cluster_custom_port(self, mock_settings, kubernetes_service):


### PR DESCRIPTION
## Summary

- Fix `resolve_agent_url` to use `DEFAULT_IN_CLUSTER_PORT` (8000) as fallback when running in-cluster, instead of always using `DEFAULT_OFF_CLUSTER_PORT` (8080)
- When the upstream Sandbox controller (kubernetes-sigs/agent-sandbox) creates a headless Service without port definitions, the backend now falls back to the correct agent port
- If the Service has ports defined, the backend does nothing extra and respects the existing Service port configuration as before
- Expanded unit tests to cover both in-cluster and off-cluster fallback scenarios

**Root cause:** The Sandbox controller creates headless Services with no `spec.ports` ([kubernetes-sigs/agent-sandbox#154](https://github.com/kubernetes-sigs/agent-sandbox/issues/154)). The backend's `lookup_service_port` finds no ports on the Service and falls back to a default. Previously the default was always 8080 (off-cluster port), but in-cluster agents listen on 8000 — causing 503 errors when fetching the agent card.

**Behavior:**
- Service has ports → use `service.spec.ports[0].port` (unchanged)
- Service has no ports (Sandbox bug) or doesn't exist → fall back to 8000 in-cluster, 8080 off-cluster

## Test plan

- [x] Unit tests pass (`pytest tests/test_routes.py` — 15 tests)
- [ ] Deploy to Kind cluster with Sandbox workload and verify agent card is fetched successfully

Assisted-By: Claude Code