### PR TITLE
fix(kind): handle empty arrays under bash 3.2 set -u

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -196,8 +196,8 @@ echo "    Agent Sandbox: $WITH_AGENT_SANDBOX"
 echo "    Skip cluster:  $SKIP_CLUSTER"
 echo "    Build images:  $BUILD_IMAGES"
 echo "    Preload imgs:  $PRELOAD_IMAGES"
-echo "    Kagenti helm --values overrides: ${KAGENTI_VALUES_FILES[*]}"
-echo "    Kagenti-deps helm --values overrides: ${KAGENTI_DEPS_VALUES_FILES[*]}"
+echo "    Kagenti helm --values overrides: ${KAGENTI_VALUES_FILES[*]:-}"
+echo "    Kagenti-deps helm --values overrides: ${KAGENTI_DEPS_VALUES_FILES[*]:-}"
 echo ""
 
 for cmd in helm kubectl; do
@@ -552,7 +552,7 @@ DEPS_FLAGS=(
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"
   --set "components.rhoai.enabled=false"
 )
-DEPS_FLAGS=( "${DEPS_FLAGS[@]}" "${KAGENTI_DEPS_VALUES_FILES[@]}" )
+DEPS_FLAGS=( "${DEPS_FLAGS[@]}" ${KAGENTI_DEPS_VALUES_FILES[@]+"${KAGENTI_DEPS_VALUES_FILES[@]}"} )
 
 log_info "Installing kagenti-deps..."
 # --skip-crds: Gateway API CRDs already installed in Step 5 at a newer version;
@@ -1103,7 +1103,7 @@ KAGENTI_FLAGS=(
   --set "ui.auth.enabled=$($WITH_SPIRE && echo true || echo false)"
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"
 )
-KAGENTI_FLAGS=( "${KAGENTI_FLAGS[@]}" "${KAGENTI_VALUES_FILES[@]}" )
+KAGENTI_FLAGS=( "${KAGENTI_FLAGS[@]}" ${KAGENTI_VALUES_FILES[@]+"${KAGENTI_VALUES_FILES[@]}"} )
 
 # When --build-images is set, the build step tags images ":latest" and loads
 # them into Kind (see list above). Override the chart's release-pinned tags


### PR DESCRIPTION
## Summary

- Fix `setup-kagenti.sh` crash on macOS default bash 3.2 when no `--kagenti-values` or `--kagenti-deps-values` are passed
- Bash 3.2 treats empty arrays as unbound under `set -u`; bash 5.x does not
- Uses `${ARR[*]:-}` for display and `${ARR[@]+"${ARR[@]}"}` for array expansion

## Root cause

Commit a183d4d4 ("Add optional helm values file override") introduced `KAGENTI_VALUES_FILES=()` with `${KAGENTI_VALUES_FILES[*]}` expansion under `set -euo pipefail`. This works on bash 5 but fails on macOS default bash 3.2.

## Test plan

- [x] Verified fix works on `/bin/bash` (3.2) and bash 5.x
- [ ] `scripts/kind/setup-kagenti.sh --with-ui --with-spire` runs past line 199

Assisted-By: Claude Code