### PR TITLE
chore: Rollback HyperShift version to 4.20.11 to test auth fix

### DIFF
--- a/.github/scripts/hypershift/create-cluster.sh
+++ b/.github/scripts/hypershift/create-cluster.sh
@@ -107,7 +107,7 @@ HYPERSHIFT_AUTOMATION_DIR=$(find_hypershift_automation)
 # Configuration with defaults
 REPLICAS="${REPLICAS:-2}"
 INSTANCE_TYPE="${INSTANCE_TYPE:-m5.xlarge}"
-OCP_VERSION="${OCP_VERSION:-4.20.21}"
+OCP_VERSION="${OCP_VERSION:-4.20.11}"
 
 # NodePool autoscaling (enabled by default)
 # Override AUTOSCALE_MIN and AUTOSCALE_MAX to adjust limits, or set to empty to disable


### PR DESCRIPTION
## Problem
  HyperShift CI failing with 403 auth errors on 4.20.21:
  `forbidden: User "system:anonymous" cannot get path "/apis"`

  ## Solution
  Rollback to 4.20.11 to test if issue is specific to 4.20.21.

  ## Testing
  Watch CI results - expecting auth errors to resolve.