### PR TITLE
fix(backend): resolve agent port from Sandbox pod template, not a constant

### DIFF
--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -6,6 +6,7 @@ Utility functions for creating HTTPRoutes (Kubernetes) and Routes (OpenShift).
 """
 
 import logging
+from typing import Optional
 
 from kubernetes.client import ApiException
 
@@ -334,13 +335,57 @@ def lookup_service_port(
     return default_port
 
 
-def resolve_agent_url(name: str, namespace: str, kube: KubernetesService) -> str:
-    """Resolve agent URL by looking up actual Service port."""
-    fallback = (
-        DEFAULT_IN_CLUSTER_PORT if settings.is_running_in_cluster else DEFAULT_OFF_CLUSTER_PORT
+def _lookup_sandbox_port(
+    name: str,
+    namespace: str,
+    kube: KubernetesService,
+) -> Optional[int]:
+    """Return the container port advertised by a Sandbox's pod template, or None.
+
+    Sandbox controllers create a headless Service with no ports
+    (kubernetes-sigs/agent-sandbox#154), so callers must discover the port from
+    the workload itself. Prefer containerPort, fall back to the PORT env var.
+    """
+    try:
+        sandbox = kube.get_sandbox(namespace=namespace, name=name)
+    except ApiException:
+        return None
+    containers = (
+        sandbox.get("spec", {}).get("podTemplate", {}).get("spec", {}).get("containers", [])
     )
-    port = lookup_service_port(name, namespace, kube, fallback)
-    return get_agent_url(name, namespace, port)
+    if not containers:
+        return None
+    ports = containers[0].get("ports") or []
+    if ports and isinstance(ports[0].get("containerPort"), int):
+        return ports[0]["containerPort"]
+    for env in containers[0].get("env", []) or []:
+        if env.get("name") == "PORT":
+            try:
+                return int(env.get("value"))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def resolve_agent_url(name: str, namespace: str, kube: KubernetesService) -> str:
+    """Resolve the URL for an agent by discovering its port.
+
+    1. If the Service exposes ports (Deployment/StatefulSet/Job path), use the
+       first port.
+    2. Else, if a Sandbox owns this name, read the port from its pod template
+       (Sandbox-created Services are headless with no ports).
+    3. Otherwise fall back to DEFAULT_OFF_CLUSTER_PORT, which matches both the
+       default external port and the default the sandbox builder writes.
+    """
+    port = lookup_service_port(name, namespace, kube, default_port=0)
+    if port:
+        return get_agent_url(name, namespace, port)
+
+    sandbox_port = _lookup_sandbox_port(name, namespace, kube)
+    if sandbox_port is not None:
+        return get_agent_url(name, namespace, sandbox_port)
+
+    return get_agent_url(name, namespace, DEFAULT_OFF_CLUSTER_PORT)
 
 
 def get_agent_url(name: str, namespace: str, port: int = DEFAULT_OFF_CLUSTER_PORT) -> str:

--- a/kagenti/backend/tests/test_routes.py
+++ b/kagenti/backend/tests/test_routes.py
@@ -63,9 +63,7 @@ class TestResolveAgentUrl:
         assert url == "http://my-agent.team1.svc.cluster.local:8080"
 
     @patch("app.utils.routes.settings")
-    def test_service_no_ports_reads_sandbox_containerport(
-        self, mock_settings, kubernetes_service
-    ):
+    def test_service_no_ports_reads_sandbox_containerport(self, mock_settings, kubernetes_service):
         """Service with empty ports → read containerPort from the owning Sandbox."""
         mock_settings.is_running_in_cluster = True
         svc = MagicMock()
@@ -74,9 +72,7 @@ class TestResolveAgentUrl:
         kubernetes_service.get_sandbox = MagicMock(
             return_value={
                 "spec": {
-                    "podTemplate": {
-                        "spec": {"containers": [{"ports": [{"containerPort": 8080}]}]}
-                    }
+                    "podTemplate": {"spec": {"containers": [{"ports": [{"containerPort": 8080}]}]}}
                 }
             }
         )
@@ -97,9 +93,7 @@ class TestResolveAgentUrl:
             return_value={
                 "spec": {
                     "podTemplate": {
-                        "spec": {
-                            "containers": [{"env": [{"name": "PORT", "value": "9000"}]}]
-                        }
+                        "spec": {"containers": [{"env": [{"name": "PORT", "value": "9000"}]}]}
                     }
                 }
             }
@@ -111,9 +105,7 @@ class TestResolveAgentUrl:
         assert url == "http://my-agent.team1.svc.cluster.local:9000"
 
     @patch("app.utils.routes.settings")
-    def test_service_missing_no_sandbox_falls_back(
-        self, mock_settings, kubernetes_service
-    ):
+    def test_service_missing_no_sandbox_falls_back(self, mock_settings, kubernetes_service):
         """No Service and no Sandbox → DEFAULT_OFF_CLUSTER_PORT (8080)."""
         mock_settings.is_running_in_cluster = True
         kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(

--- a/kagenti/backend/tests/test_routes.py
+++ b/kagenti/backend/tests/test_routes.py
@@ -63,53 +63,82 @@ class TestResolveAgentUrl:
         assert url == "http://my-agent.team1.svc.cluster.local:8080"
 
     @patch("app.utils.routes.settings")
-    def test_service_not_found_in_cluster(self, mock_settings, kubernetes_service):
-        """Missing Service in-cluster falls back to in-cluster port (8000)."""
+    def test_service_no_ports_reads_sandbox_containerport(
+        self, mock_settings, kubernetes_service
+    ):
+        """Service with empty ports → read containerPort from the owning Sandbox."""
         mock_settings.is_running_in_cluster = True
-        kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
-            status=404, reason="Not Found"
+        svc = MagicMock()
+        svc.to_dict.return_value = {"spec": {"ports": []}}
+        kubernetes_service._core_api.read_namespaced_service.return_value = svc
+        kubernetes_service.get_sandbox = MagicMock(
+            return_value={
+                "spec": {
+                    "podTemplate": {
+                        "spec": {"containers": [{"ports": [{"containerPort": 8080}]}]}
+                    }
+                }
+            }
         )
 
         from app.utils.routes import resolve_agent_url
 
         url = resolve_agent_url("my-agent", "team1", kubernetes_service)
-        assert url == "http://my-agent.team1.svc.cluster.local:8000"
+        assert url == "http://my-agent.team1.svc.cluster.local:8080"
 
     @patch("app.utils.routes.settings")
-    def test_service_not_found_off_cluster(self, mock_settings, kubernetes_service):
-        """Missing Service off-cluster falls back to off-cluster port (8080)."""
-        mock_settings.is_running_in_cluster = False
-        mock_settings.domain_name = "localtest.me"
-        kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
-            status=404, reason="Not Found"
+    def test_service_no_ports_reads_sandbox_env(self, mock_settings, kubernetes_service):
+        """No containerPort → fall back to the PORT env var on the Sandbox."""
+        mock_settings.is_running_in_cluster = True
+        svc = MagicMock()
+        svc.to_dict.return_value = {"spec": {"ports": []}}
+        kubernetes_service._core_api.read_namespaced_service.return_value = svc
+        kubernetes_service.get_sandbox = MagicMock(
+            return_value={
+                "spec": {
+                    "podTemplate": {
+                        "spec": {
+                            "containers": [{"env": [{"name": "PORT", "value": "9000"}]}]
+                        }
+                    }
+                }
+            }
         )
 
         from app.utils.routes import resolve_agent_url
 
         url = resolve_agent_url("my-agent", "team1", kubernetes_service)
-        assert url == "http://my-agent.team1.localtest.me:8080"
+        assert url == "http://my-agent.team1.svc.cluster.local:9000"
 
     @patch("app.utils.routes.settings")
-    def test_service_no_ports_in_cluster(self, mock_settings, kubernetes_service):
-        """Service with empty ports list in-cluster falls back to 8000."""
+    def test_service_missing_no_sandbox_falls_back(
+        self, mock_settings, kubernetes_service
+    ):
+        """No Service and no Sandbox → DEFAULT_OFF_CLUSTER_PORT (8080)."""
         mock_settings.is_running_in_cluster = True
-        mock_result = MagicMock()
-        mock_result.to_dict.return_value = {"spec": {"ports": []}}
-        kubernetes_service._core_api.read_namespaced_service.return_value = mock_result
+        kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+        kubernetes_service.get_sandbox = MagicMock(
+            side_effect=ApiException(status=404, reason="Not Found")
+        )
 
         from app.utils.routes import resolve_agent_url
 
         url = resolve_agent_url("my-agent", "team1", kubernetes_service)
-        assert url == "http://my-agent.team1.svc.cluster.local:8000"
+        assert url == "http://my-agent.team1.svc.cluster.local:8080"
 
     @patch("app.utils.routes.settings")
-    def test_service_no_ports_off_cluster(self, mock_settings, kubernetes_service):
-        """Service with empty ports list off-cluster falls back to 8080."""
+    def test_service_missing_off_cluster(self, mock_settings, kubernetes_service):
+        """No Service, no Sandbox, off-cluster → DEFAULT_OFF_CLUSTER_PORT with domain."""
         mock_settings.is_running_in_cluster = False
         mock_settings.domain_name = "localtest.me"
-        mock_result = MagicMock()
-        mock_result.to_dict.return_value = {"spec": {"ports": []}}
-        kubernetes_service._core_api.read_namespaced_service.return_value = mock_result
+        kubernetes_service._core_api.read_namespaced_service.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+        kubernetes_service.get_sandbox = MagicMock(
+            side_effect=ApiException(status=404, reason="Not Found")
+        )
 
         from app.utils.routes import resolve_agent_url
 


### PR DESCRIPTION
## Summary

Two previously-merged fixes disagree about which port Sandbox agents listen on:

- **PR #1507** (2026-05-08): `_build_sandbox_manifest` aligns the Sandbox pod's `PORT` env and `containerPort` with `service_port` (default `DEFAULT_OFF_CLUSTER_PORT` = **8080**) so `AGENT_ENDPOINT`, the agent card's advertised `url`, and the actual listener all agree.
- **PR #1525** (2026-05-09): `resolve_agent_url` falls back to `DEFAULT_IN_CLUSTER_PORT` (**8000**) when the Service has no ports and the backend is running in-cluster.

With both in effect, the backend calls `...:8000` while the Sandbox agent listens on `...:8080`. Envoy returns 503 and the UI surfaces "Agent card not available."

## What this PR does

Replaces the hardcoded in-cluster fallback with a read of the owning Sandbox's pod template:

1. If the Service exposes ports (Deployment/StatefulSet/Job path) -> use the first port. **Unchanged behavior.**
2. Else, if a Sandbox with the same name exists -> read `spec.podTemplate.spec.containers[0]` — `containerPort` first, then the `PORT` env var.
3. Else -> fall back to `DEFAULT_OFF_CLUSTER_PORT` (8080) — matches both the sandbox-builder default and the external port used by Gateways/Ingresses.

This also handles Sandboxes created with a custom `servicePorts[0].port` — neither prior fix covered that case.

The long-term fix is upstream [kubernetes-sigs/agent-sandbox#154](https://github.com/kubernetes-sigs/agent-sandbox/issues/154) (Sandbox controller populating its Service with ports); this is the in-tree workaround until then.

## Test plan

- [x] `uv run pytest kagenti/backend/tests/test_routes.py -v` — 15/15 pass locally
- [x] Replace the two `:8000` assertions from #1525 with Sandbox-aware tests (containerPort path + PORT-env path) and a final-fallback test
- [x] Verified end-to-end on a local Kind cluster: built the patched backend image, rolled out, deployed the weather agent via UI, confirmed `GET /.well-known/agent-card.json` returns 200 and the agent card renders in the chat tab
- [ ] CI green

## Scope check

| Path | Behavior | Changed? |
|---|---|---|
| Deployment / StatefulSet / Job | Service has ports → first lookup wins | No |
| Sandbox, default port (8080) | Service empty → Sandbox lookup returns 8080 | **Fixes current bug** |
| Sandbox, custom port | Service empty → Sandbox lookup returns custom port | **New: improvement** |
| Off-cluster, nothing found | Final fallback `:8080` with domain | Same (was 8080) |

Assisted-By: Claude (Anthropic AI) &lt;noreply@anthropic.com&gt;
