### PR TITLE
feat: Add automated HyperShift cleanup workflows

### DIFF
--- a/.github/scripts/hypershift/CLEANUP-SYSTEM.md
+++ b/.github/scripts/hypershift/CLEANUP-SYSTEM.md
@@ -1,0 +1,298 @@
+# HyperShift Cleanup System
+
+Automated cleanup of stale and zombie HyperShift resources to prevent quota exhaustion.
+
+## Overview
+
+Two complementary workflows handle different cleanup scenarios:
+
+### 1. **Stale Cluster Cleanup** (TTL-based)
+- **Workflow**: `.github/workflows/cleanup-stale-hypershift-clusters.yaml`
+- **Schedule**: Every 3 hours (at :27)
+- **Targets**: Clusters with `kagenti.io/auto-cleanup=enabled` labels
+- **Criteria**: Age > `kagenti.io/ttl-hours`
+
+### 2. **Zombie Resource Cleanup** (Orphan detection)
+- **Workflow**: `.github/workflows/cleanup-zombie-hypershift-resources.yaml`
+- **Schedule**: Every 6 hours (at :17)
+- **Targets**: Orphaned AWS resources + stuck clusters
+- **Criteria**:
+  - Clusters with `deletionTimestamp` but still exist (stuck finalizers)
+  - Clusters older than 6 hours (normal E2E < 2 hours)
+  - Clusters without CI slot leases (orphaned from failed jobs)
+  - AWS resources without matching HostedClusters (VPCs, EIPs, Route53, OIDC)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     GitHub Actions Workflows                    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌────────────────────┐         ┌──────────────────────┐      │
+│  │ Stale Cleanup      │         │ Zombie Cleanup       │      │
+│  │ (Every 3h)         │         │ (Every 6h)           │      │
+│  │                    │         │                      │      │
+│  │ - TTL-based        │         │ - Finalizer stuck    │      │
+│  │ - Label-based      │         │ - Age-based          │      │
+│  │                    │         │ - Orphan detection   │      │
+│  └─────────┬──────────┘         └──────────┬───────────┘      │
+│            │                               │                   │
+└────────────┼───────────────────────────────┼───────────────────┘
+             │                               │
+             ▼                               ▼
+    ┌────────────────────┐         ┌─────────────────────┐
+    │ cleanup-stale-     │         │ cleanup-zombies.sh  │
+    │ clusters.sh        │         │                     │
+    └─────────┬──────────┘         └──────────┬──────────┘
+              │                               │
+              └───────────┬───────────────────┘
+                          ▼
+                ┌──────────────────────┐
+                │ destroy-cluster.sh   │
+                │ (calls ↓)            │
+                └──────────┬───────────┘
+                           ▼
+                ┌──────────────────────────────┐
+                │ 55-cleanup-existing-cluster  │
+                │                              │
+                │ - Ansible playbook           │
+                │ - AWS resource cleanup       │
+                │ - Dependency ordering        │
+                └──────────────────────────────┘
+```
+
+## Cleanup Phases
+
+### Phase 1: HostedCluster Deletion
+```bash
+# For stuck clusters with deletionTimestamp
+1. Check if AWS resources cleaned → force remove finalizers
+2. Otherwise, initiate destroy via destroy-cluster.sh
+```
+
+### Phase 2: AWS Resource Cleanup (55-cleanup-existing-cluster.sh)
+```
+Dependency-ordered deletion:
+1. EC2 Instances        (terminate + wait)
+2. NAT Gateways         (delete + wait ~2 min)
+3. Internet Gateways    (detach + delete)
+4. VPC Endpoints        (delete + wait ~90s for ENI release)
+5. ENIs                 (detach + delete)
+6. Security Groups      (revoke rules + delete)
+7. Subnets              (delete - removes route table associations)
+8. Route Tables         (delete non-main)
+9. VPC                  (final deletion)
+```
+
+### Phase 3: Orphan Cleanup
+```
+- OIDC Providers (IAM)
+- Elastic IPs (unattached)
+- Route53 Zones (DNS records + zone)
+```
+
+## Required GitHub Secrets
+
+| Secret | Description | Example |
+|--------|-------------|---------|
+| `HYPERSHIFT_MGMT_KUBECONFIG` | Base64-encoded management cluster kubeconfig | `cat ~/.kube/config \| base64 -w0` |
+| `AWS_ACCESS_KEY_ID` | AWS access key with EC2/VPC/IAM permissions | `AKIA...` |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key | `...` |
+| `AWS_REGION` | AWS region | `us-east-1` |
+| `MANAGED_BY_TAG` | Tag prefix for clusters | `kagenti-hypershift-custom` |
+| `HCP_ROLE_NAME` | HyperShift IAM role name | `kagenti-hcp-role` |
+
+## Configuration
+
+### Enable Automatic Stale Cleanup
+
+Edit `.github/workflows/cleanup-stale-hypershift-clusters.yaml`:
+
+```yaml
+# Change from:
+bash ./.github/scripts/hypershift/cleanup-stale-clusters.sh --dry-run --verbose
+
+# To:
+bash ./.github/scripts/hypershift/cleanup-stale-clusters.sh --apply --verbose
+```
+
+### Enable Automatic Zombie Cleanup
+
+Zombie cleanup is **enabled by default** in scheduled mode (`--force`).
+
+To disable, change in `.github/workflows/cleanup-zombie-hypershift-resources.yaml`:
+
+```yaml
+# Change from:
+bash ./.github/scripts/hypershift/cleanup-zombies.sh --force
+
+# To:
+bash ./.github/scripts/hypershift/cleanup-zombies.sh  # dry-run
+```
+
+### Adjust Zombie Age Threshold
+
+Default: 6 hours (normal E2E runs < 2 hours)
+
+To change globally:
+
+```yaml
+# In cleanup-zombie-hypershift-resources.yaml
+env:
+  MAX_CLUSTER_AGE_HOURS: 8  # Change to 8 hours
+```
+
+## Manual Triggers
+
+### Via GitHub UI
+
+1. Go to **Actions** → **Workflows**
+2. Select workflow:
+   - "Cleanup Stale HyperShift Clusters"
+   - "Cleanup Zombie HyperShift Resources"
+3. Click **Run workflow**
+4. Configure options:
+   - **dry_run**: `true` (default) or `false`
+   - **pattern**: Filter clusters (e.g., `*-pr-*`)
+   - **max_age_hours**: Override default (zombie cleanup only)
+
+### Via CLI
+
+```bash
+# Stale cleanup (dry-run)
+gh workflow run cleanup-stale-hypershift-clusters.yaml
+
+# Stale cleanup (apply)
+gh workflow run cleanup-stale-hypershift-clusters.yaml \
+  -f dry_run=false
+
+# Zombie cleanup (dry-run)
+gh workflow run cleanup-zombie-hypershift-resources.yaml
+
+# Zombie cleanup (apply)
+gh workflow run cleanup-zombie-hypershift-resources.yaml \
+  -f dry_run=false
+```
+
+## Local Usage
+
+### Stale Cleanup
+
+```bash
+# Setup
+source .env.kagenti-hypershift-custom
+
+# Dry-run (show what would be deleted)
+./.github/scripts/hypershift/cleanup-stale-clusters.sh --dry-run --verbose
+
+# Apply (actually delete)
+./.github/scripts/hypershift/cleanup-stale-clusters.sh --apply
+
+# Filter by pattern
+./.github/scripts/hypershift/cleanup-stale-clusters.sh --dry-run --pattern "*-pr-*"
+```
+
+### Zombie Cleanup
+
+```bash
+# Setup
+source .env.kagenti-hypershift-custom
+
+# Dry-run
+./.github/scripts/hypershift/cleanup-zombies.sh
+
+# Apply
+./.github/scripts/hypershift/cleanup-zombies.sh --force
+
+# Specific cluster
+./.github/scripts/hypershift/cleanup-zombies.sh --cluster kagenti-hypershift-custom-test1 --force
+
+# Custom age threshold
+MAX_CLUSTER_AGE_HOURS=8 ./.github/scripts/hypershift/cleanup-zombies.sh --force
+```
+
+## Monitoring
+
+### Check Recent Runs
+
+```bash
+# Stale cleanup
+gh run list --workflow=cleanup-stale-hypershift-clusters.yaml --limit 5
+
+# Zombie cleanup
+gh run list --workflow=cleanup-zombie-hypershift-resources.yaml --limit 5
+```
+
+### View Logs
+
+```bash
+# Get latest run
+gh run view --workflow=cleanup-zombie-hypershift-resources.yaml --log
+
+# Download artifacts
+gh run download <run-id>
+```
+
+### Audit Trail
+
+Cleanup workflows create GitHub issues for audit:
+- Label: `automated-cleanup`
+- Contains: timestamp, deleted clusters, workflow run link
+- Logs: Available as workflow artifacts (90-day retention)
+
+## Quota Check
+
+Before cleanup:
+
+```bash
+source .env.kagenti-hypershift-custom
+./.github/scripts/hypershift/check-quotas.sh
+```
+
+## Safety Features
+
+- **Dry-run by default**: Must explicitly enable `--apply` or `--force`
+- **Protected clusters**: Never deletes `kagenti.io/protected=true`
+- **Dependency ordering**: Respects AWS resource dependencies
+- **Verification**: Checks AWS resources before removing finalizers
+- **Retry logic**: Waits for NAT gateways, VPC endpoints to fully delete
+- **Audit trail**: Creates GitHub issues with deletion summary
+- **Logs**: Uploaded as artifacts (90-day retention)
+
+## Troubleshooting
+
+### "AWS resources still exist" Error
+
+```bash
+# Debug what resources remain
+./.github/scripts/hypershift/debug-aws-hypershift.sh <cluster-name>
+
+# Force cleanup
+./.github/scripts/hypershift/ci/55-cleanup-existing-cluster.sh
+```
+
+### Stuck Finalizers
+
+```bash
+# Check if safe to remove
+./.github/scripts/hypershift/debug-aws-hypershift.sh --check <cluster-name>
+
+# If clean, manually patch
+oc patch hostedcluster -n clusters <cluster-name> \
+  -p '{"metadata":{"finalizers":null}}' --type=merge
+```
+
+### VPC Won't Delete
+
+Common blockers:
+1. NAT Gateways still deleting (wait 2-3 min)
+2. VPC Endpoint ENIs not released (wait ~90s)
+3. EC2 instances still terminating
+
+## Related Documentation
+
+- [HyperShift Cluster Creation](./create-cluster.sh)
+- [Quota Check](./check-quotas.sh)
+- [AWS Debug](./debug-aws-hypershift.sh)
+- [CI Slot Management](./ci/slots/README.md)

--- a/.github/workflows/cleanup-stale-hypershift-clusters.yaml
+++ b/.github/workflows/cleanup-stale-hypershift-clusters.yaml
@@ -1,9 +1,9 @@
 name: Cleanup Stale HyperShift Clusters
 
 on:
-  # Scheduled cleanup every 3 hours (dry-run only for safety)
+  # Scheduled cleanup every 3 hours (change to --apply for automatic deletion)
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '27 */3 * * *'  # Every 3 hours at :27 (avoid :00 and :30)
 
   # Manual trigger with configurable options
   workflow_dispatch:
@@ -44,18 +44,32 @@ jobs:
           sudo mv oc kubectl /usr/local/bin/
           oc version --client
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq awscli python3-pip
+          pip3 install ansible boto3 botocore
 
       - name: Setup management cluster kubeconfig
         env:
-          KUBECONFIG_BASE64: ${{ secrets.KUBECONFIG_HCP_MGMT }}
+          KUBECONFIG_BASE64: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
         run: |
           mkdir -p ~/.kube
           echo "$KUBECONFIG_BASE64" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           export KUBECONFIG=~/.kube/config
           oc whoami --show-server
+
+      - name: Setup HyperShift environment
+        env:
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+        run: |
+          echo "MANAGED_BY_TAG=${MANAGED_BY_TAG}" >> $GITHUB_ENV
+          echo "HCP_ROLE_NAME=${HCP_ROLE_NAME}" >> $GITHUB_ENV
+
+      - name: Clone hypershift-automation
+        run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
 
       - name: Setup AWS credentials (for cluster deletion)
         if: github.event.inputs.dry_run == 'false' || github.event_name == 'schedule'
@@ -68,12 +82,13 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> $GITHUB_ENV
           echo "AWS_REGION=${AWS_REGION}" >> $GITHUB_ENV
 
-      - name: Run cleanup script (Dry-run - Scheduled)
+      - name: Run cleanup script (Scheduled)
         if: github.event_name == 'schedule'
         env:
           KUBECONFIG: /home/runner/.kube/config
         run: |
-          bash ./.github/scripts/hypershift/cleanup-stale-clusters.sh --dry-run --verbose
+          # Change --dry-run to --apply to enable automatic deletion
+          bash ./.github/scripts/hypershift/cleanup-stale-clusters.sh --dry-run --verbose 2>&1 | tee /tmp/cleanup-output.log
 
       - name: Run cleanup script (Manual - Dry-run)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
@@ -108,7 +123,7 @@ jobs:
           bash ./.github/scripts/hypershift/cleanup-stale-clusters.sh $ARGS | tee /tmp/cleanup-output.log
 
       - name: Upload deletion logs
-        if: github.event.inputs.dry_run == 'false' && always()
+        if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: cleanup-logs-${{ github.run_id }}
@@ -116,7 +131,7 @@ jobs:
           retention-days: 90
 
       - name: Create audit issue for deletions
-        if: github.event.inputs.dry_run == 'false' && success()
+        if: (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') && success()
         uses: actions/github-script@v9.0.0
         with:
           script: |

--- a/.github/workflows/cleanup-stale-hypershift-clusters.yaml
+++ b/.github/workflows/cleanup-stale-hypershift-clusters.yaml
@@ -47,12 +47,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq python3-pip unzip
+          sudo apt-get install -y jq python3-pip
 
-          # Install AWS CLI v2 (awscli package not available in Ubuntu 24.04)
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip -q awscliv2.zip
-          sudo ./aws/install
+          # AWS CLI is pre-installed on GitHub Actions runners
           aws --version
 
           # Install Ansible and boto

--- a/.github/workflows/cleanup-stale-hypershift-clusters.yaml
+++ b/.github/workflows/cleanup-stale-hypershift-clusters.yaml
@@ -47,7 +47,15 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq awscli python3-pip
+          sudo apt-get install -y jq python3-pip unzip
+
+          # Install AWS CLI v2 (awscli package not available in Ubuntu 24.04)
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install
+          aws --version
+
+          # Install Ansible and boto
           pip3 install ansible boto3 botocore
 
       - name: Setup management cluster kubeconfig

--- a/.github/workflows/cleanup-zombie-hypershift-resources.yaml
+++ b/.github/workflows/cleanup-zombie-hypershift-resources.yaml
@@ -42,12 +42,9 @@ jobs:
 
           # Install dependencies
           sudo apt-get update
-          sudo apt-get install -y jq python3-pip unzip
+          sudo apt-get install -y jq python3-pip
 
-          # Install AWS CLI v2 (awscli package not available in Ubuntu 24.04)
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip -q awscliv2.zip
-          sudo ./aws/install
+          # AWS CLI is pre-installed on GitHub Actions runners
           aws --version
 
           # Install Ansible for hypershift-automation

--- a/.github/workflows/cleanup-zombie-hypershift-resources.yaml
+++ b/.github/workflows/cleanup-zombie-hypershift-resources.yaml
@@ -40,12 +40,17 @@ jobs:
           sudo mv oc kubectl /usr/local/bin/
           oc version --client
 
-          # Install AWS CLI
+          # Install dependencies
           sudo apt-get update
-          sudo apt-get install -y awscli jq
+          sudo apt-get install -y jq python3-pip unzip
+
+          # Install AWS CLI v2 (awscli package not available in Ubuntu 24.04)
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install
+          aws --version
 
           # Install Ansible for hypershift-automation
-          sudo apt-get install -y python3-pip
           pip3 install ansible boto3 botocore
 
       - name: Setup management cluster kubeconfig

--- a/.github/workflows/cleanup-zombie-hypershift-resources.yaml
+++ b/.github/workflows/cleanup-zombie-hypershift-resources.yaml
@@ -1,0 +1,160 @@
+name: Cleanup Zombie HyperShift Resources
+
+on:
+  # Scheduled cleanup every 6 hours (conservative for safety)
+  schedule:
+    - cron: '17 */6 * * *'  # Every 6 hours at :17 (avoid :00 and :30)
+
+  # Manual trigger with options
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (show what would be deleted)'
+        required: false
+        type: boolean
+        default: true
+      max_age_hours:
+        description: 'Max cluster age in hours before considered zombie'
+        required: false
+        type: number
+        default: 6
+
+permissions:
+  contents: read
+  issues: write  # For audit trail
+
+jobs:
+  cleanup-zombies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180  # 3 hours for deep AWS cleanup
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          # Install OpenShift CLI
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+          tar -xzf openshift-client-linux.tar.gz
+          sudo mv oc kubectl /usr/local/bin/
+          oc version --client
+
+          # Install AWS CLI
+          sudo apt-get update
+          sudo apt-get install -y awscli jq
+
+          # Install Ansible for hypershift-automation
+          sudo apt-get install -y python3-pip
+          pip3 install ansible boto3 botocore
+
+      - name: Setup management cluster kubeconfig
+        env:
+          KUBECONFIG_BASE64: ${{ secrets.HYPERSHIFT_MGMT_KUBECONFIG }}
+        run: |
+          mkdir -p ~/.kube
+          echo "$KUBECONFIG_BASE64" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          export KUBECONFIG=~/.kube/config
+          oc whoami --show-server
+
+      - name: Setup AWS credentials
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> $GITHUB_ENV
+          echo "AWS_REGION=${AWS_REGION}" >> $GITHUB_ENV
+          aws sts get-caller-identity
+
+      - name: Setup HyperShift environment
+        env:
+          MANAGED_BY_TAG: ${{ secrets.MANAGED_BY_TAG }}
+          HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
+        run: |
+          echo "MANAGED_BY_TAG=${MANAGED_BY_TAG}" >> $GITHUB_ENV
+          echo "HCP_ROLE_NAME=${HCP_ROLE_NAME}" >> $GITHUB_ENV
+
+      - name: Clone hypershift-automation
+        run: bash .github/scripts/hypershift/ci/40-clone-hypershift-automation.sh
+
+      - name: Run zombie cleanup (Scheduled - Apply Mode)
+        if: github.event_name == 'schedule'
+        env:
+          KUBECONFIG: /home/runner/.kube/config
+          MAX_CLUSTER_AGE_HOURS: 6
+        run: |
+          bash ./.github/scripts/hypershift/cleanup-zombies.sh --force \
+            --max-age-hours ${MAX_CLUSTER_AGE_HOURS} 2>&1 | tee /tmp/zombie-cleanup.log
+
+      - name: Run zombie cleanup (Manual)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          KUBECONFIG: /home/runner/.kube/config
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          MAX_AGE: ${{ github.event.inputs.max_age_hours }}
+        run: |
+          ARGS=""
+          if [ "$DRY_RUN" = "false" ]; then
+            ARGS="--force"
+          fi
+          if [ -n "$MAX_AGE" ]; then
+            ARGS="$ARGS --max-age-hours $MAX_AGE"
+          fi
+          bash ./.github/scripts/hypershift/cleanup-zombies.sh $ARGS 2>&1 | tee /tmp/zombie-cleanup.log
+
+      - name: Upload cleanup logs
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: zombie-cleanup-logs-${{ github.run_id }}
+          path: /tmp/zombie-cleanup.log
+          retention-days: 90
+
+      - name: Create audit issue
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const logContent = fs.readFileSync('/tmp/zombie-cleanup.log', 'utf8');
+            const zombieMatches = logContent.match(/\[ZOMBIE\][^\n]+/g) || [];
+            const cleanedMatches = logContent.match(/Cleaned:\s+(\d+)/);
+            const failedMatches = logContent.match(/Failed:\s+(\d+)/);
+
+            const zombieCount = zombieMatches.length;
+            const cleanedCount = cleanedMatches ? parseInt(cleanedMatches[1]) : 0;
+            const failedCount = failedMatches ? parseInt(failedMatches[1]) : 0;
+
+            if (zombieCount > 0) {
+              const timestamp = new Date().toISOString();
+              const zombieList = zombieMatches.map(z => `- ${z.replace('[ZOMBIE]', '').trim()}`).join('\n');
+
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `[Zombie Cleanup] Found ${zombieCount} zombie resource(s) - ${timestamp}`,
+                body: `## Automated Zombie Cleanup
+
+            **Timestamp:** ${timestamp}
+            **Workflow Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
+
+            **Results:**
+            - Zombies Found: ${zombieCount}
+            - Successfully Cleaned: ${cleanedCount}
+            - Failed: ${failedCount}
+
+            **Zombie Resources:**
+
+            ${zombieList}
+
+            **Logs:** Check workflow artifacts for detailed cleanup logs.
+
+            ---
+            _This issue was created automatically by the zombie cleanup workflow._
+            `,
+                labels: ['infrastructure', 'automated-cleanup', 'hypershift', 'zombie-resources']
+              });
+            }


### PR DESCRIPTION
    - Dry-run by default for manual triggers
    - Protected clusters never deleted (kagenti.io/protected=true)
    - Dependency-ordered cleanup (NAT gateways → VPC endpoints → ENIs → Security Groups →
    Subnets → VPCs)
    - Verification before removing finalizers (checks AWS resources cleaned)
    - Audit trail via GitHub issues for all deletions
    - 90-day log retention as workflow artifacts

    Testing

    - Local dry-run validation (both scripts)
    - Detected stuck cluster (1204h old with deletionTimestamp)
    - Detected orphaned VPC with 4 ENIs, 1 subnet, 1 IGW, 3 SGs
    - CI workflow validation (in progress)