### PR TITLE
feat(ui): Add mtlsMode select to AgentRuntime create form

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3619,9 +3619,7 @@ async def finalize_shipwright_build(
         # and we read it back here so build-from-source agents inherit
         # the same setting as direct-image agents).
         final_mtls_mode = (
-            request.mtlsMode
-            if request.mtlsMode is not None
-            else stored_config.get("mtlsMode")
+            request.mtlsMode if request.mtlsMode is not None else stored_config.get("mtlsMode")
         )
 
         # Persistent storage

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -20,7 +20,7 @@ import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query
 import kubernetes.client
 from kubernetes.client import ApiException
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.utils.routes import get_agent_url
@@ -257,6 +257,18 @@ class CreateAgentRequest(BaseModel):
     # operator but not surfaced through the UI today.
     authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
 
+    # Per-workload mTLS posture between AuthBridge sidecars. Maps to
+    # AgentRuntime.Spec.MTLSMode. The kagenti UI sends an explicit
+    # value (default "disabled") so users always see what they get;
+    # this means UI-created agents opt out of any namespace-level
+    # mtls.mode setting (CR-pin semantic in the operator). The
+    # operator's validating webhook rejects the envoy-sidecar +
+    # non-disabled combo because Envoy SDS isn't currently configured
+    # by the kagenti envoy-config — we mirror that check below as a
+    # model_validator so the form gets a fast 422 instead of a
+    # webhook denial after the manifest is built.
+    mtlsMode: Optional[Literal["disabled", "permissive", "strict"]] = None
+
     # Port exclusion annotations
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
@@ -283,6 +295,29 @@ class CreateAgentRequest(BaseModel):
                 f"Supported types: {', '.join(SUPPORTED_WORKLOAD_TYPES)}"
             )
         return v
+
+    @model_validator(mode="after")
+    def _check_mtls_compatible_with_mode(self) -> "CreateAgentRequest":
+        """Mirror the operator's AgentRuntime validating webhook check.
+
+        envoy-sidecar mode does not currently support mTLS — the kagenti
+        envoy-config doesn't configure SDS, so a strict/permissive value
+        here would silently produce a workload running plaintext while
+        the user believed mTLS was on. The operator webhook will reject
+        this combo at admission; we reject it earlier so the form gets
+        a clean 422 instead of a webhook denial after the manifest has
+        been constructed.
+        """
+        if self.authBridgeMode == "envoy-sidecar" and self.mtlsMode not in (
+            None,
+            "disabled",
+        ):
+            raise ValueError(
+                "mtlsMode must be 'disabled' when authBridgeMode is "
+                "'envoy-sidecar' (envoy-sidecar mTLS is tracked as a "
+                "follow-up; use proxy-sidecar or lite for mTLS today)"
+            )
+        return self
 
 
 class CreateAgentResponse(BaseModel):
@@ -2308,6 +2343,8 @@ def _build_agent_shipwright_build_manifest(
         resource_config["inboundPortsExclude"] = request.inboundPortsExclude
     if request.defaultOutboundPolicy:
         resource_config["defaultOutboundPolicy"] = request.defaultOutboundPolicy
+    if request.mtlsMode:
+        resource_config["mtlsMode"] = request.mtlsMode
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
     # Add env vars if present
@@ -2468,6 +2505,7 @@ def _build_agentruntime_manifest(
     workload_type: str,
     agent_type: str = RESOURCE_TYPE_AGENT,
     auth_bridge_mode: Optional[str] = None,
+    mtls_mode: Optional[str] = None,
 ) -> dict:
     """Build an AgentRuntime CR manifest for the given workload."""
     kind_map = {
@@ -2484,6 +2522,8 @@ def _build_agentruntime_manifest(
     }
     if auth_bridge_mode:
         spec["authBridgeMode"] = auth_bridge_mode
+    if mtls_mode:
+        spec["mtlsMode"] = mtls_mode
     return {
         "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
         "kind": "AgentRuntime",
@@ -2506,10 +2546,11 @@ def _ensure_agentruntime(
     workload_type: str,
     agent_type: str = RESOURCE_TYPE_AGENT,
     auth_bridge_mode: Optional[str] = None,
+    mtls_mode: Optional[str] = None,
 ) -> None:
     """Create an AgentRuntime CR for the workload. Skip if it already exists."""
     manifest = _build_agentruntime_manifest(
-        name, namespace, workload_type, agent_type, auth_bridge_mode
+        name, namespace, workload_type, agent_type, auth_bridge_mode, mtls_mode
     )
     try:
         kube.create_custom_resource(
@@ -3174,6 +3215,7 @@ async def create_agent(
                     namespace=request.namespace,
                     workload_type=request.workloadType,
                     auth_bridge_mode=request.authBridgeMode,
+                    mtls_mode=request.mtlsMode,
                 )
 
             message = f"Agent '{request.name}' deployed as {request.workloadType} successfully."
@@ -3295,11 +3337,34 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     authBridgeEnabled: Optional[bool] = None
     imagePullSecret: Optional[str] = None
     authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
+    # Mirrors CreateAgentRequest.mtlsMode. Threaded through the
+    # finalize flow so a build-from-source agent inherits the mtlsMode
+    # the user picked at form-submit time (stashed on the BuildRun via
+    # kagenti.io/agent-config annotation).
+    mtlsMode: Optional[Literal["disabled", "permissive", "strict"]] = None
     outboundRoutes: Optional[List[OutboundRoute]] = None
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
     defaultOutboundPolicy: Optional[Literal["passthrough", "exchange"]] = None
     persistentStorage: Optional[PersistentStorageConfig] = None
+
+    @model_validator(mode="after")
+    def _check_mtls_compatible_with_mode(self) -> "FinalizeShipwrightBuildRequest":
+        """Same cross-field check as CreateAgentRequest, applied at the
+        Shipwright finalize boundary. Either field may be None here
+        (caller falls back to the stored config); only reject when both
+        are explicitly supplied AND incompatible.
+        """
+        if self.authBridgeMode == "envoy-sidecar" and self.mtlsMode not in (
+            None,
+            "disabled",
+        ):
+            raise ValueError(
+                "mtlsMode must be 'disabled' when authBridgeMode is "
+                "'envoy-sidecar' (envoy-sidecar mTLS is tracked as a "
+                "follow-up; use proxy-sidecar or lite for mTLS today)"
+            )
+        return self
 
 
 @router.post(
@@ -3549,6 +3614,16 @@ async def finalize_shipwright_build(
             else stored_config.get("authBridgeMode")
         )
 
+        # Per-workload mTLS mode (applies to AgentRuntime spec only;
+        # the form stores it on the BuildRun annotation at submit time
+        # and we read it back here so build-from-source agents inherit
+        # the same setting as direct-image agents).
+        final_mtls_mode = (
+            request.mtlsMode
+            if request.mtlsMode is not None
+            else stored_config.get("mtlsMode")
+        )
+
         # Persistent storage
         final_persistent_storage = request.persistentStorage
         if final_persistent_storage is None and stored_config.get("persistentStorage"):
@@ -3571,6 +3646,7 @@ async def finalize_shipwright_build(
             authBridgeEnabled=final_auth_bridge,
             spireEnabled=final_spire_enabled,
             authBridgeMode=final_auth_bridge_mode,
+            mtlsMode=final_mtls_mode,
             outboundRoutes=final_outbound_routes,
             outboundPortsExclude=final_outbound_ports_exclude,
             inboundPortsExclude=final_inbound_ports_exclude,
@@ -3712,6 +3788,7 @@ async def finalize_shipwright_build(
                 namespace=namespace,
                 workload_type=final_workload_type,
                 auth_bridge_mode=final_auth_bridge_mode,
+                mtls_mode=final_mtls_mode,
             )
 
         message = f"Agent '{name}' deployed as {final_workload_type} with image '{output_image}'."

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -228,8 +228,15 @@ class CreateToolRequest(BaseModel):
     # SPIRE identity (gates spiffe-helper inside the combined authbridge container)
     spireEnabled: bool = False
 
-    # Per-workload AuthBridge mode override (maps to
-    # AgentRuntime.Spec.AuthBridgeMode; None means cluster default).
+    # Per-workload AuthBridge mode override. Tools don't create an
+    # AgentRuntime CR (they use the deprecated kagenti.io/authbridge-mode
+    # pod annotation, see tools.py:1041-1046), so this field flows
+    # through the annotation path, not via Spec.AuthBridgeMode.
+    #
+    # mtlsMode is intentionally NOT exposed for tools: it lives on the
+    # AgentRuntime CR's Spec, and there's no equivalent pod annotation
+    # for it. Once tools start producing AgentRuntime CRs (tracked as
+    # an operator-side follow-up), mtlsMode can be added here too.
     authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
 
     # Port exclusion annotations

--- a/kagenti/backend/tests/test_agentruntime_manifest.py
+++ b/kagenti/backend/tests/test_agentruntime_manifest.py
@@ -1,0 +1,155 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for _build_agentruntime_manifest and the CreateAgentRequest /
+FinalizeShipwrightBuildRequest cross-field validator.
+
+The operator's AgentRuntime CRD enum (disabled / permissive / strict)
+is matched 1:1 by the backend's Pydantic Literal. The cross-field
+"mtlsMode != disabled is incompatible with envoy-sidecar" rule is
+mirrored here so the form gets a 422 before the manifest is built —
+without this layer the user would only see the operator's webhook
+denial, which lands later in the flow and is harder to surface
+inline.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_manifest_omits_mtls_mode_when_unset():
+    """No mtlsMode → no spec.mtlsMode key (lets operator default kick in)."""
+    from app.routers.agents import _build_agentruntime_manifest
+
+    m = _build_agentruntime_manifest("a", "ns", "deployment")
+    assert "mtlsMode" not in m["spec"]
+
+
+def test_manifest_includes_mtls_mode_when_set():
+    """Each enum value flows into spec.mtlsMode unchanged."""
+    from app.routers.agents import _build_agentruntime_manifest
+
+    for mode in ("disabled", "permissive", "strict"):
+        m = _build_agentruntime_manifest("a", "ns", "deployment", mtls_mode=mode)
+        assert m["spec"]["mtlsMode"] == mode
+
+
+def test_manifest_independent_of_auth_bridge_mode():
+    """mtls_mode and auth_bridge_mode flow as independent fields.
+
+    Cross-field validation lives in the request models, not the
+    manifest builder — the builder is a dumb dict assembler.
+    """
+    from app.routers.agents import _build_agentruntime_manifest
+
+    m = _build_agentruntime_manifest(
+        "a", "ns", "deployment", auth_bridge_mode="proxy-sidecar", mtls_mode="strict"
+    )
+    assert m["spec"]["authBridgeMode"] == "proxy-sidecar"
+    assert m["spec"]["mtlsMode"] == "strict"
+
+
+def test_create_agent_request_accepts_disabled_with_envoy():
+    """envoy-sidecar + disabled (the no-op combo) is allowed."""
+    from app.routers.agents import CreateAgentRequest
+
+    r = CreateAgentRequest(
+        name="a",
+        namespace="ns",
+        authBridgeMode="envoy-sidecar",
+        mtlsMode="disabled",
+    )
+    assert r.mtlsMode == "disabled"
+
+
+def test_create_agent_request_rejects_envoy_with_strict():
+    """The operator webhook will reject this; mirror the check here."""
+    from app.routers.agents import CreateAgentRequest
+
+    with pytest.raises(ValidationError) as exc_info:
+        CreateAgentRequest(
+            name="a",
+            namespace="ns",
+            authBridgeMode="envoy-sidecar",
+            mtlsMode="strict",
+        )
+    msg = str(exc_info.value)
+    # Forward-pointing error message is part of the contract — UI
+    # surfaces this string to users.
+    assert "envoy-sidecar" in msg
+    assert "follow-up" in msg
+
+
+def test_create_agent_request_rejects_envoy_with_permissive():
+    from app.routers.agents import CreateAgentRequest
+
+    with pytest.raises(ValidationError):
+        CreateAgentRequest(
+            name="a",
+            namespace="ns",
+            authBridgeMode="envoy-sidecar",
+            mtlsMode="permissive",
+        )
+
+
+def test_create_agent_request_proxy_sidecar_allows_strict():
+    """Most common case: proxy-sidecar + strict, the documented path."""
+    from app.routers.agents import CreateAgentRequest
+
+    r = CreateAgentRequest(
+        name="a",
+        namespace="ns",
+        authBridgeMode="proxy-sidecar",
+        mtlsMode="strict",
+    )
+    assert r.authBridgeMode == "proxy-sidecar"
+    assert r.mtlsMode == "strict"
+
+
+def test_create_agent_request_lite_allows_strict():
+    """lite is a build variant of proxy-sidecar; same mtls compatibility."""
+    from app.routers.agents import CreateAgentRequest
+
+    r = CreateAgentRequest(
+        name="a",
+        namespace="ns",
+        authBridgeMode="lite",
+        mtlsMode="strict",
+    )
+    assert r.mtlsMode == "strict"
+
+
+def test_finalize_shipwright_request_mirrors_validator():
+    """Same cross-field rule on the build-finalize boundary."""
+    from app.routers.agents import FinalizeShipwrightBuildRequest
+
+    # Allowed
+    FinalizeShipwrightBuildRequest(
+        authBridgeMode="proxy-sidecar", mtlsMode="strict"
+    )
+    # Rejected
+    with pytest.raises(ValidationError):
+        FinalizeShipwrightBuildRequest(
+            authBridgeMode="envoy-sidecar", mtlsMode="strict"
+        )
+
+
+def test_create_agent_request_default_mtls_mode_is_none():
+    """Bare request → mtlsMode None → operator falls back to its default
+    (disabled). Sending undefined on the wire keeps existing behavior
+    byte-identical for users who haven't engaged the new feature.
+    """
+    from app.routers.agents import CreateAgentRequest
+
+    r = CreateAgentRequest(name="a", namespace="ns")
+    assert r.mtlsMode is None
+
+
+def test_create_agent_request_unknown_mtls_value_rejected():
+    """Pydantic Literal enforcement — any non-enum value is rejected
+    at the API layer, before the validator runs.
+    """
+    from app.routers.agents import CreateAgentRequest
+
+    with pytest.raises(ValidationError):
+        CreateAgentRequest(name="a", namespace="ns", mtlsMode="loose")

--- a/kagenti/backend/tests/test_agentruntime_manifest.py
+++ b/kagenti/backend/tests/test_agentruntime_manifest.py
@@ -124,14 +124,10 @@ def test_finalize_shipwright_request_mirrors_validator():
     from app.routers.agents import FinalizeShipwrightBuildRequest
 
     # Allowed
-    FinalizeShipwrightBuildRequest(
-        authBridgeMode="proxy-sidecar", mtlsMode="strict"
-    )
+    FinalizeShipwrightBuildRequest(authBridgeMode="proxy-sidecar", mtlsMode="strict")
     # Rejected
     with pytest.raises(ValidationError):
-        FinalizeShipwrightBuildRequest(
-            authBridgeMode="envoy-sidecar", mtlsMode="strict"
-        )
+        FinalizeShipwrightBuildRequest(authBridgeMode="envoy-sidecar", mtlsMode="strict")
 
 
 def test_create_agent_request_default_mtls_mode_is_none():

--- a/kagenti/tui/internal/api/types.go
+++ b/kagenti/tui/internal/api/types.go
@@ -211,6 +211,13 @@ type CreateAgentRequest struct {
 	AuthBridgeEnabled bool                     `json:"authBridgeEnabled"`
 	SpireEnabled      bool                     `json:"spireEnabled"`
 	AuthBridgeMode    string                   `json:"authBridgeMode,omitempty"`
+	// MTLSMode maps to AgentRuntime.Spec.MTLSMode. Backend rejects
+	// non-disabled values when AuthBridgeMode is "envoy-sidecar"
+	// (Envoy SDS not currently configured by the kagenti chart).
+	// Empty string sends nothing (operator default applies); the TUI
+	// form does not yet expose this — it's wired through here so
+	// kubectl-style or future-CLI usage paths don't drop the field.
+	MTLSMode          string                   `json:"mtlsMode,omitempty"`
 	PersistentStorage *PersistentStorageConfig `json:"persistentStorage,omitempty"`
 }
 

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -214,14 +214,13 @@ export const ImportAgentPage: React.FC = () => {
   // AuthBridge config overrides
   const [defaultOutboundPolicy, setDefaultOutboundPolicy] = useState('passthrough');
   // mTLS posture between AuthBridge sidecars. Always sends an explicit
-  // value (default 'disabled') — UI-created agents opt out of any
-  // namespace-level mtls.mode setting via the operator's CR-pin
-  // semantic. Force-reset to 'disabled' when useEnvoyMode flips on
-  // because the operator/backend reject envoy-sidecar + non-disabled.
+  // value (default 'disabled'). Force-reset to 'disabled' when either:
+  //   - useEnvoyMode is on (operator/backend reject envoy-sidecar + non-disabled)
+  //   - spireEnabled is off (mtls requires SPIRE-issued X.509 SVIDs)
   const [mtlsMode, setMtlsMode] = useState<'disabled' | 'permissive' | 'strict'>('disabled');
   useEffect(() => {
-    if (useEnvoyMode) setMtlsMode('disabled');
-  }, [useEnvoyMode]);
+    if (useEnvoyMode || !spireEnabled) setMtlsMode('disabled');
+  }, [useEnvoyMode, spireEnabled]);
   const [showOutboundRouting, setShowOutboundRouting] = useState(false);
 
   // Validation state
@@ -1222,39 +1221,29 @@ export const ImportAgentPage: React.FC = () => {
                     <FormSelectOption key="exchange" value="exchange" label="exchange — require token exchange for all outbound traffic" />
                   </FormSelect>
                 </FormGroup>
-                <FormGroup label="Sidecar mTLS" fieldId="mtlsMode">
+                <FormGroup label="mTLS" fieldId="mtlsMode">
                   <FormSelect
                     id="mtlsMode"
                     value={mtlsMode}
                     onChange={(_e, v) => setMtlsMode(v as 'disabled' | 'permissive' | 'strict')}
-                    aria-label="Sidecar mTLS mode"
-                    isDisabled={useEnvoyMode}
+                    aria-label="mTLS mode"
+                    isDisabled={useEnvoyMode || !spireEnabled}
                   >
                     <FormSelectOption key="disabled" value="disabled" label="disabled — no mTLS between sidecars (default)" />
-                    <FormSelectOption key="permissive" value="permissive" label="permissive — try mTLS, fall back to plaintext on handshake failure" />
-                    <FormSelectOption key="strict" value="strict" label="strict — require mTLS, fail closed on handshake failure" />
+                    <FormSelectOption key="permissive" value="permissive" label="permissive — try mTLS, fall back to plaintext on failure" />
+                    <FormSelectOption key="strict" value="strict" label="strict — require mTLS, fail closed" />
                   </FormSelect>
-                  <FormHelperText>
-                    <HelperText>
-                      {useEnvoyMode ? (
+                  {(useEnvoyMode || !spireEnabled) && (
+                    <FormHelperText>
+                      <HelperText>
                         <HelperTextItem variant="warning">
-                          envoy-sidecar mode does not currently support mTLS (Envoy SDS not configured by the kagenti chart). Forced to disabled.
+                          {useEnvoyMode
+                            ? 'Not supported with envoy mode.'
+                            : 'Requires SPIRE — enable SPIRE to use mTLS.'}
                         </HelperTextItem>
-                      ) : (
-                        <>
-                          <HelperTextItem>
-                            Controls byte-peek mTLS between AuthBridge sidecars on the proxy-sidecar / lite paths.
-                          </HelperTextItem>
-                          <HelperTextItem>
-                            Requires SPIRE in the cluster — selecting permissive or strict auto-enables SPIRE for this workload.
-                          </HelperTextItem>
-                          <HelperTextItem variant="warning">
-                            permissive falls back silently to plaintext on TLS handshake failure (e.g. peer not yet running mTLS); use strict for production posture once rollout completes.
-                          </HelperTextItem>
-                        </>
-                      )}
-                    </HelperText>
-                  </FormHelperText>
+                      </HelperText>
+                    </FormHelperText>
+                  )}
                 </FormGroup>
               </ExpandableSection>
               )}

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -213,6 +213,15 @@ export const ImportAgentPage: React.FC = () => {
   const [inboundPortsExclude, setInboundPortsExclude] = useState('');
   // AuthBridge config overrides
   const [defaultOutboundPolicy, setDefaultOutboundPolicy] = useState('passthrough');
+  // mTLS posture between AuthBridge sidecars. Always sends an explicit
+  // value (default 'disabled') — UI-created agents opt out of any
+  // namespace-level mtls.mode setting via the operator's CR-pin
+  // semantic. Force-reset to 'disabled' when useEnvoyMode flips on
+  // because the operator/backend reject envoy-sidecar + non-disabled.
+  const [mtlsMode, setMtlsMode] = useState<'disabled' | 'permissive' | 'strict'>('disabled');
+  useEffect(() => {
+    if (useEnvoyMode) setMtlsMode('disabled');
+  }, [useEnvoyMode]);
   const [showOutboundRouting, setShowOutboundRouting] = useState(false);
 
   // Validation state
@@ -503,6 +512,9 @@ export const ImportAgentPage: React.FC = () => {
         authBridgeEnabled,
         spireEnabled,
         authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
+        // mTLS posture — only meaningful when AuthBridge is on AND we're
+        // not in envoy-sidecar mode (backend rejects that combo).
+        mtlsMode: authBridgeEnabled && !useEnvoyMode ? mtlsMode : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -538,6 +550,9 @@ export const ImportAgentPage: React.FC = () => {
         authBridgeEnabled,
         spireEnabled,
         authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
+        // mTLS posture — only meaningful when AuthBridge is on AND we're
+        // not in envoy-sidecar mode (backend rejects that combo).
+        mtlsMode: authBridgeEnabled && !useEnvoyMode ? mtlsMode : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -1206,6 +1221,40 @@ export const ImportAgentPage: React.FC = () => {
                     <FormSelectOption key="passthrough" value="passthrough" label="passthrough — pass traffic through unchanged (default)" />
                     <FormSelectOption key="exchange" value="exchange" label="exchange — require token exchange for all outbound traffic" />
                   </FormSelect>
+                </FormGroup>
+                <FormGroup label="Sidecar mTLS" fieldId="mtlsMode">
+                  <FormSelect
+                    id="mtlsMode"
+                    value={mtlsMode}
+                    onChange={(_e, v) => setMtlsMode(v as 'disabled' | 'permissive' | 'strict')}
+                    aria-label="Sidecar mTLS mode"
+                    isDisabled={useEnvoyMode}
+                  >
+                    <FormSelectOption key="disabled" value="disabled" label="disabled — no mTLS between sidecars (default)" />
+                    <FormSelectOption key="permissive" value="permissive" label="permissive — try mTLS, fall back to plaintext on handshake failure" />
+                    <FormSelectOption key="strict" value="strict" label="strict — require mTLS, fail closed on handshake failure" />
+                  </FormSelect>
+                  <FormHelperText>
+                    <HelperText>
+                      {useEnvoyMode ? (
+                        <HelperTextItem variant="warning">
+                          envoy-sidecar mode does not currently support mTLS (Envoy SDS not configured by the kagenti chart). Forced to disabled.
+                        </HelperTextItem>
+                      ) : (
+                        <>
+                          <HelperTextItem>
+                            Controls byte-peek mTLS between AuthBridge sidecars on the proxy-sidecar / lite paths.
+                          </HelperTextItem>
+                          <HelperTextItem>
+                            Requires SPIRE in the cluster — selecting permissive or strict auto-enables SPIRE for this workload.
+                          </HelperTextItem>
+                          <HelperTextItem variant="warning">
+                            permissive falls back silently to plaintext on TLS handshake failure (e.g. peer not yet running mTLS); use strict for production posture once rollout completes.
+                          </HelperTextItem>
+                        </>
+                      )}
+                    </HelperText>
+                  </FormHelperText>
                 </FormGroup>
               </ExpandableSection>
               )}

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -233,6 +233,9 @@ export const agentService = {
     spireEnabled?: boolean;
     // Per-workload AuthBridge mode (maps to AgentRuntime.Spec.AuthBridgeMode)
     authBridgeMode?: 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
+    // Per-workload mTLS posture (maps to AgentRuntime.Spec.MTLSMode).
+    // Backend rejects mtlsMode != 'disabled' when authBridgeMode === 'envoy-sidecar'.
+    mtlsMode?: 'disabled' | 'permissive' | 'strict';
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -444,6 +447,7 @@ export const shipwrightService = {
       createHttpRoute?: boolean;
       authBridgeEnabled?: boolean;
       authBridgeMode?: 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
+      mtlsMode?: 'disabled' | 'permissive' | 'strict';
       outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
       outboundPortsExclude?: string;
       inboundPortsExclude?: string;

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -453,6 +453,11 @@ export interface CreateSkillResponse {
 // AuthBridge types
 export type AuthBridgeMode = 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
 
+// mTLS posture for AuthBridge sidecars (proxy-sidecar / lite paths only;
+// envoy-sidecar mTLS is not currently configured in the kagenti envoy-config).
+// Maps 1:1 to AgentRuntime.Spec.MTLSMode in the operator.
+export type MtlsMode = 'disabled' | 'permissive' | 'strict';
+
 export interface AuthBridgeConfig {
   AuthBridge: boolean | null;
   mode: AuthBridgeMode | null;


### PR DESCRIPTION
## Summary

Surfaces the new `AgentRuntime.Spec.MTLSMode` field (added in [kagenti-operator PR #369](https://github.com/kagenti/kagenti-operator/pull/369)) through the kagenti backend + UI + TUI struct so users can pick a per-workload mTLS posture from the Import Agent form rather than hand-editing the CR or namespace ConfigMap.

The mTLS feature is fully implemented on the operator + authbridge side ([kagenti-extensions PR #424](https://github.com/kagenti/kagenti-extensions/pull/424) merged authbridge mTLS, kagenti-operator PR #369 merged the CR field + auto-SPIRE + validation). This PR is the user-facing wiring.

## What ships

### Backend (`kagenti/backend/app/routers/agents.py`)

- `mtlsMode: Optional[Literal["disabled", "permissive", "strict"]]` on `CreateAgentRequest` AND `FinalizeShipwrightBuildRequest`.
- `@model_validator` on both that mirrors the operator's validating webhook check: rejects `mtlsMode != disabled` when `authBridgeMode == envoy-sidecar`. Returns 422 from FastAPI rather than letting the operator webhook deny later.
- `_build_agentruntime_manifest` emits `spec.mtlsMode` when set, omits the key when `None`.
- Both `_ensure_agentruntime` call sites updated (direct-create and Shipwright finalize).
- Shipwright finalize: the field is stashed on the BuildRun via `kagenti.io/agent-config` annotation at submit time and read back at finalize, so build-from-source agents inherit the form setting (parity with direct-image agents).

### UI (`kagenti/ui-v2/src/pages/ImportAgentPage.tsx`)

- New `FormSelect` "Sidecar mTLS" inside the existing **AuthBridge Advanced Configuration** ExpandableSection (sits next to `defaultOutboundPolicy`).
- Three options: `disabled` (default) / `permissive` / `strict`.
- Greys out and force-resets to `disabled` when `useEnvoyMode` is checked.
- Helper text covers two operator-relevant caveats:
  - Requires SPIRE in the cluster (the operator auto-enables SPIRE for workloads with `mtlsMode != disabled`).
  - Permissive falls back **silently** to plaintext on TLS handshake failure; use strict for production posture once rollout completes.

### Types

- `MtlsMode` type alias in `types/index.ts`.
- `mtlsMode` field on `agentService.create` and `shipwrightService.finalizeBuild` body types in `services/api.ts`.

### TUI (`kagenti/tui/internal/api/types.go`)

- `MTLSMode string` field on `CreateAgentRequest`. No form/CLI work — TUI's deploy form doesn't yet expose `authBridgeMode` either; bundling form work would widen parity gaps. Tracked as a follow-up.

### Tests

- New `kagenti/backend/tests/test_agentruntime_manifest.py` — 11 tests covering manifest builder, cross-field validator on both request models, default behavior, Pydantic enum enforcement.

## Defense in depth

The incompatible combo `mtlsMode != disabled` + `authBridgeMode = envoy-sidecar` is rejected at four layers:

| Layer | Mechanism |
|---|---|
| UI | `FormSelect` greyed out + force-reset to `disabled` when `useEnvoyMode` is checked |
| Backend | Pydantic `model_validator` on both `CreateAgentRequest` and `FinalizeShipwrightBuildRequest` |
| Operator | `AgentRuntimeValidator.checkMTLSCompatibleWithMode` (kagenti-operator PR #369) |
| Authbridge | (Implicit) envoy-sidecar mode doesn't read the `mtls:` block; the field has no effect there |

## Trade-off worth flagging

The form **always** sends an explicit `mtlsMode` value (default `disabled`). Combined with the operator's CR-pin semantic, this means **UI-created agents opt out of any namespace-level `mtls.mode` setting**. A cluster admin who sets `mtls.mode: strict` in `authbridge-runtime-config` expecting it to apply to all new agents in the namespace will be surprised when UI-created agents come up plaintext.

Reasoning: the form should reflect what the user picks; cluster admins should use admission policy (Kyverno / OPA) rather than ConfigMap defaults to enforce posture. Power users can still get namespace-default inheritance by `kubectl edit agentruntime <name>` to clear `Spec.MTLSMode`.

## Out of scope (intentional)

- **Tools (`kagenti/backend/app/routers/tools.py`)**: tools don't create AgentRuntime CRs (they use the deprecated `kagenti.io/authbridge-mode` pod annotation), so `mtlsMode` has no place to live. Clarifying comment added near tools' `authBridgeMode` field.
- **AgentDetailPage display**: showing the resolved `mtlsMode` for an existing agent would require a backend GET endpoint for the AgentRuntime CR. Deferred — agents are read-only post-creation today, and adding GET-only display is a separate concern.
- **Edit-after-creation**: kagenti has no edit-agent flow. Changing mtlsMode on an existing agent requires `kubectl edit agentruntime <name>`. Same constraint applies to `authBridgeMode`.
- **envoy-sidecar mTLS**: requires extending the kagenti meta-chart's envoy-config template to configure SDS. Comparable in size to the original PR #424.
- **TUI form parity**: the TUI doesn't expose `authBridgeMode` either; widening that form is a separate piece of work.

## Test plan

- [x] Backend: `pytest tests/test_agentruntime_manifest.py` — 11/11 pass
- [x] Backend: smoke-test via `python -c 'from app.routers.agents import ...'` — model validates, manifest emits, validator rejects the bad combo
- [x] UI: `npx tsc --noEmit` clean
- [x] UI: `npm run lint` adds no new errors (the two pre-existing `'id' unused-var` warnings on the `outboundRoutes` destructure shifted line numbers due to state additions; count unchanged at 2)
- [x] TUI: `go build ./...` clean
- [ ] CI passes
- [ ] End-to-end demo verification:
  1. Deploy operator from `main` (PR #369 merged)
  2. Deploy kagenti with this branch
  3. Open the UI, navigate to **Import Agent**, expand **AuthBridge Advanced Configuration**
  4. Pick `mtlsMode = strict`, submit
  5. Verify `kubectl get agentruntime <name> -o yaml` shows `spec.mtlsMode: strict`
  6. Verify the per-agent ConfigMap has `mtls: {mode: strict}` block
  7. Verify two agent pods perform TLS handshakes on the wire (tcpdump from a debug pod)
  8. Toggle the form to `useEnvoyMode = true`, observe `mtlsMode` greys out and resets to `disabled`
  9. Negative path: bypass the form (curl POST), confirm backend returns 422 with the forward-pointing error

## Files

- `kagenti/backend/app/routers/agents.py` — Pydantic field + validator + manifest plumbing + Shipwright finalize plumbing
- `kagenti/backend/app/routers/tools.py` — clarifying comment (no field added)
- `kagenti/backend/tests/test_agentruntime_manifest.py` — 11 new tests
- `kagenti/ui-v2/src/types/index.ts` — `MtlsMode` type alias
- `kagenti/ui-v2/src/services/api.ts` — request body types
- `kagenti/ui-v2/src/pages/ImportAgentPage.tsx` — state + FormSelect + submit-mapping
- `kagenti/tui/internal/api/types.go` — Go struct field

Net: ~+308 / -4 LOC across 7 files.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
