### PR TITLE
fix(backend,ui): make Shipwright optional — no 404 spam when absent

### DIFF
--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 class FeatureFlagsResponse(BaseModel):
     """Response model for feature flag status."""
 
+    builds: bool = Field(description="Shipwright build-from-source capability available")
     sandbox: bool = Field(description="Interactive sandbox session UI (Legion)")
     integrations: bool = Field(description="Third-party integration endpoints")
     triggers: bool = Field(description="Event-driven trigger system")
@@ -71,9 +72,12 @@ router = APIRouter(prefix="/config", tags=["config"])
     "/features",
     response_model=FeatureFlagsResponse,
 )
-async def get_feature_flags() -> FeatureFlagsResponse:
+async def get_feature_flags(
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> FeatureFlagsResponse:
     """Return enabled feature flags for UI gating (public, no auth required)."""
     return FeatureFlagsResponse(
+        builds=kube.api_group_exists("shipwright.io"),
         sandbox=settings.kagenti_feature_flag_sandbox,
         integrations=settings.kagenti_feature_flag_integrations,
         triggers=settings.kagenti_feature_flag_triggers,

--- a/kagenti/backend/app/routers/shipwright.py
+++ b/kagenti/backend/app/routers/shipwright.py
@@ -60,6 +60,9 @@ async def list_shipwright_builds(
 
     Uses the `kagenti.io/type` label (agent | tool). Intended for CLI and automation.
     """
+    if not kube.api_group_exists("shipwright.io"):
+        return ShipwrightBuildListResponse(items=[])
+
     namespaces_to_scan: List[str] = []
     if all_namespaces:
         namespaces_to_scan = kube.list_enabled_namespaces()

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -598,6 +598,9 @@ async def list_tool_shipwright_builds(
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> ShipwrightBuildListResponse:
     """List Shipwright Build resources for tools only (kagenti.io/type=tool)."""
+    if not kube.api_group_exists("shipwright.io"):
+        return ShipwrightBuildListResponse(items=[])
+
     namespaces_to_scan: List[str] = []
     if all_namespaces:
         namespaces_to_scan = kube.list_enabled_namespaces()

--- a/kagenti/backend/app/services/reconciliation.py
+++ b/kagenti/backend/app/services/reconciliation.py
@@ -53,6 +53,11 @@ def _workload_exists(kube: KubernetesService, namespace: str, name: str) -> bool
 async def reconcile_builds() -> None:
     """Single reconciliation pass — find and finalize orphaned builds."""
     kube = get_kubernetes_service()
+
+    if not kube.api_group_exists("shipwright.io"):
+        logger.debug("Shipwright API group not found, skipping build reconciliation")
+        return
+
     namespaces = kube.list_enabled_namespaces()
 
     for namespace in namespaces:

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -4,6 +4,8 @@
 import { useState, useEffect } from 'react';
 
 export interface FeatureFlags {
+  /** Shipwright build-from-source capability available in the cluster. */
+  builds: boolean;
   /** Sandboxed agent runtime UI and APIs (legacy runtime sandbox). */
   sandbox: boolean;
   integrations: boolean;
@@ -18,6 +20,7 @@ export interface FeatureFlags {
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
+  builds: false,
   sandbox: false,
   integrations: false,
   triggers: false,
@@ -39,6 +42,7 @@ export function useFeatureFlags(): FeatureFlags {
       .then(res => res.ok ? res.json() : DEFAULT_FLAGS)
       .then((data) => {
         const validated: FeatureFlags = {
+          builds: data.builds === true,
           sandbox: data.sandbox === true,
           integrations: data.integrations === true,
           triggers: data.triggers === true,

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -67,6 +67,7 @@ const STATUS_COLOR: Record<ComponentStatus['status'], 'green' | 'gold' | 'grey'>
 type DisplayedFlag = Exclude<keyof FeatureFlags, 'admin'>;
 
 const FLAG_LABELS: Record<DisplayedFlag, string> = {
+  builds: 'Builds (Shipwright)',
   sandbox: 'Sandbox',
   integrations: 'Integrations',
   triggers: 'Triggers',

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -111,8 +111,10 @@ export const ImportAgentPage: React.FC = () => {
   const queryClient = useQueryClient();
   const features = useFeatureFlags();
 
-  // Deployment method
-  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
+  // Deployment method — default to 'image' when builds unavailable
+  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>(
+    features.builds ? 'source' : 'image'
+  );
 
   // Basic info
   const [namespace, setNamespace] = useState('team1');
@@ -613,14 +615,16 @@ export const ImportAgentPage: React.FC = () => {
               </Title>
 
               <FormGroup role="radiogroup" fieldId="deployment-method">
-                <Radio
-                  id="method-source"
-                  name="deployment-method"
-                  label="Build from Source"
-                  description="Build container image from a git repository"
-                  isChecked={deploymentMethod === 'source'}
-                  onChange={() => setDeploymentMethod('source')}
-                />
+                {features.builds && (
+                  <Radio
+                    id="method-source"
+                    name="deployment-method"
+                    label="Build from Source"
+                    description="Build container image from a git repository"
+                    isChecked={deploymentMethod === 'source'}
+                    onChange={() => setDeploymentMethod('source')}
+                  />
+                )}
                 <Radio
                   id="method-image"
                   name="deployment-method"
@@ -628,7 +632,7 @@ export const ImportAgentPage: React.FC = () => {
                   description="Deploy using an existing container image"
                   isChecked={deploymentMethod === 'image'}
                   onChange={() => setDeploymentMethod('image')}
-                  style={{ marginTop: '8px' }}
+                  style={{ marginTop: features.builds ? '8px' : undefined }}
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidEnvVarName, isValidContainerImage, isValidImageTag } from '../utils/validation';
 import { newRouteRowId } from '../utils/routeRowId';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 import {
   PageSection,
   Title,
@@ -87,9 +88,12 @@ interface ServicePort {
 
 export const ImportToolPage: React.FC = () => {
   const navigate = useNavigate();
+  const features = useFeatureFlags();
 
-  // Deployment method
-  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
+  // Deployment method — default to 'image' when builds unavailable
+  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>(
+    features.builds ? 'source' : 'image'
+  );
 
   // Form state
   const [namespace, setNamespace] = useState('team1');
@@ -580,14 +584,16 @@ export const ImportToolPage: React.FC = () => {
               </Title>
 
               <FormGroup role="radiogroup" fieldId="deploymentMethod">
-                <Radio
-                  name="deploymentMethod"
-                  label="Build from Source"
-                  description="Build container image from source code using Shipwright"
-                  isChecked={deploymentMethod === 'source'}
-                  onChange={() => setDeploymentMethod('source')}
-                  id="deploymentMethod-source"
-                />
+                {features.builds && (
+                  <Radio
+                    name="deploymentMethod"
+                    label="Build from Source"
+                    description="Build container image from source code using Shipwright"
+                    isChecked={deploymentMethod === 'source'}
+                    onChange={() => setDeploymentMethod('source')}
+                    id="deploymentMethod-source"
+                  />
+                )}
                 <Radio
                   name="deploymentMethod"
                   label="Deploy from Image"
@@ -595,7 +601,7 @@ export const ImportToolPage: React.FC = () => {
                   isChecked={deploymentMethod === 'image'}
                   onChange={() => setDeploymentMethod('image')}
                   id="deploymentMethod-image"
-                  style={{ marginTop: '8px' }}
+                  style={{ marginTop: features.builds ? '8px' : undefined }}
                 />
               </FormGroup>
 


### PR DESCRIPTION
## Summary

- Backend reconciliation loop now checks `api_group_exists("shipwright.io")` before listing builds — returns early with a DEBUG log when Shipwright is absent instead of spamming ERROR/WARNING every 30s
- New runtime `builds` field in `GET /config/features` dynamically reports Shipwright availability to the frontend
- Shipwright API endpoints (`/shipwright/builds`, `/tools/.../shipwright-builds`) return empty lists instead of 404 when CRDs are missing
- Import Agent/Tool pages hide "Build from Source" radio when `builds: false`, defaulting to "Deploy from Existing Image"

## Test plan

See testing instructions in the issue: https://github.com/kagenti/kagenti/issues/1538#issuecomment-4434524598

**Quick verification:**
- Deploy without `--with-builds` → `curl .../config/features | jq .builds` returns `false`, no 404 spam in logs, UI only shows image deploy
- Deploy with `--with-builds` → `builds: true`, both deploy methods visible, build-from-source works

Fixes #1538

Assisted-By: Claude Code