### PR TITLE
fix(charts): Add pinned defaults for utility images in templates

### DIFF
--- a/charts/kagenti/templates/otel-collector-restart-job.yaml
+++ b/charts/kagenti/templates/otel-collector-restart-job.yaml
@@ -83,7 +83,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: restarter
-        image: {{ .Values.common.kubectlImage }}
+        image: {{ .Values.common.kubectlImage | default "quay.io/kubestellar/kubectl:1.30.14" }}
         command:
         - /bin/sh
         - -c

--- a/charts/kagenti/templates/ui-oauth-secret-job.yaml
+++ b/charts/kagenti/templates/ui-oauth-secret-job.yaml
@@ -92,7 +92,7 @@ spec:
       restartPolicy: Never
       initContainers:
       - name: wait-for-dependencies
-        image: {{ .Values.common.kubectlImage }}
+        image: {{ .Values.common.kubectlImage | default "quay.io/kubestellar/kubectl:1.30.14" }}
         command:
         - sh
         - -c

--- a/charts/kagenti/templates/ui-routes-job.yaml
+++ b/charts/kagenti/templates/ui-routes-job.yaml
@@ -194,7 +194,7 @@ spec:
       serviceAccountName: {{ include "kagenti.fullname" . }}-route-processor-sa
       containers:
       - name: script-runner
-        image: {{ .Values.common.oseCLIImage }}
+        image: {{ .Values.common.oseCLIImage | default "registry.redhat.io/openshift4/ose-cli:v4.17" }}
         command: ["/bin/bash", "-c", "/scripts/process_routes.sh"]
         volumeMounts:
         - name: script-volume


### PR DESCRIPTION
## Summary

Closes #1603 (follow-up to #1397, raised by @pdettori in [this review comment](https://github.com/kagenti/kagenti/pull/1397#discussion_r3223181433))

#1397 removed the `| default "..."` fallback expressions from three templates so the pin-validation script wouldn't flag any `:latest` reference. That left the templates dependent on `values.yaml` defaults — but a user supplying their own minimal `values.yaml` (without merging ours, or overriding `common: {}`) would render an empty `image:` string and break the install.

This PR restores the `default` clauses with **pinned** tags (not `:latest`), exactly matching the values currently in `charts/kagenti/values.yaml`:

| Template | Default added |
|----------|---------------|
| `ui-oauth-secret-job.yaml` | `quay.io/kubestellar/kubectl:1.30.14` |
| `otel-collector-restart-job.yaml` | `quay.io/kubestellar/kubectl:1.30.14` |
| `ui-routes-job.yaml` | `registry.redhat.io/openshift4/ose-cli:v4.17` |

The pin-validation script's intent is "no `:latest`," not "no defaults" — so pinned defaults in templates are fully compatible with the gate.

## Test plan

- [x] `bash scripts/check-release-pins.sh` passes (no `:latest` introduced)
- [x] Verified empty-override behavior: `helm template test charts/kagenti --set common.kubectlImage="" --set common.oseCLIImage=""` renders the pinned defaults rather than empty image refs
- [x] CI: `Helm Chart Lint`, `Check Release Pins`, `Workflow Lint` all pass
- [x] Default install (full `values.yaml`) renders the same as before

## Related

- #1349 — original feature request
- #1397 — release pin-validation script + E2E dispatch (merged)
- #1603 — this issue

Assisted-By: Claude Code