### PR TITLE
fix(ocp): add --reset-values to helm upgrade to prevent stale overrides

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1202,6 +1202,7 @@ run_cmd $KUBECTL create namespace mcp-system --dry-run=client -o yaml | $KUBECTL
 
 run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   -n kagenti-system --create-namespace \
+  --reset-values \
   -f "$SECRETS_FILE" \
   ${KAGENTI_UI_FLAGS[@]+"${KAGENTI_UI_FLAGS[@]}"} \
   ${OPERATOR_IMAGE_FLAGS[@]+"${OPERATOR_IMAGE_FLAGS[@]}"} \

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -661,6 +661,7 @@ EOF
     # cluster-monitoring-config is managed by another operator)
     log_info "kagenti-deps already installed — upgrading (hooks skipped)"
     run_cmd helm upgrade kagenti-deps "$KAGENTI_REPO/charts/kagenti-deps/" \
+      --reset-values \
       "${KAGENTI_DEPS_HELM_ARGS[@]}"
     # Apply operand CRs on upgrade too — catches CRs missed by a previous
     # failed install (e.g. Keycloak CRD wasn't ready yet on first run)
@@ -928,6 +929,7 @@ _ensure_rhoai_shared_trust
 # .Capabilities.APIVersions.Has (e.g. AuthorizationPolicy, shared-trust certs).
 log_info "Reconciling CRD-dependent resources..."
 run_cmd helm upgrade kagenti-deps "$KAGENTI_REPO/charts/kagenti-deps/" \
+  --reset-values \
   "${KAGENTI_DEPS_HELM_ARGS[@]}"
 [ -n "$KAGENTI_DEPS_MLFLOW_VALS_FILE" ] && rm -f "$KAGENTI_DEPS_MLFLOW_VALS_FILE"
 log_success "kagenti-deps reconciled"


### PR DESCRIPTION
## Summary

- Add `--reset-values` to the main `helm upgrade --install kagenti` command in the OCP installer

## Problem

Without `--reset-values`, `helm upgrade` carries forward user-supplied values from the previous release. This causes version switches to be silently ignored — e.g. when downgrading from `v0.7.0-alpha.1` to `v0.6.0-rc.5`, the old `ui.frontend.tag: v0.7.0-alpha.1` override persists because helm merges it on top of the new chart defaults.

## Why this is safe

The installer script already passes all required configuration explicitly:
- `-f .secrets.yaml` (credentials)
- `--set` flags for keycloak URL, realm, SA cert, SPIFFE prefix, feature flags, operator image, etc.

There is nothing legitimate that `--reuse-values` would preserve that isn't already declared in the script. Any ad-hoc `helm upgrade --set` done between script runs is an anti-pattern for a declarative installer.

## Test plan

- [ ] Run `setup-kagenti.sh --kagenti-repo .` on a cluster that previously had a different version
- [ ] Verify deployed image tags match the chart's `values.yaml` defaults

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
