### PR TITLE
fix(ui): retry agent card fetch until successful

### DIFF
--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -185,6 +185,11 @@ export const AgentDetailPage: React.FC = () => {
     queryKey: ['agentCard', namespace, name],
     queryFn: () => chatService.getAgentCard(namespace!, name!),
     enabled: !!namespace && !!name && isAgentReady,
+    retry: 3,
+    retryDelay: 2000,
+    refetchInterval: (query) => {
+      return query.state.data ? false : 5000;
+    },
   });
 
   // Check if an HTTPRoute/Route exists for this agent


### PR DESCRIPTION
## Summary

- Add retry (3 attempts, 2s delay) and polling (every 5s) to the agent card query on the Agent Detail page
- Fixes the issue where navigating to an agent while it's still starting shows "Agent card not available" permanently, requiring a manual page refresh
- Once the card is fetched successfully, polling stops automatically

**Root cause:** The `useQuery` for agent card fires when `isAgentReady` is true, which includes the `Progressing` state. If the agent isn't responding yet, React Query caches the error. When the agent transitions to `Ready`, the `enabled` condition doesn't change (was already `true`), so no re-fetch is triggered.

## Test plan

- [ ] Deploy a Sandbox agent, navigate to detail page during startup — card should appear within seconds of agent becoming ready (no manual refresh needed)
- [ ] Verify polling stops once card is loaded (no unnecessary network requests)

Assisted-By: Claude Code