### PR TITLE
fix(ui): retry agent and agent-card queries after import

### DIFF
--- a/kagenti/ui-v2/src/components/AgentChat.tsx
+++ b/kagenti/ui-v2/src/components/AgentChat.tsx
@@ -96,6 +96,11 @@ export const AgentChat: React.FC<AgentChatProps> = ({ namespace, name }) => {
   const { data: agentCard, isLoading: isLoadingCard, error: cardError } = useQuery({
     queryKey: ['agent-card', namespace, name],
     queryFn: () => chatService.getAgentCard(namespace, name),
+    retry: 3,
+    retryDelay: 2000,
+    refetchInterval: (query) => {
+      return query.state.data ? false : 5000;
+    },
   });
 
   const sendMessageMutation = useMutation({

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -166,10 +166,10 @@ export const AgentDetailPage: React.FC = () => {
     queryKey: ['agent', namespace, name],
     queryFn: () => agentService.get(namespace!, name!),
     enabled: !!namespace && !!name,
+    retry: 3,
+    retryDelay: 2000,
     refetchInterval: (query) => {
-      // Poll every 5 seconds if agent is not ready
-      // Use readyStatus from backend (handles Deployment, StatefulSet, Job)
-      // For Jobs: stop polling once Completed or Failed, but continue for Running
+      if (!query.state.data) return 5000;
       const readyStatus = query.state.data?.readyStatus;
       const isStable = readyStatus === 'Ready' || readyStatus === 'Completed' || readyStatus === 'Failed';
       return isStable ? false : 5000;

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -35,7 +35,7 @@ import {
   Checkbox,
 } from '@patternfly/react-core';
 import { TrashIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { agentService, ShipwrightBuildConfig } from '@/services/api';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
@@ -108,6 +108,7 @@ interface ServicePort {
 
 export const ImportAgentPage: React.FC = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const features = useFeatureFlags();
 
   // Deployment method
@@ -217,9 +218,8 @@ export const ImportAgentPage: React.FC = () => {
     mutationFn: (data: Parameters<typeof agentService.create>[0]) =>
       agentService.create(data),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['agents'] });
       const finalName = name || getNameFromPath();
-      // Navigate to build progress page if using Shipwright for source builds
-      // Always navigate to build page for source builds (Shipwright)
       if (deploymentMethod === 'source') {
         navigate(`/agents/${namespace}/${finalName}/build`);
       } else {


### PR DESCRIPTION
## Summary

- Add retry (3x, 2s delay) and poll-until-found to the primary agent query in `AgentDetailPage` so it waits for the K8s resource instead of showing "Agent not found"
- Add retry and poll-until-found to the agent-card query in `AgentChat` so the Chat tab waits instead of showing "Failed to load agent"
- Invalidate the `['agents']` list cache on successful import so the catalog is fresh

Closes #1556

## Root Cause

After Import Agent, the UI navigates immediately to the detail page. The backend may return 404 if the K8s resource isn't queryable yet. The agent query had no retry (global default is 1) and the Chat tab's agent-card query had no retry or polling at all — any initial 404 was treated as a permanent failure.

## Test plan

- [ ] Import an agent via image deploy, verify detail page polls until agent appears
- [ ] Click Chat tab on a newly imported agent, verify it loads once agent card is available
- [ ] Verify existing Ready agents load immediately with no visible delay

Assisted-By: Claude Code