### PR TITLE
fix: :wrench: Update MCP gateway router tracing for MLFlow

### DIFF
--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -169,8 +169,8 @@ data:
 {{- end }}
 {{- if and .Values.components.otel.enabled .Values.components.mcpGateway.enabled }}
 ---
-# Allow workloads to push traces to the OTel collector.
-# Covers MCP Gateway router (mcp-system) and agent namespaces (team1, team2, kagenti-system).
+# Allow any mesh workload to push traces to the OTel collector.
+# Open allow-all on the collector workload avoids hardcoding agent or MCP gateway namespaces.
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -167,3 +167,22 @@ data:
   base.yaml: |
     {{- include "kagenti.otel.collectorConfig" . | nindent 4 }}
 {{- end }}
+{{- if and .Values.components.otel.enabled .Values.components.mcpGateway.enabled }}
+---
+# Allow workloads to push traces to the OTel collector.
+# Covers MCP Gateway router (mcp-system) and agent namespaces (team1, team2, kagenti-system).
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: otel-collector-from-mcp-system
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: otel-collector
+  action: ALLOW
+  rules:
+  - {}
+{{- end }}

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -167,7 +167,7 @@ data:
   base.yaml: |
     {{- include "kagenti.otel.collectorConfig" . | nindent 4 }}
 {{- end }}
-{{- if and .Values.components.otel.enabled .Values.components.mcpGateway.enabled }}
+{{- if .Values.components.otel.enabled }}
 ---
 # Allow any mesh workload to push traces to the OTel collector.
 # Open allow-all on the collector workload avoids hardcoding agent or MCP gateway namespaces.

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -181,6 +181,7 @@ otel:
       tag: "0.122.1"
     service: otel-collector.kagenti-system.svc.cluster.local
     port: 4317
+
     # Base collector configuration rendered as the ConfigMap base.yaml.
     # Override any key via values files or --set flags.
     config:
@@ -295,7 +296,8 @@ otel:
           traces:
             span:
               - 'IsMatch(name, "^a2a\\..*")'
-              - 'attributes["http.method"] != nil'
+              - 'name == "POST" or name == "GET" or name == "DELETE"'
+              - 'IsMatch(name, "^mcp-router\\..*") and (attributes["http.method"] == "GET" or attributes["http.method"] == "DELETE")'
               - 'attributes["mcp.method.name"] == "initialize"'
               - 'attributes["mcp.method.name"] == "notifications/initialized"'
               - 'attributes["mcp.method.name"] == "notifications/cancelled"'

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -296,7 +296,7 @@ otel:
           traces:
             span:
               - 'IsMatch(name, "^a2a\\..*")'
-              - 'name == "POST" or name == "GET" or name == "DELETE"'
+              - 'attributes["http.method"] != nil and IsMatch(name, "^(POST|GET|DELETE)$")'
               - 'IsMatch(name, "^mcp-router\\..*") and (attributes["http.method"] == "GET" or attributes["http.method"] == "DELETE")'
               - 'attributes["mcp.method.name"] == "initialize"'
               - 'attributes["mcp.method.name"] == "notifications/initialized"'

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1181,6 +1181,20 @@ if $WITH_MCP_GATEWAY; then
     -n mcp-system --create-namespace --version "$MCP_GATEWAY_VERSION" \
     --set "broker.create=true"
   log_success "MCP Gateway installed"
+
+  if $WITH_OTEL; then
+    # The mcp-gateway chart deploys the broker-router via its controller and does not
+    # expose OTel config via Helm values. kubectl set env is the only injection point.
+    log_info "Patching MCP Gateway router with OTel exporter..."
+    if kubectl get deployment mcp-gateway -n mcp-system &>/dev/null; then
+      run_cmd kubectl set env deployment/mcp-gateway -n mcp-system \
+        OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.kagenti-system.svc.cluster.local:8335 \
+        OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      log_success "MCP Gateway OTel exporter configured"
+    else
+      log_warn "deployment/mcp-gateway not found in mcp-system — skipping OTel patch (check chart version)"
+    fi
+  fi
 else
   log_info "Skipped (use --with-mcp-gateway)"
 fi


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

- Ports the MCP gateway otel env var patch from the Ansible installer (added in #1301) to the bash setup script setup-kagenti.sh. The MCP gateway chart  does not expose OTel config via Helm values, so kubectl set env is the only injection point.
- Adds an AuthorizationPolicy allowing any mesh workload to push traces to the OTel collector (previously blocked by  implicit deny from ambient mesh with a workload-scoped policy). Uses selector + rules: [{}] to work for any agent namespace without configuration.
- Updates the otel collecgtor configuration for MLFlow: the attributes["http.method"] != nil dropped all HTTP spans including MCP router tool call spans in MLFlow. Now we drop HTTP method verb spans (POST/GET/DELETE) and MCP gateway session handshake noise (initialize, notifications/*, tools/list, mcp-router.* GET/DELETE).
