### PR TITLE
docs: Fix broken link to gateway-api HTTPRoute reference

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -35,7 +35,7 @@ mcp-controller-666f8cf9bf-dcpbc      1/1     Running   0          30h
 ### Register Weather MCP Server
 
 The Weather Service Tool can be installed using the Kagenti UI [as usual](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-3-import-the-weather-tool-via-kagenti-ui). Once it is
-installed, to register it with the Gateway, create an [`HTTPRoute`](https://gateway-api.sigs.k8s.io/api-types/httproute/):
+installed, to register it with the Gateway, create an [`HTTPRoute`](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/):
 
 ```
 echo 'apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
Automated fix by OpenClaw Link Health Fixer.
Broken external link updated to point to current location.

| File | Old URL | New URL |
|------|---------|---------|
| `docs/gateway.md` | `https://gateway-api.sigs.k8s.io/api-types/httproute/` | `https://gateway-api.sigs.k8s.io/reference/api-types/httproute/` |

The gateway-api.sigs.k8s.io site moved the HTTPRoute reference page from `/api-types/` to `/reference/api-types/` without a redirect.

Closes #1600