### PR TITLE
feat(chart): enable agentSandbox feature flag by default

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -10,7 +10,7 @@ featureFlags:
   sandbox: false
   integrations: false
   triggers: false
-  agentSandbox: false
+  agentSandbox: true
   skills: false
   authbridgeAPI: false
 


### PR DESCRIPTION
## Summary

- Enable `featureFlags.agentSandbox` by default (`false` → `true`) in `charts/kagenti/values.yaml`
- Sandbox is the intended default workload type — the UI already labels it "Sandbox (Recommended)"
- All operator dependencies have landed: kagenti/kagenti-operator#338, #339, #340, #341, #342

Closes #1519

## Test plan

- [ ] Deploy to Kind with default values, verify Sandbox workload type is available in UI without manual override
- [ ] Verify existing Deployment-based agents still work (flag only adds Sandbox option, doesn't remove Deployment)

Assisted-By: Claude Code