### PR TITLE
fix: use /health for MLflow probes to avoid OIDC 401

### DIFF
--- a/charts/kagenti-deps/templates/mlflow.yaml
+++ b/charts/kagenti-deps/templates/mlflow.yaml
@@ -410,14 +410,14 @@ spec:
           failureThreshold: 30  # Allow up to 5 minutes for startup
         readinessProbe:
           httpGet:
-            path: /version
+            path: /health
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 10
           failureThreshold: 3
         livenessProbe:
           httpGet:
-            path: /version
+            path: /health
             port: 5000
           initialDelaySeconds: 10
           periodSeconds: 30


### PR DESCRIPTION
## Summary

- Change MLflow liveness/readiness probe endpoint from `/version` to `/health`
- `/health` is natively unprotected in `mlflow-oidc-auth`'s `AuthMiddleware`, so probes pass without authentication
- Fixes CrashLoopBackOff when `mlflow.auth.enabled=true`

Fixes #1559

## Test plan

- [x] Deploy to Kind with `mlflow.auth.enabled=true`
- [x] Verify pod reaches `1/1 Running` with 0 restarts
- [x] Confirm `/health` returns 200 without authentication

Assisted-By: Claude Code