### PR TITLE
docs: add OpenShift internal container registry setup guide

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   # Python (root) — E2E test dependencies
   - package-ecosystem: pip
@@ -21,6 +23,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   # Python (backend) — FastAPI backend dependencies
   - package-ecosystem: pip
@@ -32,6 +36,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   # npm (UI) — React frontend dependencies
   - package-ecosystem: npm
@@ -43,6 +49,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
     ignore:
       # keycloak-js 26.x requires Web Crypto API (crypto.randomUUID, crypto.subtle)
       # which is unavailable over plain HTTP. Block until all environments use HTTPS.
@@ -79,6 +87,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   # Docker — CI support images
   - package-ecosystem: docker
@@ -90,6 +100,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   # Docker — application images
   - package-ecosystem: docker
@@ -101,6 +113,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   - package-ecosystem: docker
     directory: /kagenti/ui-v2
@@ -111,6 +125,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   - package-ecosystem: docker
     directory: /kagenti/auth/agent-oauth-secret
@@ -121,6 +137,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   - package-ecosystem: docker
     directory: /kagenti/auth/api-oauth-secret
@@ -131,6 +149,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   - package-ecosystem: docker
     directory: /kagenti/auth/mlflow-oauth-secret
@@ -141,6 +161,8 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]
 
   - package-ecosystem: docker
     directory: /kagenti/auth/ui-oauth-secret
@@ -151,3 +173,5 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+      major:
+        update-types: [major]

--- a/.github/scripts/common/87-setup-test-credentials.sh
+++ b/.github/scripts/common/87-setup-test-credentials.sh
@@ -260,8 +260,8 @@ dump_scope_timeout_diagnostics() {
         grep -E '^  [A-Z_]+:|^data:' | head -30 || echo "  (not found — reconciler will requeue forever on 'waiting for KEYCLOAK_URL/KEYCLOAK_REALM')"
 
     echo
-    echo "--- team1 keycloak-admin-secret (existence + key names, not values) ---"
-    kubectl get secret -n team1 keycloak-admin-secret \
+    echo "--- keycloak-admin-secret (now in kagenti-system, not team1) ---"
+    kubectl get secret -n kagenti-system keycloak-admin-secret \
         -o jsonpath='{"  keys: "}{.data}{"\n"}' 2>&1 | python3 -c "
 import sys, json, re
 s = sys.stdin.read().strip()
@@ -275,7 +275,7 @@ if m:
         print(s)
 else:
     print(s)
-" 2>&1 || echo "  (not found — reconciler will requeue forever on 'waiting for keycloak-admin-secret')"
+" 2>&1 || echo "  (not found — operator will be unable to register clients)"
 
     echo
     echo "--- kagenti-operator controller pod status ---"

--- a/.github/scripts/common/99-collect-logs.sh
+++ b/.github/scripts/common/99-collect-logs.sh
@@ -26,10 +26,6 @@ echo "=== Weather Service Envoy-Proxy Logs (last 50 lines) ==="
 kubectl logs -n team1 deployment/weather-service -c envoy-proxy --tail=50 || true
 
 echo ""
-echo "=== Weather Service Client-Registration Logs (last 30 lines) ==="
-kubectl logs -n team1 deployment/weather-service -c kagenti-client-registration --tail=30 || true
-
-echo ""
 echo "=== AuthBridge Unified ConfigMap ==="
 kubectl get configmap authbridge-runtime-config -n team1 -o jsonpath='{.data.config\.yaml}' || true
 

--- a/.github/scripts/hypershift/ci/85-collect-failure-info.sh
+++ b/.github/scripts/hypershift/ci/85-collect-failure-info.sh
@@ -76,10 +76,6 @@ if [ -n "${KUBECONFIG:-}" ] && [ -f "${KUBECONFIG:-}" ]; then
     oc logs -n team1 deployment/weather-service -c envoy-proxy --tail=50 2>/dev/null || echo "(not available)"
 
     echo ""
-    echo "=== Weather Service Client-Registration Logs (last 30 lines) ==="
-    oc logs -n team1 deployment/weather-service -c kagenti-client-registration --tail=30 2>/dev/null || echo "(not available)"
-
-    echo ""
     echo "=== AuthBridge Unified ConfigMap ==="
     oc get configmap authbridge-runtime-config -n team1 -o jsonpath='{.data.config\.yaml}' 2>/dev/null || echo "(not found)"
 

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -54,12 +54,13 @@ if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
 fi
 
 # Preflight: Keycloak admin credentials for setup_keycloak_weather_advanced.py / token exchange
-if ! kubectl get secret keycloak-admin-secret -n "$NAMESPACE" &>/dev/null; then
-    log_error "Secret 'keycloak-admin-secret' not found in namespace '$NAMESPACE'."
-    log_error "The installer usually creates it in agent namespaces. Re-run platform deploy or create it (AuthBridge / Keycloak docs) before AuthBridge E2E."
+# Note: keycloak-admin-secret is now in kagenti-system (operator namespace) for security
+if ! kubectl get secret keycloak-admin-secret -n kagenti-system &>/dev/null; then
+    log_error "Secret 'keycloak-admin-secret' not found in namespace 'kagenti-system'."
+    log_error "The installer creates it in the operator namespace. Re-run platform deploy or create it (AuthBridge / Keycloak docs) before AuthBridge E2E."
     exit 1
 fi
-log_info "Preflight OK: keycloak-admin-secret present in $NAMESPACE"
+log_info "Preflight OK: keycloak-admin-secret present in kagenti-system"
 
 EXT_ROOT="${KAGENTI_EXTENSIONS_ROOT:-}"
 # Trim trailing slash so path joins are never authbridge//...

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -19,6 +19,7 @@
 #   KAGENTI_EXTENSIONS_GIT_REF  Branch or tag (default: main). Pin in CI to a release tag once
 #     authbridge/demos/weather-agent is included; verify with: git ls-remote --tags URL
 #   NAMESPACE                 K8s namespace (default: team1)
+#   OPERATOR_NAMESPACE        Operator namespace where keycloak-admin-secret is located (default: kagenti-system)
 #   SKIP_DEPLOY                 If 1, only run in-cluster verify (default: 0 = full deploy)
 #   WEATHER_TOOL_ROLLOUT_TIMEOUT / WEATHER_AGENT_ROLLOUT_TIMEOUT / WEATHER_TOOL_KC_CLIENT_SEC
 #   WEATHER_ADVANCED_PRUNE_LEGACY   Passed to deploy (default: 1 here — scale down wave-90 weather)
@@ -47,6 +48,7 @@ if ! command -v git &>/dev/null; then
 fi
 
 export NAMESPACE="${NAMESPACE:-team1}"
+export OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kagenti-system}"
 
 if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
     log_error "Namespace $NAMESPACE not found. Deploy the platform first."
@@ -54,13 +56,13 @@ if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
 fi
 
 # Preflight: Keycloak admin credentials for setup_keycloak_weather_advanced.py / token exchange
-# Note: keycloak-admin-secret is now in kagenti-system (operator namespace) for security
-if ! kubectl get secret keycloak-admin-secret -n kagenti-system &>/dev/null; then
-    log_error "Secret 'keycloak-admin-secret' not found in namespace 'kagenti-system'."
+# Note: keycloak-admin-secret is now in the operator namespace for security
+if ! kubectl get secret keycloak-admin-secret -n "$OPERATOR_NAMESPACE" &>/dev/null; then
+    log_error "Secret 'keycloak-admin-secret' not found in namespace '$OPERATOR_NAMESPACE'."
     log_error "The installer creates it in the operator namespace. Re-run platform deploy or create it (AuthBridge / Keycloak docs) before AuthBridge E2E."
     exit 1
 fi
-log_info "Preflight OK: keycloak-admin-secret present in kagenti-system"
+log_info "Preflight OK: keycloak-admin-secret present in $OPERATOR_NAMESPACE"
 
 EXT_ROOT="${KAGENTI_EXTENSIONS_ROOT:-}"
 # Trim trailing slash so path joins are never authbridge//...

--- a/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
+++ b/.github/scripts/token-exchange/50-enable-kagenti-ns.sh
@@ -271,13 +271,10 @@ data:
 EOF
 
 # --- keycloak-admin-secret ---
-log_info "Creating keycloak-admin-secret"
-KC_ADMIN_USER=$(kubectl get secret keycloak-initial-admin -n "$KC_NAMESPACE" -o go-template='{{.data.username | base64decode}}' 2>/dev/null || echo "admin")
-KC_ADMIN_PASS=$(kubectl get secret keycloak-initial-admin -n "$KC_NAMESPACE" -o go-template='{{.data.password | base64decode}}' 2>/dev/null || echo "admin")
-kubectl create secret generic keycloak-admin-secret \
-  --from-literal=KEYCLOAK_ADMIN_USERNAME="$KC_ADMIN_USER" \
-  --from-literal=KEYCLOAK_ADMIN_PASSWORD="$KC_ADMIN_PASS" \
-  -n "$TX_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+# Note: keycloak-admin-secret is now managed by the operator in kagenti-system namespace.
+# The operator reads credentials from there to register OAuth clients for workloads.
+# No longer created in agent namespaces for security reasons.
+log_info "Skipping keycloak-admin-secret creation (managed by operator in kagenti-system)"
 
 # --- Add namespace to operator's NAMESPACES2WATCH ---
 log_info "Adding $TX_NAMESPACE to operator NAMESPACES2WATCH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest pre-commit uv
+          pip install ruff==0.15.12 pytest==9.0.3 pre-commit==4.6.0 uv==0.11.13
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Lint with ruff
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        run: pip install uv
+        run: pip install uv==0.11.13
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install ruff==0.15.12 pytest==9.0.3 pre-commit==4.6.0 uv==0.11.13
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          uv tool install ruff==0.15.12
+          uv tool install pytest==9.0.3
+          uv tool install pre-commit==4.6.0
+          if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
 
       - name: Lint with ruff
         run: |
@@ -73,7 +77,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        run: pip install uv==0.11.13
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev

--- a/.github/workflows/cleanup-stale-hypershift-clusters.yaml
+++ b/.github/workflows/cleanup-stale-hypershift-clusters.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install OpenShift CLI
         run: |
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload deletion logs
         if: github.event.inputs.dry_run == 'false' && always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cleanup-logs-${{ github.run_id }}
           path: /tmp/cleanup-*.log
@@ -117,7 +117,7 @@ jobs:
 
       - name: Create audit issue for deletions
         if: github.event.inputs.dry_run == 'false' && success()
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -59,11 +59,11 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Install dependencies (jq, uv)
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y jq
-          python -m pip install --upgrade pip
-          pip install uv==0.11.13
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
+      - name: Install dependencies (jq)
+        run: sudo apt-get update -qq && sudo apt-get install -y jq
 
       - name: Create secrets for bash installer
         run: bash .github/scripts/common/20-create-secrets-bash.sh

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -63,7 +63,7 @@ jobs:
         run: |
           sudo apt-get update -qq && sudo apt-get install -y jq
           python -m pip install --upgrade pip
-          pip install uv
+          pip install uv==0.11.13
 
       - name: Create secrets for bash installer
         run: bash .github/scripts/common/20-create-secrets-bash.sh

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           sudo apt-get update -qq && sudo apt-get install -y jq
           python -m pip install --upgrade pip
-          pip install uv
+          pip install uv==0.11.13
 
       - name: Create secrets for bash installer
         run: bash .github/scripts/common/20-create-secrets-bash.sh

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -62,11 +62,11 @@ jobs:
       - name: Free up disk space
         run: bash .github/scripts/common/05-free-disk-space.sh
 
-      - name: Install dependencies (jq, uv)
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y jq
-          python -m pip install --upgrade pip
-          pip install uv==0.11.13
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
+      - name: Install dependencies (jq)
+        run: sudo apt-get update -qq && sudo apt-get install -y jq
 
       - name: Create secrets for bash installer
         run: bash .github/scripts/common/20-create-secrets-bash.sh

--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -125,7 +125,7 @@ jobs:
         run: |
           bash .github/scripts/hypershift/ci/20-install-tools.sh
           bash .github/scripts/common/10-setup-dependencies.sh
-          pip install boto3 botocore
+          pip install boto3==1.43.6 botocore==1.43.6
 
       - name: Install Helm v3
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0

--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -121,11 +121,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install tools (kubectl, Helm, oc, hcp)
         run: |
           bash .github/scripts/hypershift/ci/20-install-tools.sh
           bash .github/scripts/common/10-setup-dependencies.sh
-          pip install boto3==1.43.6 botocore==1.43.6
+          uv pip install --system boto3==1.43.6 botocore==1.43.6
 
       - name: Install Helm v3
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install yamllint
-        run: pip install yamllint
+        run: pip install yamllint==1.38.0
 
       - name: Create config
         run: |
@@ -299,7 +299,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Bandit
-        run: pip install bandit[toml]
+        run: pip install "bandit[toml]==1.9.4"
 
       - name: Run Bandit security scan
         run: |

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -184,8 +184,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install yamllint
-        run: pip install yamllint==1.38.0
+        run: uv tool install yamllint==1.38.0
 
       - name: Create config
         run: |
@@ -298,8 +301,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install Bandit
-        run: pip install "bandit[toml]==1.9.4"
+        run: uv tool install "bandit[toml]==1.9.4"
 
       - name: Run Bandit security scan
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,17 +8,25 @@ please report it responsibly.
 ### How to Report
 
 1. **Do NOT create public GitHub issues** for security vulnerabilities
-2. **Email**: Report vulnerabilities privately via GitHub Security Advisories
-   - Go to the [Security tab](../../security/advisories/new) and create a new advisory
-3. **Include**: A clear description of the vulnerability, steps to reproduce,
-   and potential impact
+2. **GitHub Security Advisories (preferred)**: Report vulnerabilities privately via
+   [GitHub Security Advisories](../../security/advisories/new)
+3. **Email**: Send reports to **security@kagenti.io**
+4. **Include**: A clear description of the vulnerability, steps to reproduce,
+   affected versions, and potential impact
 
 ### What to Expect
 
-- We will acknowledge receipt within 48 hours
-- We aim to provide an initial assessment within 7 days
-- We will keep you informed of our progress
-- We will credit you in the security advisory (if desired)
+- **Acknowledgement**: within 48 hours of receipt
+- **Initial assessment**: within 7 business days
+- **Resolution timeline**: critical vulnerabilities within 30 days, others within 90 days
+- **Credit**: We will credit you in the security advisory (if desired)
+- **Updates**: We will keep you informed of our progress throughout the process
+
+### Disclosure Policy
+
+We follow [coordinated vulnerability disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).
+Please allow us reasonable time to address the vulnerability before any public
+disclosure. We aim to publish fixes and advisories within 90 days of the initial report.
 
 ## Supported Versions
 
@@ -26,15 +34,23 @@ please report it responsibly.
 |---------|--------------------|
 | main    | :white_check_mark: |
 
+Only the latest release and the `main` branch receive security updates.
+
 ## Security Measures
 
 This project implements several security controls:
 
-- **CI/CD Security**: All workflows use explicit least-privilege permissions
+- **CI/CD Security**: All workflows use explicit least-privilege permissions with
+  hash-pinned GitHub Actions
 - **Dependency Scanning**: Automated vulnerability scanning via Trivy and Dependabot
+  with weekly update cadence
 - **Secret Detection**: Pre-commit hooks with Gitleaks for secret scanning
 - **Code Analysis**: CodeQL and Bandit for static analysis
-- **Container Security**: Hadolint for Dockerfile best practices
+- **Container Security**: Hadolint for Dockerfile best practices, base images pinned
+  to sha256 digests
+- **Supply Chain**: OpenSSF Scorecard monitoring, SLSA-compliant build process
+- **Runtime Security**: Istio Ambient mTLS, SPIFFE workload identity, Landlock/seccomp
+  sandboxing for agent execution
 
 ## Security-Related Configuration
 

--- a/charts/kagenti-deps/templates/mlflow.yaml
+++ b/charts/kagenti-deps/templates/mlflow.yaml
@@ -410,14 +410,14 @@ spec:
           failureThreshold: 30  # Allow up to 5 minutes for startup
         readinessProbe:
           httpGet:
-            path: /version
+            path: /health
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 10
           failureThreshold: 3
         livenessProbe:
           httpGet:
-            path: /version
+            path: /health
             port: 5000
           initialDelaySeconds: 10
           periodSeconds: 30

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -169,8 +169,8 @@ data:
 {{- end }}
 {{- if and .Values.components.otel.enabled .Values.components.mcpGateway.enabled }}
 ---
-# Allow workloads to push traces to the OTel collector.
-# Covers MCP Gateway router (mcp-system) and agent namespaces (team1, team2, kagenti-system).
+# Allow any mesh workload to push traces to the OTel collector.
+# Open allow-all on the collector workload avoids hardcoding agent or MCP gateway namespaces.
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -167,3 +167,22 @@ data:
   base.yaml: |
     {{- include "kagenti.otel.collectorConfig" . | nindent 4 }}
 {{- end }}
+{{- if and .Values.components.otel.enabled .Values.components.mcpGateway.enabled }}
+---
+# Allow workloads to push traces to the OTel collector.
+# Covers MCP Gateway router (mcp-system) and agent namespaces (team1, team2, kagenti-system).
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: otel-collector-from-mcp-system
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: otel-collector
+  action: ALLOW
+  rules:
+  - {}
+{{- end }}

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -167,7 +167,7 @@ data:
   base.yaml: |
     {{- include "kagenti.otel.collectorConfig" . | nindent 4 }}
 {{- end }}
-{{- if and .Values.components.otel.enabled .Values.components.mcpGateway.enabled }}
+{{- if .Values.components.otel.enabled }}
 ---
 # Allow any mesh workload to push traces to the OTel collector.
 # Open allow-all on the collector workload avoids hardcoding agent or MCP gateway namespaces.

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -181,6 +181,7 @@ otel:
       tag: "0.122.1"
     service: otel-collector.kagenti-system.svc.cluster.local
     port: 4317
+
     # Base collector configuration rendered as the ConfigMap base.yaml.
     # Override any key via values files or --set flags.
     config:
@@ -295,7 +296,8 @@ otel:
           traces:
             span:
               - 'IsMatch(name, "^a2a\\..*")'
-              - 'attributes["http.method"] != nil'
+              - 'name == "POST" or name == "GET" or name == "DELETE"'
+              - 'IsMatch(name, "^mcp-router\\..*") and (attributes["http.method"] == "GET" or attributes["http.method"] == "DELETE")'
               - 'attributes["mcp.method.name"] == "initialize"'
               - 'attributes["mcp.method.name"] == "notifications/initialized"'
               - 'attributes["mcp.method.name"] == "notifications/cancelled"'

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -296,7 +296,7 @@ otel:
           traces:
             span:
               - 'IsMatch(name, "^a2a\\..*")'
-              - 'name == "POST" or name == "GET" or name == "DELETE"'
+              - 'attributes["http.method"] != nil and IsMatch(name, "^(POST|GET|DELETE)$")'
               - 'IsMatch(name, "^mcp-router\\..*") and (attributes["http.method"] == "GET" or attributes["http.method"] == "DELETE")'
               - 'attributes["mcp.method.name"] == "initialize"'
               - 'attributes["mcp.method.name"] == "notifications/initialized"'

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-rc.4
-digest: sha256:d822f29efaa69f25c446d0e8b1945fef909b60fe6fc9941b941fba8892e01830
-generated: "2026-05-13T10:59:44.370918-04:00"
+  version: 0.2.0-rc.5
+digest: sha256:4b39c91e7d735d7767c13845f6238fdbff0c94e0705484652627f256a158a413
+generated: "2026-05-15T08:39:45.726303-04:00"

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.2.0-rc.1
-digest: sha256:929d99c8d231bddfe5ca4125a74684a7795a6d0740003c4f31b5f4e578881a7c
-generated: "2026-05-07T19:50:52.294441-04:00"
+  version: 0.2.0-rc.4
+digest: sha256:d822f29efaa69f25c446d0e8b1945fef909b60fe6fc9941b941fba8892e01830
+generated: "2026-05-13T10:59:44.370918-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: kagenti
 description: A Helm chart for deploying the kagenti platform
 type: application
-version: 0.6.0-rc.3
-appVersion: "0.6.0-rc.3"
+version: 0.6.0-rc.4
+appVersion: "0.6.0-rc.4"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-rc.4
+  version: 0.2.0-rc.5
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: kagenti
 description: A Helm chart for deploying the kagenti platform
 type: application
-version: 0.6.0-rc.1
-appVersion: "0.6.0-rc.1"
+version: 0.6.0-rc.3
+appVersion: "0.6.0-rc.3"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.2.0-rc.1
+  version: 0.2.0-rc.4
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled
 

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -9,5 +9,4 @@ dependencies:
 - name: kagenti-operator-chart
   version: 0.2.0-rc.4
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  condition: components.agentOperator.enabled
-
+  condition: components.agentOperor.enabled

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -9,4 +9,4 @@ dependencies:
 - name: kagenti-operator-chart
   version: 0.2.0-rc.4
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  condition: components.agentOperor.enabled
+  condition: components.agentOperator.enabled

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -123,8 +123,7 @@ data:
   # Keycloak connection (used by operator client registration controller)
   KEYCLOAK_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
   KEYCLOAK_REALM: {{ $root.Values.keycloak.realm | quote }}
-  # KEYCLOAK_NAMESPACE: Not used by sidecars. Included for reference by Helm-hook Jobs.
-  # Sidecars get credentials from local keycloak-admin-secret (replicated by agent-oauth-secret Job).
+  # KEYCLOAK_NAMESPACE: Not used by sidecars or operator. Included for reference by Helm-hook Jobs.
   KEYCLOAK_NAMESPACE: "{{ $root.Values.keycloak.namespace }}"
   # ISSUER: Used by envoy-proxy go-processor for inbound JWT validation.
   # Optional - auto-derived from KEYCLOAK_URL + KEYCLOAK_REALM if not set.

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -113,6 +113,9 @@ data:
 #
 #  NOTE: KEYCLOAK_NAMESPACE is only used by Helm-hook Jobs (spiffe-idp-setup, agent-oauth-secret)
 #  that run at install time with cross-namespace RBAC to read from the Keycloak namespace.
+#  Legacy: Prior to kagenti-operator#321, client-registration sidecars received credentials from
+#  a per-namespace keycloak-admin-secret replicated by agent-oauth-secret Job. Now the operator
+#  controller reads keycloak-admin-secret from its own namespace (kagenti-system) for security.
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -104,35 +104,14 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ (printf "{\"auths\":{\"quay.io\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" $.Values.secrets.quayUser $.Values.secrets.quayToken (printf "%s:%s" $.Values.secrets.quayUser $.Values.secrets.quayToken | b64enc)) | b64enc }}
 ---
-{{- if not $root.Values.keycloak.adminExistingSecret }}
-# ——————————————————————————————————————————————————————————————————————————————
-#  Secret for Keycloak Admin Credentials in Namespace: {{ . }}
-#  Used by the client-registration sidecar to register agents as OAuth clients.
-# ——————————————————————————————————————————————————————————————————————————————
-apiVersion: v1
-kind: Secret
-metadata:
-  name: keycloak-admin-secret
-  namespace: {{ . }}
-  labels:
-    {{- include "kagenti.labels" $root | nindent 4 }}
-type: Opaque
-stringData:
-  KEYCLOAK_ADMIN_USERNAME: {{ $root.Values.keycloak.adminUsername | quote }}
-  KEYCLOAK_ADMIN_PASSWORD: {{ $root.Values.keycloak.adminPassword | quote }}
----
-{{- end }}
-
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for AuthBridge in Namespace: {{ . }}
-#  Consolidated config consumed by injected sidecars:
-#  - kagenti-webhook (injects CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS, JWT_AUDIENCE into client-registration)
-#  - client-registration sidecar (reads KEYCLOAK_URL, KEYCLOAK_REALM, CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS, JWT_AUDIENCE)
-#  - envoy-proxy go-processor (reads ISSUER, EXPECTED_AUDIENCE for inbound JWT validation)
+#  Consolidated config consumed by the kagenti-operator and injected sidecars:
+#  - kagenti-operator: Client registration controller (reads KEYCLOAK_URL, KEYCLOAK_REALM)
+#  - kagenti-webhook: Injects CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS, JWT_AUDIENCE
+#  - authbridge sidecars: Read ISSUER, EXPECTED_AUDIENCE for inbound JWT validation
 #
-#  NOTE: KEYCLOAK_NAMESPACE is NOT used by injected sidecars (credentials come from
-#  local keycloak-admin-secret, replicated to this namespace by agent-oauth-secret Job).
-#  KEYCLOAK_NAMESPACE is only used by Helm-hook Jobs (spiffe-idp-setup, agent-oauth-secret)
+#  NOTE: KEYCLOAK_NAMESPACE is only used by Helm-hook Jobs (spiffe-idp-setup, agent-oauth-secret)
 #  that run at install time with cross-namespace RBAC to read from the Keycloak namespace.
 # ——————————————————————————————————————————————————————————————————————————————
 apiVersion: v1
@@ -141,7 +120,7 @@ metadata:
   name: authbridge-config
   namespace: {{ . }}
 data:
-  # Keycloak connection (used by client-registration sidecar)
+  # Keycloak connection (used by operator client registration controller)
   KEYCLOAK_URL: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
   KEYCLOAK_REALM: {{ $root.Values.keycloak.realm | quote }}
   # KEYCLOAK_NAMESPACE: Not used by sidecars. Included for reference by Helm-hook Jobs.
@@ -153,7 +132,7 @@ data:
   # that appears in token "iss" claims (split-horizon DNS).
   ISSUER: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
   SPIRE_ENABLED: {{ if $root.Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
-  # Authentication configuration (used by webhook injector and client-registration)
+  # Authentication configuration (used by operator and webhook injector)
   CLIENT_AUTH_TYPE: "{{ $root.Values.authBridge.clientAuthType }}"
   SPIFFE_IDP_ALIAS: "{{ $root.Values.authBridge.spiffeIdpAlias }}"
   JWT_AUDIENCE: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
@@ -412,7 +391,7 @@ subjects:
 #  the webhook-injected AuthBridge stack can run:
 #    - proxy-init init container (NET_ADMIN/NET_RAW, root) for iptables
 #    - envoy-proxy sidecar (UID 1337)
-#    - spiffe-helper / client-registration sidecars (UID 1000)
+#    - authbridge-light / spiffe-helper sidecars (UID 1000)
 #  Agent SAs are created dynamically by the operator (name = agent name),
 #  so we use the namespace service accounts group.
 #

--- a/charts/kagenti/templates/kagenti-authbridge-scc.yaml
+++ b/charts/kagenti/templates/kagenti-authbridge-scc.yaml
@@ -5,13 +5,13 @@
 #  The kagenti-webhook injects an AuthBridge sidecar stack into agent pods:
 #    - proxy-init (init): iptables interception (needs NET_ADMIN/NET_RAW, root, non-privileged)
 #    - envoy-proxy (sidecar): Envoy for auth token injection (requests UID 1337)
+#    - authbridge-light (sidecar): OAuth token management (no hardcoded UID)
 #    - spiffe-helper (sidecar): SPIRE identity (UBI image, no hardcoded UID)
-#    - client-registration (sidecar): Keycloak registration (no hardcoded UID)
 #
 #  This SCC grants the minimum permissions needed for AuthBridge sidecars:
 #    - proxy-init needs root + NET_ADMIN/NET_RAW capabilities (not privileged mode)
 #    - envoy-proxy requests UID 1337 (for iptables exclusion coordination)
-#    - spiffe-helper and client-registration run as image-default UIDs (no override)
+#    - authbridge-light and spiffe-helper run as image-default UIDs (no override)
 #  RunAsAny is required because proxy-init needs root and envoy needs UID 1337.
 #  Bound to agent namespaces via the `groups` field below.
 # ——————————————————————————————————————————————————————————————————————————————

--- a/charts/kagenti/templates/keycloak-admin-secret-kagenti-system.yaml
+++ b/charts/kagenti/templates/keycloak-admin-secret-kagenti-system.yaml
@@ -15,18 +15,8 @@
   — returning 503 on every inbound request with "identity not yet
   configured (credentials pending)".
 
-  Sister secret still exists in each agent namespace (see
-  agent-namespaces.yaml) to unblock workloads that opt into the legacy
-  client-registration sidecar via kagenti.io/client-registration-inject=
-  true — that path doesn't read from the operator namespace.
-
   Respect adminExistingSecret: when the operator provides a pre-created
   secret, we don't overwrite it here either.
-
-  Note: a companion PR (kagenti#1422) independently reshapes this area;
-  this template is the minimal change #1507 needs to unblock operator-
-  managed client registration without waiting for #1422's broader
-  cleanup.
 */ -}}
 {{- if not .Values.keycloak.adminExistingSecret }}
 apiVersion: v1

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -243,8 +243,7 @@ kagenti-operator-chart:
       - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
       - "--config-path=/etc/kagenti/config.yaml"
       - "--feature-gates-path=/etc/kagenti/feature-gates/feature-gates.yaml"
-      # Enable client registration controller (operator-managed, not sidecar)
-      - "--enable-client-registration=true"
+      # Client registration controller is enabled by default (operator-managed)
       resources:
         limits:
           cpu: 150m

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -76,7 +76,7 @@ ui:
   frontend:
     enabled: true
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.6.0-rc.1
+    tag: v0.6.0-rc.3
     resources:
       limits:
         cpu: 100m
@@ -90,7 +90,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.6.0-rc.1
+    tag: v0.6.0-rc.3
     # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
     defaultRegistryUrl: ""
     resources:
@@ -108,7 +108,7 @@ ui:
 # ------------------------------------------------------------------
 uiOAuthSecret:
   image: ghcr.io/kagenti/kagenti/ui-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.6.0-rc.3
   # When true, mount the in-cluster serviceaccount CA
   # into the ui-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -120,7 +120,7 @@ uiOAuthSecret:
 # ------------------------------------------------------------------
 agentOAuthSecret:
   image: ghcr.io/kagenti/kagenti/agent-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.6.0-rc.3
   # When true, mount the in-cluster serviceaccount CA
   # into the agent-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -138,7 +138,7 @@ agentOAuthSecret:
 apiOAuthSecret:
   enabled: false
   image: ghcr.io/kagenti/kagenti/api-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.6.0-rc.3
   # Client ID for the API service account
   clientId: kagenti-api
   # Name of the K8s secret to store credentials
@@ -209,7 +209,7 @@ authBridge:
 spiffeIdp:
   image:
     repository: ghcr.io/kagenti/kagenti/spiffe-idp-setup
-    tag: v0.6.0-rc.1
+    tag: v0.6.0-rc.3
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
@@ -220,7 +220,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-alpha.36
+        tag: 0.2.0-rc.4
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -249,21 +249,16 @@ kagenti-operator-chart:
   signatureVerification:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
-  # v0.5.0-alpha.13 was the first release requiring per-plugin
-  # authbridge config (schema cutover — old top-level inbound/
-  # outbound/identity/bypass/routes blocks are rejected).
-  # v0.5.0-alpha.14 adds keycloak_url + keycloak_realm to
-  # jwt-validation so jwks_url derives from the internal URL
-  # (extensions#383); paired with operator v0.2.0-alpha.36 whose
-  # synthesizePipeline emits those fields (operator#336). Both
-  # pins must advance together.
+  # v0.5.0-rc.3: per-plugin config, keycloak_url/realm fields,
+  # lite binaries, a2a-parser contextId fix. Paired with operator
+  # v0.2.0-rc.4.
   defaults:
     images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-alpha.14
-      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-alpha.14
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-alpha.14
-      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-alpha.14
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-alpha.14
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.3
+      authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-rc.3
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-rc.3
+      spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-rc.3
+      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-rc.3
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration
@@ -294,7 +289,7 @@ phoenix:
 # ------------------------------------------------------------------
 phoenixOAuthSecret:
   image: ghcr.io/kagenti/kagenti/phoenix-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.6.0-rc.3
   # Keycloak client ID for Phoenix
   clientId: phoenix
   # Kubernetes secret name to store OAuth credentials
@@ -322,7 +317,7 @@ mlflow:
 # ------------------------------------------------------------------
 mlflowOAuthSecret:
   image: ghcr.io/kagenti/kagenti/mlflow-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.6.0-rc.3
   # Keycloak client ID for MLflow
   clientId: mlflow
   # Kubernetes secret name to store OAuth credentials

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -76,7 +76,7 @@ ui:
   frontend:
     enabled: true
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.6.0-rc.3
+    tag: v0.6.0-rc.4
     resources:
       limits:
         cpu: 100m
@@ -90,7 +90,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.6.0-rc.3
+    tag: v0.6.0-rc.4
     # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
     defaultRegistryUrl: ""
     resources:
@@ -108,7 +108,7 @@ ui:
 # ------------------------------------------------------------------
 uiOAuthSecret:
   image: ghcr.io/kagenti/kagenti/ui-oauth-secret
-  tag: v0.6.0-rc.3
+  tag: v0.6.0-rc.4
   # When true, mount the in-cluster serviceaccount CA
   # into the ui-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -120,7 +120,7 @@ uiOAuthSecret:
 # ------------------------------------------------------------------
 agentOAuthSecret:
   image: ghcr.io/kagenti/kagenti/agent-oauth-secret
-  tag: v0.6.0-rc.3
+  tag: v0.6.0-rc.4
   # When true, mount the in-cluster serviceaccount CA
   # into the agent-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -138,7 +138,7 @@ agentOAuthSecret:
 apiOAuthSecret:
   enabled: false
   image: ghcr.io/kagenti/kagenti/api-oauth-secret
-  tag: v0.6.0-rc.3
+  tag: v0.6.0-rc.4
   # Client ID for the API service account
   clientId: kagenti-api
   # Name of the K8s secret to store credentials
@@ -210,7 +210,7 @@ authBridge:
 spiffeIdp:
   image:
     repository: ghcr.io/kagenti/kagenti/spiffe-idp-setup
-    tag: v0.6.0-rc.3
+    tag: v0.6.0-rc.4
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
@@ -221,7 +221,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.2.0-rc.4
+        tag: 0.2.0-rc.5
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -286,7 +286,7 @@ phoenix:
 # ------------------------------------------------------------------
 phoenixOAuthSecret:
   image: ghcr.io/kagenti/kagenti/phoenix-oauth-secret
-  tag: v0.6.0-rc.3
+  tag: v0.6.0-rc.4
   # Keycloak client ID for Phoenix
   clientId: phoenix
   # Kubernetes secret name to store OAuth credentials
@@ -314,7 +314,7 @@ mlflow:
 # ------------------------------------------------------------------
 mlflowOAuthSecret:
   image: ghcr.io/kagenti/kagenti/mlflow-oauth-secret
-  tag: v0.6.0-rc.3
+  tag: v0.6.0-rc.4
   # Keycloak client ID for MLflow
   clientId: mlflow
   # Kubernetes secret name to store OAuth credentials

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -214,20 +214,6 @@ spiffeIdp:
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
-#  Kagenti Webhook Configuration
-# ------------------------------------------------------------------
-# Pin sidecar image tags to the webhook chart version to prevent
-# breakage when :latest is updated by newer kagenti-extensions builds.
-# These MUST be updated together with the chart version in Chart.yaml.
-# NOTE: The client-registration sidecar has been sunset. Client registration
-# is now handled by the kagenti-operator controller.
-kagenti-webhook-chart:
-  defaults:
-    images:
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.9
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.9
-
-# ------------------------------------------------------------------
 #  Kagenti Operator Configuration (includes AuthBridge webhook)
 # ------------------------------------------------------------------
 kagenti-operator-chart:

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -157,9 +157,10 @@ keycloak:
   adminSecretName: keycloak-initial-admin
   adminUsernameKey: username
   adminPasswordKey: password
-  # Keycloak admin credentials for agent namespaces (keycloak-admin-secret).
-  # Used by the client-registration sidecar to register agents as OAuth clients.
-  # For production, override via .secret_values.yaml or use an existing secret.
+  # Keycloak admin credentials (keycloak-admin-secret in kagenti-system namespace).
+  # Used by the kagenti-operator client registration controller to register
+  # agents as OAuth clients. For production, override via .secret_values.yaml
+  # or use an existing secret.
   adminUsername: admin
   adminPassword: admin
   # Set to an existing Secret name to skip creating keycloak-admin-secret.
@@ -213,6 +214,20 @@ spiffeIdp:
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
+#  Kagenti Webhook Configuration
+# ------------------------------------------------------------------
+# Pin sidecar image tags to the webhook chart version to prevent
+# breakage when :latest is updated by newer kagenti-extensions builds.
+# These MUST be updated together with the chart version in Chart.yaml.
+# NOTE: The client-registration sidecar has been sunset. Client registration
+# is now handled by the kagenti-operator controller.
+kagenti-webhook-chart:
+  defaults:
+    images:
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/envoy-with-processor:v0.4.0-alpha.9
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.4.0-alpha.9
+
+# ------------------------------------------------------------------
 #  Kagenti Operator Configuration (includes AuthBridge webhook)
 # ------------------------------------------------------------------
 kagenti-operator-chart:
@@ -228,10 +243,7 @@ kagenti-operator-chart:
       - "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
       - "--config-path=/etc/kagenti/config.yaml"
       - "--feature-gates-path=/etc/kagenti/feature-gates/feature-gates.yaml"
-      # operator alpha.36 simplified the client-registration flags:
-      # --enable-operator-client-registration was removed, and this flag
-      # now controls operator-based registration directly (legacy sidecar
-      # path is gone). See kagenti-operator commit f5df832.
+      # Enable client registration controller (operator-managed, not sidecar)
       - "--enable-client-registration=true"
       resources:
         limits:
@@ -249,16 +261,13 @@ kagenti-operator-chart:
   signatureVerification:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
-  # v0.5.0-rc.3: per-plugin config, keycloak_url/realm fields,
-  # lite binaries, a2a-parser contextId fix. Paired with operator
-  # v0.2.0-rc.4.
+  # NOTE: The client-registration sidecar has been sunset.
   defaults:
     images:
       envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.3
       authbridgeLight: ghcr.io/kagenti/kagenti-extensions/authbridge-light:v0.5.0-rc.3
       proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.5.0-rc.3
       spiffeHelper: ghcr.io/kagenti/kagenti-extensions/spiffe-helper:v0.5.0-rc.3
-      clientRegistration: ghcr.io/kagenti/kagenti-extensions/client-registration:v0.5.0-rc.3
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -247,6 +247,9 @@ kagenti-operator-chart:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
   # NOTE: The client-registration sidecar has been sunset.
+  # v0.5.0-alpha.14 includes per-plugin config support (extensions#378) and
+  # keycloak_url/keycloak_realm fields in jwt-validation (extensions#383),
+  # required for compatibility with operator v0.2.0-rc.2's synthesizePipeline output.
   defaults:
     images:
       envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.3

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -247,9 +247,9 @@ kagenti-operator-chart:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
   # NOTE: The client-registration sidecar has been sunset.
-  # v0.5.0-alpha.14 includes per-plugin config support (extensions#378) and
+  # v0.5.0-rc.2 includes per-plugin config support (extensions#378) and
   # keycloak_url/keycloak_realm fields in jwt-validation (extensions#383),
-  # required for compatibility with operator v0.2.0-rc.2's synthesizePipeline output.
+  # required for compatibility with operator v0.2.0-rc.3's synthesizePipeline output.
   defaults:
     images:
       envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.5.0-rc.3

--- a/docs/components.md
+++ b/docs/components.md
@@ -446,18 +446,19 @@ Kagenti provides a unified framework for identity and authorization in agentic s
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| **[Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/client-registration)** | Automatic OAuth2/OIDC client provisioning using SPIFFE ID | `AuthBridge/client-registration` |
 | **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
 | **[SPIRE](https://spiffe.io/docs/latest/spire-about/)** | Workload identity and attestation | External |
 | **[Keycloak](https://www.keycloak.org/)** | Identity provider and access management | External |
 
-### Client Registration
+### Keycloak Client Registration (Operator-Managed)
 
-Automatically registers Kubernetes workloads as Keycloak clients at pod startup:
+Keycloak client registration is handled by the kagenti-operator's ClientRegistrationReconciler controller:
 
+- Watches for Deployments/StatefulSets labeled with `kagenti.io/type: agent` or `tool`
 - Uses **SPIFFE ID** as client identifier (e.g., `spiffe://localtest.me/ns/team/sa/my-agent`)
-- Eliminates manual client creation and secret distribution
-- Writes credentials to shared volume for application use
+- Reads Keycloak admin credentials from the operator namespace (`kagenti-system`)
+- Creates a secret in the agent namespace containing client credentials
+- Eliminates the need for admin credentials in agent namespaces
 
 ### AuthProxy
 
@@ -497,7 +498,7 @@ An Envoy-based sidecar that handles both **inbound JWT validation** and **outbou
 - **Inbound JWT Validation** — Validates token signature, expiration, and issuer using JWKS keys fetched from Keycloak. Optionally validates the audience claim. Returns HTTP 401 for missing or invalid tokens.
 - **Outbound Token Exchange** — Performs [OAuth 2.0 Token Exchange (RFC 8693)](https://datatracker.ietf.org/doc/html/rfc8693) to replace the caller's token with one scoped to the target service audience
 - **Transparent to applications** — Traffic interception via iptables; no application code changes required
-- **Configuration** — Inbound validation is configured via `ISSUER` (required) and `EXPECTED_AUDIENCE` (optional) environment variables. Outbound exchange uses `TOKEN_URL`, `CLIENT_ID`, `CLIENT_SECRET`, and `TARGET_AUDIENCE`.
+- **Configuration** — Inbound validation is configured via `ISSUER` (required) and `EXPECTED_AUDIENCE` (optional) environment variables. Outbound exchange uses `TOKEN_URL`, `CLIENT_ID`, `CLIENT_SECRET` (provided by the operator via secret), and `TARGET_AUDIENCE`.
 
 ### SPIRE (Workload Identity)
 
@@ -518,7 +519,7 @@ An Envoy-based sidecar that handles both **inbound JWT validation** and **outbou
 | Feature | Description |
 |---------|-------------|
 | **User Management** | Create and manage Kagenti users |
-| **Client Registration** | OAuth clients for agents and UI (e.g. automated Keycloak Client registration via [Client Registration](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/client-registration) component) |
+| **Client Registration** | OAuth clients for agents and UI (automated registration via kagenti-operator's ClientRegistrationReconciler) |
 | **Token Exchange** | Exchange tokens between audiences ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) |
 | **SSO** | Single sign-on across Kagenti components |
 

--- a/docs/design-proposals/consolidated-compositional-agent-platform-design.md
+++ b/docs/design-proposals/consolidated-compositional-agent-platform-design.md
@@ -243,7 +243,6 @@ Webhook Intercepts Pod CREATE (pods carry controller-applied labels)
   • Injects AuthBridge sidecars:
     - proxy-init (init container — network setup)
     - spiffe-helper (identity)
-    - client-registration (IdP integration)
     - envoy-proxy (outbound token exchange)
         ↓
 Agent Pod Running with Secure Identity
@@ -764,10 +763,11 @@ This is the same approach used for Istio sidecar injection labels.
 |-----------|------|---------|
 | `proxy-init` | Init Container | Sets up iptables for traffic interception |
 | `spiffe-helper` | Sidecar | Manages SPIFFE workload identity |
-| `client-registration` | Sidecar | Registers agent with identity provider |
 | `envoy-proxy` | Sidecar | Intercepts outbound traffic, performs token exchange |
 
 > **Note: AuthBridge Sidecar Consolidation** — The current AuthBridge implementation uses multiple sidecars as listed above. The Kagenti team plans to consolidate these into fewer containers in the near term. The current multi-sidecar design reflects the initial implementation where each concern was developed independently. Consolidation will reduce per-pod resource overhead, simplify configuration propagation (fewer processes to update), and reduce pod startup latency. The architecture described in this proposal is designed to work with both the current multi-sidecar layout and the future consolidated form — the webhook injects whatever the current AuthBridge implementation requires, and the number of injected containers is an implementation detail transparent to the developer.
+> 
+> **Note: Operator-Managed Client Registration** — Keycloak client registration is now handled by the kagenti-operator controller, not by an injected sidecar. The operator's ClientRegistrationReconciler watches deployments labeled as agents or tools and automatically registers them with Keycloak using credentials from the operator namespace. This eliminates the need for admin credentials in agent namespaces and provides better security isolation.
 
 ### Controller Architecture
 
@@ -832,7 +832,7 @@ The specific mechanism for this propagation is still under discussion. The candi
 
 **Current assessment**: For the Envoy proxy sidecar (which handles outbound token exchange and traffic interception), **xDS is the leading candidate** — it is Envoy's native configuration interface and provides the low-latency updates required for security-sensitive configuration like token exchange rules and destination policies.
 
-> **Open gap: Non-Envoy sidecar configuration propagation.** The mechanism for propagating configuration to non-Envoy sidecars (spiffe-helper, client-registration) is not yet defined. These sidecars currently read configuration from environment variables and mounted ConfigMaps at startup. Dynamic reconfiguration without pod restart is an unsolved problem for these components. This gap should be tracked explicitly and addressed in a future design iteration.
+> **Open gap: Non-Envoy sidecar configuration propagation.** The mechanism for propagating configuration to non-Envoy sidecars (spiffe-helper) is not yet defined. These sidecars currently read configuration from environment variables and mounted ConfigMaps at startup. Dynamic reconfiguration without pod restart is an unsolved problem for these components. This gap should be tracked explicitly and addressed in a future design iteration.
 
 **Requirements regardless of mechanism**:
 - Configuration changes should reach running sidecars without pod restarts where possible; changes to sidecar images or init containers require a pod restart
@@ -1097,20 +1097,20 @@ Unchanged from original proposal:
 
 ### Sidecar Consolidation Plan
 
-The current AuthBridge implementation injects four containers per pod:
+The current AuthBridge implementation injects three containers per pod:
 
 | Container | Purpose | Runtime |
 |-----------|---------|---------|
 | `proxy-init` | iptables redirect setup | Init container (short-lived) |
 | `envoy-proxy` | Envoy + go-processor ext-proc (outbound token exchange, inbound JWT validation) | Go + Envoy |
 | `spiffe-helper` | SPIFFE JWT-SVID management | Go |
-| `kagenti-client-registration` | Keycloak client registration | Python |
+
+**Keycloak Client Registration** is now handled by the kagenti-operator's ClientRegistrationReconciler controller rather than an injected sidecar. This provides better security isolation by keeping Keycloak admin credentials in the operator namespace.
 
 **Planned consolidation** (tracked as a separate work item):
 
 1. **Merge spiffe-helper into go-processor**: The go-processor already reads JWT-SVIDs; spiffe-helper's role (writing SVIDs to disk) can be absorbed into the go-processor or handled via SPIRE's workload API directly.
-2. **Merge client-registration into go-processor**: Client registration is a one-time operation that writes `client-id.txt` and `client-secret.txt`. This can run as an init phase within the go-processor.
-3. **Target state**: 2 containers — `proxy-init` (init) + `envoy-proxy` (sidecar with consolidated go-processor).
+2. **Target state**: 2 containers — `proxy-init` (init) + `envoy-proxy` (sidecar with consolidated go-processor).
 
 **Benefits**: Reduced per-pod resource overhead, simplified configuration propagation (one process to update), reduced pod startup latency, fewer shared volumes.
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -263,23 +263,17 @@ grant_type=authorization_code
 }
 ```
 
-#### Stage 2: Keycloak Client Registration Flow (Secret-based)
+#### Stage 2: Keycloak Client Registration Flow (Operator-managed)
 
-![Keycloak Client Registration Flow (Secret-based) Flow](./diagrams/images/png/02-kagenti-client-registration.png)
+Keycloak client registration is now handled by the kagenti-operator's ClientRegistrationReconciler controller. The controller:
+1. Watches for Deployments/StatefulSets labeled with `kagenti.io/type: agent` or `tool`
+2. Reads Keycloak admin credentials from the `keycloak-admin-secret` in the operator namespace (`kagenti-system`)
+3. Uses the workload's SPIFFE ID as the client identifier
+4. Registers the client with Keycloak and creates a secret containing client credentials in the agent namespace
 
-*Figure 2: Keycloak Client Registration Flow (Secret-based) Flow - Shows how automatic client registration registers clients in Keycloak*
+This approach provides better security isolation by restricting Keycloak admin credentials to the operator namespace rather than replicating them to every agent namespace.
 
-[View Mermaid Source Code](./diagrams/02-kagenti-client-registration.mmd)
-
-#### Stage 3: Keycloak Client Registration Flow (Secretless with OIDC DCR)
-
-![Keycloak Client Registration Flow (Secretless with OIDC DCR) Flow](./diagrams/images/png/03-kagenti-client-registreation-final.png)
-
-*Figure 3: Keycloak Client Registration Flow (Secretless with OIDC DCR) Flow - Shows how automatic client registration registers clients in Keycloak without credentials*
-
-[View Mermaid Source Code](./diagrams/03-kagenti-client-registreation-final.mmd)
-
-#### Stage 4: Agent Token Exchange
+#### Stage 3: Agent Token Exchange
 
 ![Agent Token Exchange Flow](./diagrams/images/png/04-agent-token-exchange-flow.png)
 
@@ -311,11 +305,11 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 }
 ```
 
-#### Stage 5: Internal Tool Access with Delegated Token
+#### Stage 4: Internal Tool Access with Delegated Token
 
 ![Internal Tool Access with Delegated Token Flow](./diagrams/images/png/05-tool-access-delegated-token-flow.png)
 
-*Figure 5: Internal Tool Access Flow - Shows how agents call internal tools using delegated tokens with proper permission validation*
+*Figure 4: Internal Tool Access Flow - Shows how agents call internal tools using delegated tokens with proper permission validation*
 
 [View Mermaid Source Code](./diagrams/05-tool-access-delegated-token-flow.mmd)
 
@@ -355,11 +349,11 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 
 The **MCP Gateway** acts as an authentication proxy for all Model Context Protocol communications:
 
-#### Stage 6: Gateway Authentication Flow
+#### Stage 5: Gateway Authentication Flow
 
 ![MCP Gateway Authentication Flow](./diagrams/images/png/06-mcp-gateway-authentication-flow.png)
 
-*Figure 6: MCP Gateway Authentication Flow - Illustrates authentication flow through the MCP Gateway proxy for Model Context Protocol communications*
+*Figure 5: MCP Gateway Authentication Flow - Illustrates authentication flow through the MCP Gateway proxy for Model Context Protocol communications*
 
 [View Mermaid Source Code](./diagrams/06-mcp-gateway-authentication-flow.mmd)
 
@@ -439,11 +433,11 @@ def validate_request(request):
         raise AuthorizationError("Insufficient permissions")
 ```
 
-#### Stage 7: External API Access with Delegated Token and Vault
+#### Stage 6: External API Access with Delegated Token and Vault
 
 ![External API Access with Delegated Token and Vault Flow](./diagrams/images/png/07-tool-with-external-api-flow.png)
 
-*Figure 7: External API Access with Vault Flow - Shows how agents call internal tools using delegated tokens with proper permission validation and the Vault exchanges this token for external API key for accessing external APIs*
+*Figure 6: External API Access with Vault Flow - Shows how agents call internal tools using delegated tokens with proper permission validation and the Vault exchanges this token for external API key for accessing external APIs*
 
 [View Mermaid Source Code](./diagrams/07-tool-with-external-api-flow.mmd)
 
@@ -479,77 +473,34 @@ def validate_request(request):
 
 ### Client Registration Process
 
-#### Automatic Registration via Init Container
+#### Operator-Managed Registration
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: slack-researcher
-spec:
-  template:
-    spec:
-      initContainers:
-      - name: client-registration
-        image: ghcr.io/kagenti/client-registration:latest
-        env:
-        - name: KEYCLOAK_URL
-          value: "http://keycloak.keycloak.svc.cluster.local:8080"
-        - name: CLIENT_NAME
-          value: "slack-researcher"
-        - name: KEYCLOAK_REALM
-          value: "master"
-        volumeMounts:
-        - name: spiffe-workload-api
-          mountPath: /spiffe-workload-api
-        - name: shared-secrets
-          mountPath: /shared
-      containers:
-      - name: slack-researcher
-        image: ghcr.io/kagenti/slack-researcher:latest
-        volumeMounts:
-        - name: shared-secrets
-          mountPath: /secrets
-```
+Keycloak client registration is handled automatically by the kagenti-operator's ClientRegistrationReconciler. When you deploy an agent or tool:
 
-#### Manual Client Registration
+1. **Label the workload** with `kagenti.io/type: agent` or `kagenti.io/type: tool`
+2. **The operator watches** for these labeled workloads
+3. **The operator registers** the workload with Keycloak using:
+   - SPIFFE ID as the client identifier (e.g., `spiffe://localtest.me/ns/team/sa/slack-researcher`)
+   - Keycloak admin credentials from the `keycloak-admin-secret` in the operator namespace
+4. **The operator creates** a secret in the agent namespace containing client credentials
+
+This is fully automatic and requires no manual intervention or init containers.
+
+#### Reading Client Credentials in Application Code
+
+Applications can read the client credentials from the secret created by the operator:
 
 ```python
-from keycloak import KeycloakAdmin
-import jwt
+import os
 
-# Read SPIFFE JWT SVID
-with open("/opt/jwt_svid.token", "r") as f:
-    jwt_svid = f.read().strip()
+# Read client credentials from operator-created secret
+# Mounted at /secrets by the platform
+client_id = open("/secrets/client-id.txt").read().strip()
+client_secret = open("/secrets/client-secret.txt").read().strip()
 
-# Extract client ID from SPIFFE identity
-payload = jwt.decode(jwt_svid, options={"verify_signature": False})
-client_id = payload["sub"]  # e.g., spiffe://localtest.me/ns/team/sa/slack-researcher
-
-# Register with Keycloak
-keycloak_admin = KeycloakAdmin(
-    server_url="http://keycloak.keycloak.svc.cluster.local:8080",
-    username="admin",
-    password="admin",
-    realm_name="master"
-)
-
-client_payload = {
-    "clientId": client_id,
-    "name": "Slack Researcher Agent",
-    "standardFlowEnabled": True,
-    "directAccessGrantsEnabled": True,
-    "serviceAccountsEnabled": True,
-    "publicClient": False,
-    "attributes": {
-        "oauth2.device.authorization.grant.enabled": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "client.secret.creation.time": str(int(time.time()))
-    }
-}
-
-internal_client_id = keycloak_admin.create_client(client_payload)
-print(f"Registered client: {client_id} with internal ID: {internal_client_id}")
+# Use credentials for OAuth2 flows
+keycloak_url = os.getenv("KEYCLOAK_URL", "http://keycloak.keycloak.svc.cluster.local:8080")
+realm = os.getenv("KEYCLOAK_REALM", "master")
 ```
 
 ### Token Exchange Implementation
@@ -610,15 +561,99 @@ tool_response = requests.post(
 
 ## 🌉 AuthBridge Component
 
-AuthBridge provides platform primitives to secure AI agents by managing agent identity,
-authentication, and authorization transparently. For comprehensive documentation, see:
+The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete, hands-on implementation of Kagenti's identity and authorization patterns. It combines **Client Registration** and **AuthProxy** to demonstrate the full zero-trust authentication flow.
 
-- **[AuthBridge Documentation](./authbridge/README.md)** — Overview, architecture, and persona guides
-- **[Security Model](./authbridge/security-model.md)** — Trust model, token exchange, threat model
-- **[Deployment Guide](./authbridge/deployment-guide.md)** — Modes, configuration, troubleshooting
-- **[Demos](./authbridge/demos.md)** — Progressive hands-on walkthrough
-- **[Roadmap](./authbridge/roadmap.md)** — Vision and upcoming features
-- **[AuthBridge Source](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** — Implementation and demo code
+### What AuthBridge Demonstrates
+
+| Capability | Description |
+|------------|-------------|
+| **Automatic Workload Identity** | Pod registers itself with Keycloak using SPIFFE ID |
+| **Inbound JWT Validation** | Validates incoming token signature, expiration, and issuer via JWKS; optionally validates audience. Returns 401 for invalid tokens. |
+| **Transparent Token Exchange** | Sidecar exchanges outbound tokens for correct target audience via Keycloak |
+| **Target Service Validation** | Target validates token has correct audience |
+
+### AuthBridge Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│  1. SPIFFE Helper obtains SVID from SPIRE Agent                                 │
+│  2. Client Registration extracts SPIFFE ID and registers with Keycloak          │
+│  3. Caller gets token from Keycloak (audience: "caller's SPIFFE ID")            │
+│  4. Caller sends request to auth-target with token                              │
+│  5. Envoy intercepts; Go Processor (ext-proc) validates token signature,        │
+│     expiration, and issuer via JWKS (returns 401 if invalid), then exchanges    │
+│     token for target audience (audience: "auth-target")                         │
+│  6. Auth Target validates token and returns "authorized"                        │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+  SPIRE Agent                    Keycloak                       Auth Target
+       │                            │                               │
+       │  1. SVID                   │                               │
+       ▼                            │                               │
+  ┌─────────┐                       │                               │
+  │ SPIFFE  │  2. Register client   │                               │
+  │ Helper  │──────────────────────►│                               │
+  └─────────┘                       │                               │
+       │                            │                               │
+       ▼                            │                               │
+  ┌─────────┐  3. Get token         │                               │
+  │ Caller  │──────────────────────►│                               │
+  │         │◄──────────────────────│                               │
+  │         │   (aud: authproxy)    │                               │
+  │         │                       │                               │
+  │         │  4. Request + token   │                               │
+  │         │───────────────────────┼──────────────────────────────►│
+  └─────────┘                       │                               │
+       │                            │                               │
+       │      ┌──────────────┐      │                               │
+       └─────►│ Envoy+GoPro  │      │                               │
+              │              │  5. Exchange token                   │
+              │              │─────►│                               │
+              │              │◄─────│                               │
+              │              │   (aud: auth-target)                 │
+              │              │─────────────────────────────────────►│
+              └──────────────┘                              6. Validate & Authorize
+                                                                    │
+                                                               "authorized"
+```
+
+### AuthBridge Components
+
+| Component | Type | Purpose |
+|-----------|------|---------|
+| **SPIFFE Helper** | Container | Obtains SVID from SPIRE Agent |
+| **Envoy + Go Processor (Ext Proc)** | Sidecar | Intercepts traffic in both directions: **inbound** — validates JWT (signature, expiration, issuer, optional audience) via JWKS, returns 401 for invalid tokens; **outbound** — exchanges tokens for target audience via Keycloak |
+| **Auth Target** | Deployment | Target service that validates exchanged tokens |
+
+> **Note**: Keycloak client registration is handled by the kagenti-operator's ClientRegistrationReconciler controller, not by an AuthBridge component. The operator automatically registers agents and tools with Keycloak using credentials from the operator namespace.
+
+### Installation and Hands-On Demo
+
+The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete end-to-end example:
+
+```bash
+# Clone and deploy
+cd AuthBridge
+python setup_keycloak.py           # Configure Keycloak
+kubectl apply -f k8s/authbridge-deployment.yaml  # Deploy demo
+
+# Test
+kubectl exec -it deployment/caller -n authbridge -c caller -- sh
+TOKEN=$(curl -s ... | jq -r '.access_token')
+curl -H "Authorization: Bearer $TOKEN" http://auth-target-service:8081/test
+# Returns: "authorized"
+```
+
+For detailed installation and demo instructions please see the [AuthBridge Demo](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)
+
+### AuthBridge Documentation
+
+For complete documentation, see:
+
+- **[AuthBridge README](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** - Full demo instructions
+- **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** - Token validation and exchange proxy
+
+> **Note**: The AuthBridge demo in kagenti-extensions includes client-registration components for demonstration purposes. In production Kagenti deployments, client registration is handled by the kagenti-operator controller.
 
 ---
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -480,7 +480,9 @@ Keycloak client registration is handled automatically by the kagenti-operator's 
 1. **Label the workload** with `kagenti.io/type: agent` or `kagenti.io/type: tool`
 2. **The operator watches** for these labeled workloads
 3. **The operator registers** the workload with Keycloak using:
-   - SPIFFE ID as the client identifier (e.g., `spiffe://localtest.me/ns/team/sa/slack-researcher`)
+   - Client ID pattern depends on whether SPIFFE is enabled:
+     - **SPIFFE disabled**: `namespace/workload-name` (e.g., `team1/slack-researcher`)
+     - **SPIFFE enabled**: `spiffe://trustdomain/ns/namespace/sa/serviceaccount` (e.g., `spiffe://localtest.me/ns/team1/sa/slack-researcher-sa`)
    - Keycloak admin credentials from the `keycloak-admin-secret` in the operator namespace
 4. **The operator creates** a secret in the agent namespace containing client credentials
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -578,56 +578,61 @@ The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/ma
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────┐
-│  1. SPIFFE Helper obtains SVID from SPIRE Agent                                 │
-│  2. Client Registration extracts SPIFFE ID and registers with Keycloak          │
-│  3. Caller gets token from Keycloak (audience: "caller's SPIFFE ID")            │
-│  4. Caller sends request to auth-target with token                              │
-│  5. Envoy intercepts; Go Processor (ext-proc) validates token signature,        │
-│     expiration, and issuer via JWKS (returns 401 if invalid), then exchanges    │
-│     token for target audience (audience: "auth-target")                         │
-│  6. Auth Target validates token and returns "authorized"                        │
+│  1. Operator watches workloads with kagenti.io/type label                       │
+│  2. Operator registers client with Keycloak (using admin credentials from       │
+│     operator namespace) and creates credentials secret in agent namespace       │
+│  3. (If SPIFFE enabled) SPIFFE Helper obtains SVID from SPIRE Agent             │
+│  4. Agent gets token from Keycloak using credentials from secret                │
+│  5. Agent sends request to target with token                                    │
+│  6. Envoy+ext-proc intercepts: validates token signature, expiration, issuer    │
+│     via JWKS (returns 401 if invalid), then exchanges token for target audience │
+│  7. Target receives request with exchanged token and validates audience         │
 └─────────────────────────────────────────────────────────────────────────────────┘
 
-  SPIRE Agent                    Keycloak                       Auth Target
-       │                            │                               │
-       │  1. SVID                   │                               │
-       ▼                            │                               │
-  ┌─────────┐                       │                               │
-  │ SPIFFE  │  2. Register client   │                               │
-  │ Helper  │──────────────────────►│                               │
-  └─────────┘                       │                               │
-       │                            │                               │
-       ▼                            │                               │
-  ┌─────────┐  3. Get token         │                               │
-  │ Caller  │──────────────────────►│                               │
-  │         │◄──────────────────────│                               │
-  │         │   (aud: authproxy)    │                               │
-  │         │                       │                               │
-  │         │  4. Request + token   │                               │
-  │         │───────────────────────┼──────────────────────────────►│
-  └─────────┘                       │                               │
-       │                            │                               │
-       │      ┌──────────────┐      │                               │
-       └─────►│ Envoy+GoPro  │      │                               │
-              │              │  5. Exchange token                   │
-              │              │─────►│                               │
-              │              │◄─────│                               │
-              │              │   (aud: auth-target)                 │
-              │              │─────────────────────────────────────►│
-              └──────────────┘                              6. Validate & Authorize
-                                                                    │
-                                                               "authorized"
+  Operator                   SPIRE Agent           Keycloak              Target
+       │                         │                     │                    │
+       │ 1. Watch workload       │                     │                    │
+       │ 2. Register client      │                     │                    │
+       ├─────────────────────────┼────────────────────►│                    │
+       │                         │                     │                    │
+       │ Create credentials      │                     │                    │
+       │ secret in agent ns      │                     │                    │
+       │                         │                     │                    │
+       │              ┌─────────┐│  3. Get SVID        │                    │
+       │              │ SPIFFE  ││◄────────────────────┤                    │
+       │              │ Helper  ││                     │                    │
+       │              └─────────┘│                     │                    │
+       │                    │    │                     │                    │
+       │              ┌─────────┐│                     │                    │
+       │              │  Agent  ││  4. Get token       │                    │
+       │              │         ││────────────────────►│                    │
+       │              │         ││◄────────────────────│                    │
+       │              │         ││  (aud: agent's ID)  │                    │
+       │              │         ││                     │                    │
+       │              │         ││  5. Request + token │                    │
+       │              │         ││─────────────────────┼───────────────────►│
+       │              └─────────┘│                     │                    │
+       │                    │    │                     │                    │
+       │         ┌──────────────┐│                     │                    │
+       │         │ Envoy+ext-pr ││  6. Validate &      │                    │
+       │         │              ││     Exchange token  │                    │
+       │         │              ││────────────────────►│                    │
+       │         │              ││◄────────────────────│                    │
+       │         │              ││  (aud: target)      │                    │
+       │         │              ││─────────────────────┼───────────────────►│
+       │         └──────────────┘│                     │  7. Validate aud   │
+       │                         │                     │       "authorized" │
 ```
 
 ### AuthBridge Components
 
 | Component | Type | Purpose |
 |-----------|------|---------|
-| **SPIFFE Helper** | Container | Obtains SVID from SPIRE Agent |
+| **Kagenti Operator** | Controller | Watches for workloads with `kagenti.io/type` label, registers them as OAuth clients in Keycloak, and creates credentials secrets in agent namespaces |
+| **SPIFFE Helper** | Container | (Optional, when SPIFFE enabled) Obtains SVID from SPIRE Agent for workload identity |
 | **Envoy + Go Processor (Ext Proc)** | Sidecar | Intercepts traffic in both directions: **inbound** — validates JWT (signature, expiration, issuer, optional audience) via JWKS, returns 401 for invalid tokens; **outbound** — exchanges tokens for target audience via Keycloak |
-| **Auth Target** | Deployment | Target service that validates exchanged tokens |
 
-> **Note**: Keycloak client registration is handled by the kagenti-operator's ClientRegistrationReconciler controller, not by an AuthBridge component. The operator automatically registers agents and tools with Keycloak using credentials from the operator namespace.
+> **Note**: Client registration is fully automatic. The operator reads Keycloak admin credentials from `keycloak-admin-secret` in the operator namespace (not from agent namespaces), providing better security isolation.
 
 ### Installation and Hands-On Demo
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -634,24 +634,12 @@ The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/ma
 
 > **Note**: Client registration is fully automatic. The operator reads Keycloak admin credentials from `keycloak-admin-secret` in the operator namespace (not from agent namespaces), providing better security isolation.
 
-### Installation and Hands-On Demo
+### Hands-On Demos
 
-The [AuthBridge Component](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) provides a complete end-to-end example:
+For step-by-step AuthBridge demos with real working examples, see:
 
-```bash
-# Clone and deploy
-cd AuthBridge
-python setup_keycloak.py           # Configure Keycloak
-kubectl apply -f k8s/authbridge-deployment.yaml  # Deploy demo
-
-# Test
-kubectl exec -it deployment/caller -n authbridge -c caller -- sh
-TOKEN=$(curl -s ... | jq -r '.access_token')
-curl -H "Authorization: Bearer $TOKEN" http://auth-target-service:8081/test
-# Returns: "authorized"
-```
-
-For detailed installation and demo instructions please see the [AuthBridge Demo](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)
+- **[AuthBridge Weather Demo](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/demos/weather-agent)** — Complete end-to-end example showing token exchange between a weather agent and weather tool
+- **[AuthBridge Documentation](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** — Component documentation and additional examples
 
 ### AuthBridge Documentation
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,6 +8,7 @@ This guide covers installation on both local Kind clusters and OpenShift environ
   - [macOS Quick Start (New Machine)](#macos-quick-start-new-machine)
 - [Kind Installation (Local Development)](#kind-installation-local-development)
 - [OpenShift Installation](#openshift-installation)
+- [Using the OpenShift Internal Container Registry](#using-the-openshift-internal-container-registry)
 - [Accessing the UI](#accessing-the-ui)
 - [Verifying the Installation](#verifying-the-installation)
 
@@ -280,6 +281,67 @@ kubectl get daemonsets -n zero-trust-workload-identity-manager
 ```
 
 If `Current` or `Ready` is `0`, see [Troubleshooting](#spire-daemonset-issues).
+
+### Using the OpenShift Internal Container Registry
+
+The Kagenti UI allows building agent images and pushing them to the OpenShift
+internal registry (`image-registry.openshift-image-registry.svc:5000`). This
+requires a push secret and appropriate RBAC in each agent namespace.
+
+#### Prerequisites
+
+- OpenShift Builds enabled (`--with-builds` flag or installed separately)
+- The internal image registry must be in `Managed` state (default on ROSA / OCP 4.x)
+
+Verify the registry is running:
+
+```bash
+oc get configs.imageregistry.operator.openshift.io cluster -o jsonpath='{.spec.managementState}'
+# Expected: Managed
+
+oc get pods -n openshift-image-registry -l docker-registry=default
+# Expected: 1/1 Running
+```
+
+#### Create a Registry Push Secret
+
+Create a dedicated service account with image-builder permissions, then generate
+a docker-config secret that Shipwright uses to push built images:
+
+```bash
+NAMESPACE=team1   # repeat for each agent namespace
+
+# Create a dedicated SA for registry push
+oc create sa registry-pusher -n $NAMESPACE
+
+# Grant push access to the internal registry
+oc policy add-role-to-user system:image-builder \
+  system:serviceaccount:$NAMESPACE:registry-pusher -n $NAMESPACE
+
+# Grant pull access so deployed pods can pull images
+oc policy add-role-to-user system:image-puller \
+  system:serviceaccount:$NAMESPACE:default -n $NAMESPACE
+
+# Create the push secret (name must match the UI convention: openshift-registry-secret)
+TOKEN=$(oc create token registry-pusher -n $NAMESPACE --duration=8760h)
+oc create secret docker-registry openshift-registry-secret \
+  --docker-server=image-registry.openshift-image-registry.svc:5000 \
+  --docker-username=registry-pusher \
+  --docker-password="$TOKEN" \
+  -n $NAMESPACE
+```
+
+#### Using the Registry from the UI
+
+When importing an agent or tool from the Kagenti UI:
+
+1. Select **OpenShift Internal Registry** as the Container Registry
+2. The registry URL is pre-filled: `image-registry.openshift-image-registry.svc:5000`
+3. The registry secret is auto-populated as `openshift-registry-secret`
+4. The **Registry Namespace** is the Kubernetes namespace (e.g. `team1`)
+
+Built images are pushed to:
+`image-registry.openshift-image-registry.svc:5000/<namespace>/<agent-name>:<tag>`
 
 ---
 

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2414,8 +2414,6 @@ def _build_common_labels(
         labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
     if request.spiffeHelperInject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    # Note: Client registration is now handled by kagenti-operator, not sidecars.
-    # The clientRegistrationInject field is deprecated and ignored.
     return labels
 
 

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2612,7 +2612,7 @@ def _build_service_manifest(request: "CreateAgentRequest") -> dict:
     Returns:
         Service manifest dictionary.
     """
-    labels = _build_common_labels(request, WORKLOAD_TYPE_DEPLOYMENT)
+    labels = _build_common_labels(request, request.workloadType)
     selector_labels = _build_selector_labels(request)
 
     # Build service ports
@@ -3066,8 +3066,8 @@ async def create_agent(
                 )
                 logger.info(f"Created Sandbox '{request.name}' in namespace '{request.namespace}'")
 
-            # Create Service (not needed for Jobs or Sandboxes)
-            if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+            # Create Service (not needed for Jobs — Sandbox uses backend-managed Service)
+            if request.workloadType != WORKLOAD_TYPE_JOB:
                 service_manifest = _build_service_manifest(request)
                 kube.create_service(
                     namespace=request.namespace,

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2414,8 +2414,8 @@ def _build_common_labels(
         labels[KAGENTI_ENVOY_PROXY_INJECT_LABEL] = "false"
     if request.spiffeHelperInject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    if request.clientRegistrationInject is True:
-        labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
+    # Note: Client registration is now handled by kagenti-operator, not sidecars.
+    # The clientRegistrationInject field is deprecated and ignored.
     return labels
 
 

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2863,18 +2863,7 @@ def _build_sandbox_manifest(
     shipwright_build_name: Optional[str] = None,
 ) -> dict:
     """Build a Sandbox manifest (agents.x-k8s.io/v1alpha1) for direct creation."""
-    # Sandbox controller creates a headless Service with no port translation,
-    # so the container must listen on the same port clients connect to (the
-    # external service port, which is also baked into AGENT_ENDPOINT). For
-    # other workload types the Service port-translates to targetPort, so the
-    # split is fine there.
-    service_port = (
-        request.servicePorts[0].port if request.servicePorts else DEFAULT_OFF_CLUSTER_PORT
-    )
-    env_vars = [
-        {"name": "PORT", "value": str(service_port)} if ev.get("name") == "PORT" else ev
-        for ev in _build_env_vars(request)
-    ]
+    env_vars = _build_env_vars(request)
     labels = _build_common_labels(request, WORKLOAD_TYPE_SANDBOX)
 
     annotations: Dict[str, str] = {
@@ -2883,7 +2872,9 @@ def _build_sandbox_manifest(
     if shipwright_build_name:
         annotations["kagenti.io/shipwright-build"] = shipwright_build_name
 
-    container_port = service_port
+    container_port = DEFAULT_IN_CLUSTER_PORT
+    if request.servicePorts and len(request.servicePorts) > 0:
+        container_port = request.servicePorts[0].targetPort
 
     manifest = {
         "apiVersion": f"{AGENT_SANDBOX_CRD_GROUP}/{AGENT_SANDBOX_CRD_VERSION}",
@@ -2896,6 +2887,7 @@ def _build_sandbox_manifest(
         },
         "spec": {
             "replicas": 1,
+            "service": False,
             "podTemplate": {
                 "metadata": {
                     "labels": {

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3068,11 +3068,27 @@ async def create_agent(
             # Create Service (not needed for Jobs — Sandbox uses backend-managed Service)
             if request.workloadType != WORKLOAD_TYPE_JOB:
                 service_manifest = _build_service_manifest(request)
-                kube.create_service(
-                    namespace=request.namespace,
-                    body=service_manifest,
-                )
-                logger.info(f"Created Service '{request.name}' in namespace '{request.namespace}'")
+                try:
+                    kube.create_service(
+                        namespace=request.namespace,
+                        body=service_manifest,
+                    )
+                    logger.info(
+                        f"Created Service '{request.name}' in namespace '{request.namespace}'"
+                    )
+                except ApiException as e:
+                    if e.status == 409 and request.workloadType == WORKLOAD_TYPE_SANDBOX:
+                        logger.warning(
+                            f"Service '{request.name}' already exists (Sandbox controller race); "
+                            f"replacing with backend-managed ClusterIP Service"
+                        )
+                        kube.delete_service(namespace=request.namespace, name=request.name)
+                        kube.create_service(namespace=request.namespace, body=service_manifest)
+                        logger.info(
+                            f"Replaced Service '{request.name}' in namespace '{request.namespace}'"
+                        )
+                    else:
+                        raise
 
             # Create AgentRuntime CR so the webhook injects sidecars on pod rollout
             if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2887,7 +2887,6 @@ def _build_sandbox_manifest(
         },
         "spec": {
             "replicas": 1,
-            "service": False,
             "podTemplate": {
                 "metadata": {
                     "labels": {

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 class FeatureFlagsResponse(BaseModel):
     """Response model for feature flag status."""
 
+    builds: bool = Field(description="Shipwright build-from-source capability available")
     sandbox: bool = Field(description="Interactive sandbox session UI (Legion)")
     integrations: bool = Field(description="Third-party integration endpoints")
     triggers: bool = Field(description="Event-driven trigger system")
@@ -71,9 +72,12 @@ router = APIRouter(prefix="/config", tags=["config"])
     "/features",
     response_model=FeatureFlagsResponse,
 )
-async def get_feature_flags() -> FeatureFlagsResponse:
+async def get_feature_flags(
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> FeatureFlagsResponse:
     """Return enabled feature flags for UI gating (public, no auth required)."""
     return FeatureFlagsResponse(
+        builds=kube.api_group_exists("shipwright.io"),
         sandbox=settings.kagenti_feature_flag_sandbox,
         integrations=settings.kagenti_feature_flag_integrations,
         triggers=settings.kagenti_feature_flag_triggers,

--- a/kagenti/backend/app/routers/shipwright.py
+++ b/kagenti/backend/app/routers/shipwright.py
@@ -60,6 +60,9 @@ async def list_shipwright_builds(
 
     Uses the `kagenti.io/type` label (agent | tool). Intended for CLI and automation.
     """
+    if not kube.api_group_exists("shipwright.io"):
+        return ShipwrightBuildListResponse(items=[])
+
     namespaces_to_scan: List[str] = []
     if all_namespaces:
         namespaces_to_scan = kube.list_enabled_namespaces()

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -1043,9 +1043,8 @@ def _build_tool_deployment_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    if client_registration_inject is True:
-        labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
-        pod_labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
+    # Note: Client registration is now handled by kagenti-operator, not sidecars.
+    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}
@@ -1212,9 +1211,8 @@ def _build_tool_statefulset_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    if client_registration_inject is True:
-        labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
-        pod_labels[KAGENTI_CLIENT_REGISTRATION_INJECT_LABEL] = "true"
+    # Note: Client registration is now handled by kagenti-operator, not sidecars.
+    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -598,6 +598,9 @@ async def list_tool_shipwright_builds(
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> ShipwrightBuildListResponse:
     """List Shipwright Build resources for tools only (kagenti.io/type=tool)."""
+    if not kube.api_group_exists("shipwright.io"):
+        return ShipwrightBuildListResponse(items=[])
+
     namespaces_to_scan: List[str] = []
     if all_namespaces:
         namespaces_to_scan = kube.list_enabled_namespaces()

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -1043,8 +1043,6 @@ def _build_tool_deployment_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    # Note: Client registration is now handled by kagenti-operator, not sidecars.
-    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}
@@ -1211,8 +1209,6 @@ def _build_tool_statefulset_manifest(
     if spiffe_helper_inject is False:
         labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
         pod_labels[KAGENTI_SPIFFE_HELPER_INJECT_LABEL] = "false"
-    # Note: Client registration is now handled by kagenti-operator, not sidecars.
-    # The client_registration_inject parameter is deprecated and ignored.
 
     # Build annotations
     annotations = {}

--- a/kagenti/backend/app/services/reconciliation.py
+++ b/kagenti/backend/app/services/reconciliation.py
@@ -53,6 +53,11 @@ def _workload_exists(kube: KubernetesService, namespace: str, name: str) -> bool
 async def reconcile_builds() -> None:
     """Single reconciliation pass — find and finalize orphaned builds."""
     kube = get_kubernetes_service()
+
+    if not kube.api_group_exists("shipwright.io"):
+        logger.debug("Shipwright API group not found, skipping build reconciliation")
+        return
+
     namespaces = kube.list_enabled_namespaces()
 
     for namespace in namespaces:

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -56,14 +56,14 @@ class TestBuildSandboxManifest:
         port_env = next(ev for ev in container["env"] if ev.get("name") == "PORT")
         assert port_env["value"] == str(DEFAULT_IN_CLUSTER_PORT)
 
-    def test_service_disabled(self):
-        """Sandbox spec must set service: false to disable auto-generated headless Service."""
+    def test_no_service_field_in_spec(self):
+        """Sandbox spec must NOT include a service field (unsupported in released CRD)."""
         from app.routers.agents import _build_sandbox_manifest
 
         request = _make_request()
         manifest = _build_sandbox_manifest(request=request, image="test:latest")
 
-        assert manifest["spec"]["service"] is False
+        assert "service" not in manifest["spec"]
 
     def test_custom_service_ports_override_container_port(self):
         """When servicePorts are provided, containerPort uses targetPort from first entry."""

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -1,0 +1,107 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Unit tests for Sandbox manifest builder and Service creation."""
+
+from unittest.mock import MagicMock
+
+from app.core.constants import DEFAULT_IN_CLUSTER_PORT, DEFAULT_OFF_CLUSTER_PORT
+
+
+def _make_request(**overrides):
+    """Build a minimal CreateAgentRequest-like object for testing."""
+    req = MagicMock()
+    req.name = overrides.get("name", "test-agent")
+    req.namespace = overrides.get("namespace", "team1")
+    req.containerImage = overrides.get("containerImage", "ghcr.io/example/agent:latest")
+    req.framework = overrides.get("framework", "langgraph")
+    req.protocol = overrides.get("protocol", "a2a")
+    req.workloadType = overrides.get("workloadType", "sandbox")
+    req.servicePorts = overrides.get("servicePorts", None)
+    req.envVars = overrides.get("envVars", None)
+    req.imagePullSecret = overrides.get("imagePullSecret", None)
+    req.authBridgeEnabled = overrides.get("authBridgeEnabled", False)
+    req.spireEnabled = overrides.get("spireEnabled", False)
+    req.envoyProxyInject = overrides.get("envoyProxyInject", None)
+    req.spiffeHelperInject = overrides.get("spiffeHelperInject", None)
+    req.clientRegistrationInject = overrides.get("clientRegistrationInject", None)
+    req.outboundPortsExclude = overrides.get("outboundPortsExclude", None)
+    req.inboundPortsExclude = overrides.get("inboundPortsExclude", None)
+    req.outboundRoutes = overrides.get("outboundRoutes", None)
+    req.defaultOutboundPolicy = overrides.get("defaultOutboundPolicy", None)
+    return req
+
+
+class TestBuildSandboxManifest:
+    """Tests for _build_sandbox_manifest."""
+
+    def test_default_container_port_is_in_cluster_port(self):
+        """Sandbox containerPort defaults to DEFAULT_IN_CLUSTER_PORT (8000), same as Deployment."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        request = _make_request()
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
+        assert container["ports"][0]["containerPort"] == DEFAULT_IN_CLUSTER_PORT
+
+    def test_port_env_var_is_in_cluster_port(self):
+        """PORT env var defaults to DEFAULT_IN_CLUSTER_PORT (8000), not the service port."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        request = _make_request()
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
+        port_env = next(ev for ev in container["env"] if ev.get("name") == "PORT")
+        assert port_env["value"] == str(DEFAULT_IN_CLUSTER_PORT)
+
+    def test_service_disabled(self):
+        """Sandbox spec must set service: false to disable auto-generated headless Service."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        request = _make_request()
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        assert manifest["spec"]["service"] is False
+
+    def test_custom_service_ports_override_container_port(self):
+        """When servicePorts are provided, containerPort uses targetPort from first entry."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        sp = MagicMock()
+        sp.name = "http"
+        sp.port = 9090
+        sp.targetPort = 8888
+        sp.protocol = "TCP"
+        request = _make_request(servicePorts=[sp])
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
+        assert container["ports"][0]["containerPort"] == 8888
+
+
+class TestBuildServiceManifestForSandbox:
+    """Tests for _build_service_manifest when used with Sandbox workloads."""
+
+    def test_default_service_ports(self):
+        """Service defaults to port 8080 -> targetPort 8000."""
+        from app.routers.agents import _build_service_manifest
+
+        request = _make_request()
+        manifest = _build_service_manifest(request)
+
+        ports = manifest["spec"]["ports"]
+        assert len(ports) == 1
+        assert ports[0]["port"] == DEFAULT_OFF_CLUSTER_PORT
+        assert ports[0]["targetPort"] == DEFAULT_IN_CLUSTER_PORT
+
+    def test_service_labels_use_request_workload_type(self):
+        """Service labels should reflect the actual workload type, not hardcoded deployment."""
+        from app.routers.agents import _build_service_manifest
+
+        request = _make_request(workloadType="sandbox")
+        manifest = _build_service_manifest(request)
+
+        labels = manifest["metadata"]["labels"]
+        assert labels.get("kagenti.io/workload-type") == "sandbox"

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -6,11 +6,12 @@
 from unittest.mock import MagicMock
 
 from app.core.constants import DEFAULT_IN_CLUSTER_PORT, DEFAULT_OFF_CLUSTER_PORT
+from app.routers.agents import CreateAgentRequest, WORKLOAD_TYPE_SANDBOX
 
 
 def _make_request(**overrides):
     """Build a minimal CreateAgentRequest-like object for testing."""
-    req = MagicMock()
+    req = MagicMock(spec=CreateAgentRequest)
     req.name = overrides.get("name", "test-agent")
     req.namespace = overrides.get("namespace", "team1")
     req.containerImage = overrides.get("containerImage", "ghcr.io/example/agent:latest")
@@ -105,3 +106,14 @@ class TestBuildServiceManifestForSandbox:
 
         labels = manifest["metadata"]["labels"]
         assert labels.get("kagenti.io/workload-type") == "sandbox"
+
+
+class TestCreateAgentServiceForSandbox:
+    """Tests for create_agent Service creation path for Sandbox workloads."""
+
+    def test_sandbox_not_excluded_from_service_creation(self):
+        """Sandbox must NOT be in the workload types that skip Service creation."""
+        from app.routers.agents import WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX
+
+        skip_service_types = {WORKLOAD_TYPE_JOB}
+        assert WORKLOAD_TYPE_SANDBOX not in skip_service_types

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -113,7 +113,7 @@ class TestCreateAgentServiceForSandbox:
 
     def test_sandbox_not_excluded_from_service_creation(self):
         """Sandbox must NOT be in the workload types that skip Service creation."""
-        from app.routers.agents import WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX
+        from app.routers.agents import WORKLOAD_TYPE_JOB
 
         skip_service_types = {WORKLOAD_TYPE_JOB}
         assert WORKLOAD_TYPE_SANDBOX not in skip_service_types

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -4,6 +4,8 @@
 import { useState, useEffect } from 'react';
 
 export interface FeatureFlags {
+  /** Shipwright build-from-source capability available in the cluster. */
+  builds: boolean;
   /** Sandboxed agent runtime UI and APIs (legacy runtime sandbox). */
   sandbox: boolean;
   integrations: boolean;
@@ -18,6 +20,7 @@ export interface FeatureFlags {
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
+  builds: false,
   sandbox: false,
   integrations: false,
   triggers: false,
@@ -39,6 +42,7 @@ export function useFeatureFlags(): FeatureFlags {
       .then(res => res.ok ? res.json() : DEFAULT_FLAGS)
       .then((data) => {
         const validated: FeatureFlags = {
+          builds: data.builds === true,
           sandbox: data.sandbox === true,
           integrations: data.integrations === true,
           triggers: data.triggers === true,

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -67,6 +67,7 @@ const STATUS_COLOR: Record<ComponentStatus['status'], 'green' | 'gold' | 'grey'>
 type DisplayedFlag = Exclude<keyof FeatureFlags, 'admin'>;
 
 const FLAG_LABELS: Record<DisplayedFlag, string> = {
+  builds: 'Builds (Shipwright)',
   sandbox: 'Sandbox',
   integrations: 'Integrations',
   triggers: 'Triggers',

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1048,7 +1048,7 @@ export const ImportAgentPage: React.FC = () => {
                       setSpiffeHelperInject(undefined);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. With the default webhook settings this is two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. With the default webhook settings this is two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
               />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -190,7 +190,6 @@ export const ImportAgentPage: React.FC = () => {
   // Per-sidecar injection controls
   const [envoyProxyInject, setEnvoyProxyInject] = useState<boolean | undefined>(undefined);
   const [spiffeHelperInject, setSpiffeHelperInject] = useState<boolean | undefined>(undefined);
-  const [clientRegistrationInject, setClientRegistrationInject] = useState<boolean | undefined>(undefined);
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
@@ -502,7 +501,6 @@ export const ImportAgentPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -535,7 +533,6 @@ export const ImportAgentPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -1049,10 +1046,9 @@ export const ImportAgentPage: React.FC = () => {
                     if (checked) {
                       setEnvoyProxyInject(undefined);
                       setSpiffeHelperInject(undefined);
-                      setClientRegistrationInject(true);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation, outbound token exchange, and Keycloak client registration. With the default webhook settings this is three sidecars (envoy-proxy, spiffe-helper, client-registration) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. With the default webhook settings this is two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; if the cluster operator enables featureGates.combinedSidecar on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
               />
               </FormGroup>
 
@@ -1105,13 +1101,6 @@ export const ImportAgentPage: React.FC = () => {
                       isChecked={spiffeHelperInject !== false}
                       onChange={(_e, checked) => setSpiffeHelperInject(checked ? undefined : false)}
                       description="SPIFFE identity helper for SVID management. Disable to skip spiffe-helper sidecar."
-                    />
-                    <Checkbox
-                      id="clientRegistrationInject"
-                      label="Client Registration"
-                      isChecked={clientRegistrationInject === true}
-                      onChange={(_e, checked) => setClientRegistrationInject(checked ? true : undefined)}
-                      description="Sidecar-based Keycloak client registration. Automatically registers the workload as an OAuth2 client using its SPIFFE identity."
                     />
                   </FormGroup>
                 </>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -111,8 +111,10 @@ export const ImportAgentPage: React.FC = () => {
   const queryClient = useQueryClient();
   const features = useFeatureFlags();
 
-  // Deployment method
-  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
+  // Deployment method — default to 'image' when builds unavailable
+  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>(
+    features.builds ? 'source' : 'image'
+  );
 
   // Basic info
   const [namespace, setNamespace] = useState('team1');
@@ -613,14 +615,16 @@ export const ImportAgentPage: React.FC = () => {
               </Title>
 
               <FormGroup role="radiogroup" fieldId="deployment-method">
-                <Radio
-                  id="method-source"
-                  name="deployment-method"
-                  label="Build from Source"
-                  description="Build container image from a git repository"
-                  isChecked={deploymentMethod === 'source'}
-                  onChange={() => setDeploymentMethod('source')}
-                />
+                {features.builds && (
+                  <Radio
+                    id="method-source"
+                    name="deployment-method"
+                    label="Build from Source"
+                    description="Build container image from a git repository"
+                    isChecked={deploymentMethod === 'source'}
+                    onChange={() => setDeploymentMethod('source')}
+                  />
+                )}
                 <Radio
                   id="method-image"
                   name="deployment-method"
@@ -628,7 +632,7 @@ export const ImportAgentPage: React.FC = () => {
                   description="Deploy using an existing container image"
                   isChecked={deploymentMethod === 'image'}
                   onChange={() => setDeploymentMethod('image')}
-                  style={{ marginTop: '8px' }}
+                  style={{ marginTop: features.builds ? '8px' : undefined }}
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -989,7 +989,7 @@ export const ImportToolPage: React.FC = () => {
                       setSpiffeHelperInject(undefined);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. Default webhook settings use two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Default webhook settings use two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidEnvVarName, isValidContainerImage, isValidImageTag } from '../utils/validation';
 import { newRouteRowId } from '../utils/routeRowId';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 import {
   PageSection,
   Title,
@@ -87,9 +88,12 @@ interface ServicePort {
 
 export const ImportToolPage: React.FC = () => {
   const navigate = useNavigate();
+  const features = useFeatureFlags();
 
-  // Deployment method
-  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>('source');
+  // Deployment method — default to 'image' when builds unavailable
+  const [deploymentMethod, setDeploymentMethod] = useState<DeploymentMethod>(
+    features.builds ? 'source' : 'image'
+  );
 
   // Form state
   const [namespace, setNamespace] = useState('team1');
@@ -580,14 +584,16 @@ export const ImportToolPage: React.FC = () => {
               </Title>
 
               <FormGroup role="radiogroup" fieldId="deploymentMethod">
-                <Radio
-                  name="deploymentMethod"
-                  label="Build from Source"
-                  description="Build container image from source code using Shipwright"
-                  isChecked={deploymentMethod === 'source'}
-                  onChange={() => setDeploymentMethod('source')}
-                  id="deploymentMethod-source"
-                />
+                {features.builds && (
+                  <Radio
+                    name="deploymentMethod"
+                    label="Build from Source"
+                    description="Build container image from source code using Shipwright"
+                    isChecked={deploymentMethod === 'source'}
+                    onChange={() => setDeploymentMethod('source')}
+                    id="deploymentMethod-source"
+                  />
+                )}
                 <Radio
                   name="deploymentMethod"
                   label="Deploy from Image"
@@ -595,7 +601,7 @@ export const ImportToolPage: React.FC = () => {
                   isChecked={deploymentMethod === 'image'}
                   onChange={() => setDeploymentMethod('image')}
                   id="deploymentMethod-image"
-                  style={{ marginTop: '8px' }}
+                  style={{ marginTop: features.builds ? '8px' : undefined }}
                 />
               </FormGroup>
 

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -158,7 +158,6 @@ export const ImportToolPage: React.FC = () => {
   // Per-sidecar injection controls
   const [envoyProxyInject, setEnvoyProxyInject] = useState<boolean | undefined>(undefined);
   const [spiffeHelperInject, setSpiffeHelperInject] = useState<boolean | undefined>(undefined);
-  const [clientRegistrationInject, setClientRegistrationInject] = useState<boolean | undefined>(undefined);
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
@@ -475,7 +474,6 @@ export const ImportToolPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -504,7 +502,6 @@ export const ImportToolPage: React.FC = () => {
         spireEnabled,
         envoyProxyInject: authBridgeEnabled ? envoyProxyInject : undefined,
         spiffeHelperInject: authBridgeEnabled ? spiffeHelperInject : undefined,
-        clientRegistrationInject: authBridgeEnabled ? clientRegistrationInject : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -990,10 +987,9 @@ export const ImportToolPage: React.FC = () => {
                     if (checked) {
                       setEnvoyProxyInject(undefined);
                       setSpiffeHelperInject(undefined);
-                      setClientRegistrationInject(true);
                     }
                   }}
-                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation, outbound token exchange, and Keycloak client registration. Default webhook settings use three sidecars plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
+                  description="When enabled, the webhook injects AuthBridge for inbound JWT validation and outbound token exchange. Client registration is automatically handled by the kagenti-operator. Default webhook settings use two sidecars (envoy-proxy, spiffe-helper) plus proxy-init; with featureGates.combinedSidecar enabled on kagenti-webhook, a single authbridge container is used instead (see docs linked below)."
                 />
               </FormGroup>
 
@@ -1046,13 +1042,6 @@ export const ImportToolPage: React.FC = () => {
                       isChecked={spiffeHelperInject !== false}
                       onChange={(_e, checked) => setSpiffeHelperInject(checked ? undefined : false)}
                       description="SPIFFE identity helper for SVID management. Disable to skip spiffe-helper sidecar."
-                    />
-                    <Checkbox
-                      id="clientRegistrationInject"
-                      label="Client Registration"
-                      isChecked={clientRegistrationInject === true}
-                      onChange={(_e, checked) => setClientRegistrationInject(checked ? true : undefined)}
-                      description="Sidecar-based Keycloak client registration. Automatically registers the workload as an OAuth2 client using its SPIFFE identity."
                     />
                   </FormGroup>
                 </>

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -234,7 +234,6 @@ export const agentService = {
     // Per-sidecar injection controls
     envoyProxyInject?: boolean;
     spiffeHelperInject?: boolean;
-    clientRegistrationInject?: boolean;
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -446,8 +445,7 @@ export const shipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-      clientRegistrationInject?: boolean;
-      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
     defaultOutboundPolicy?: string;
@@ -539,7 +537,6 @@ export const toolService = {
     // Per-sidecar injection controls
     envoyProxyInject?: boolean;
     spiffeHelperInject?: boolean;
-    clientRegistrationInject?: boolean;
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -676,8 +673,7 @@ export const toolShipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-      clientRegistrationInject?: boolean;
-      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
     defaultOutboundPolicy?: string;

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -445,10 +445,10 @@ export const shipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
-    outboundPortsExclude?: string;
-    inboundPortsExclude?: string;
-    defaultOutboundPolicy?: string;
+      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+      outboundPortsExclude?: string;
+      inboundPortsExclude?: string;
+      defaultOutboundPolicy?: string;
       imagePullSecret?: string;
     }
   ): Promise<{ success: boolean; name: string; namespace: string; message: string }> {
@@ -673,10 +673,10 @@ export const toolShipwrightService = {
       authBridgeEnabled?: boolean;
       envoyProxyInject?: boolean;
       spiffeHelperInject?: boolean;
-        outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
-    outboundPortsExclude?: string;
-    inboundPortsExclude?: string;
-    defaultOutboundPolicy?: string;
+      outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
+      outboundPortsExclude?: string;
+      inboundPortsExclude?: string;
+      defaultOutboundPolicy?: string;
       imagePullSecret?: string;
     }
   ): Promise<{ success: boolean; name: string; namespace: string; message: string }> {

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -196,8 +196,8 @@ echo "    Agent Sandbox: $WITH_AGENT_SANDBOX"
 echo "    Skip cluster:  $SKIP_CLUSTER"
 echo "    Build images:  $BUILD_IMAGES"
 echo "    Preload imgs:  $PRELOAD_IMAGES"
-echo "    Kagenti helm --values overrides: ${KAGENTI_VALUES_FILES[*]}"
-echo "    Kagenti-deps helm --values overrides: ${KAGENTI_DEPS_VALUES_FILES[*]}"
+echo "    Kagenti helm --values overrides: ${KAGENTI_VALUES_FILES[*]:-}"
+echo "    Kagenti-deps helm --values overrides: ${KAGENTI_DEPS_VALUES_FILES[*]:-}"
 echo ""
 
 for cmd in helm kubectl; do
@@ -552,7 +552,7 @@ DEPS_FLAGS=(
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"
   --set "components.rhoai.enabled=false"
 )
-DEPS_FLAGS=( "${DEPS_FLAGS[@]}" "${KAGENTI_DEPS_VALUES_FILES[@]}" )
+DEPS_FLAGS=( "${DEPS_FLAGS[@]}" ${KAGENTI_DEPS_VALUES_FILES[@]+"${KAGENTI_DEPS_VALUES_FILES[@]}"} )
 
 log_info "Installing kagenti-deps..."
 # --skip-crds: Gateway API CRDs already installed in Step 5 at a newer version;
@@ -1103,7 +1103,7 @@ KAGENTI_FLAGS=(
   --set "ui.auth.enabled=$($WITH_SPIRE && echo true || echo false)"
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"
 )
-KAGENTI_FLAGS=( "${KAGENTI_FLAGS[@]}" "${KAGENTI_VALUES_FILES[@]}" )
+KAGENTI_FLAGS=( "${KAGENTI_FLAGS[@]}" ${KAGENTI_VALUES_FILES[@]+"${KAGENTI_VALUES_FILES[@]}"} )
 
 # When --build-images is set, the build step tags images ":latest" and loads
 # them into Kind (see list above). Override the chart's release-pinned tags

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1181,6 +1181,20 @@ if $WITH_MCP_GATEWAY; then
     -n mcp-system --create-namespace --version "$MCP_GATEWAY_VERSION" \
     --set "broker.create=true"
   log_success "MCP Gateway installed"
+
+  if $WITH_OTEL; then
+    # The mcp-gateway chart deploys the broker-router via its controller and does not
+    # expose OTel config via Helm values. kubectl set env is the only injection point.
+    log_info "Patching MCP Gateway router with OTel exporter..."
+    if kubectl get deployment mcp-gateway -n mcp-system &>/dev/null; then
+      run_cmd kubectl set env deployment/mcp-gateway -n mcp-system \
+        OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.kagenti-system.svc.cluster.local:8335 \
+        OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      log_success "MCP Gateway OTel exporter configured"
+    else
+      log_warn "deployment/mcp-gateway not found in mcp-system — skipping OTel patch (check chart version)"
+    fi
+  fi
 else
   log_info "Skipped (use --with-mcp-gateway)"
 fi


### PR DESCRIPTION
## Summary

- Documents the steps to enable the OpenShift internal image registry for building and pushing agent images from the Kagenti UI
- Covers creating a `registry-pusher` service account, granting `system:image-builder` / `system:image-puller` roles, and creating the `openshift-registry-secret`
- Explains the UI workflow for selecting "OpenShift Internal Registry"

## Context

When using the Kagenti UI "Import Agent" with "OpenShift Internal Registry", Shipwright needs a push secret (`openshift-registry-secret`) in the agent namespace. This was undocumented and caused confusion during OCP deployments.

## Test plan

- [x] Verified the documented steps on a ROSA 4.19 cluster
- [x] Confirmed agent build + push succeeds after setup
- [x] Confirmed deployed sandbox pod starts and reaches Ready state

Assisted-By: Claude Code