### PR TITLE
fix(ocp): enable Build from Source with OpenShift internal registry

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -123,6 +123,10 @@ spec:
             - name: DEFAULT_REGISTRY_URL
               value: {{ .Values.ui.backend.defaultRegistryUrl | quote }}
             {{- end }}
+            {{- if .Values.ui.backend.shipwrightDefaultStrategy }}
+            - name: SHIPWRIGHT_DEFAULT_STRATEGY
+              value: {{ .Values.ui.backend.shipwrightDefaultStrategy | quote }}
+            {{- end }}
             # Feature flags
             - name: KAGENTI_FEATURE_FLAG_SANDBOX
               value: "{{ .Values.featureFlags.sandbox }}"

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -94,6 +94,9 @@ ui:
     tag: v0.7.0-alpha.1
     # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
     defaultRegistryUrl: ""
+    # Default Shipwright build strategy for internal registries
+    # Kind: "buildah-insecure-push" (no TLS), OCP: "buildah" (TLS-enabled registry)
+    shipwrightDefaultStrategy: ""
     resources:
       limits:
         cpu: 250m

--- a/deployments/envs/ocp_ci_values.yaml
+++ b/deployments/envs/ocp_ci_values.yaml
@@ -80,6 +80,7 @@ charts:
           enabled: true
         backend:
           defaultRegistryUrl: "image-registry.openshift-image-registry.svc:5000"
+          shipwrightDefaultStrategy: "buildah"
       uiOAuthSecret:
         useServiceAccountCA: true
       keycloak:

--- a/deployments/envs/ocp_minimal_values.yaml
+++ b/deployments/envs/ocp_minimal_values.yaml
@@ -102,6 +102,7 @@ charts:
           enabled: true
         backend:
           defaultRegistryUrl: "image-registry.openshift-image-registry.svc:5000"
+          shipwrightDefaultStrategy: "buildah"
       uiOAuthSecret:
         # for a OCP with self-signed certs for routes it should be true.
         # for a OCP with CA-signed certs for routes it should be false.

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -102,6 +102,7 @@ charts:
           enabled: true
         backend:
           defaultRegistryUrl: "image-registry.openshift-image-registry.svc:5000"
+          shipwrightDefaultStrategy: "buildah"
       uiOAuthSecret:
         # for a OCP with self-signed certs for routes it should be true.
         # for a OCP with CA-signed certs for routes it should be false.

--- a/docs/ocp/openshift-install.md
+++ b/docs/ocp/openshift-install.md
@@ -350,27 +350,9 @@ When opening the MCP inspector through the **MCP Gateway** tab on a new installa
 
 *Note: These settings are persisted in your browser and only need to be configured once per browser installation.*
 
-## Running the demo
-
-You may use the pre-built images available at [https://github.com/orgs/kagenti/packages?repo_name=agent-examples](https://github.com/orgs/kagenti/packages?repo_name=agent-examples) or build from source. Agents support both Ollama and OpenAI backends — select the appropriate environment variable set when importing an agent. See the [Local Models Guide](../local-models.md) for details.
-
-Building from source has been tested only with `quay.io`, and requires setting up a robot account on [quay.io](https://quay.io), creating empty repos in your organization for the repos to build (e.g.`a2a-contact-extractor` and `a2a-currency-converter`) and granting the robot account write access to those repos.
-
-Finally, you may get the Kubernetes secret from the robot account you created, and apply the secret to the namespaces
-you enabled for agents and tools (e.g. `team1` and `team2`).
-
-You should now be able to use the UI to:
-
-- Import an agent
-- List the agent
-- Interact with the agent from the agent details page
-- Import a MCP tool
-- List the tool
-- Interact with the tool from the tool details page
-
 # Running the Demo
 
-There are two ways to get the agent images for the demo: using pre-built images (recommended for a quick start) or building them from source. Both Ollama and OpenAI backends are supported — see the [Local Models Guide](../local-models.md) for details.
+There are three ways to get agent images for the demo: using pre-built images (recommended for a quick start), building from source using the OpenShift internal registry, or building from source with an external registry. Both Ollama and OpenAI backends are supported — see the [Local Models Guide](../local-models.md) for details.
 
 ---
 
@@ -383,20 +365,57 @@ This is the fastest way to get started. The required images are already built an
 
 ---
 
-## Option 2: Build from Source
+## Option 2: Build from Source (Internal Registry)
 
-Follow this path if you want to build the agent container images yourself.
+When the installer is run with the `--with-builds` flag, the OpenShift internal image registry is automatically configured as the build target. No external registry account or push secrets are needed.
 
 ### Prerequisites
 
-- A user or organization account on **[quay.io](https://quay.io)**.
-- Namespaces created in your Kubernetes cluster where you will run agents and tools (e.g., `team1` and `team2`).
+- OpenShift cluster with the internal image registry enabled (default on most OCP installations)
+- Installer run with the `--with-builds` flag:
+
+  ```bash
+  ./scripts/ocp/setup-kagenti.sh --with-builds
+  ```
+
+### How it works
+
+The `--with-builds` flag automatically:
+
+1. Installs the **OpenShift Builds operator** (Shipwright) and **Tekton Pipelines**
+2. Configures the backend to use the internal registry (`image-registry.openshift-image-registry.svc:5000`)
+3. Sets the build strategy to `buildah` (TLS-enabled, matching the internal registry)
+4. Grants the `pipeline` ServiceAccount `system:image-builder` permissions in each agent namespace (standard OpenShift RBAC)
+
+### Using Build from Source in the UI
+
+Once installed with `--with-builds`:
+
+1. Navigate to **Agents** or **Tools** in the Kagenti UI
+2. Click **Import** and select **Build from Source**
+3. Provide the git repository URL (and branch/path if needed)
+4. The build runs in-cluster using Shipwright, pushing the image to the internal registry
+5. Once the build completes, the agent/tool is deployed automatically
+
+No registry URL or push secret configuration is needed in the UI — the internal registry is used by default.
+
+---
+
+## Option 3: Build from Source (External Registry)
+
+Use this path if you prefer to push built images to an external registry like Quay.io.
+
+### Prerequisites
+
+- A user or organization account on **[quay.io](https://quay.io)**
+- Installer run with the `--with-builds` flag
+- Namespaces created for agents and tools (e.g., `team1` and `team2`)
 
 ### Steps
 
 1. **Configure Quay.io**
     - [Create a robot account](https://docs.redhat.com/en/documentation/red_hat_quay/3/html/user_guide/managing_robot_accounts) for your organization.
-    - Create empty repositories for the images you need to build (e.g., `a2a-content-extractor` and `a2a-currency-converter`).
+    - Create empty repositories for the images you need to build (e.g., `a2a-contact-extractor` and `a2a-currency-converter`).
     - Grant your robot account **write access** to these new repositories.
 
 2. **Create Kubernetes Image Pull Secret**
@@ -410,14 +429,17 @@ Follow this path if you want to build the agent container images yourself.
       kubectl apply -f quay-secret.yaml -n team2
       ```
 
-3. **Build and Push the Images**
-    - Follow the project's build instructions to build the agent images and push them to your Quay.io repositories.
+3. **Build from Source in the UI**
+    - When importing an agent/tool, select **Build from Source**
+    - Enter the external registry URL (e.g., `quay.io/myorg`)
+    - Select the push secret you created above
+    - The build uses the `buildah` strategy with TLS for external registries
 
 ---
 
 ## Verifying in the UI
 
-After completing either of the setup options above, you should be able to use the UI to:
+After completing any of the setup options above, you should be able to use the UI to:
 
 - **Agents**
     1. Import a new agent.

--- a/kagenti/backend/app/services/shipwright.py
+++ b/kagenti/backend/app/services/shipwright.py
@@ -67,14 +67,19 @@ def select_build_strategy(registry_url: str, requested_strategy: Optional[str] =
     (no TLS); on OpenShift it should be "buildah" (TLS-enabled internal registry).
     For external registries, always uses the secure "buildah" strategy.
 
+    Note: for internal registries, any requested_strategy that doesn't match the
+    configured internal strategy is overridden. This ensures the correct TLS
+    behavior regardless of what the caller requests.
+
     Args:
         registry_url: The registry URL to push images to
-        requested_strategy: Optional explicitly requested strategy
+        requested_strategy: Optional explicitly requested strategy (ignored for
+            internal registries if it doesn't match the configured strategy)
 
     Returns:
         The build strategy name to use
     """
-    from app.core.config import settings
+    from app.core.config import settings  # deferred: avoid circular dep with config→constants
 
     is_internal_registry = (
         registry_url == DEFAULT_INTERNAL_REGISTRY or "svc.cluster.local" in registry_url

--- a/kagenti/backend/app/services/shipwright.py
+++ b/kagenti/backend/app/services/shipwright.py
@@ -62,8 +62,10 @@ def select_build_strategy(registry_url: str, requested_strategy: Optional[str] =
     """
     Select the appropriate build strategy based on the registry.
 
-    For internal registries (svc.cluster.local), uses the insecure push strategy.
-    For external registries with TLS, uses the secure strategy.
+    For internal registries, uses the configured default strategy (configurable
+    via SHIPWRIGHT_DEFAULT_STRATEGY env var). On Kind this is "buildah-insecure-push"
+    (no TLS); on OpenShift it should be "buildah" (TLS-enabled internal registry).
+    For external registries, always uses the secure "buildah" strategy.
 
     Args:
         registry_url: The registry URL to push images to
@@ -72,22 +74,22 @@ def select_build_strategy(registry_url: str, requested_strategy: Optional[str] =
     Returns:
         The build strategy name to use
     """
+    from app.core.config import settings
+
     is_internal_registry = (
         registry_url == DEFAULT_INTERNAL_REGISTRY or "svc.cluster.local" in registry_url
     )
+    internal_strategy = settings.shipwright_default_strategy
 
-    # If a strategy was explicitly requested, use it unless it's secure for internal registry
     if requested_strategy:
-        if is_internal_registry and requested_strategy == SHIPWRIGHT_STRATEGY_SECURE:
-            # Override to insecure for internal registries
+        if is_internal_registry and requested_strategy != internal_strategy:
             logger.debug(
-                f"Overriding secure strategy to insecure for internal registry: {registry_url}"
+                f"Overriding strategy to {internal_strategy} for internal registry: {registry_url}"
             )
-            return SHIPWRIGHT_STRATEGY_INSECURE
+            return internal_strategy
         return requested_strategy
 
-    # Default strategy based on registry type
-    return SHIPWRIGHT_STRATEGY_INSECURE if is_internal_registry else SHIPWRIGHT_STRATEGY_SECURE
+    return internal_strategy if is_internal_registry else SHIPWRIGHT_STRATEGY_SECURE
 
 
 def build_shipwright_build_manifest(

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1200,6 +1200,14 @@ if [ -n "$OPERATOR_IMAGE" ]; then
   log_info "Operator image: ${OPERATOR_IMAGE}"
 fi
 
+# Build-from-source flags: configure the OCP internal registry and build strategy
+BUILD_FLAGS=()
+if [ "$WITH_BUILDS" = true ]; then
+  BUILD_FLAGS+=(--set "ui.backend.defaultRegistryUrl=image-registry.openshift-image-registry.svc:5000")
+  BUILD_FLAGS+=(--set "ui.backend.shipwrightDefaultStrategy=buildah")
+  log_info "Build from source: internal registry + buildah strategy"
+fi
+
 run_cmd $KUBECTL create namespace mcp-system --dry-run=client -o yaml | $KUBECTL apply -f -
 
 run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
@@ -1209,6 +1217,7 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   ${KAGENTI_UI_FLAGS[@]+"${KAGENTI_UI_FLAGS[@]}"} \
   ${OPERATOR_IMAGE_FLAGS[@]+"${OPERATOR_IMAGE_FLAGS[@]}"} \
   ${KC_ADMIN_FLAGS[@]+"${KC_ADMIN_FLAGS[@]}"} \
+  ${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"} \
   --set "agentOAuthSecret.spiffePrefix=spiffe://${DOMAIN}/sa" \
   --set uiOAuthSecret.useServiceAccountCA=false \
   --set agentOAuthSecret.useServiceAccountCA=false \


### PR DESCRIPTION
## Summary

- Wire the existing `shipwright_default_strategy` config setting into `select_build_strategy()` so OCP's TLS-enabled internal registry uses the standard `buildah` ClusterBuildStrategy (instead of the Kind-only `buildah-insecure-push` which doesn't exist on OCP)
- OCP installer (`--with-builds`) now automatically configures the internal registry URL and build strategy
- Documentation rewritten to show that internal registry is used automatically with `--with-builds`

## Problem

On OpenShift, "Build from Source" failed because:
1. The installer never set `defaultRegistryUrl` for the backend
2. `select_build_strategy()` hardcoded `buildah-insecure-push` for internal registries, but that ClusterBuildStrategy only exists on Kind — OCP's internal registry has TLS and needs the standard `buildah` strategy

## Changes

| File | Change |
|------|--------|
| `kagenti/backend/app/services/shipwright.py` | Use `settings.shipwright_default_strategy` instead of hardcoded constant |
| `charts/kagenti/templates/ui.yaml` | Pass `SHIPWRIGHT_DEFAULT_STRATEGY` env var |
| `charts/kagenti/values.yaml` | Add `shipwrightDefaultStrategy` field |
| `scripts/ocp/setup-kagenti.sh` | Add `BUILD_FLAGS` block for `--with-builds` |
| `deployments/envs/ocp_*.yaml` | Add `shipwrightDefaultStrategy: "buildah"` |
| `docs/ocp/openshift-install.md` | Rewrite Build from Source section |

## Test plan

- [ ] On Kind: verify no behavior change (strategy stays `buildah-insecure-push`)
- [ ] On OCP with `--with-builds`: verify backend receives correct env vars
- [ ] On OCP: Build from Source in UI creates Shipwright Build with `buildah` strategy targeting internal registry
- [ ] On OCP: built image is pushed to internal registry without push secret

Assisted-By: Claude Code