### PR TITLE
:sparkles: feat: add PVC support for Sandbox workloads

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -204,6 +204,13 @@ class ServicePort(BaseModel):
     protocol: str = "TCP"
 
 
+class PersistentStorageConfig(BaseModel):
+    """Persistent storage configuration for Sandbox and StatefulSet agents."""
+
+    enabled: bool = False
+    size: str = "1Gi"
+
+
 class CreateAgentRequest(BaseModel):
     """Request to create a new agent."""
 
@@ -259,6 +266,9 @@ class CreateAgentRequest(BaseModel):
 
     # Outbound routing rules (authproxy-routes ConfigMap)
     outboundRoutes: Optional[List["OutboundRoute"]] = None
+
+    # Persistent storage (for Sandbox and StatefulSet workloads)
+    persistentStorage: Optional[PersistentStorageConfig] = None
 
     # Shipwright build configuration
     shipwrightConfig: Optional[ShipwrightBuildConfig] = None
@@ -931,7 +941,7 @@ async def delete_agent(
         else:
             logger.warning("Failed to delete Job '%s': %s", safe_name, e.reason)
 
-    # Delete the Sandbox (if exists)
+    # Delete the Sandbox (if exists) and its PVCs
     if settings.kagenti_feature_flag_agent_sandbox:
         try:
             kube.delete_sandbox(namespace=namespace, name=name)
@@ -941,6 +951,18 @@ async def delete_agent(
                 logger.debug("Sandbox '%s' not found (may be other workload type)", safe_name)
             else:
                 logger.warning("Failed to delete Sandbox '%s': %s", safe_name, e.reason)
+
+        try:
+            pvcs = kube.list_persistent_volume_claims(
+                namespace=namespace,
+                label_selector=f"app.kubernetes.io/name={name}",
+            )
+            for pvc_name in pvcs:
+                kube.delete_persistent_volume_claim(namespace=namespace, name=pvc_name)
+                messages.append(f"PVC '{pvc_name}' deleted")
+        except ApiException as e:
+            if e.status != 404:
+                logger.warning("Failed to clean up PVCs for '%s': %s", safe_name, e.reason)
 
     # Delete the Service
     try:
@@ -2286,6 +2308,8 @@ def _build_agent_shipwright_build_manifest(
         resource_config["inboundPortsExclude"] = request.inboundPortsExclude
     if request.defaultOutboundPolicy:
         resource_config["defaultOutboundPolicy"] = request.defaultOutboundPolicy
+    if request.persistentStorage:
+        resource_config["persistentStorage"] = request.persistentStorage.model_dump()
     # Add env vars if present
     if request.envVars:
         resource_config["envVars"] = [ev.model_dump(exclude_none=True) for ev in request.envVars]
@@ -2972,12 +2996,27 @@ def _build_sandbox_manifest(
                     "volumes": [
                         {"name": "cache", "emptyDir": {}},
                         {"name": "marvin", "emptyDir": {}},
-                        {"name": "shared-data", "emptyDir": {}},
-                    ],
+                    ]
+                    + (
+                        []
+                        if request.persistentStorage and request.persistentStorage.enabled
+                        else [{"name": "shared-data", "emptyDir": {}}]
+                    ),
                 },
             },
         },
     }
+
+    if request.persistentStorage and request.persistentStorage.enabled:
+        manifest["spec"]["volumeClaimTemplates"] = [
+            {
+                "metadata": {"name": "shared-data"},
+                "spec": {
+                    "accessModes": ["ReadWriteOnce"],
+                    "resources": {"requests": {"storage": request.persistentStorage.size}},
+                },
+            }
+        ]
 
     if request.imagePullSecret:
         manifest["spec"]["podTemplate"]["spec"]["imagePullSecrets"] = [
@@ -3257,6 +3296,7 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
     defaultOutboundPolicy: Optional[Literal["passthrough", "exchange"]] = None
+    persistentStorage: Optional[PersistentStorageConfig] = None
 
 
 @router.post(
@@ -3506,6 +3546,11 @@ async def finalize_shipwright_build(
             else stored_config.get("authBridgeMode")
         )
 
+        # Persistent storage
+        final_persistent_storage = request.persistentStorage
+        if final_persistent_storage is None and stored_config.get("persistentStorage"):
+            final_persistent_storage = PersistentStorageConfig(**stored_config["persistentStorage"])
+
         # Step 3: Create workload + Service with the built image
         # Build a CreateAgentRequest-like object for manifest builders
         agent_request = CreateAgentRequest(
@@ -3527,6 +3572,7 @@ async def finalize_shipwright_build(
             outboundPortsExclude=final_outbound_ports_exclude,
             inboundPortsExclude=final_inbound_ports_exclude,
             defaultOutboundPolicy=final_default_outbound_policy,
+            persistentStorage=final_persistent_storage,
         )
 
         # Ensure a dedicated ServiceAccount exists so the webhook's

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3010,7 +3010,10 @@ def _build_sandbox_manifest(
     if request.persistentStorage and request.persistentStorage.enabled:
         manifest["spec"]["volumeClaimTemplates"] = [
             {
-                "metadata": {"name": "shared-data"},
+                "metadata": {
+                    "name": "shared-data",
+                    "labels": {APP_KUBERNETES_IO_NAME: request.name},
+                },
                 "spec": {
                     "accessModes": ["ReadWriteOnce"],
                     "resources": {"requests": {"storage": request.persistentStorage.size}},

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -790,6 +790,19 @@ class KubernetesService:
             body,
         )
 
+    def list_persistent_volume_claims(
+        self, namespace: str, label_selector: Optional[str] = None
+    ) -> List[str]:
+        """List PVC names in a namespace, optionally filtered by label."""
+        result = self.core_api.list_namespaced_persistent_volume_claim(
+            namespace=namespace, label_selector=label_selector or ""
+        )
+        return [pvc.metadata.name for pvc in result.items]
+
+    def delete_persistent_volume_claim(self, namespace: str, name: str) -> None:
+        """Delete a PersistentVolumeClaim by name."""
+        self.core_api.delete_namespaced_persistent_volume_claim(name=name, namespace=namespace)
+
 
 @lru_cache
 def get_kubernetes_service() -> KubernetesService:

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -6,7 +6,7 @@
 from unittest.mock import MagicMock
 
 from app.core.constants import DEFAULT_IN_CLUSTER_PORT, DEFAULT_OFF_CLUSTER_PORT
-from app.routers.agents import CreateAgentRequest, WORKLOAD_TYPE_SANDBOX
+from app.routers.agents import CreateAgentRequest, PersistentStorageConfig, WORKLOAD_TYPE_SANDBOX
 
 
 def _make_request(**overrides):
@@ -30,6 +30,7 @@ def _make_request(**overrides):
     req.inboundPortsExclude = overrides.get("inboundPortsExclude", None)
     req.outboundRoutes = overrides.get("outboundRoutes", None)
     req.defaultOutboundPolicy = overrides.get("defaultOutboundPolicy", None)
+    req.persistentStorage = overrides.get("persistentStorage", None)
     return req
 
 
@@ -80,6 +81,85 @@ class TestBuildSandboxManifest:
 
         container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
         assert container["ports"][0]["containerPort"] == 8888
+
+
+class TestBuildSandboxManifestPVC:
+    """Tests for PVC support in _build_sandbox_manifest."""
+
+    def test_no_pvc_by_default(self):
+        """No volumeClaimTemplates when persistentStorage is None."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        request = _make_request()
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        assert "volumeClaimTemplates" not in manifest["spec"]
+        volume_names = [v["name"] for v in manifest["spec"]["podTemplate"]["spec"]["volumes"]]
+        assert "shared-data" in volume_names
+
+    def test_pvc_when_enabled(self):
+        """volumeClaimTemplates present with correct size when persistentStorage enabled."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        storage = PersistentStorageConfig(enabled=True, size="5Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        vct = manifest["spec"]["volumeClaimTemplates"]
+        assert len(vct) == 1
+        assert vct[0]["metadata"]["name"] == "shared-data"
+        assert vct[0]["spec"]["accessModes"] == ["ReadWriteOnce"]
+        assert vct[0]["spec"]["resources"]["requests"]["storage"] == "5Gi"
+
+    def test_pvc_replaces_shared_data_emptydir(self):
+        """shared-data emptyDir is removed from volumes when PVC is enabled."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        storage = PersistentStorageConfig(enabled=True, size="1Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        volume_names = [v["name"] for v in manifest["spec"]["podTemplate"]["spec"]["volumes"]]
+        assert "shared-data" not in volume_names
+        assert "cache" in volume_names
+        assert "marvin" in volume_names
+
+    def test_pvc_volume_mount_unchanged(self):
+        """/shared mount is present regardless of PVC enablement."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        storage = PersistentStorageConfig(enabled=True, size="1Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
+        mount_names = [m["name"] for m in container["volumeMounts"]]
+        assert "shared-data" in mount_names
+        mount = next(m for m in container["volumeMounts"] if m["name"] == "shared-data")
+        assert mount["mountPath"] == "/shared"
+
+    def test_pvc_disabled_keeps_emptydir(self):
+        """When persistentStorage.enabled is False, shared-data stays as emptyDir."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        storage = PersistentStorageConfig(enabled=False, size="1Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        assert "volumeClaimTemplates" not in manifest["spec"]
+        volume_names = [v["name"] for v in manifest["spec"]["podTemplate"]["spec"]["volumes"]]
+        assert "shared-data" in volume_names
+
+    def test_pvc_default_size(self):
+        """Default PVC size is 1Gi."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        storage = PersistentStorageConfig(enabled=True)
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        vct = manifest["spec"]["volumeClaimTemplates"]
+        assert vct[0]["spec"]["resources"]["requests"]["storage"] == "1Gi"
 
 
 class TestBuildServiceManifestForSandbox:

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -108,6 +108,7 @@ class TestBuildSandboxManifestPVC:
         vct = manifest["spec"]["volumeClaimTemplates"]
         assert len(vct) == 1
         assert vct[0]["metadata"]["name"] == "shared-data"
+        assert vct[0]["metadata"]["labels"]["app.kubernetes.io/name"] == "test-agent"
         assert vct[0]["spec"]["accessModes"] == ["ReadWriteOnce"]
         assert vct[0]["spec"]["resources"]["requests"]["storage"] == "5Gi"
 

--- a/kagenti/tui/internal/api/types.go
+++ b/kagenti/tui/internal/api/types.go
@@ -185,30 +185,33 @@ type ServicePort struct {
 	Protocol   string `json:"protocol"`
 }
 
+// PersistentStorageConfig configures PVC storage for Sandbox and StatefulSet workloads.
+type PersistentStorageConfig struct {
+	Enabled bool   `json:"enabled"`
+	Size    string `json:"size"`
+}
+
 // CreateAgentRequest is the request to create an agent.
 type CreateAgentRequest struct {
-	Name             string        `json:"name"`
-	Namespace        string        `json:"namespace"`
-	Protocol         string        `json:"protocol"`
-	Framework        string        `json:"framework"`
-	DeploymentMethod string        `json:"deploymentMethod"`
-	WorkloadType     string        `json:"workloadType"`
-	EnvVars          []EnvVar      `json:"envVars,omitempty"`
-	GitURL           string        `json:"gitUrl,omitempty"`
-	GitPath          string        `json:"gitPath,omitempty"`
-	GitBranch        string        `json:"gitBranch,omitempty"`
-	ImageTag         string        `json:"imageTag,omitempty"`
-	ContainerImage   string        `json:"containerImage,omitempty"`
-	ImagePullSecret  string        `json:"imagePullSecret,omitempty"`
-	ServicePorts     []ServicePort `json:"servicePorts,omitempty"`
-	CreateHTTPRoute  bool          `json:"createHttpRoute"`
-	AuthBridgeEnabled bool         `json:"authBridgeEnabled"`
-	SpireEnabled     bool          `json:"spireEnabled"`
-	// AuthBridgeMode maps to AgentRuntime.Spec.AuthBridgeMode for
-	// agents (the deprecated kagenti.io/authbridge-mode annotation
-	// for tools). Valid values: "proxy-sidecar" (default),
-	// "envoy-sidecar", "lite", "waypoint". Empty = cluster default.
-	AuthBridgeMode string `json:"authBridgeMode,omitempty"`
+	Name              string                   `json:"name"`
+	Namespace         string                   `json:"namespace"`
+	Protocol          string                   `json:"protocol"`
+	Framework         string                   `json:"framework"`
+	DeploymentMethod  string                   `json:"deploymentMethod"`
+	WorkloadType      string                   `json:"workloadType"`
+	EnvVars           []EnvVar                 `json:"envVars,omitempty"`
+	GitURL            string                   `json:"gitUrl,omitempty"`
+	GitPath           string                   `json:"gitPath,omitempty"`
+	GitBranch         string                   `json:"gitBranch,omitempty"`
+	ImageTag          string                   `json:"imageTag,omitempty"`
+	ContainerImage    string                   `json:"containerImage,omitempty"`
+	ImagePullSecret   string                   `json:"imagePullSecret,omitempty"`
+	ServicePorts      []ServicePort            `json:"servicePorts,omitempty"`
+	CreateHTTPRoute   bool                     `json:"createHttpRoute"`
+	AuthBridgeEnabled bool                     `json:"authBridgeEnabled"`
+	SpireEnabled      bool                     `json:"spireEnabled"`
+	AuthBridgeMode    string                   `json:"authBridgeMode,omitempty"`
+	PersistentStorage *PersistentStorageConfig `json:"persistentStorage,omitempty"`
 }
 
 // CreateAgentResponse is the response after creating an agent.

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -172,6 +172,9 @@ export const ImportAgentPage: React.FC = () => {
     features.agentSandbox ? 'sandbox' : 'deployment'
   );
 
+  // Persistent storage (Sandbox / StatefulSet)
+  const [persistentStorageSize, setPersistentStorageSize] = useState('1Gi');
+
   // Sync default when feature flags load async (first page load before cache is warm)
   useEffect(() => {
     if (features.agentSandbox) {
@@ -503,6 +506,10 @@ export const ImportAgentPage: React.FC = () => {
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
+        // Persistent storage (Sandbox / StatefulSet)
+        persistentStorage: (workloadType === 'sandbox' || workloadType === 'statefulset')
+          ? { enabled: true, size: persistentStorageSize }
+          : undefined,
         // Shipwright build configuration (always enabled)
         shipwrightConfig,
       });
@@ -534,6 +541,10 @@ export const ImportAgentPage: React.FC = () => {
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
+        // Persistent storage (Sandbox / StatefulSet)
+        persistentStorage: (workloadType === 'sandbox' || workloadType === 'statefulset')
+          ? { enabled: true, size: persistentStorageSize }
+          : undefined,
       });
     }
   };
@@ -1021,6 +1032,24 @@ export const ImportAgentPage: React.FC = () => {
                   </HelperText>
                 </FormHelperText>
               </FormGroup>
+
+              {(workloadType === 'sandbox' || workloadType === 'statefulset') && (
+                <FormGroup label="Persistent Volume Size" fieldId="persistentStorageSize">
+                  <TextInput
+                    id="persistentStorageSize"
+                    value={persistentStorageSize}
+                    onChange={(_e, value) => setPersistentStorageSize(value)}
+                    placeholder="1Gi"
+                  />
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem>
+                        Size of the persistent volume claim (e.g., 1Gi, 5Gi, 10Gi)
+                      </HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                </FormGroup>
+              )}
 
               {/* HTTPRoute/Route Creation */}
               <FormGroup fieldId="createHttpRoute">

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -173,6 +173,7 @@ export const ImportAgentPage: React.FC = () => {
   );
 
   // Persistent storage (Sandbox / StatefulSet)
+  const [persistentStorageEnabled, setPersistentStorageEnabled] = useState(true);
   const [persistentStorageSize, setPersistentStorageSize] = useState('1Gi');
 
   // Sync default when feature flags load async (first page load before cache is warm)
@@ -507,7 +508,7 @@ export const ImportAgentPage: React.FC = () => {
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
         // Persistent storage (Sandbox / StatefulSet)
-        persistentStorage: (workloadType === 'sandbox' || workloadType === 'statefulset')
+        persistentStorage: (workloadType === 'sandbox' || workloadType === 'statefulset') && persistentStorageEnabled
           ? { enabled: true, size: persistentStorageSize }
           : undefined,
         // Shipwright build configuration (always enabled)
@@ -542,7 +543,7 @@ export const ImportAgentPage: React.FC = () => {
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
         // Persistent storage (Sandbox / StatefulSet)
-        persistentStorage: (workloadType === 'sandbox' || workloadType === 'statefulset')
+        persistentStorage: (workloadType === 'sandbox' || workloadType === 'statefulset') && persistentStorageEnabled
           ? { enabled: true, size: persistentStorageSize }
           : undefined,
       });
@@ -1034,21 +1035,37 @@ export const ImportAgentPage: React.FC = () => {
               </FormGroup>
 
               {(workloadType === 'sandbox' || workloadType === 'statefulset') && (
-                <FormGroup label="Persistent Volume Size" fieldId="persistentStorageSize">
-                  <TextInput
-                    id="persistentStorageSize"
-                    value={persistentStorageSize}
-                    onChange={(_e, value) => setPersistentStorageSize(value)}
-                    placeholder="1Gi"
-                  />
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem>
-                        Size of the persistent volume claim (e.g., 1Gi, 5Gi, 10Gi)
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                </FormGroup>
+                <>
+                  <FormGroup fieldId="persistentStorageEnabled">
+                    <Checkbox
+                      id="persistentStorageEnabled"
+                      label="Enable persistent storage"
+                      isChecked={persistentStorageEnabled}
+                      onChange={(_e, checked) => setPersistentStorageEnabled(checked)}
+                      description="Allocate a PersistentVolumeClaim for the /shared mount. When disabled, an ephemeral emptyDir is used instead."
+                    />
+                  </FormGroup>
+                  {persistentStorageEnabled && (
+                    <FormGroup label="Persistent Volume Size" fieldId="persistentStorageSize">
+                      <TextInput
+                        id="persistentStorageSize"
+                        value={persistentStorageSize}
+                        onChange={(_e, value) => setPersistentStorageSize(value)}
+                        placeholder="1Gi"
+                        validated={/^\d+(Gi|Mi|Ki|Ti|G|M|K|T)$/.test(persistentStorageSize) ? 'default' : 'error'}
+                      />
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem variant={/^\d+(Gi|Mi|Ki|Ti|G|M|K|T)$/.test(persistentStorageSize) ? 'default' : 'error'}>
+                            {/^\d+(Gi|Mi|Ki|Ti|G|M|K|T)$/.test(persistentStorageSize)
+                              ? 'Size of the persistent volume claim (e.g., 1Gi, 5Gi, 10Gi)'
+                              : 'Invalid size — use a number followed by a unit (e.g., 1Gi, 500Mi)'}
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    </FormGroup>
+                  )}
+                </>
               )}
 
               {/* HTTPRoute/Route Creation */}

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -237,6 +237,7 @@ export const agentService = {
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
     defaultOutboundPolicy?: string;
+    persistentStorage?: { enabled: boolean; size: string };
     shipwrightConfig?: ShipwrightBuildConfig;
   }): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
     return apiFetch('/agents', {


### PR DESCRIPTION
## Summary

- Add persistent storage (PVC) support for Sandbox workloads end-to-end: backend model, manifest builder, PVC cleanup on delete, UI form field, TUI types, and tests
- When enabled, replaces the `shared-data` emptyDir with a `volumeClaimTemplate` so data survives pod restarts
- Follows the existing StatefulSet PVC pattern from tools.py

## Details

**Backend** (`agents.py`, `kubernetes.py`):
- `PersistentStorageConfig` model with `enabled` (default false) and `size` (default 1Gi)
- `_build_sandbox_manifest()` emits `spec.volumeClaimTemplates` when enabled
- Agent delete flow cleans up PVCs via label-selector lookup
- New `list_persistent_volume_claims` / `delete_persistent_volume_claim` on KubernetesService

**UI** (`ImportAgentPage.tsx`, `api.ts`):
- "Persistent Volume Size" text input shown when workload type is `sandbox` or `statefulset`

**TUI** (`types.go`):
- `PersistentStorageConfig` struct and field on `CreateAgentRequest`

**Tests** (`test_sandbox_manifest.py`):
- 6 new tests: no PVC by default, PVC when enabled, emptyDir replacement, volume mount unchanged, disabled keeps emptyDir, default size

## Test plan

- [x] `uv run pytest tests/test_sandbox_manifest.py -v` — 13 tests passing
- [x] `ruff check` and `ruff format` clean
- [x] Local Kind cluster: deployed Sandbox agent with PVC via UI, confirmed `shared-data-<name>` PVC bound and pod running 3/3
- [ ] Verify PVC cleanup on agent deletion

Closes #1585

Assisted-By: Claude Code