### PR TITLE
:bug: Show correct pod status for Sandbox workloads

### DIFF
--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -481,18 +481,27 @@ export const AgentDetailPage: React.FC = () => {
                           </Label>
                         </DescriptionListDescription>
                       </DescriptionListGroup>
-                      <DescriptionListGroup>
-                        <DescriptionListTerm>Replicas</DescriptionListTerm>
-                        <DescriptionListDescription>
-                          {readyReplicas}/{replicas} ready
-                          {availableReplicas > 0 && ` (${availableReplicas} available)`}
-                          {workloadType === 'statefulset' && updatedReplicas < replicas && (
-                            <Label color="blue" isCompact style={{ marginLeft: 8 }}>
-                              {updatedReplicas}/{replicas} updated
-                            </Label>
-                          )}
-                        </DescriptionListDescription>
-                      </DescriptionListGroup>
+                      {workloadType === 'sandbox' ? (
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Pods</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            {isReady ? (status.replicas ?? 1) : 0}/{status.replicas ?? 1} ready
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      ) : workloadType !== 'job' && (
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>Replicas</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            {readyReplicas}/{replicas} ready
+                            {availableReplicas > 0 && ` (${availableReplicas} available)`}
+                            {workloadType === 'statefulset' && updatedReplicas < replicas && (
+                              <Label color="blue" isCompact style={{ marginLeft: 8 }}>
+                                {updatedReplicas}/{replicas} updated
+                              </Label>
+                            )}
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      )}
                       <DescriptionListGroup>
                         <DescriptionListTerm>Created</DescriptionListTerm>
                         <DescriptionListDescription>


### PR DESCRIPTION
## Summary

- Fix Sandbox agents always showing `0/1 ready` on the detail page regardless of actual health
- Show "Pods: 1/1 ready" for Sandbox (derived from Ready condition), hide replica row for Jobs, keep "Replicas" for Deployment/StatefulSet

## Problem

Sandbox CRs don't have `readyReplicas` in their status — only `replicas: 1` and a `conditions` array. The UI unconditionally read `status.readyReplicas` (defaulting to 0) and `spec.replicas` (defaulting to 1), always displaying `0/1 ready`.

## Test plan

- [ ] Sandbox agent detail page shows `1/1 pods ready` when pod is running
- [ ] Deployment agent detail page still shows `N/N ready` with "Replicas" label
- [ ] Job agent detail page does not show a replica/pod row

Fixes #1590

Assisted-By: Claude Code