### PR TITLE
fix(ui): render Pydantic validation errors as readable messages

### DIFF
--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -69,6 +69,13 @@ export class ApiError extends Error {
   }
 }
 
+function extractErrorMessage(errorData: Record<string, unknown>, fallback: string): string {
+  const detail = errorData.detail;
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) return detail.map((e: { msg?: string }) => e.msg).join(', ');
+  return fallback;
+}
+
 /**
  * Generic fetch wrapper with error handling, optional authentication,
  * and automatic token refresh on 401 responses.
@@ -119,7 +126,7 @@ async function apiFetch<T>(
         if (!retryResponse.ok) {
           const errorData = await retryResponse.json().catch(() => ({}));
           throw new Error(
-            errorData.detail || `API error: ${retryResponse.status} ${retryResponse.statusText}`
+            extractErrorMessage(errorData, `API error: ${retryResponse.status} ${retryResponse.statusText}`)
           );
         }
         return retryResponse.json();
@@ -136,7 +143,7 @@ async function apiFetch<T>(
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
     throw new ApiError(
-      errorData.detail || `API error: ${response.status} ${response.statusText}`,
+      extractErrorMessage(errorData, `API error: ${response.status} ${response.statusText}`),
       response.status
     );
   }


### PR DESCRIPTION
## Summary

- Fix `[object Object],[object Object]` error display when backend returns Pydantic 422 validation errors
- Add `extractErrorMessage()` helper that handles both string and array `detail` formats from FastAPI

## Root Cause

FastAPI returns `detail` as either a string (custom errors) or an array of objects (Pydantic validation). `new Error(array)` calls `.toString()`, producing `[object Object],[object Object]`.

## Fix

Extract the `msg` field from each validation error object and join them into a readable comma-separated string.

Fixes #1617

## Test plan

- [ ] Deploy to Kind cluster
- [ ] Import a new agent with invalid/missing fields
- [ ] Verify error banner shows readable validation messages instead of `[object Object]`
- [ ] Verify custom string errors (e.g., "gitUrl is required") still display correctly