### PR TITLE
ci: add scheduled cleanup for SHA-tagged container images

### DIFF
--- a/.github/workflows/cleanup-container-images.yaml
+++ b/.github/workflows/cleanup-container-images.yaml
@@ -19,13 +19,14 @@ on:
         type: number
         default: 7
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cleanup-container-images.yaml
+++ b/.github/workflows/cleanup-container-images.yaml
@@ -1,0 +1,139 @@
+name: Cleanup Container Images
+
+on:
+  # Daily cleanup at 03:17 UTC (off-peak, avoids :00/:30 contention)
+  schedule:
+    - cron: '17 3 * * *'
+
+  # Manual trigger with configurable options
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (show what would be deleted without actually deleting)'
+        required: false
+        type: boolean
+        default: false
+      retention_days:
+        description: 'Delete SHA-tagged images older than this many days'
+        required: false
+        type: number
+        default: 7
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - ui-v2
+          - backend
+          - ui-oauth-secret
+          - agent-oauth-secret
+          - api-oauth-secret
+          - mlflow-oauth-secret
+          - spiffe-idp-setup
+
+    steps:
+      - name: Delete stale SHA-tagged images for ${{ matrix.package }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const package_name = `kagenti/${{ matrix.package }}`;
+            const retentionDays = ${{ inputs.retention_days || 7 }};
+            const dryRun = ${{ inputs.dry_run || false }};
+            const cutoffDate = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+
+            // Pattern: any branch prefix followed by a 7-12 char hex SHA
+            const shaTagPattern = /^.+-[0-9a-f]{7,12}$/;
+            // Tags to never delete
+            const protectedTagPattern = /^(v\d|latest$)/;
+
+            console.log(`Package: ${package_name}`);
+            console.log(`Retention: ${retentionDays} days (cutoff: ${cutoffDate.toISOString()})`);
+            console.log(`Dry run: ${dryRun}`);
+            console.log('---');
+
+            let deleted = 0;
+            let skipped = 0;
+            let page = 1;
+            const perPage = 100;
+
+            while (true) {
+              const versions = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
+                package_type: 'container',
+                package_name: package_name,
+                org: 'kagenti',
+                page: page,
+                per_page: perPage,
+              });
+
+              if (versions.data.length === 0) break;
+
+              for (const version of versions.data) {
+                const tags = version.metadata?.container?.tags || [];
+                const createdAt = new Date(version.created_at);
+
+                // Skip if no tags (untagged manifests are handled separately)
+                if (tags.length === 0) {
+                  // Untagged versions older than cutoff — delete them too
+                  if (createdAt < cutoffDate) {
+                    if (dryRun) {
+                      console.log(`[DRY RUN] Would delete untagged version ${version.id} (${createdAt.toISOString()})`);
+                    } else {
+                      await github.rest.packages.deletePackageVersionForOrg({
+                        package_type: 'container',
+                        package_name: package_name,
+                        org: 'kagenti',
+                        package_version_id: version.id,
+                      });
+                      console.log(`Deleted untagged version ${version.id} (${createdAt.toISOString()})`);
+                    }
+                    deleted++;
+                  }
+                  continue;
+                }
+
+                // Skip if any tag is protected (release tag or latest)
+                if (tags.some(tag => protectedTagPattern.test(tag))) {
+                  skipped++;
+                  continue;
+                }
+
+                // Skip if not all tags match SHA pattern
+                if (!tags.every(tag => shaTagPattern.test(tag))) {
+                  skipped++;
+                  continue;
+                }
+
+                // Skip if newer than cutoff
+                if (createdAt >= cutoffDate) {
+                  skipped++;
+                  continue;
+                }
+
+                // Delete this version
+                if (dryRun) {
+                  console.log(`[DRY RUN] Would delete ${tags.join(', ')} (${createdAt.toISOString()})`);
+                } else {
+                  await github.rest.packages.deletePackageVersionForOrg({
+                    package_type: 'container',
+                    package_name: package_name,
+                    org: 'kagenti',
+                    package_version_id: version.id,
+                  });
+                  console.log(`Deleted ${tags.join(', ')} (${createdAt.toISOString()})`);
+                }
+                deleted++;
+              }
+
+              if (versions.data.length < perPage) break;
+              page++;
+            }
+
+            console.log('---');
+            console.log(`Summary: ${deleted} deleted, ${skipped} preserved`);

--- a/.github/workflows/cleanup-container-images.yaml
+++ b/.github/workflows/cleanup-container-images.yaml
@@ -59,7 +59,8 @@ jobs:
             console.log(`Dry run: ${dryRun}`);
             console.log('---');
 
-            let deleted = 0;
+            // Phase 1: collect all version IDs to delete (avoids pagination drift)
+            const toDelete = [];
             let skipped = 0;
             let page = 1;
             const perPage = 100;
@@ -79,62 +80,49 @@ jobs:
                 const tags = version.metadata?.container?.tags || [];
                 const createdAt = new Date(version.created_at);
 
-                // Skip if no tags (untagged manifests are handled separately)
                 if (tags.length === 0) {
-                  // Untagged versions older than cutoff — delete them too
                   if (createdAt < cutoffDate) {
-                    if (dryRun) {
-                      console.log(`[DRY RUN] Would delete untagged version ${version.id} (${createdAt.toISOString()})`);
-                    } else {
-                      await github.rest.packages.deletePackageVersionForOrg({
-                        package_type: 'container',
-                        package_name: package_name,
-                        org: 'kagenti',
-                        package_version_id: version.id,
-                      });
-                      console.log(`Deleted untagged version ${version.id} (${createdAt.toISOString()})`);
-                    }
-                    deleted++;
+                    toDelete.push({ id: version.id, label: `untagged ${version.id}`, createdAt });
                   }
                   continue;
                 }
 
-                // Skip if any tag is protected (release tag or latest)
                 if (tags.some(tag => protectedTagPattern.test(tag))) {
                   skipped++;
                   continue;
                 }
 
-                // Skip if not all tags match SHA pattern
                 if (!tags.every(tag => shaTagPattern.test(tag))) {
                   skipped++;
                   continue;
                 }
 
-                // Skip if newer than cutoff
                 if (createdAt >= cutoffDate) {
                   skipped++;
                   continue;
                 }
 
-                // Delete this version
-                if (dryRun) {
-                  console.log(`[DRY RUN] Would delete ${tags.join(', ')} (${createdAt.toISOString()})`);
-                } else {
-                  await github.rest.packages.deletePackageVersionForOrg({
-                    package_type: 'container',
-                    package_name: package_name,
-                    org: 'kagenti',
-                    package_version_id: version.id,
-                  });
-                  console.log(`Deleted ${tags.join(', ')} (${createdAt.toISOString()})`);
-                }
-                deleted++;
+                toDelete.push({ id: version.id, label: tags.join(', '), createdAt });
               }
 
               if (versions.data.length < perPage) break;
               page++;
             }
 
+            // Phase 2: delete collected versions
+            for (const item of toDelete) {
+              if (dryRun) {
+                console.log(`[DRY RUN] Would delete ${item.label} (${item.createdAt.toISOString()})`);
+              } else {
+                await github.rest.packages.deletePackageVersionForOrg({
+                  package_type: 'container',
+                  package_name: package_name,
+                  org: 'kagenti',
+                  package_version_id: item.id,
+                });
+                console.log(`Deleted ${item.label} (${item.createdAt.toISOString()})`);
+              }
+            }
+
             console.log('---');
-            console.log(`Summary: ${deleted} deleted, ${skipped} preserved`);
+            console.log(`Summary: ${toDelete.length} deleted, ${skipped} preserved`);


### PR DESCRIPTION
## Summary

- Adds a daily GitHub Actions workflow that deletes container image versions from ghcr.io older than 7 days when tagged with the ephemeral `<branch>-<sha>` pattern
- Covers all 7 packages built by the `Build-Publish` workflow (ui-v2, backend, *-oauth-secret, spiffe-idp-setup)
- Also cleans up untagged manifests (orphaned multi-arch layers)
- Protected tags (`v*`, `latest`) are never touched

## Context

PR #1263 builds all platform images from source in E2E workflows, which means every merge to main creates 7 new tagged images. These accumulate indefinitely at https://github.com/orgs/kagenti/packages?repo_name=kagenti and need periodic cleanup.

## Design choices

| Choice | Rationale |
|--------|-----------|
| 7-day retention | Covers a full sprint for bisect/debugging; images are always rebuildable from git |
| Pattern: `<branch>-<hex7-12>` | Matches both `main-abc1234` and PR branch tags like `feature-xyz-abc1234` |
| `fail-fast: false` | One package error doesn't block cleanup of others |
| `workflow_dispatch` with dry_run | Safe manual preview before first real run |
| `actions/github-script` | Full control over pattern matching without external action dependencies |

## Test plan

- [ ] Trigger workflow manually with `dry_run: true` to verify correct identification of stale images
- [ ] Verify protected tags (`latest`, `v0.6.0`) are never listed for deletion
- [ ] Let one real run execute and confirm image count drops on the packages page

Assisted-By: Claude Code