### PR TITLE
chore: post-architecture follow-ups for kagenti-extensions#411 / kagenti-operator#361

### DIFF
--- a/.github/scripts/token-exchange/10-build-extensions.sh
+++ b/.github/scripts/token-exchange/10-build-extensions.sh
@@ -25,13 +25,16 @@ if [[ -z "$EXT_ROOT" ]]; then
   EXT_ROOT="$CLONE_DIR"
 fi
 
-# Images to build
+# Images to build. After kagenti-extensions#411 the unified binary was
+# split into three mode-specific binaries, each with its own combined
+# image (spiffe-helper bundled inside, gated by SPIRE_ENABLED). The
+# old client-registration and standalone spiffe-helper images are gone
+# (operator-managed and bundled, respectively).
 IMAGES=(
-  "authbridge-envoy:authbridge:cmd/authbridge/Dockerfile"
-  "authbridge-light:authbridge:cmd/authbridge/Dockerfile.light"
+  "authbridge:authbridge:cmd/authbridge-proxy/Dockerfile"
+  "authbridge-envoy:authbridge:cmd/authbridge-envoy/Dockerfile"
+  "authbridge-lite:authbridge:cmd/authbridge-lite/Dockerfile"
   "proxy-init:authbridge/authproxy:Dockerfile.init"
-  "client-registration:authbridge/client-registration:Dockerfile"
-  "spiffe-helper:authbridge/spiffe-helper:Dockerfile"
 )
 
 REGISTRY="ghcr.io/kagenti/kagenti-extensions"

--- a/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
+++ b/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
@@ -216,7 +216,6 @@ metadata:
   name: authbridge-runtime-config
 data:
   config.yaml: |
-    mode: envoy-sidecar
     bypass:
       inbound_paths:
         - "/.well-known/*"

--- a/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
+++ b/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
@@ -216,6 +216,12 @@ metadata:
   name: authbridge-runtime-config
 data:
   config.yaml: |
+    # Pin this E2E namespace to envoy-sidecar so the TX e2e exercises the
+    # Envoy ext_proc path explicitly (the rest of the test reads JWT SVID
+    # files via `kubectl exec -c envoy-proxy`, which only exists in this
+    # mode). Without the pin, the operator falls back to the cluster
+    # default (proxy-sidecar) and container names diverge.
+    mode: envoy-sidecar
     bypass:
       inbound_paths:
         - "/.well-known/*"

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-rc.3
-digest: sha256:64a86558be0230bee8c83880c57e5ca81389566f3bae52dcdad4fb0662edd255
-generated: "2026-05-12T15:32:56.030668-04:00"
+  version: 0.3.0-alpha.1
+digest: sha256:a0a720de063f170860ed123257ab450f3a569bdb4e55864df33f47dc4bcb9add
+generated: "2026-05-15T09:55:06.320852-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,6 +7,6 @@ appVersion: "0.6.0-rc.1"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-rc.3
+  version: 0.3.0-alpha.1
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -314,10 +314,15 @@ data:
 ---
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for AuthBridge in Namespace: {{ . }}
-#  YAML config for the authbridge binary (cmd/authbridge).
-#  Supports envoy-sidecar and proxy-sidecar modes. The mode is selected
-#  by the operator via annotation; listener addresses are injected as env
-#  vars and expanded via ${...} at startup.
+#  YAML config for the authbridge binaries (authbridge-proxy / -envoy /
+#  -lite — see kagenti-extensions#411). Supports envoy-sidecar,
+#  proxy-sidecar (default), and lite shapes. The operator resolves the
+#  per-workload mode via the chain
+#    AgentRuntime.Spec.AuthBridgeMode → this ConfigMap's `mode:` field
+#    → deprecated kagenti.io/authbridge-mode annotation → cluster default
+#  (kagenti-operator#361) and layers it onto each per-agent ConfigMap.
+#  Listener addresses are injected as env vars and expanded via ${...}
+#  at startup.
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: v1
 kind: ConfigMap
@@ -331,8 +336,10 @@ data:
   # bypass_paths, identity file paths, etc.) are applied by the
   # authbridge binary itself — see
   # authbridge/authlib/plugins/CONVENTIONS.md in kagenti-extensions.
+  #
+  # No top-level `mode:` — see the matching template-configmap in
+  # authbridge-template-configmaps.yaml for the rationale.
   config.yaml: |
-    mode: envoy-sidecar
     pipeline:
       inbound:
         plugins:
@@ -390,10 +397,12 @@ subjects:
 # ——————————————————————————————————————————————————————————————————————————————
 #  SCC RoleBinding for AuthBridge in Namespace: {{ . }}
 #  Grants the kagenti-authbridge custom SCC to all service accounts so that
-#  the webhook-injected AuthBridge stack can run:
-#    - proxy-init init container (NET_ADMIN/NET_RAW, root) for iptables
-#    - envoy-proxy sidecar (UID 1337)
-#    - authbridge-light / spiffe-helper sidecars (UID 1000)
+#  the webhook-injected AuthBridge stack can run. After kagenti-extensions#411
+#  there's a single combined sidecar per mode (spiffe-helper bundled inside,
+#  client-registration is operator-managed):
+#    - proxy-sidecar (default): authbridge container (UID 1337)
+#    - envoy-sidecar: proxy-init init container (NET_ADMIN/NET_RAW, root)
+#      for iptables, then authbridge-envoy container (UID 1337)
 #  Agent SAs are created dynamically by the operator (name = agent name),
 #  so we use the namespace service accounts group.
 #

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -42,8 +42,16 @@ data:
   # bypass_paths, identity file paths, etc.) are applied by the
   # authbridge binary itself — see
   # authbridge/authlib/plugins/CONVENTIONS.md in kagenti-extensions.
+  #
+  # No top-level `mode:` is set here. After kagenti-operator#361 the
+  # operator resolves mode per workload from
+  #   AgentRuntime.Spec.AuthBridgeMode → namespace ConfigMap (this one,
+  #   if it had a `mode:`) → deprecated annotation → cluster default,
+  # then layers the resolved mode onto each per-agent ConfigMap. Leaving
+  # `mode:` unset here keeps this template mode-agnostic so the cluster
+  # default (proxy-sidecar) wins by default, and a namespace-level
+  # override can still be added later by editing this ConfigMap.
   config.yaml: |
-    mode: envoy-sidecar
     pipeline:
       inbound:
         plugins:

--- a/charts/kagenti/templates/kagenti-authbridge-scc.yaml
+++ b/charts/kagenti/templates/kagenti-authbridge-scc.yaml
@@ -2,17 +2,22 @@
 # ——————————————————————————————————————————————————————————————————————————————
 #  Custom SCC for AuthBridge sidecars in agent namespaces.
 #
-#  The kagenti-webhook injects an AuthBridge sidecar stack into agent pods:
-#    - proxy-init (init): iptables interception (needs NET_ADMIN/NET_RAW, root, non-privileged)
-#    - envoy-proxy (sidecar): Envoy for auth token injection (requests UID 1337)
-#    - authbridge-light (sidecar): OAuth token management (no hardcoded UID)
-#    - spiffe-helper (sidecar): SPIRE identity (UBI image, no hardcoded UID)
+#  The kagenti-webhook injects an AuthBridge sidecar stack into agent pods.
+#  After kagenti-extensions#411 there's a single combined sidecar per mode
+#  (spiffe-helper bundled inside, client-registration is operator-managed):
+#    - proxy-sidecar (default): authbridge container (UID 1337)
+#    - envoy-sidecar:
+#        - proxy-init (init): iptables interception
+#          (NET_ADMIN/NET_RAW, root, non-privileged)
+#        - authbridge-envoy (sidecar): Envoy + ext_proc + spiffe-helper
+#          (UID 1337)
 #
 #  This SCC grants the minimum permissions needed for AuthBridge sidecars:
 #    - proxy-init needs root + NET_ADMIN/NET_RAW capabilities (not privileged mode)
-#    - envoy-proxy requests UID 1337 (for iptables exclusion coordination)
-#    - authbridge-light and spiffe-helper run as image-default UIDs (no override)
-#  RunAsAny is required because proxy-init needs root and envoy needs UID 1337.
+#    - the combined authbridge / authbridge-envoy sidecar runs as UID 1337
+#      (matches Envoy's traditional UID for iptables exclusion coordination
+#      and is preserved by authbridge-proxy for image consistency)
+#  RunAsAny is required because proxy-init needs root and the sidecar needs UID 1337.
 #  Bound to agent namespaces via the `groups` field below.
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: security.openshift.io/v1

--- a/charts/kagenti/templates/kagenti-authbridge-scc.yaml
+++ b/charts/kagenti/templates/kagenti-authbridge-scc.yaml
@@ -5,12 +5,13 @@
 #  The kagenti-webhook injects an AuthBridge sidecar stack into agent pods.
 #  After kagenti-extensions#411 there's a single combined sidecar per mode
 #  (spiffe-helper bundled inside, client-registration is operator-managed):
-#    - proxy-sidecar (default): authbridge container (UID 1337)
+#    - proxy-sidecar (default): container "authbridge-proxy"
+#      from the "authbridge" image (UID 1337)
 #    - envoy-sidecar:
 #        - proxy-init (init): iptables interception
 #          (NET_ADMIN/NET_RAW, root, non-privileged)
-#        - authbridge-envoy (sidecar): Envoy + ext_proc + spiffe-helper
-#          (UID 1337)
+#        - container "envoy-proxy" from the "authbridge-envoy" image:
+#          Envoy + ext_proc + spiffe-helper (UID 1337)
 #
 #  This SCC grants the minimum permissions needed for AuthBridge sidecars:
 #    - proxy-init needs root + NET_ADMIN/NET_RAW capabilities (not privileged mode)

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -221,7 +221,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-rc.3
+        tag: 0.3.0-alpha.1
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -246,16 +246,24 @@ kagenti-operator-chart:
   signatureVerification:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
-  # NOTE: The client-registration sidecar has been sunset.
-  # v0.5.0-rc.2 includes per-plugin config support (extensions#378) and
-  # keycloak_url/keycloak_realm fields in jwt-validation (extensions#383),
-  # required for compatibility with operator v0.2.0-rc.3's synthesizePipeline output.
+  #
+  # After kagenti-extensions#411 there are three combined images:
+  #   * authbridge      — proxy-sidecar mode (default), full plugin set
+  #                       including the a2a/mcp/inference parsers.
+  #   * authbridge-envoy — envoy-sidecar mode, full plugin set, expects
+  #                       proxyInit's iptables setup.
+  #   * authbridge-lite  — proxy-sidecar shape, auth-only plugins
+  #                       (parsers dropped). For size-constrained deployments;
+  #                       not selected by default.
+  # Spiffe-helper is bundled inside each combined image and gated per
+  # workload by the SPIRE_ENABLED env var; it is no longer a separate
+  # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.2
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-rc.2
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-rc.2
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-rc.2
+      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.1
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.1
+      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.1
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.1
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -2,39 +2,68 @@
 
 ## Deployment Modes
 
-AuthBridge supports deployment modes `envoy-sidecar`, `waypoint`, and `proxy-sidecar`.
-The proxy-sidecar mode is the recommended default for most environments.
+AuthBridge ships three combined sidecar images, each hardcoded to its
+deployment shape (kagenti-extensions#411):
 
-| | Proxy-Sidecar (default) | Envoy-Sidecar (advanced) |
-|---|---|---|
-| **Containers per pod** | 1 sidecar | 2+ (Envoy + processor + init) |
-| **Memory overhead** | ~15-30 MB | ~150-200 MB |
-| **Privileged mode** | No | Yes (iptables init) |
-| **Interception** | HTTP_PROXY env vars | iptables NAT rules |
-| **Debugging** | Standard HTTP proxy logs | iptables chains + Envoy stats + ext_proc |
-| **Image** | `authbridge-light` (29 MB, distroless) | `authbridge-envoy` (140 MB, UBI9-micro) |
-| **Use when** | Standard deployments | Need transparent interception of non-HTTP protocols |
+| | `authbridge` (proxy-sidecar, default) | `authbridge-envoy` (envoy-sidecar, advanced) | `authbridge-lite` (proxy-sidecar, auth-only) |
+|---|---|---|---|
+| **Containers per pod** | 1 combined sidecar | 1 combined sidecar + proxy-init container | 1 combined sidecar |
+| **Privileged mode** | No | Yes (iptables init) | No |
+| **Interception** | HTTP_PROXY env vars | iptables NAT rules | HTTP_PROXY env vars |
+| **Plugins included** | jwt-validation + token-exchange + a2a/mcp/inference parsers | Same as proxy-sidecar | jwt-validation + token-exchange only |
+| **Use when** | Standard deployments | Need transparent interception of non-HTTP protocols | Size-constrained / no protocol-aware events |
+
+`spiffe-helper` is bundled inside every combined image and runs only when the
+operator sets `SPIRE_ENABLED=true` on the workload (driven by the
+`kagenti.io/spire: enabled` label). Client registration is handled by the
+operator's reconciler — there's no in-pod client-registration sidecar.
+
+## Selecting a mode
+
+The operator resolves mode per workload from this chain
+(kagenti-operator#361):
+
+1. `AgentRuntime.Spec.AuthBridgeMode` on the workload's CR (canonical).
+2. `mode:` field on the namespace-level `authbridge-runtime-config` ConfigMap.
+3. The deprecated `kagenti.io/authbridge-mode` pod annotation (still honored).
+4. Cluster-wide default (`proxy-sidecar`).
+
+```yaml
+# Canonical: per-workload override on the AgentRuntime CR
+apiVersion: kagenti.io/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: weather-service
+spec:
+  authBridgeMode: envoy-sidecar
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: weather-service
+```
+
+The deprecated annotation is retained for tools and other workloads that
+don't have their own AgentRuntime CR yet:
+
+```yaml
+metadata:
+  labels:
+    kagenti.io/type: tool
+  annotations:
+    kagenti.io/authbridge-mode: "envoy-sidecar"
+```
 
 ## Proxy-Sidecar Mode (Default)
 
 ### How It Works
 
-The Kagenti operator webhook automatically injects the AuthBridge sidecar when it
-detects the `kagenti.io/type: agent` label on a pod:
+The Kagenti operator webhook injects a single `authbridge` container when
+the workload's resolved mode is `proxy-sidecar`:
 
 1. The reverse proxy takes over the agent's original port (e.g., `:8000`)
 2. The agent is moved to a free port (e.g., `:8001`) via `PORT` env var
 3. `HTTP_PROXY` and `HTTPS_PROXY` env vars are injected into the agent container
 4. The Kubernetes Service targetPort remains unchanged — traffic flows through the proxy
-
-```yaml
-# To use proxy-sidecar mode, annotate your workload:
-metadata:
-  labels:
-    kagenti.io/type: agent
-  annotations:
-    kagenti.io/authbridge-mode: "proxy-sidecar"
-```
 
 ### Traffic Flow
 
@@ -46,83 +75,80 @@ Outbound:  Agent → HTTP_PROXY → Forward Proxy → Token Exchange → Externa
 ## Envoy-Sidecar Mode (Advanced)
 
 For environments that require transparent interception of all TCP traffic
-(not just HTTP), the Envoy-sidecar mode uses iptables to redirect traffic:
+(not just HTTP), envoy-sidecar mode uses iptables to redirect traffic
+through Envoy with an ext_proc gRPC filter:
 
 ```yaml
-# Envoy-sidecar is the default if no annotation is set, but will change to
-# proxy-sidecar in a future release
-metadata:
-  labels:
-    kagenti.io/type: agent
-  # No annotation = envoy-sidecar (current default)
+spec:
+  authBridgeMode: envoy-sidecar
 ```
 
-This mode requires privileged mode for the iptables init container and adds
-a sidecar running [Envoy](https://www.envoyproxy.io/docs/envoy/latest/) as a
-dependency. Use it only when you need protocol-level transparent interception.
+This mode requires privileged mode for the `proxy-init` iptables init
+container and uses [Envoy](https://www.envoyproxy.io/docs/envoy/latest/)
+as the data path inside the combined `authbridge-envoy` container. Use it
+only when you need protocol-level transparent interception.
 
 ## Configuration
 
 AuthBridge is configured via YAML with `${ENV_VAR}` expansion. The operator
 mounts the configuration from a ConfigMap such as `authbridge-config-weather-service`.
 
-### Minimal Proxy-Sidecar Config
+After kagenti-extensions#411 the runtime config uses a per-plugin
+schema: every plugin-specific setting lives under its own `config:`
+block inside `pipeline.inbound.plugins[]` or
+`pipeline.outbound.plugins[]`. Plugin-level defaults (audience_file,
+bypass_paths, identity file paths) are applied by the authbridge
+binary itself — see `authbridge/authlib/plugins/CONVENTIONS.md` in
+kagenti-extensions for the full reference. The chart-rendered
+ConfigMaps and the backend's per-agent ConfigMap renderer both emit
+this shape.
+
+### Minimal config (mode-agnostic)
 
 ```yaml
-mode: proxy-sidecar
-listener:
-  reverse_proxy_backend: "http://localhost:8081"
-inbound:
-  issuer: "${ISSUER}"
-outbound:
-  keycloak_url: "${KEYCLOAK_URL}"
-  keycloak_realm: "${KEYCLOAK_REALM}"
-identity:
-  type: spiffe
-  client_id: "${CLIENT_ID}"
-  jwt_svid_path: "/opt/jwt_svid.token"
-routes:
-  rules:
-    - host: "weather-api.example.com"
-      target_audience: "weather-api"
-```
-
-### Minimal Envoy-Sidecar Config
-
-```yaml
-mode: envoy-sidecar
-inbound:
-  issuer: "${ISSUER}"
-outbound:
-  keycloak_url: "${KEYCLOAK_URL}"
-  keycloak_realm: "${KEYCLOAK_REALM}"
-  default_policy: "passthrough"
-identity:
-  type: spiffe
-  client_id: "${CLIENT_ID}"
-  jwt_svid_path: "/opt/jwt_svid.token"
-routes:
-  file: "/etc/authproxy/routes.yaml"
+# No top-level mode: — the operator resolves it per workload (CR →
+# namespace ConfigMap → annotation → cluster default) and layers the
+# resolved value onto each per-agent ConfigMap.
+pipeline:
+  inbound:
+    plugins:
+      - name: jwt-validation
+        config:
+          issuer: "${ISSUER}"
+          keycloak_url: "${KEYCLOAK_URL}"
+          keycloak_realm: "${KEYCLOAK_REALM}"
+  outbound:
+    plugins:
+      - name: token-exchange
+        config:
+          keycloak_url: "${KEYCLOAK_URL}"
+          keycloak_realm: "${KEYCLOAK_REALM}"
+          default_policy: "passthrough"
+          identity:
+            type: spiffe
 ```
 
 ### Configuration Reference
 
-| Field | Description | Default |
-|---|---|---|
-| `mode` | Deployment mode: `proxy-sidecar`, `envoy-sidecar`, `waypoint` | `envoy-sidecar` |
-| `inbound.issuer` | Expected JWT issuer for inbound validation | Derived from keycloak_url |
-| `inbound.jwks_url` | JWKS endpoint for signature verification | Derived from token_url |
-| `outbound.token_url` | Keycloak token endpoint | Derived from keycloak_url + realm |
-| `outbound.keycloak_url` | Keycloak base URL | Required |
-| `outbound.keycloak_realm` | Keycloak realm name | Required |
-| `outbound.default_policy` | `passthrough` or `exchange` | `passthrough` |
-| `identity.type` | `spiffe` or `client-secret` | Required |
-| `identity.client_id` | OAuth client ID (or file path with `client_id_file`) | Required |
-| `identity.jwt_svid_path` | Path to SPIFFE JWT-SVID token file | — |
-| `routes.rules[].host` | Glob pattern for destination host | — |
-| `routes.rules[].target_audience` | OAuth audience for token exchange | — |
-| `routes.rules[].token_scopes` | Space-separated scopes to request | `openid` |
-| `bypass.inbound_paths` | Paths to skip inbound JWT validation | `/.well-known/*, /healthz, /readyz, /livez` |
+The fields below appear inside each plugin's `config:` block, not at
+the top level. See `authbridge/docs/plugin-reference.md` in
+kagenti-extensions for the per-plugin authoritative reference.
+
+| Field | Plugin | Description | Default |
+|---|---|---|---|
+| `mode` (top-level) | — | Deployment mode: `proxy-sidecar`, `envoy-sidecar`, `lite`, `waypoint`. Usually unset; layered in by the operator. | `proxy-sidecar` |
+| `issuer` | jwt-validation | Expected JWT issuer for inbound validation | Derived from keycloak_url |
+| `jwks_url` | jwt-validation | JWKS endpoint for signature verification | Derived from issuer |
+| `keycloak_url` | jwt-validation, token-exchange | Internal Keycloak base URL | Required |
+| `keycloak_realm` | jwt-validation, token-exchange | Keycloak realm name | Required |
+| `token_url` | token-exchange | Keycloak token endpoint | Derived from keycloak_url + realm |
+| `default_policy` | token-exchange | `passthrough` or `exchange` | `passthrough` |
+| `identity.type` | token-exchange | `spiffe` or `client-secret` | Required |
+| `routes.file` | token-exchange | Path to `routes.yaml` (per-host token exchange rules) | `/etc/authproxy/routes.yaml` |
+| `routes.rules[].host` | token-exchange | Glob pattern for destination host | — |
+| `routes.rules[].target_audience` | token-exchange | OAuth audience for token exchange | — |
+| `routes.rules[].token_scopes` | token-exchange | Space-separated scopes to request | `openid` |
+| `bypass_paths` | jwt-validation | Paths to skip inbound JWT validation | `/.well-known/*, /healthz, /readyz, /livez` |
 
 ### URL Derivation
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -68,7 +68,7 @@ artifacts when a tag is pushed:
 | Repository | Artifacts on tag push | CI workflow(s) |
 |------------|----------------------|----------------|
 | [kagenti/kagenti](https://github.com/kagenti/kagenti) | Container images (ui-v2, backend, oauth-secrets), Helm charts (kagenti, kagenti-deps) | `build.yaml` |
-| [kagenti/kagenti-extensions](https://github.com/kagenti/kagenti-extensions) | Container images (authbridge-envoy, authbridge-light, proxy-init, client-registration, spiffe-helper) | `build.yaml` |
+| [kagenti/kagenti-extensions](https://github.com/kagenti/kagenti-extensions) | Container images (authbridge, authbridge-envoy, authbridge-lite, proxy-init) | `build.yaml` |
 | [kagenti/kagenti-operator](https://github.com/kagenti/kagenti-operator) | Operator image, Helm chart (kagenti-operator-chart) | repo-specific |
 | [kagenti/agent-examples](https://github.com/kagenti/agent-examples) | Sample agent/tool images | repo-specific |
 

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -34,10 +34,13 @@ APP_KUBERNETES_IO_COMPONENT = "app.kubernetes.io/component"
 KAGENTI_SPIRE_LABEL = "kagenti.io/spire"
 KAGENTI_SPIRE_ENABLED_VALUE = "enabled"
 
-# Per-sidecar injection labels (matched by kagenti-webhook precedence evaluator)
-KAGENTI_ENVOY_PROXY_INJECT_LABEL = "kagenti.io/envoy-proxy-inject"
-KAGENTI_SPIFFE_HELPER_INJECT_LABEL = "kagenti.io/spiffe-helper-inject"
-KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL = "kagenti.io/client-registration-inject"
+# Per-sidecar injection labels are gone after kagenti-extensions#411 /
+# kagenti-operator#361: the per-sidecar split (envoy-proxy +
+# spiffe-helper + client-registration) collapsed into one combined
+# authbridge container, spiffe-helper bundled and gated by
+# SPIRE_ENABLED, client-registration operator-managed. Per-workload
+# mode selection moved to AgentRuntime.Spec.AuthBridgeMode (label-based
+# selection no longer exists).
 
 # Port exclusion annotations (matched by kagenti-webhook init-iptables.sh)
 KAGENTI_OUTBOUND_PORTS_EXCLUDE = "kagenti.io/outbound-ports-exclude"

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -34,13 +34,11 @@ APP_KUBERNETES_IO_COMPONENT = "app.kubernetes.io/component"
 KAGENTI_SPIRE_LABEL = "kagenti.io/spire"
 KAGENTI_SPIRE_ENABLED_VALUE = "enabled"
 
-# Per-sidecar injection labels are gone after kagenti-extensions#411 /
-# kagenti-operator#361: the per-sidecar split (envoy-proxy +
-# spiffe-helper + client-registration) collapsed into one combined
-# authbridge container, spiffe-helper bundled and gated by
-# SPIRE_ENABLED, client-registration operator-managed. Per-workload
-# mode selection moved to AgentRuntime.Spec.AuthBridgeMode (label-based
-# selection no longer exists).
+# Per-sidecar opt-out labels (envoy-proxy / spiffe-helper /
+# client-registration) are gone after kagenti-extensions#411 — they
+# referenced separate sidecars that no longer exist. The master enable
+# /disable trigger is still KAGENTI_INJECT_LABEL above; per-workload
+# mode now lives on AgentRuntime.Spec.AuthBridgeMode.
 
 # Port exclusion annotations (matched by kagenti-webhook init-iptables.sh)
 KAGENTI_OUTBOUND_PORTS_EXCLUDE = "kagenti.io/outbound-ports-exclude"

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -70,10 +70,6 @@ from app.core.constants import (
     # SPIRE identity constants
     KAGENTI_SPIRE_LABEL,
     KAGENTI_SPIRE_ENABLED_VALUE,
-    # Per-sidecar injection labels
-    KAGENTI_ENVOY_PROXY_INJECT_LABEL,
-    KAGENTI_SPIFFE_HELPER_INJECT_LABEL,
-    KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL,
     # Port exclusion annotations
     KAGENTI_OUTBOUND_PORTS_EXCLUDE,
     KAGENTI_INBOUND_PORTS_EXCLUDE,
@@ -244,13 +240,15 @@ class CreateAgentRequest(BaseModel):
 
     # AuthBridge sidecar injection (default enabled for agents)
     authBridgeEnabled: bool = True
-    # SPIRE identity (spiffe-helper sidecar injection)
+    # SPIRE identity (gates spiffe-helper inside the combined authbridge container)
     spireEnabled: bool = False
 
-    # Per-sidecar injection controls (None = use webhook defaults)
-    envoyProxyInject: Optional[bool] = None
-    spiffeHelperInject: Optional[bool] = None
-    clientRegistrationInject: Optional[bool] = None
+    # Per-workload AuthBridge mode override. Maps to
+    # AgentRuntime.Spec.AuthBridgeMode; when None the operator falls
+    # back through namespace ConfigMap → cluster default
+    # (proxy-sidecar). The lite/waypoint shapes are accepted by the
+    # operator but not surfaced through the UI today.
+    authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
 
     # Port exclusion annotations
     outboundPortsExclude: Optional[str] = None
@@ -2026,8 +2024,11 @@ def _build_authbridge_runtime_yaml(
     # kagenti-extensions#383.
     # Note: Remember to keep AuthBridgeConfig in kagenti/ui-v2/src/types/index.ts
     # in sync with this YAML runtime configuration.
+    # No top-level `mode:` — the operator resolves it per workload from
+    # AgentRuntime.Spec.AuthBridgeMode → namespace ConfigMap →
+    # cluster default (proxy-sidecar). Hardcoding it here would pin
+    # every backend-rendered ConfigMap to one shape regardless of CR.
     config = {
-        "mode": "envoy-sidecar",
         "pipeline": {
             "inbound": {
                 "plugins": [
@@ -2275,9 +2276,7 @@ def _build_agent_shipwright_build_manifest(
         "workloadType": request.workloadType,  # Store workload type for finalization
         "authBridgeEnabled": request.authBridgeEnabled,
         "spireEnabled": request.spireEnabled,
-        "envoyProxyInject": request.envoyProxyInject,
-        "spiffeHelperInject": request.spiffeHelperInject,
-        "clientRegistrationInject": request.clientRegistrationInject,
+        "authBridgeMode": request.authBridgeMode,
     }
     if request.outboundRoutes:
         resource_config["outboundRoutes"] = [r.model_dump() for r in request.outboundRoutes]
@@ -2406,14 +2405,10 @@ def _build_common_labels(
     # Protocol label(s) using new prefix format
     if request.protocol:
         labels[f"{PROTOCOL_LABEL_PREFIX}{request.protocol}"] = ""
-    # SPIRE identity label (triggers spiffe-helper sidecar injection by kagenti-webhook)
+    # SPIRE identity label — the operator's webhook reads this to set
+    # SPIRE_ENABLED=true on the combined sidecar's spiffe-helper.
     if request.spireEnabled:
         labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
-    # Per-sidecar injection labels (opt-out for envoy/spiffe, opt-in for client-registration)
-    if request.envoyProxyInject is False:
-        labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
-    if request.spiffeHelperInject is False:
-        labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
     return labels
 
 
@@ -2448,12 +2443,23 @@ def _build_agentruntime_manifest(
     namespace: str,
     workload_type: str,
     agent_type: str = RESOURCE_TYPE_AGENT,
+    auth_bridge_mode: Optional[str] = None,
 ) -> dict:
     """Build an AgentRuntime CR manifest for the given workload."""
     kind_map = {
         WORKLOAD_TYPE_DEPLOYMENT: "Deployment",
         WORKLOAD_TYPE_STATEFULSET: "StatefulSet",
     }
+    spec: dict = {
+        "type": agent_type,
+        "targetRef": {
+            "apiVersion": "apps/v1",
+            "kind": kind_map.get(workload_type, "Deployment"),
+            "name": name,
+        },
+    }
+    if auth_bridge_mode:
+        spec["authBridgeMode"] = auth_bridge_mode
     return {
         "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
         "kind": "AgentRuntime",
@@ -2465,14 +2471,7 @@ def _build_agentruntime_manifest(
                 APP_KUBERNETES_IO_MANAGED_BY: KAGENTI_UI_CREATOR_LABEL,
             },
         },
-        "spec": {
-            "type": agent_type,
-            "targetRef": {
-                "apiVersion": "apps/v1",
-                "kind": kind_map.get(workload_type, "Deployment"),
-                "name": name,
-            },
-        },
+        "spec": spec,
     }
 
 
@@ -2482,9 +2481,12 @@ def _ensure_agentruntime(
     namespace: str,
     workload_type: str,
     agent_type: str = RESOURCE_TYPE_AGENT,
+    auth_bridge_mode: Optional[str] = None,
 ) -> None:
     """Create an AgentRuntime CR for the workload. Skip if it already exists."""
-    manifest = _build_agentruntime_manifest(name, namespace, workload_type, agent_type)
+    manifest = _build_agentruntime_manifest(
+        name, namespace, workload_type, agent_type, auth_bridge_mode
+    )
     try:
         kube.create_custom_resource(
             group=CRD_GROUP,
@@ -3088,6 +3090,7 @@ async def create_agent(
                     name=request.name,
                     namespace=request.namespace,
                     workload_type=request.workloadType,
+                    auth_bridge_mode=request.authBridgeMode,
                 )
 
             message = f"Agent '{request.name}' deployed as {request.workloadType} successfully."
@@ -3208,9 +3211,7 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     createHttpRoute: Optional[bool] = None
     authBridgeEnabled: Optional[bool] = None
     imagePullSecret: Optional[str] = None
-    envoyProxyInject: Optional[bool] = None
-    spiffeHelperInject: Optional[bool] = None
-    clientRegistrationInject: Optional[bool] = None
+    authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
     outboundRoutes: Optional[List[OutboundRoute]] = None
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
@@ -3457,21 +3458,11 @@ async def finalize_shipwright_build(
         elif stored_routes:
             final_outbound_routes = [OutboundRoute(**r) for r in stored_routes]
 
-        # Per-sidecar injection controls
-        final_envoy_proxy_inject = (
-            request.envoyProxyInject
-            if request.envoyProxyInject is not None
-            else stored_config.get("envoyProxyInject")
-        )
-        final_spiffe_helper_inject = (
-            request.spiffeHelperInject
-            if request.spiffeHelperInject is not None
-            else stored_config.get("spiffeHelperInject")
-        )
-        final_client_registration_inject = (
-            request.clientRegistrationInject
-            if request.clientRegistrationInject is not None
-            else stored_config.get("clientRegistrationInject")
+        # Per-workload AuthBridge mode override
+        final_auth_bridge_mode = (
+            request.authBridgeMode
+            if request.authBridgeMode is not None
+            else stored_config.get("authBridgeMode")
         )
 
         # Step 3: Create workload + Service with the built image
@@ -3490,9 +3481,7 @@ async def finalize_shipwright_build(
             createHttpRoute=final_create_route,
             authBridgeEnabled=final_auth_bridge,
             spireEnabled=final_spire_enabled,
-            envoyProxyInject=final_envoy_proxy_inject,
-            spiffeHelperInject=final_spiffe_helper_inject,
-            clientRegistrationInject=final_client_registration_inject,
+            authBridgeMode=final_auth_bridge_mode,
             outboundRoutes=final_outbound_routes,
             outboundPortsExclude=final_outbound_ports_exclude,
             inboundPortsExclude=final_inbound_ports_exclude,
@@ -3627,6 +3616,7 @@ async def finalize_shipwright_build(
                 name=name,
                 namespace=namespace,
                 workload_type=final_workload_type,
+                auth_bridge_mode=final_auth_bridge_mode,
             )
 
         message = f"Agent '{name}' deployed as {final_workload_type} with image '{output_image}'."

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -50,10 +50,6 @@ from app.core.constants import (
     # SPIRE identity constants
     KAGENTI_SPIRE_LABEL,
     KAGENTI_SPIRE_ENABLED_VALUE,
-    # Per-sidecar injection labels
-    KAGENTI_ENVOY_PROXY_INJECT_LABEL,
-    KAGENTI_SPIFFE_HELPER_INJECT_LABEL,
-    KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL,
     KAGENTI_OUTBOUND_PORTS_EXCLUDE,
     KAGENTI_INBOUND_PORTS_EXCLUDE,
 )
@@ -229,13 +225,12 @@ class CreateToolRequest(BaseModel):
 
     # AuthBridge sidecar injection (default disabled for tools)
     authBridgeEnabled: bool = False
-    # SPIRE identity (spiffe-helper sidecar injection)
+    # SPIRE identity (gates spiffe-helper inside the combined authbridge container)
     spireEnabled: bool = False
 
-    # Per-sidecar injection controls (None = use webhook defaults)
-    envoyProxyInject: Optional[bool] = None
-    spiffeHelperInject: Optional[bool] = None
-    clientRegistrationInject: Optional[bool] = None
+    # Per-workload AuthBridge mode override (maps to
+    # AgentRuntime.Spec.AuthBridgeMode; None means cluster default).
+    authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
 
     # Port exclusion annotations
     outboundPortsExclude: Optional[str] = None
@@ -260,9 +255,7 @@ class FinalizeToolBuildRequest(BaseModel):
     createHttpRoute: Optional[bool] = None
     authBridgeEnabled: Optional[bool] = None
     imagePullSecret: Optional[str] = None
-    envoyProxyInject: Optional[bool] = None
-    spiffeHelperInject: Optional[bool] = None
-    clientRegistrationInject: Optional[bool] = None
+    authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
     outboundRoutes: Optional[List[OutboundRoute]] = None
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
@@ -529,9 +522,7 @@ def _build_tool_shipwright_build_manifest(
         "workloadType": request.workloadType,
         "authBridgeEnabled": request.authBridgeEnabled,
         "spireEnabled": request.spireEnabled,
-        "envoyProxyInject": request.envoyProxyInject,
-        "spiffeHelperInject": request.spiffeHelperInject,
-        "clientRegistrationInject": request.clientRegistrationInject,
+        "authBridgeMode": request.authBridgeMode,
     }
     if request.outboundRoutes:
         resource_config["outboundRoutes"] = [r.model_dump() for r in request.outboundRoutes]
@@ -978,11 +969,9 @@ def _build_tool_deployment_manifest(
     shipwright_build_name: Optional[str] = None,
     auth_bridge_enabled: bool = False,
     spire_enabled: bool = False,
-    envoy_proxy_inject: Optional[bool] = None,
-    spiffe_helper_inject: Optional[bool] = None,
-    client_registration_inject: Optional[bool] = None,
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
+    auth_bridge_mode: Optional[str] = None,
 ) -> dict:
     """
     Build a Kubernetes Deployment manifest for an MCP tool.
@@ -1037,12 +1026,6 @@ def _build_tool_deployment_manifest(
     if spire_enabled:
         labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
         pod_labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
-    if envoy_proxy_inject is False:
-        labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
-        pod_labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
-    if spiffe_helper_inject is False:
-        labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-        pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
 
     # Build annotations
     annotations = {}
@@ -1055,6 +1038,12 @@ def _build_tool_deployment_manifest(
         pod_annotations[KAGENTI_OUTBOUND_PORTS_EXCLUDE] = outbound_ports_exclude
     if inbound_ports_exclude:
         pod_annotations[KAGENTI_INBOUND_PORTS_EXCLUDE] = inbound_ports_exclude
+    if auth_bridge_mode:
+        # The deprecated kagenti.io/authbridge-mode annotation is the
+        # only per-pod mode override path for workloads without an
+        # AgentRuntime CR (tools today). The operator's resolution
+        # chain still honors it.
+        pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
 
     manifest = {
         "apiVersion": "apps/v1",
@@ -1140,11 +1129,9 @@ def _build_tool_statefulset_manifest(
     storage_size: str = "1Gi",
     auth_bridge_enabled: bool = False,
     spire_enabled: bool = False,
-    envoy_proxy_inject: Optional[bool] = None,
-    spiffe_helper_inject: Optional[bool] = None,
-    client_registration_inject: Optional[bool] = None,
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
+    auth_bridge_mode: Optional[str] = None,
 ) -> dict:
     """
     Build a Kubernetes StatefulSet manifest for an MCP tool.
@@ -1203,12 +1190,6 @@ def _build_tool_statefulset_manifest(
     if spire_enabled:
         labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
         pod_labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
-    if envoy_proxy_inject is False:
-        labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
-        pod_labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
-    if spiffe_helper_inject is False:
-        labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-        pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
 
     # Build annotations
     annotations = {}
@@ -1221,6 +1202,12 @@ def _build_tool_statefulset_manifest(
         pod_annotations[KAGENTI_OUTBOUND_PORTS_EXCLUDE] = outbound_ports_exclude
     if inbound_ports_exclude:
         pod_annotations[KAGENTI_INBOUND_PORTS_EXCLUDE] = inbound_ports_exclude
+    if auth_bridge_mode:
+        # The deprecated kagenti.io/authbridge-mode annotation is the
+        # only per-pod mode override path for workloads without an
+        # AgentRuntime CR (tools today). The operator's resolution
+        # chain still honors it.
+        pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
 
     manifest = {
         "apiVersion": "apps/v1",
@@ -1521,11 +1508,9 @@ async def create_tool(
                     description=description,
                     auth_bridge_enabled=request.authBridgeEnabled,
                     spire_enabled=request.spireEnabled,
-                    envoy_proxy_inject=request.envoyProxyInject,
-                    spiffe_helper_inject=request.spiffeHelperInject,
-                    client_registration_inject=request.clientRegistrationInject,
                     outbound_ports_exclude=request.outboundPortsExclude,
                     inbound_ports_exclude=request.inboundPortsExclude,
+                    auth_bridge_mode=request.authBridgeMode,
                 )
                 kube.create_statefulset(request.namespace, workload_manifest)
                 logger.info(
@@ -1545,11 +1530,9 @@ async def create_tool(
                     description=description,
                     auth_bridge_enabled=request.authBridgeEnabled,
                     spire_enabled=request.spireEnabled,
-                    envoy_proxy_inject=request.envoyProxyInject,
-                    spiffe_helper_inject=request.spiffeHelperInject,
-                    client_registration_inject=request.clientRegistrationInject,
                     outbound_ports_exclude=request.outboundPortsExclude,
                     inbound_ports_exclude=request.inboundPortsExclude,
+                    auth_bridge_mode=request.authBridgeMode,
                 )
                 kube.create_deployment(request.namespace, workload_manifest)
                 logger.info(
@@ -1906,21 +1889,11 @@ async def finalize_tool_shipwright_build(
         elif stored_routes:
             final_outbound_routes = [OutboundRoute(**r) for r in stored_routes]
 
-        # Per-sidecar injection controls
-        envoy_proxy_inject = (
-            request.envoyProxyInject
-            if request.envoyProxyInject is not None
-            else tool_config_dict.get("envoyProxyInject")
-        )
-        spiffe_helper_inject = (
-            request.spiffeHelperInject
-            if request.spiffeHelperInject is not None
-            else tool_config_dict.get("spiffeHelperInject")
-        )
-        client_registration_inject = (
-            request.clientRegistrationInject
-            if request.clientRegistrationInject is not None
-            else tool_config_dict.get("clientRegistrationInject")
+        # Per-workload AuthBridge mode override
+        auth_bridge_mode = (
+            request.authBridgeMode
+            if request.authBridgeMode is not None
+            else tool_config_dict.get("authBridgeMode")
         )
 
         # Port exclusion and policy overrides
@@ -1989,11 +1962,9 @@ async def finalize_tool_shipwright_build(
                 storage_size=storage_size,
                 auth_bridge_enabled=auth_bridge_enabled,
                 spire_enabled=spire_enabled,
-                envoy_proxy_inject=envoy_proxy_inject,
-                spiffe_helper_inject=spiffe_helper_inject,
-                client_registration_inject=client_registration_inject,
                 outbound_ports_exclude=outbound_ports_exclude,
                 inbound_ports_exclude=inbound_ports_exclude,
+                auth_bridge_mode=auth_bridge_mode,
             )
             kube.create_statefulset(namespace, workload_manifest)
             logger.info(
@@ -2014,11 +1985,9 @@ async def finalize_tool_shipwright_build(
                 shipwright_build_name=name,
                 auth_bridge_enabled=auth_bridge_enabled,
                 spire_enabled=spire_enabled,
-                envoy_proxy_inject=envoy_proxy_inject,
-                spiffe_helper_inject=spiffe_helper_inject,
-                client_registration_inject=client_registration_inject,
                 outbound_ports_exclude=outbound_ports_exclude,
                 inbound_ports_exclude=inbound_ports_exclude,
+                auth_bridge_mode=auth_bridge_mode,
             )
             kube.create_deployment(namespace, workload_manifest)
             logger.info(

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -35,7 +35,13 @@ def test_build_authbridge_runtime_yaml_client_secret():
     )
     cfg = yaml.safe_load(result)
 
-    assert cfg["mode"] == "envoy-sidecar"
+    # The backend no longer emits a top-level `mode:` — the operator
+    # layers it on per workload from
+    #   AgentRuntime.Spec.AuthBridgeMode → namespace ConfigMap →
+    #   deprecated annotation → cluster default (proxy-sidecar).
+    # Locking absence here so a future revert that re-pins
+    # mode in _build_authbridge_runtime_yaml doesn't go unnoticed.
+    assert "mode" not in cfg
 
     jwt = _plugin_config(cfg, "inbound", "jwt-validation")
     assert jwt["issuer"] == "http://keycloak.example.com/realms/kagenti"

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -42,6 +42,10 @@ def test_build_authbridge_runtime_yaml_client_secret():
     # Locking absence here so a future revert that re-pins
     # mode in _build_authbridge_runtime_yaml doesn't go unnoticed.
     assert "mode" not in cfg
+    # Structural sanity: a future change that drops both `mode` and
+    # `pipeline` (e.g., a botched refactor) would still pass the
+    # negative assertion above. Pin the positive too.
+    assert "pipeline" in cfg
 
     jwt = _plugin_config(cfg, "inbound", "jwt-validation")
     assert jwt["issuer"] == "http://keycloak.example.com/realms/kagenti"

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -29,14 +29,6 @@ spec:
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
-        # Opt this E2E agent into the legacy client-registration sidecar
-        # (rather than the default operator-managed registration). The
-        # legacy path creates the Keycloak client + agent-*-aud scope
-        # synchronously at pod startup, so the test fixture's scope poll
-        # reliably finds it. The operator-managed reconciler has been
-        # observed stuck on HyperShift CI; see fix/e2e-audience-scope-gate.
-        # Remove this label once the operator-managed path is reliable.
-        kagenti.io/client-registration-inject: "true"
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/tests/e2e/common/test_mlflow_auth.py
+++ b/kagenti/tests/e2e/common/test_mlflow_auth.py
@@ -251,10 +251,19 @@ class TestMLflowAuth:
     @pytest.mark.asyncio
     async def test_mlflow_version_endpoint(self, require_mlflow_url, is_openshift):
         """
-        Test MLflow /version endpoint is accessible.
+        Test MLflow /version endpoint responds correctly to auth state.
 
-        When OIDC auth is enabled, the /version endpoint may redirect (302/307)
-        to the login page. Both 200 (no auth) and 302/307 (auth enabled) are valid.
+        mlflow-oidc-auth protects /version with session authentication
+        (see commit 63366cb0 where pod probes were moved to /health for
+        the same reason). For an unauthenticated request the endpoint
+        may legitimately return:
+            * 200 — auth is disabled
+            * 302/307 — auth enabled and configured to redirect to the
+              login page
+            * 401/403 — auth enabled and configured to reject directly
+              (the default mlflow-oidc-auth behavior)
+        Any of those means MLflow is up and the auth gate is doing
+        what it's supposed to. Other codes are real failures.
         """
         mlflow_url = require_mlflow_url
         logger.info("=" * 70)
@@ -274,16 +283,19 @@ class TestMLflowAuth:
         logger.info(f"Response status: {response.status_code}")
         logger.info(f"Response body: {response.text}")
 
-        # Accept 200 (no auth) or 302/307 (OAuth redirect) as healthy
-        assert response.status_code in (200, 302, 307), (
+        assert response.status_code in (200, 302, 307, 401, 403), (
             f"MLflow /version endpoint failed: {response.status_code} - {response.text}"
         )
 
         if response.status_code == 200:
             logger.info("TEST PASSED: MLflow version endpoint accessible (no auth)")
-        else:
+        elif response.status_code in (302, 307):
             logger.info(
                 f"TEST PASSED: MLflow version endpoint redirects to auth ({response.status_code})"
+            )
+        else:
+            logger.info(
+                f"TEST PASSED: MLflow version endpoint enforces auth ({response.status_code})"
             )
 
     @pytest.mark.asyncio
@@ -463,8 +475,11 @@ class TestMLflowBackend:
         """
         Test MLflow responds to health check.
 
-        Uses /version endpoint. When OIDC auth is enabled, a 302/307 redirect
-        to the login page indicates MLflow is healthy and auth is working.
+        Uses /health, not /version: mlflow-oidc-auth protects /version with
+        session auth and returns 401 to unauthenticated probes (commit
+        63366cb0 moved the pod liveness/readiness probes to /health for
+        exactly this reason). /health is unprotected by the OIDC middleware
+        and is the right surface for "is MLflow up."
         """
         mlflow_url = require_mlflow_url
         logger.info("Testing: MLflow Health Check")
@@ -472,25 +487,16 @@ class TestMLflowBackend:
         try:
             response = await query_mlflow_api(
                 mlflow_url=mlflow_url,
-                endpoint="/version",
+                endpoint="/health",
                 token=None,
                 timeout=10,
                 verify_ssl=self.ssl_verify,
             )
 
-            # Accept 200 (no auth) or 302/307 (OAuth redirect) as healthy
-            assert response.status_code in (200, 302, 307), (
-                f"MLflow health check failed: {response.status_code}"
+            assert response.status_code == 200, (
+                f"MLflow /health failed: {response.status_code} - {response.text}"
             )
-
-            if response.status_code == 200:
-                version = response.text.strip().strip('"')
-                logger.info(f"MLflow version: {version}")
-                logger.info("TEST PASSED: MLflow is healthy (no auth)")
-            else:
-                logger.info(
-                    f"TEST PASSED: MLflow is healthy (auth redirect {response.status_code})"
-                )
+            logger.info("TEST PASSED: MLflow is healthy (/health returned 200)")
 
         except httpx.ConnectError as e:
             pytest.fail(f"Could not connect to MLflow at {mlflow_url}: {e}")

--- a/kagenti/tests/e2e/common/test_mlflow_traces.py
+++ b/kagenti/tests/e2e/common/test_mlflow_traces.py
@@ -807,7 +807,14 @@ class TestMLflowConnectivity:
     def test_mlflow_accessible(
         self, mlflow_url: str, mlflow_configured: bool, openshift_ingress_ca
     ):
-        """Verify MLflow is accessible."""
+        """Verify MLflow is accessible.
+
+        Hits /health rather than /version: mlflow-oidc-auth protects
+        /version with session auth, so unauthenticated probes get 401.
+        /health is unprotected by the OIDC middleware (the same reason
+        commit 63366cb0 moved the pod liveness/readiness probes there)
+        and is the right surface for a connectivity check.
+        """
         import httpx
 
         # Use CA cert for SSL verification on OpenShift
@@ -819,11 +826,10 @@ class TestMLflowConnectivity:
             ssl_ctx = True
 
         try:
-            response = httpx.get(f"{mlflow_url}/version", verify=ssl_ctx, timeout=30.0)
-            # Accept 200 (no auth) or 302/307 (OAuth redirect) as healthy
-            assert response.status_code in (200, 302, 307), (
-                f"MLflow returned unexpected status {response.status_code}. "
-                f"Expected 200, 302, or 307."
+            response = httpx.get(f"{mlflow_url}/health", verify=ssl_ctx, timeout=30.0)
+            assert response.status_code == 200, (
+                f"MLflow /health returned unexpected status {response.status_code}. "
+                f"Expected 200."
             )
         except httpx.RequestError as e:
             pytest.fail(f"Cannot connect to MLflow at {mlflow_url}: {e}")

--- a/kagenti/tests/e2e/token_exchange/test_token_exchange.py
+++ b/kagenti/tests/e2e/token_exchange/test_token_exchange.py
@@ -134,11 +134,15 @@ class TestSidecarInjection:
             f"envoy-proxy sidecar not found in tool pod. Containers: {containers}"
         )
 
-    def test_agent_has_client_registration(self):
-        """Agent pod has client-registration init/sidecar."""
-        containers = self._get_pod_containers("tx-e2e-agent")
-        has_cr = any("client-registration" in c for c in containers)
-        # client-registration may be an init container instead
+    def test_agent_has_operator_managed_credentials(self):
+        """Agent pod mounts the operator-managed Keycloak client Secret.
+
+        Replaces the legacy test_agent_has_client_registration check.
+        After kagenti-operator#361 the in-pod client-registration sidecar
+        is gone — the operator's ClientRegistrationReconciler creates a
+        Secret with client-id.txt + client-secret.txt and the webhook
+        mounts it at /shared/ inside the authbridge sidecar.
+        """
         result = subprocess.run(
             [
                 "kubectl",
@@ -149,15 +153,21 @@ class TestSidecarInjection:
                 "-l",
                 "app=tx-e2e-agent",
                 "-o",
-                "jsonpath={.items[0].spec.initContainers[*].name}",
+                "jsonpath={.items[0].spec.volumes[*].secret.secretName}",
             ],
             capture_output=True,
             text=True,
             timeout=30,
         )
-        init_containers = result.stdout.split() if result.returncode == 0 else []
-        has_cr = has_cr or any("client-registration" in c for c in init_containers)
-        assert has_cr, "client-registration not found in agent pod"
+        secret_names = result.stdout.split() if result.returncode == 0 else []
+        # The operator-managed Secret name is derived from the workload's
+        # CR name; we only assert that *some* keycloak-client secret is
+        # mounted, which is the post-#361 contract.
+        has_kc_secret = any("keycloak-client" in s or "client-credentials" in s for s in secret_names)
+        assert has_kc_secret, (
+            "operator-managed Keycloak client Secret not mounted; "
+            f"volumes referenced: {secret_names}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -786,29 +796,11 @@ class TestAuthbridgeExtProc:
             "ext_proc",
         ]
         has_evidence = any(marker in logs.lower() for marker in exchange_markers)
-        # This is a soft check — log format may vary
-        if not has_evidence:
-            # Also check authbridge-light container if present
-            result2 = subprocess.run(
-                [
-                    "kubectl",
-                    "logs",
-                    "-n",
-                    TX_NAMESPACE,
-                    "-l",
-                    "app=tx-e2e-agent",
-                    "-c",
-                    "authbridge-light",
-                    "--tail=100",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            logs2 = result2.stdout + result2.stderr
-            has_evidence = any(marker in logs2.lower() for marker in exchange_markers)
-        # Don't fail on missing logs — the token comparison tests above
-        # are the definitive proof. This is supplementary evidence.
+        # This is a soft check — log format may vary. The legacy
+        # authbridge-light container is gone after kagenti-extensions#411
+        # (everything's bundled into the envoy-proxy container in
+        # envoy-sidecar mode), so we only inspect that one container now.
+        # The token comparison tests above are the definitive proof.
         if has_evidence:
             pass  # Good: logs confirm exchange
         else:

--- a/kagenti/tests/e2e/token_exchange/test_token_exchange.py
+++ b/kagenti/tests/e2e/token_exchange/test_token_exchange.py
@@ -160,12 +160,20 @@ class TestSidecarInjection:
             timeout=30,
         )
         secret_names = result.stdout.split() if result.returncode == 0 else []
-        # The operator-managed Secret name is derived from the workload's
-        # CR name; we only assert that *some* keycloak-client secret is
-        # mounted, which is the post-#361 contract.
-        has_kc_secret = any("keycloak-client" in s or "client-credentials" in s for s in secret_names)
+        # The operator's ClientRegistrationReconciler emits Secrets named
+        # `kagenti-keycloak-client-credentials-<sha256_hex8(ns,workload)>`
+        # (see KeycloakClientCredentialsSecretName in
+        # kagenti-operator/internal/clientreg/names.go — the suffix is a
+        # truncated hash of namespace+workload+a constant). Match the
+        # full prefix so a misnamed Secret can't accidentally satisfy
+        # this gate; do NOT pin the suffix because it is intentionally
+        # deterministic-but-derived. A loose substring match was
+        # flagged in PR review.
+        prefix = "kagenti-keycloak-client-credentials-"
+        has_kc_secret = any(s.startswith(prefix) for s in secret_names)
         assert has_kc_secret, (
             "operator-managed Keycloak client Secret not mounted; "
+            f"expected a Secret starting with {prefix!r}; "
             f"volumes referenced: {secret_names}"
         )
 

--- a/kagenti/tui/internal/api/types.go
+++ b/kagenti/tui/internal/api/types.go
@@ -204,9 +204,11 @@ type CreateAgentRequest struct {
 	CreateHTTPRoute  bool          `json:"createHttpRoute"`
 	AuthBridgeEnabled bool         `json:"authBridgeEnabled"`
 	SpireEnabled     bool          `json:"spireEnabled"`
-	EnvoyProxyInject          *bool `json:"envoyProxyInject,omitempty"`
-	SpiffeHelperInject        *bool `json:"spiffeHelperInject,omitempty"`
-	ClientRegistrationInject  *bool `json:"clientRegistrationInject,omitempty"`
+	// AuthBridgeMode maps to AgentRuntime.Spec.AuthBridgeMode for
+	// agents (the deprecated kagenti.io/authbridge-mode annotation
+	// for tools). Valid values: "proxy-sidecar" (default),
+	// "envoy-sidecar", "lite", "waypoint". Empty = cluster default.
+	AuthBridgeMode string `json:"authBridgeMode,omitempty"`
 }
 
 // CreateAgentResponse is the response after creating an agent.
@@ -237,9 +239,11 @@ type CreateToolRequest struct {
 	CreateHTTPRoute  bool          `json:"createHttpRoute"`
 	AuthBridgeEnabled bool         `json:"authBridgeEnabled"`
 	SpireEnabled     bool          `json:"spireEnabled"`
-	EnvoyProxyInject          *bool `json:"envoyProxyInject,omitempty"`
-	SpiffeHelperInject        *bool `json:"spiffeHelperInject,omitempty"`
-	ClientRegistrationInject  *bool `json:"clientRegistrationInject,omitempty"`
+	// AuthBridgeMode maps to AgentRuntime.Spec.AuthBridgeMode for
+	// agents (the deprecated kagenti.io/authbridge-mode annotation
+	// for tools). Valid values: "proxy-sidecar" (default),
+	// "envoy-sidecar", "lite", "waypoint". Empty = cluster default.
+	AuthBridgeMode string `json:"authBridgeMode,omitempty"`
 }
 
 // CreateToolResponse is the response after creating a tool.

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -187,9 +187,8 @@ export const ImportAgentPage: React.FC = () => {
   // SPIRE identity
   const [spireEnabled, setSpireEnabled] = useState(true);
 
-  // Per-sidecar injection controls
-  const [envoyProxyInject, setEnvoyProxyInject] = useState<boolean | undefined>(undefined);
-  const [spiffeHelperInject, setSpiffeHelperInject] = useState<boolean | undefined>(undefined);
+  // Use envoy-sidecar mode (false = proxy-sidecar, the default)
+  const [useEnvoyMode, setUseEnvoyMode] = useState(false);
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
@@ -499,8 +498,7 @@ export const ImportAgentPage: React.FC = () => {
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,
-        envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
-        spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
+        authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -531,8 +529,7 @@ export const ImportAgentPage: React.FC = () => {
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,
-        envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
-        spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
+        authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -1043,68 +1040,35 @@ export const ImportAgentPage: React.FC = () => {
                   isChecked={authBridgeEnabled}
                   onChange={(_e, checked) => {
                     setAuthBridgeEnabled(checked);
-                    if (checked) {
-                      setEnvoyProxyInject(undefined);
-                      setSpiffeHelperInject(undefined);
+                    if (!checked) {
+                      setUseEnvoyMode(false);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. With the default webhook settings this is two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the operator injects a combined AuthBridge sidecar for inbound JWT validation and outbound token exchange. Defaults to proxy-sidecar mode (HTTP_PROXY)."
               />
               </FormGroup>
 
               {authBridgeEnabled && (
-                <Alert
-                  variant="info"
-                  isInline
-                  title="Combined AuthBridge container"
-                  style={{ marginBottom: '16px' }}
-                >
-                  <Text component="p">
-                    There is no toggle here for the single-container mode. When{' '}
-                    <code>featureGates.combinedSidecar</code> is <code>true</code> on the admission
-                    webhook, injected pods get one <code>authbridge</code> container (see{' '}
-                    <a
-                      href="https://github.com/kagenti/kagenti/blob/main/docs/authbridge-combined-sidecar.md"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Combined AuthBridge sidecar
-                    </a>
-                    ). Advanced injection checkboxes still apply as flags inside that container.
-                  </Text>
-                </Alert>
+                <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
+                  <Checkbox
+                    id="useEnvoyMode"
+                    label="Use envoy-sidecar mode"
+                    isChecked={useEnvoyMode}
+                    onChange={(_e, checked) => setUseEnvoyMode(checked)}
+                    description="Switch from proxy-sidecar (default) to envoy-sidecar mode (Envoy + ext_proc + iptables interception)."
+                  />
+                </FormGroup>
               )}
 
               {/* SPIRE Identity */}
               <FormGroup fieldId="spireEnabled">
                 <Checkbox
                   id="spireEnabled"
-                  label="Enable SPIRE identity (spiffe-helper sidecar)"
+                  label="Enable SPIRE identity (JWT-SVID via spiffe-helper)"
                   isChecked={spireEnabled}
                   onChange={(_e, checked) => setSpireEnabled(checked)}
                 />
               </FormGroup>
-
-              {authBridgeEnabled && (
-                <>
-                  <FormGroup fieldId="sidecarControls" label="Advanced Injection Controls">
-                    <Checkbox
-                      id="envoyProxyInject"
-                      label="Envoy Proxy"
-                      isChecked={envoyProxyInject !== false}
-                      onChange={(_e, checked) => setEnvoyProxyInject(checked ? undefined : false)}
-                      description="Envoy proxy with go-processor for traffic interception. Disable to skip envoy-proxy sidecar."
-                    />
-                    <Checkbox
-                      id="spiffeHelperInject"
-                      label="SPIFFE Helper"
-                      isChecked={spiffeHelperInject !== false}
-                      onChange={(_e, checked) => setSpiffeHelperInject(checked ? undefined : false)}
-                      description="SPIFFE identity helper for SVID management. Disable to skip spiffe-helper sidecar."
-                    />
-                  </FormGroup>
-                </>
-              )}
 
 
               {authBridgeEnabled && (

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -155,9 +155,8 @@ export const ImportToolPage: React.FC = () => {
   // SPIRE identity
   const [spireEnabled, setSpireEnabled] = useState(false);
 
-  // Per-sidecar injection controls
-  const [envoyProxyInject, setEnvoyProxyInject] = useState<boolean | undefined>(undefined);
-  const [spiffeHelperInject, setSpiffeHelperInject] = useState<boolean | undefined>(undefined);
+  // Use envoy-sidecar mode (false = proxy-sidecar, the default)
+  const [useEnvoyMode, setUseEnvoyMode] = useState(false);
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
@@ -472,8 +471,7 @@ export const ImportToolPage: React.FC = () => {
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,
-        envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
-        spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
+        authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -500,8 +498,7 @@ export const ImportToolPage: React.FC = () => {
         createHttpRoute,
         authBridgeEnabled,
         spireEnabled,
-        envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
-        spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
+        authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -984,68 +981,35 @@ export const ImportToolPage: React.FC = () => {
                   isChecked={authBridgeEnabled}
                   onChange={(_e, checked) => {
                     setAuthBridgeEnabled(checked);
-                    if (checked) {
-                      setEnvoyProxyInject(undefined);
-                      setSpiffeHelperInject(undefined);
+                    if (!checked) {
+                      setUseEnvoyMode(false);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Default webhook settings use two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the operator injects a combined AuthBridge sidecar for inbound JWT validation and outbound token exchange. Defaults to proxy-sidecar mode (HTTP_PROXY)."
                 />
               </FormGroup>
 
               {authBridgeEnabled && (
-                <Alert
-                  variant="info"
-                  isInline
-                  title="Combined AuthBridge container"
-                  style={{ marginBottom: '16px' }}
-                >
-                  <Text component="p">
-                    Combined mode is configured on the admission webhook (
-                    <code>featureGates.combinedSidecar</code>), not on this page. See{' '}
-                    <a
-                      href="https://github.com/kagenti/kagenti/blob/main/docs/authbridge-combined-sidecar.md"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Combined AuthBridge sidecar
-                    </a>{' '}
-                    for operator steps. Advanced injection checkboxes still apply as flags inside the
-                    combined container when that gate is on.
-                  </Text>
-                </Alert>
+                <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
+                  <Checkbox
+                    id="useEnvoyMode"
+                    label="Use envoy-sidecar mode"
+                    isChecked={useEnvoyMode}
+                    onChange={(_e, checked) => setUseEnvoyMode(checked)}
+                    description="Switch from proxy-sidecar (default) to envoy-sidecar mode (Envoy + ext_proc + iptables interception)."
+                  />
+                </FormGroup>
               )}
 
               {/* SPIRE Identity */}
               <FormGroup fieldId="spireEnabled">
                 <Checkbox
                   id="spireEnabled"
-                  label="Enable SPIRE identity (spiffe-helper sidecar)"
+                  label="Enable SPIRE identity (JWT-SVID via spiffe-helper)"
                   isChecked={spireEnabled}
                   onChange={(_e, checked) => setSpireEnabled(checked)}
                 />
               </FormGroup>
-
-              {authBridgeEnabled && (
-                <>
-                  <FormGroup fieldId="sidecarControls" label="Advanced Injection Controls">
-                    <Checkbox
-                      id="envoyProxyInject"
-                      label="Envoy Proxy"
-                      isChecked={envoyProxyInject !== false}
-                      onChange={(_e, checked) => setEnvoyProxyInject(checked ? undefined : false)}
-                      description="Envoy proxy with go-processor for traffic interception. Disable to skip envoy-proxy sidecar."
-                    />
-                    <Checkbox
-                      id="spiffeHelperInject"
-                      label="SPIFFE Helper"
-                      isChecked={spiffeHelperInject !== false}
-                      onChange={(_e, checked) => setSpiffeHelperInject(checked ? undefined : false)}
-                      description="SPIFFE identity helper for SVID management. Disable to skip spiffe-helper sidecar."
-                    />
-                  </FormGroup>
-                </>
-              )}
 
 
               {authBridgeEnabled && (

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -231,9 +231,8 @@ export const agentService = {
     authBridgeEnabled?: boolean;
     // SPIRE identity
     spireEnabled?: boolean;
-    // Per-sidecar injection controls
-    envoyProxyInject?: boolean;
-    spiffeHelperInject?: boolean;
+    // Per-workload AuthBridge mode (maps to AgentRuntime.Spec.AuthBridgeMode)
+    authBridgeMode?: 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -443,8 +442,7 @@ export const shipwrightService = {
       }>;
       createHttpRoute?: boolean;
       authBridgeEnabled?: boolean;
-      envoyProxyInject?: boolean;
-      spiffeHelperInject?: boolean;
+      authBridgeMode?: 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
       outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
       outboundPortsExclude?: string;
       inboundPortsExclude?: string;
@@ -534,9 +532,9 @@ export const toolService = {
     authBridgeEnabled?: boolean;
     // SPIRE identity
     spireEnabled?: boolean;
-    // Per-sidecar injection controls
-    envoyProxyInject?: boolean;
-    spiffeHelperInject?: boolean;
+    // Per-workload AuthBridge mode (maps to AgentRuntime.Spec.AuthBridgeMode
+    // for agents; deprecated kagenti.io/authbridge-mode pod annotation for tools)
+    authBridgeMode?: 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -671,8 +669,7 @@ export const toolShipwrightService = {
       }>;
       createHttpRoute?: boolean;
       authBridgeEnabled?: boolean;
-      envoyProxyInject?: boolean;
-      spiffeHelperInject?: boolean;
+      authBridgeMode?: 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
       outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
       outboundPortsExclude?: string;
       inboundPortsExclude?: string;

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -451,9 +451,11 @@ export interface CreateSkillResponse {
 }
 
 // AuthBridge types
+export type AuthBridgeMode = 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
+
 export interface AuthBridgeConfig {
   AuthBridge: boolean | null;
-  mode: string | null;
+  mode: AuthBridgeMode | null;
   pipeline: PipelineConfig | null;
 }
 


### PR DESCRIPTION
## Summary

Sweep through the kagenti repo to land all the consumer-side changes for the architecture moves that already merged upstream:

- **kagenti-extensions#411** — three-binary split (`authbridge-proxy` / `authbridge-envoy` / `authbridge-lite`) with one combined image per mode and `spiffe-helper` bundled inside. Dropped the standalone `authbridge-light`, `client-registration`, and `spiffe-helper` images from CI.
- **kagenti-operator#361** — operator-managed Keycloak client registration; per-workload mode resolution chain (`AgentRuntime.Spec.AuthBridgeMode` → namespace ConfigMap → deprecated annotation → cluster default = `proxy-sidecar`); the per-sidecar inject feature gates were removed.

Goal of this PR: every place in the kagenti repo that referenced the dropped sidecars / images / fields gets updated, and every place that needs to surface the new `authBridgeMode` selector picks it up. Single PR for reviewer coherence; commit-by-commit for narrow blast radius if any one slice needs revisiting.

## Commits (9)

| | Commit | Touch |
|---|---|---|
| 1 | `chore(chart): pin authbridge v0.6.0-alpha.1, drop dead image keys` | Chart.yaml subchart bump → operator chart 0.3.0-alpha.1; values.yaml drops authbridgeLight/clientRegistration/spiffeHelper, adds authbridge + authbridge-lite. |
| 2 | `chore(chart): drop hardcoded mode, refresh sidecar UID matrix` | Drop `mode: envoy-sidecar` in both template ConfigMaps so cluster default wins; refresh SCC + RoleBinding comments for the single-combined-sidecar shape. |
| 3 | `ci(token-exchange): rebuild image list for three-binary split` | TX e2e build script switches to authbridge / authbridge-envoy / authbridge-lite / proxy-init. |
| 4 | `chore(examples): drop legacy client-registration-inject label` | Weather-agent OCP fixture no longer opts into a sidecar image that no longer ships. |
| 5 | `test(e2e): replace dead client-registration / authbridge-light checks` | Replace `test_agent_has_client_registration` with an operator-managed-Secret check; drop the authbridge-light log fallback; pin `mode: envoy-sidecar` back into `50-enable-kagenti-ns.sh` (this fixture explicitly tests the Envoy ext_proc path). |
| 6 | `refactor(backend): replace dead inject fields with authBridgeMode` | Drop `envoyProxyInject` / `spiffeHelperInject` / `clientRegistrationInject` from `Create*Request` + `Finalize*Request` + helper-fn signatures + label-write blocks; introduce a single typed `authBridgeMode` field; agents.py plumbs it onto `AgentRuntime.Spec.AuthBridgeMode`; tools.py plumbs it onto the deprecated `kagenti.io/authbridge-mode` pod annotation; drop the `mode: envoy-sidecar` hardcode in the backend's config-builder. |
| 7 | `feat(ui): collapse advanced injection into envoy-mode toggle` | ImportAgentPage + ImportToolPage replace the "Advanced Injection Controls" + "Combined AuthBridge container" Alert with a single nested "Use envoy-sidecar mode" checkbox; `services/api.ts` + `types/index.ts` updated to the new shape. |
| 8 | `refactor(tui): replace dead inject fields with AuthBridgeMode` | Mirror of the backend change in `kagenti/tui/internal/api/types.go`. |
| 9 | `docs: refresh deployment guide and release inventory for #411 / #361` | Rewrite the deployment-modes table + minimal config example + reference table for the per-plugin schema; add the resolution-chain section; fix the kagenti-extensions image inventory in releasing.md. |

## Verification

- `helm template charts/kagenti` renders cleanly; `kagenti-platform-config` no longer leaks the three dropped image keys.
- `bash -n` on both updated TX-e2e scripts.
- `python3 -c "import ast; ast.parse(...)"` on every modified Python file.
- `go build ./... && go vet ./...` on `kagenti/tui`.
- `npx tsc --noEmit` on `kagenti/ui-v2` (exit 0).
- Backend-wide grep shows no lingering references to the dropped fields, parameters, or constants.

## Test plan

- [ ] `helm install kagenti charts/kagenti --dry-run` and inspect the rendered ConfigMaps + the operator subchart.
- [ ] Bring up a kind cluster off this branch + the matching kagenti-extensions release and walk through the weather-agent demo end-to-end to confirm the new UI checkbox path produces a working pod with the correct mode.
- [ ] Run a workload with `Spec.AuthBridgeMode: envoy-sidecar` and verify the operator picks the `authbridge-envoy` image; default workload should pick `authbridge`.
- [ ] If TX e2e is exercised: confirm the `mode: envoy-sidecar` pin in `50-enable-kagenti-ns.sh` keeps the test on its existing container-name expectations.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
