### PR TITLE
fix: remove deprecated sidecar client registration toggle from UI

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2414,8 +2414,6 @@ def _build_common_labels(
         labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
     if request.spiffeHelperInject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    # Note: Client registration is now handled by kagenti-operator, not sidecars.
-    # The clientRegistrationInject field is deprecated and ignored.
     return labels
 
 

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2414,8 +2414,8 @@ def _build_common_labels(
         labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
     if request.spiffeHelperInject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    if request.clientRegistrationInject is True:
-        labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
+    # Note: Client registration is now handled by kagenti-operator, not sidecars.
+    # The clientRegistrationInject field is deprecated and ignored.
     return labels
 
 

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -1043,9 +1043,8 @@ def _build_tool_deployment_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    if client_registration_inject is True:
-        labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
-        pod_labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
+    # Note: Client registration is now handled by kagenti-operator, not sidecars.
+    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}
@@ -1212,9 +1211,8 @@ def _build_tool_statefulset_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    if client_registration_inject is True:
-        labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
-        pod_labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
+    # Note: Client registration is now handled by kagenti-operator, not sidecars.
+    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -1043,8 +1043,6 @@ def _build_tool_deployment_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    # Note: Client registration is now handled by kagenti-operator, not sidecars.
-    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}
@@ -1211,8 +1209,6 @@ def _build_tool_statefulset_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    # Note: Client registration is now handled by kagenti-operator, not sidecars.
-    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1048,7 +1048,7 @@ export const ImportAgentPage: React.FC = () => {
                       setSpiffeHelperInject(undefined);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. With the default webhook settings this is two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. With the default webhook settings this is two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
               />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -190,7 +190,6 @@ export const ImportAgentPage: React.FC = () => {
   // Per-sidecar injection controls
   const [envoyProxyInject, setEnvoyProxyInject] = useState<boolean | undefined>(undefined);
   const [spiffeHelperInject, setSpiffeHelperInject] = useState<boolean | undefined>(undefined);
-  const [clientRegistrationInject, setClientRegistrationInject] = useState<boolean | undefined>(undefined);
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
@@ -502,7 +501,6 @@ export const ImportAgentPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -535,7 +533,6 @@ export const ImportAgentPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -1049,10 +1046,9 @@ export const ImportAgentPage: React.FC = () => {
                     if (checked) {
                       setEnvoyProxyInject(undefined);
                       setSpiffeHelperInject(undefined);
-                      setClientRegistrationInject(true);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation, outbound token exchange, and Keycloak client registration. With the default webhook settings this is three sidecars (envoy-proxy, spiffe-helper, client-registration) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. With the default webhook settings this is two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
               />
               </FormGroup>
 
@@ -1105,13 +1101,6 @@ export const ImportAgentPage: React.FC = () => {
                       isChecked={spiffeHelperInject !== false}
                       onChange={(_e, checked) => setSpiffeHelperInject(checked ? undefined : false)}
                       description="SPIFFE identity helper for SVID management. Disable to skip spiffe-helper sidecar."
-                    />
-                    <Checkbox
-                      id="clientRegistrationInject"
-                      label="Client Registration"
-                      isChecked={clientRegistrationInject === true}
-                      onChange={(_e, checked) => setClientRegistrationInject(checked ? true : undefined)}
-                      description="Sidecar-based Keycloak client registration. Automatically registers the workload as an OAuth2 client using its SPIFFE identity."
                     />
                   </FormGroup>
                 </>

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -989,7 +989,7 @@ export const ImportToolPage: React.FC = () => {
                       setSpiffeHelperInject(undefined);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. Default webhook settings use two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Default webhook settings use two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -158,7 +158,6 @@ export const ImportToolPage: React.FC = () => {
   // Per-sidecar injection controls
   const [envoyProxyInject, setEnvoyProxyInject] = useState<boolean | undefined>(undefined);
   const [spiffeHelperInject, setSpiffeHelperInject] = useState<boolean | undefined>(undefined);
-  const [clientRegistrationInject, setClientRegistrationInject] = useState<boolean | undefined>(undefined);
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
@@ -475,7 +474,6 @@ export const ImportToolPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -504,7 +502,6 @@ export const ImportToolPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -990,10 +987,9 @@ export const ImportToolPage: React.FC = () => {
                     if (checked) {
                       setEnvoyProxyInject(undefined);
                       setSpiffeHelperInject(undefined);
-                      setClientRegistrationInject(true);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation, outbound token exchange, and Keycloak client registration. Default webhook settings use three sidecars plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. Default webhook settings use two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
                 />
               </FormGroup>
 
@@ -1046,13 +1042,6 @@ export const ImportToolPage: React.FC = () => {
                       isChecked={spiffeHelperInject !== false}
                       onChange={(_e, checked) => setSpiffeHelperInject(checked ? undefined : false)}
                       description="SPIFFE identity helper for SVID management. Disable to skip spiffe-helper sidecar."
-                    />
-                    <Checkbox
-                      id="clientRegistrationInject"
-                      label="Client Registration"
-                      isChecked={clientRegistrationInject === true}
-                      onChange={(_e, checked) => setClientRegistrationInject(checked ? true : undefined)}
-                      description="Sidecar-based Keycloak client registration. Automatically registers the workload as an OAuth2 client using its SPIFFE identity."
                     />
                   </FormGroup>
                 </>

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -234,7 +234,6 @@ export const agentService = {
     // Per-sidecar injection controls
     envoyProxyInject?: boolean;
     spiffeHelperInject?: boolean;
-    clientRegistrationInject?: boolean;
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -446,8 +445,7 @@ export const shipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-      clientRegistrationInject?: boolean;
-      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
     defaultOutboundPolicy?: string;
@@ -539,7 +537,6 @@ export const toolService = {
     // Per-sidecar injection controls
     envoyProxyInject?: boolean;
     spiffeHelperInject?: boolean;
-    clientRegistrationInject?: boolean;
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -676,8 +673,7 @@ export const toolShipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-      clientRegistrationInject?: boolean;
-      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
     defaultOutboundPolicy?: string;

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -445,10 +445,10 @@ export const shipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
-    outboundPortsExclude?: string;
-    inboundPortsExclude?: string;
-    defaultOutboundPolicy?: string;
+      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+      outboundPortsExclude?: string;
+      inboundPortsExclude?: string;
+      defaultOutboundPolicy?: string;
       imagePullSecret?: string;
     }
   ): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
@@ -673,10 +673,10 @@ export const toolShipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
-    outboundPortsExclude?: string;
-    inboundPortsExclude?: string;
-    defaultOutboundPolicy?: string;
+      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+      outboundPortsExclude?: string;
+      inboundPortsExclude?: string;
+      defaultOutboundPolicy?: string;
       imagePullSecret?: string;
     }
   ): Promise<{ success: boolean; name: string; namespace: string; message: string }> {


### PR DESCRIPTION
## Summary

Client registration is now exclusively handled by the kagenti-operator controller (see kagenti-operator#321). The UI toggle and backend label injection for sidecar-based client registration are no longer needed.

## Changes

### UI (Frontend)
- ❌ Remove `clientRegistrationInject` toggle from ImportAgentPage and ImportToolPage
- ❌ Remove `clientRegistrationInject` field from API types
- 📝 Update AuthBridge descriptions to reflect operator-managed registration
- 📝 Change "three sidecars" → "two sidecars" (envoy-proxy + spiffe-helper, no more client-registration)

### Backend
- 🔒 Deprecate `clientRegistrationInject` parameter (still accepted for backward compatibility but ignored)
- ❌ Remove logic that sets `KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL` when field is True
- 📝 Add comments explaining client registration is now operator-managed

## Context

Per @huang195's comment:
> One thing I noticed is that we completely removed client registration image from Operator's helm values. A problem could arise since our UI still has the toggle to allow a user to select client registration to be done in a sidecar. This would break the agent if this setting is enabled. We should either remove this toggle from the UI or add the client registration back to the Operator's helm values.

This PR removes the toggle since sidecar-based client registration is sunset.

## Testing

- [ ] Deploy Kagenti from origin/main to Kind cluster
- [ ] Import weather agent with AuthBridge enabled
- [ ] Verify operator handles client registration (check keycloak-admin-secret in kagenti-system only)
- [ ] Verify no client-registration sidecar injected
- [ ] Verify weather agent works correctly

## Related

- kagenti-operator#321 - Move keycloak-admin-secret to operator namespace
- #1422 - Security fix that moved credentials to kagenti-system

Assisted-By: Claude Code