### PR TITLE
chore: Update default HyperShift hosted cluster version to 4.20.21

### DIFF
--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -107,7 +107,7 @@ HYPERSHIFT_AUTOMATION_DIR=$(find_hypershift_automation)
 # Configuration with defaults
 REPLICAS="${REPLICAS:-2}"
 INSTANCE_TYPE="${INSTANCE_TYPE:-m5.xlarge}"
-OCP_VERSION="${OCP_VERSION:-4.20.11}"
+OCP_VERSION="${OCP_VERSION:-4.20.21}"
 
 # NodePool autoscaling (enabled by default)
 # Override AUTOSCALE_MIN and AUTOSCALE_MAX to adjust limits, or set to empty to disable


### PR DESCRIPTION
## Summary

  Updates the default OpenShift version for HyperShift hosted clusters from `4.20.11` to `4.20.21`.

  ## Changes

  - Modified `.github/scripts/hypershift/create-cluster.sh` to use `OCP_VERSION=4.20.21` as the default

  ## Impact

  - New hosted clusters created via `create-cluster.sh` will default to OpenShift 4.20.21
  - Existing clusters are unaffected
  - Can still override with `OCP_VERSION` environment variable

  ## Testing

  - [ ] Verified script syntax
  - [ ] Tested cluster creation with new default version