### PR TITLE
chore: Bump chart to 0.7.0-alpha.1

### DIFF
--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kagenti
 description: A Helm chart for deploying the kagenti platform
 type: application
-version: 0.6.0-rc.1
-appVersion: "0.6.0-rc.1"
+version: 0.7.0-alpha.1
+appVersion: "0.7.0-alpha.1"
 
 dependencies:
 - name: kagenti-operator-chart

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -76,7 +76,7 @@ ui:
   frontend:
     enabled: true
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.6.0-rc.1
+    tag: v0.7.0-alpha.1
     resources:
       limits:
         cpu: 100m
@@ -90,7 +90,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.6.0-rc.1
+    tag: v0.7.0-alpha.1
     # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
     defaultRegistryUrl: ""
     resources:
@@ -108,7 +108,7 @@ ui:
 # ------------------------------------------------------------------
 uiOAuthSecret:
   image: ghcr.io/kagenti/kagenti/ui-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.7.0-alpha.1
   # When true, mount the in-cluster serviceaccount CA
   # into the ui-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -120,7 +120,7 @@ uiOAuthSecret:
 # ------------------------------------------------------------------
 agentOAuthSecret:
   image: ghcr.io/kagenti/kagenti/agent-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.7.0-alpha.1
   # When true, mount the in-cluster serviceaccount CA
   # into the agent-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -138,7 +138,7 @@ agentOAuthSecret:
 apiOAuthSecret:
   enabled: false
   image: ghcr.io/kagenti/kagenti/api-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.7.0-alpha.1
   # Client ID for the API service account
   clientId: kagenti-api
   # Name of the K8s secret to store credentials
@@ -210,7 +210,7 @@ authBridge:
 spiffeIdp:
   image:
     repository: ghcr.io/kagenti/kagenti/spiffe-idp-setup
-    tag: v0.6.0-rc.1
+    tag: v0.7.0-alpha.1
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
@@ -294,7 +294,7 @@ phoenix:
 # ------------------------------------------------------------------
 phoenixOAuthSecret:
   image: ghcr.io/kagenti/kagenti/phoenix-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.7.0-alpha.1
   # Keycloak client ID for Phoenix
   clientId: phoenix
   # Kubernetes secret name to store OAuth credentials
@@ -322,7 +322,7 @@ mlflow:
 # ------------------------------------------------------------------
 mlflowOAuthSecret:
   image: ghcr.io/kagenti/kagenti/mlflow-oauth-secret
-  tag: v0.6.0-rc.1
+  tag: v0.7.0-alpha.1
   # Keycloak client ID for MLflow
   clientId: mlflow
   # Kubernetes secret name to store OAuth credentials


### PR DESCRIPTION
## Summary

Bump the kagenti chart for the `v0.7.0-alpha.1` cut.

## Version pins changed

| Component | Where | Old | New |
|---|---|---|---|
| kagenti chart itself | `Chart.yaml` `version` + `appVersion` | `0.6.0-rc.1` | `0.7.0-alpha.1` |
| kagenti images x8 | `values.yaml` `tag` fields | `v0.6.0-rc.1` | `v0.7.0-alpha.1` |

The 8 kagenti image tags: `ui-v2`, `backend`, `ui-oauth-secret`, `agent-oauth-secret`, `api-oauth-secret`, `spiffe-idp-setup`, `phoenix-oauth-secret`, `mlflow-oauth-secret`.

## Untouched (already at requested target)

| Component | Where | Current = target |
|---|---|---|
| kagenti-operator chart dep | `Chart.yaml` `dependencies[].version` + `Chart.lock` | `0.3.0-alpha.1` |
| kagenti-extensions images x4 | `values.yaml` `authBridge.images.*` | `v0.6.0-alpha.3` |

`authbridge`, `authbridge-envoy`, `authbridge-lite`, `proxy-init`.

## What's new in `v0.7.0-alpha.1` vs `v0.6.0-rc.1`

- #1581 — Sandbox-Service handling for the image-based agent-create flow
- #1592 — Track kagenti-extensions `authproxy/` → `proxy-init/` rename
- #1593 — Sandbox-Service handling for the source-build / Shipwright finalize flow

Tag created upstream: https://github.com/kagenti/kagenti/releases/tag/v0.7.0-alpha.1

## Test plan

- [x] `helm lint charts/kagenti/` — passes (only the pre-existing INFO about the missing icon)
- [ ] CI's chart-tests + helm-chart-lint pass
- [ ] Manual: install the chart on a kind cluster, verify all pods come up with the new tags

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
