### PR TITLE
Feat: Add a health and configuration dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,7 @@ and lets us decouple merge velocity from release readiness.
 | `kagenti_feature_flag_sandbox` | Sandboxed agent runtime UI and APIs |
 | `kagenti_feature_flag_integrations` | Third-party integration endpoints |
 | `kagenti_feature_flag_triggers` | Event-driven trigger system |
+| `kagenti_feature_flag_admin` | Platform Status card and /platform-status endpoint |
 
 ### TODO
 

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -136,6 +136,8 @@ spec:
               value: "{{ .Values.featureFlags.skills }}"
             - name: KAGENTI_FEATURE_FLAG_AUTHBRIDGE_API
               value: "{{ .Values.featureFlags.authbridgeAPI }}"
+            - name: KAGENTI_FEATURE_FLAG_ADMIN
+              value: "{{ .Values.featureFlags.admin }}"
             - name: KEYCLOAK_URL
               value: {{ .Values.keycloak.url | quote }}
             - name: KEYCLOAK_PUBLIC_URL

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -13,6 +13,7 @@ featureFlags:
   agentSandbox: false
   skills: false
   authbridgeAPI: false
+  admin: false
 
 # ------------------------------------------------------------------
 #  Control Panel: Enable or disable components here

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     kagenti_feature_flag_agent_sandbox: bool = False
     kagenti_feature_flag_authbridge_api: bool = False
     kagenti_feature_flag_skills: bool = False
+    kagenti_feature_flag_admin: bool = False
     kagenti_feature_flag_sidecars: bool = (
         False  # sidecar agents (looper, hallucination, context guardian)
     )

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -5,12 +5,24 @@
 Configuration API endpoints.
 """
 
+import logging
+from typing import List, Literal
+
 from fastapi import APIRouter, Depends
+from kubernetes.client import ApiException
 from pydantic import BaseModel, Field
 
 from app.core.auth import require_roles, ROLE_VIEWER
 from app.core.config import settings
+from app.core.constants import (
+    SHIPWRIGHT_CRD_GROUP,
+    SHIPWRIGHT_CRD_VERSION,
+    SHIPWRIGHT_CLUSTER_BUILD_STRATEGIES_PLURAL,
+)
 from app.models.responses import DashboardConfigResponse
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+
+logger = logging.getLogger(__name__)
 
 
 class FeatureFlagsResponse(BaseModel):
@@ -22,6 +34,33 @@ class FeatureFlagsResponse(BaseModel):
     agentSandbox: bool = Field(description="agent-sandbox (k8s-sigs) as a workload type")
     skills: bool = Field(description="Skill management system (CRUD + catalog UI)")
     authbridgeAPI: bool = Field(description="AuthBridge statistics (API and UI)")
+
+
+class ComponentStatus(BaseModel):
+    """Health of a single platform component (Istio, Keycloak, SPIRE, etc.)."""
+
+    name: str
+    status: Literal[
+        "Ready",     # API group or service exists and is reachable
+        "Degraded",  # Resource exists but returned a non-404 error
+        "Missing",   # API group or service not found in the cluster
+        "Unknown",   # Probe could not determine status (e.g. timeout, RBAC)
+    ]
+
+
+class RegistryBuildInfo(BaseModel):
+    """Container registry endpoint and Shipwright ClusterBuildStrategy availability."""
+
+    clusterBuildStrategyPresent: bool
+    clusterBuildStrategies: List[str]
+    registryEndpoint: str
+
+
+class PlatformStatusResponse(BaseModel):
+    """Aggregated platform status returned by GET /config/platform-status."""
+
+    components: List[ComponentStatus]
+    registry: RegistryBuildInfo
 
 
 router = APIRouter(prefix="/config", tags=["config"])
@@ -70,3 +109,111 @@ async def get_dashboard_config() -> DashboardConfigResponse:
         ),
         domainName=domain,
     )
+
+
+def _check_api_group(kube: KubernetesService, group: str) -> str:
+    """Return 'Ready' if the API group exists, 'Missing' otherwise."""
+    try:
+        return "Ready" if kube.api_group_exists(group) else "Missing"
+    except Exception:
+        logger.debug("Failed to check API group %s", group, exc_info=True)
+        return "Missing"
+
+
+def _check_service(kube: KubernetesService, namespace: str, name: str) -> str:
+    """Return 'Ready' if the service exists, 'Missing' otherwise."""
+    try:
+        kube.core_api.read_namespaced_service(name=name, namespace=namespace)
+        return "Ready"
+    except ApiException as e:
+        if e.status == 404:
+            return "Missing"
+        logger.debug("Error checking service %s/%s: %s", namespace, name, e)
+        return "Degraded"
+    except Exception:
+        logger.debug("Failed to check service %s/%s", namespace, name, exc_info=True)
+        return "Missing"
+
+
+def _check_deployment_ready(kube: KubernetesService, namespace: str, name: str) -> str:
+    """Return Ready/Degraded/Missing based on a Deployment's ready replica count."""
+    try:
+        dep = kube.apps_api.read_namespaced_deployment(name=name, namespace=namespace)
+        desired = dep.spec.replicas or 1
+        ready = (dep.status and dep.status.ready_replicas) or 0
+        if ready >= desired:
+            return "Ready"
+        return "Degraded"
+    except ApiException as e:
+        if e.status == 404:
+            return "Missing"
+        logger.debug("Error checking deployment %s/%s: %s", namespace, name, e)
+        return "Degraded"
+    except Exception:
+        logger.debug("Failed to check deployment %s/%s", namespace, name, exc_info=True)
+        return "Missing"
+
+
+def _check_statefulset_ready(kube: KubernetesService, namespace: str, name: str) -> str:
+    """Return Ready/Degraded/Missing based on a StatefulSet's ready replica count."""
+    try:
+        sts = kube.apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
+        desired = sts.spec.replicas or 1
+        ready = (sts.status and sts.status.ready_replicas) or 0
+        if ready >= desired:
+            return "Ready"
+        return "Degraded"
+    except ApiException as e:
+        if e.status == 404:
+            return "Missing"
+        logger.debug("Error checking statefulset %s/%s: %s", namespace, name, e)
+        return "Degraded"
+    except Exception:
+        logger.debug("Failed to check statefulset %s/%s", namespace, name, exc_info=True)
+        return "Missing"
+
+
+@router.get(
+    "/platform-status",
+    response_model=PlatformStatusResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_platform_status(
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> PlatformStatusResponse:
+    """Return health status of platform components, build strategies, and registry info."""
+    components = [
+        ComponentStatus(name="Istio", status=_check_deployment_ready(kube, "istio-system", "istiod")),
+        ComponentStatus(name="Keycloak", status=_check_statefulset_ready(kube, "keycloak", "keycloak")),
+        # SPIRE uses spire-system on Kind but zero-trust-workload-identity-manager on
+        # OpenShift, so we check the API group instead of a specific workload.
+        ComponentStatus(name="SPIRE", status=_check_api_group(kube, "spire.spiffe.io")),
+        # Shipwright uses different namespaces on Kind (shipwright-build) vs OpenShift
+        # (openshift-builds), so we check the API group instead of a specific service.
+        ComponentStatus(name="Shipwright", status=_check_api_group(kube, "shipwright.io")),
+        ComponentStatus(name="Phoenix", status=_check_service(kube, "kagenti-system", "phoenix")),
+    ]
+
+    strategy_names: List[str] = []
+    try:
+        response = kube.list_cluster_custom_resources(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            plural=SHIPWRIGHT_CLUSTER_BUILD_STRATEGIES_PLURAL,
+            suppress_api_error=True,
+        )
+        strategy_names = [
+            item.get("metadata", {}).get("name", "")
+            for item in response.get("items", [])
+            if item.get("metadata", {}).get("name")
+        ]
+    except Exception:
+        logger.debug("Failed to list ClusterBuildStrategies", exc_info=True)
+
+    registry = RegistryBuildInfo(
+        clusterBuildStrategyPresent=len(strategy_names) > 0,
+        clusterBuildStrategies=strategy_names,
+        registryEndpoint=settings.default_registry_url,
+    )
+
+    return PlatformStatusResponse(components=components, registry=registry)

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -41,10 +41,10 @@ class ComponentStatus(BaseModel):
 
     name: str
     status: Literal[
-        "Ready",     # API group or service exists and is reachable
+        "Ready",  # API group or service exists and is reachable
         "Degraded",  # Resource exists but returned a non-404 error
-        "Missing",   # API group or service not found in the cluster
-        "Unknown",   # Probe could not determine status (e.g. timeout, RBAC)
+        "Missing",  # API group or service not found in the cluster
+        "Unknown",  # Probe could not determine status (e.g. timeout, RBAC)
     ]
 
 
@@ -183,8 +183,12 @@ async def get_platform_status(
 ) -> PlatformStatusResponse:
     """Return health status of platform components, build strategies, and registry info."""
     components = [
-        ComponentStatus(name="Istio", status=_check_deployment_ready(kube, "istio-system", "istiod")),
-        ComponentStatus(name="Keycloak", status=_check_statefulset_ready(kube, "keycloak", "keycloak")),
+        ComponentStatus(
+            name="Istio", status=_check_deployment_ready(kube, "istio-system", "istiod")
+        ),
+        ComponentStatus(
+            name="Keycloak", status=_check_statefulset_ready(kube, "keycloak", "keycloak")
+        ),
         # SPIRE uses spire-system on Kind but zero-trust-workload-identity-manager on
         # OpenShift, so we check the API group instead of a specific workload.
         ComponentStatus(name="SPIRE", status=_check_api_group(kube, "spire.spiffe.io")),

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -42,7 +42,7 @@ class ComponentStatus(BaseModel):
     name: str
     status: Literal[
         "Ready",  # API group or service exists and is reachable
-        "Degraded",  # Resource exists but returned a non-404 error
+        "Degraded",  # Workload exists but not fully ready (e.g. ready < desired for deployments/statefulsets, or a non-404 API error)
         "Missing",  # API group or service not found in the cluster
         "Unknown",  # Probe could not determine status (e.g. timeout, RBAC)
     ]
@@ -204,7 +204,7 @@ async def get_platform_status(
             group=SHIPWRIGHT_CRD_GROUP,
             version=SHIPWRIGHT_CRD_VERSION,
             plural=SHIPWRIGHT_CLUSTER_BUILD_STRATEGIES_PLURAL,
-            suppress_api_error=True,
+            log_api_error=False,
         )
         strategy_names = [
             item.get("metadata", {}).get("name", "")

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -8,7 +8,7 @@ Configuration API endpoints.
 import logging
 from typing import List, Literal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from kubernetes.client import ApiException
 from pydantic import BaseModel, Field
 
@@ -34,6 +34,7 @@ class FeatureFlagsResponse(BaseModel):
     agentSandbox: bool = Field(description="agent-sandbox (k8s-sigs) as a workload type")
     skills: bool = Field(description="Skill management system (CRUD + catalog UI)")
     authbridgeAPI: bool = Field(description="AuthBridge statistics (API and UI)")
+    admin: bool = Field(description="Platform Status card and /platform-status endpoint")
 
 
 class ComponentStatus(BaseModel):
@@ -79,6 +80,7 @@ async def get_feature_flags() -> FeatureFlagsResponse:
         agentSandbox=settings.kagenti_feature_flag_agent_sandbox,
         skills=settings.kagenti_feature_flag_skills,
         authbridgeAPI=settings.kagenti_feature_flag_authbridge_api,
+        admin=settings.kagenti_feature_flag_admin,
     )
 
 
@@ -182,6 +184,9 @@ async def get_platform_status(
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> PlatformStatusResponse:
     """Return health status of platform components, build strategies, and registry info."""
+    if not settings.kagenti_feature_flag_admin:
+        raise HTTPException(status_code=404, detail="Admin feature disabled")
+
     components = [
         ComponentStatus(
             name="Istio", status=_check_deployment_ready(kube, "istio-system", "istiod")

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -177,6 +177,7 @@ class KubernetesService:
         version: str,
         plural: str,
         label_selector: Optional[str] = None,
+        suppress_api_error: bool = False,
     ) -> dict:
         """List cluster-scoped custom resources (e.g., ClusterBuildStrategies)."""
         try:
@@ -187,7 +188,8 @@ class KubernetesService:
                 label_selector=label_selector,
             )
         except ApiException as e:
-            logger.error(f"Error listing cluster-scoped {plural}: {e}")
+            if not suppress_api_error:
+                logger.error(f"Error listing cluster-scoped {plural}: {e}")
             raise
 
     def get_custom_resource(

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -177,7 +177,7 @@ class KubernetesService:
         version: str,
         plural: str,
         label_selector: Optional[str] = None,
-        suppress_api_error: bool = False,
+        log_api_error: bool = True,
     ) -> dict:
         """List cluster-scoped custom resources (e.g., ClusterBuildStrategies)."""
         try:
@@ -188,7 +188,7 @@ class KubernetesService:
                 label_selector=label_selector,
             )
         except ApiException as e:
-            if not suppress_api_error:
+            if log_api_error:
                 logger.error(f"Error listing cluster-scoped {plural}: {e}")
             raise
 

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -13,6 +13,8 @@ export interface FeatureFlags {
   skills: boolean;
   /** AuthBridge statistics */
   authbridgeAPI: boolean;
+  /** Platform Status card and /platform-status endpoint */
+  admin: boolean;
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -22,6 +24,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   agentSandbox: false,
   skills: false,
   authbridgeAPI: false,
+  admin: false,
 };
 
 let cachedFlags: FeatureFlags | null = null;
@@ -42,6 +45,7 @@ export function useFeatureFlags(): FeatureFlags {
           agentSandbox: data.agentSandbox === true,
           skills: data.skills === true,
           authbridgeAPI: data.authbridgeAPI === true,
+          admin: data.admin === true,
           };
         cachedFlags = validated;
         setFlags(validated);

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -22,6 +22,9 @@ import {
   DescriptionListDescription,
   Label,
   Skeleton,
+  Checkbox,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
 import {
   KeyIcon,
@@ -34,6 +37,8 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useAuth } from '@/contexts';
 import { configService } from '@/services/api';
+import type { ComponentStatus } from '@/services/api';
+import { useFeatureFlags, type FeatureFlags } from '@/hooks/useFeatureFlags';
 
 // Auth status API service
 async function getAuthStatus(): Promise<{
@@ -49,6 +54,115 @@ async function getAuthStatus(): Promise<{
   }
   return response.json();
 }
+
+const STATUS_COLOR: Record<ComponentStatus['status'], 'green' | 'gold' | 'grey'> = {
+  Ready: 'green',
+  Degraded: 'gold',
+  Missing: 'grey',
+  Unknown: 'grey',
+};
+
+const FLAG_LABELS: Record<keyof FeatureFlags, string> = {
+  sandbox: 'Sandbox',
+  integrations: 'Integrations',
+  triggers: 'Triggers',
+  agentSandbox: 'Agent Sandbox',
+  skills: 'Skills',
+  authbridgeAPI: 'AuthBridge API',
+};
+
+const PlatformStatusCard: React.FC = () => {
+  const flags = useFeatureFlags();
+
+  const { data: platformStatus, isLoading } = useQuery({
+    queryKey: ['platform-status'],
+    queryFn: () => configService.getPlatformStatus(),
+    refetchInterval: 15000,
+  });
+
+  return (
+    <Card isFullHeight>
+      <CardTitle>
+        <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <CogIcon />
+          Platform Status
+        </span>
+      </CardTitle>
+      <CardBody>
+        {isLoading ? (
+          <>
+            <Skeleton width="80%" style={{ marginBottom: '8px' }} />
+            <Skeleton width="60%" style={{ marginBottom: '8px' }} />
+            <Skeleton width="70%" />
+          </>
+        ) : (
+          <>
+            <Split hasGutter>
+              <SplitItem isFilled>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '8px', display: 'block' }}>
+                  Components
+                </Text>
+                <DescriptionList isCompact isHorizontal>
+                  {(platformStatus?.components ?? []).map((c) => (
+                    <DescriptionListGroup key={c.name}>
+                      <DescriptionListTerm>{c.name}</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Label color={STATUS_COLOR[c.status]} isCompact>
+                          {c.status}
+                        </Label>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  ))}
+                </DescriptionList>
+              </SplitItem>
+
+              <SplitItem isFilled>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '8px', display: 'block' }}>
+                  Feature Flags
+                </Text>
+                {(Object.keys(FLAG_LABELS) as (keyof FeatureFlags)[]).map((key) => (
+                  <Checkbox
+                    key={key}
+                    id={`flag-${key}`}
+                    label={FLAG_LABELS[key]}
+                    isChecked={flags[key]}
+                    isDisabled
+                    style={{ marginBottom: '4px' }}
+                  />
+                ))}
+              </SplitItem>
+            </Split>
+
+            <Divider component="div" style={{ margin: '12px 0' }} />
+
+            <Text component="small" style={{ fontWeight: 600, marginBottom: '8px', display: 'block' }}>
+              Registry &amp; Build
+            </Text>
+            <DescriptionList isCompact isHorizontal style={{ '--pf-v5-c-description-list--m-horizontal__term--width': '11rem' } as React.CSSProperties}>
+              <DescriptionListGroup>
+                <DescriptionListTerm style={{ whiteSpace: 'nowrap' }}>ClusterBuildStrategy</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Label
+                    color={platformStatus?.registry.clusterBuildStrategyPresent ? 'green' : 'grey'}
+                    isCompact
+                  >
+                    {platformStatus?.registry.clusterBuildStrategyPresent ? 'Present' : 'Missing'}
+                  </Label>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Registry endpoint</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <code>{platformStatus?.registry.registryEndpoint ?? '—'}</code>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </>
+        )}
+      </CardBody>
+    </Card>
+  );
+};
 
 export const AdminPage: React.FC = () => {
   const { user, isAuthenticated, isEnabled } = useAuth();
@@ -254,23 +368,9 @@ export const AdminPage: React.FC = () => {
             </Card>
           </GridItem>
 
-          {/* Platform Configuration */}
+          {/* Platform Status */}
           <GridItem md={6}>
-            <Card isFullHeight>
-              <CardTitle>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <CogIcon />
-                  Platform Configuration
-                </span>
-              </CardTitle>
-              <CardBody>
-                <Alert variant="info" title="Coming soon" isInline>
-                  Platform configuration settings (global agent settings,
-                  resource quotas, namespace management, etc.) will be available
-                  in a future release.
-                </Alert>
-              </CardBody>
-            </Card>
+            <PlatformStatusCard />
           </GridItem>
         </Grid>
       </PageSection>

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -40,6 +40,8 @@ import { configService } from '@/services/api';
 import type { ComponentStatus } from '@/services/api';
 import { useFeatureFlags, type FeatureFlags } from '@/hooks/useFeatureFlags';
 
+const POLL_INTERVAL_MS = 15_000;
+
 // Auth status API service
 async function getAuthStatus(): Promise<{
   enabled: boolean;
@@ -77,7 +79,7 @@ const PlatformStatusCard: React.FC = () => {
   const { data: platformStatus, isLoading } = useQuery({
     queryKey: ['platform-status'],
     queryFn: () => configService.getPlatformStatus(),
-    refetchInterval: 15000,
+    refetchInterval: POLL_INTERVAL_MS,
   });
 
   return (

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -64,7 +64,9 @@ const STATUS_COLOR: Record<ComponentStatus['status'], 'green' | 'gold' | 'grey'>
   Unknown: 'grey',
 };
 
-const FLAG_LABELS: Record<keyof FeatureFlags, string> = {
+type DisplayedFlag = Exclude<keyof FeatureFlags, 'admin'>;
+
+const FLAG_LABELS: Record<DisplayedFlag, string> = {
   sandbox: 'Sandbox',
   integrations: 'Integrations',
   triggers: 'Triggers',
@@ -122,7 +124,7 @@ const PlatformStatusCard: React.FC = () => {
                 <Text component="small" style={{ fontWeight: 600, marginBottom: '8px', display: 'block' }}>
                   Feature Flags
                 </Text>
-                {(Object.keys(FLAG_LABELS) as (keyof FeatureFlags)[]).map((key) => (
+                {(Object.keys(FLAG_LABELS) as DisplayedFlag[]).map((key) => (
                   <Checkbox
                     key={key}
                     id={`flag-${key}`}
@@ -168,6 +170,7 @@ const PlatformStatusCard: React.FC = () => {
 
 export const AdminPage: React.FC = () => {
   const { user, isAuthenticated, isEnabled } = useAuth();
+  const featureFlags = useFeatureFlags();
 
   const { data: authStatus, isLoading } = useQuery({
     queryKey: ['auth-status'],
@@ -371,9 +374,11 @@ export const AdminPage: React.FC = () => {
           </GridItem>
 
           {/* Platform Status */}
-          <GridItem md={6}>
-            <PlatformStatusCard />
-          </GridItem>
+          {featureFlags.admin && (
+            <GridItem md={6}>
+              <PlatformStatusCard />
+            </GridItem>
+          )}
         </Grid>
       </PageSection>
     </>

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -708,11 +708,34 @@ export interface DashboardConfig {
 }
 
 /**
+ * Platform status types
+ */
+export interface ComponentStatus {
+  name: string;
+  status: 'Ready' | 'Degraded' | 'Missing' | 'Unknown';
+}
+
+export interface RegistryBuildInfo {
+  clusterBuildStrategyPresent: boolean;
+  clusterBuildStrategies: string[];
+  registryEndpoint: string;
+}
+
+export interface PlatformStatusResponse {
+  components: ComponentStatus[];
+  registry: RegistryBuildInfo;
+}
+
+/**
  * Config service
  */
 export const configService = {
   async getDashboards(): Promise<DashboardConfig> {
     return apiFetch('/config/dashboards');
+  },
+
+  async getPlatformStatus(): Promise<PlatformStatusResponse> {
+    return apiFetch('/config/platform-status');
   },
 };
 


### PR DESCRIPTION
## Summary

For #1373

Adds a new configuration dashboard to Kagenti.

Note that this PR misses one of the criteria, "Degraded components shown in amber/red with a link to docs".  I would like to hold off on that until the Docs website has been restructured.

Also note that we don't yet check for "degraded" SPIRE and Shipwright due to differences between OpenShift and Kind installs.

Note that the "Admin Coming Soon" panel no longer appears, even when the feature flag is off suppressing the Admin panel.

## (Optional) Testing Instructions

```bash
oc -n kagenti-system set env deployment/kagenti-backend KAGENTI_FEATURE_FLAG_ADMIN=TRUE
oc -n kagenti-system set env deployment/kagenti-ui KAGENTI_FEATURE_FLAG_ADMIN=TRUE
kubectl -n kagenti-system rollout status deployment kagenti-backend
kubectl -n kagenti-system rollout status deployment kagenti-ui
```

The status panel polls every 15 seconds.  To test this, do `oc -n keycloak delete pod keycloak-0` and within about 15 seconds Keycloak should report that it is degraded.

(It is hard to test what happens when Istio isn't running ... Istio restarts quickly.)

Note that the Spire and Shipwright services currently only check installation, not liveness.  This is because of their different configuration on OpenShift.
