### PR TITLE
docs: Add PR/issue templates and improve .gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug in Kagenti
+labels: kind/bug
+---
+
+## Environment
+
+- Kagenti version:
+- Kubernetes/OpenShift version:
+- Install method (Helm / Ansible / Kind script):
+
+## What happened?
+
+<!-- Describe the bug. -->
+
+## What did you expect?
+
+<!-- Describe the expected behavior. -->
+
+## Steps to reproduce
+
+1.
+
+## Logs or error messages
+
+```
+(paste relevant logs here)
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: kind/feature
+---
+
+## Problem
+
+<!-- What problem does this feature solve? -->
+
+## Proposed solution
+
+<!-- How should it work? -->
+
+## Alternatives considered
+
+<!-- What other approaches did you consider? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- What does this PR do? Link to related issues. -->
+
+Fixes #
+
+## Changes
+
+<!-- Brief summary of what changed and why. -->
+
+-
+
+## How to test
+
+<!-- Steps to verify the change works. -->
+
+1.
+
+## Checklist
+
+- [ ] Commits are signed off (`git commit -s`)
+- [ ] Tests pass locally
+- [ ] Documentation updated (if applicable)

--- a/.gitignore
+++ b/.gitignore
@@ -160,7 +160,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 **/.DS_Store
 


### PR DESCRIPTION
## Summary

- Add pull request template (CONTRIBUTING.md references one at line 53, but none existed)
- Add bug report and feature request issue templates
- Uncomment `.idea/` in `.gitignore` (was commented out, JetBrains users currently have to add it locally)

## Why

New contributors don't have a consistent format for PRs or issues. The templates provide structure without being heavy-handed. All three are short and focused.

## Test plan

- [ ] GitHub renders PR template when creating a new PR
- [ ] GitHub shows bug report and feature request options when creating a new issue
- [ ] `.gitignore` change doesn't affect any tracked files

Assisted-By: 🤖 Claude Code