### PR TITLE
fix: track kagenti-extensions authproxy → proxy-init rename

### DIFF
--- a/.github/scripts/token-exchange/10-build-extensions.sh
+++ b/.github/scripts/token-exchange/10-build-extensions.sh
@@ -34,7 +34,7 @@ IMAGES=(
   "authbridge:authbridge:cmd/authbridge-proxy/Dockerfile"
   "authbridge-envoy:authbridge:cmd/authbridge-envoy/Dockerfile"
   "authbridge-lite:authbridge:cmd/authbridge-lite/Dockerfile"
-  "proxy-init:authbridge/authproxy:Dockerfile.init"
+  "proxy-init:authbridge/proxy-init:Dockerfile.init"
 )
 
 REGISTRY="ghcr.io/kagenti/kagenti-extensions"

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -260,10 +260,10 @@ kagenti-operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.2
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.2
-      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.2
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.2
+      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.3
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.3
+      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.3
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.3
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -260,10 +260,10 @@ kagenti-operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.1
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.1
-      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.1
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.1
+      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.2
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.2
+      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.2
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.2
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/docs/components.md
+++ b/docs/components.md
@@ -446,7 +446,7 @@ Kagenti provides a unified framework for identity and authorization in agentic s
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
+| **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
 | **[SPIRE](https://spiffe.io/docs/latest/spire-about/)** | Workload identity and attestation | External |
 | **[Keycloak](https://www.keycloak.org/)** | Identity provider and access management | External |
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -646,7 +646,7 @@ For step-by-step AuthBridge demos with real working examples, see:
 For complete documentation, see:
 
 - **[AuthBridge README](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** - Full demo instructions
-- **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge/authproxy)** - Token validation and exchange proxy
+- **[AuthProxy](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge)** - Token validation and exchange proxy
 
 > **Note**: The AuthBridge demo in kagenti-extensions includes client-registration components for demonstration purposes. In production Kagenti deployments, client registration is handled by the kagenti-operator controller.
 


### PR DESCRIPTION
## Summary

Three small path-fixes for the kagenti-extensions PR #414 ([kagenti-extensions#414](https://github.com/kagenti/kagenti-extensions/pull/414)) that renames `authbridge/authproxy/` → `authbridge/proxy-init/`. After that PR lands, the old path 404s and one of the kagenti CI scripts stops finding its Dockerfile.

### Why the rename in extensions#414

`authbridge/authproxy/` historically held both the auth-proxy *application* (with main.go + Dockerfile, used by the deleted webhook demo) and the iptables init container (`init-iptables.sh` + `Dockerfile.init`). The webhook demo and auth-proxy application were both retired in extensions#414 along with the standalone quickstart that referenced them. The remaining contents are exactly the iptables init container, so the directory was renamed to match: `proxy-init/`.

### Three breaks this PR fixes

| File | Old | New |
|---|---|---|
| `.github/scripts/token-exchange/10-build-extensions.sh:37` | `proxy-init:authbridge/authproxy:Dockerfile.init` | `proxy-init:authbridge/proxy-init:Dockerfile.init` |
| `docs/components.md:449` | Link to `kagenti-extensions/tree/main/authbridge/authproxy` | Link to `kagenti-extensions/tree/main/authbridge` |
| `docs/identity-guide.md:649` | Same broken link | Retargeted at `authbridge/` |

The two doc links use the word "AuthProxy" as a general term for the AuthBridge feature (JWT validation + token exchange). The new `authbridge/proxy-init/` directory is *just* the iptables init container, which is much narrower than what those docs are describing — so the right retarget is `authbridge/` (the AuthBridge entry-point README) rather than the new `proxy-init/` directory specifically.

## Test plan

- [x] `bash -n` on the build script
- [x] Repo-wide grep for `authbridge/authproxy` returns zero hits after the change
- [ ] Re-run the token-exchange e2e once extensions#414 lands and the kagenti workflow's clone of extensions main picks up the rename

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
