### PR TITLE
fix(ui): add OpenShift Internal Registry option to Import Tool page

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -68,6 +68,7 @@ const TOOL_EXAMPLES = [
 
 const REGISTRY_OPTIONS = [
   { value: 'local', label: 'Local Registry (In-Cluster)', url: 'registry.cr-system.svc.cluster.local:5000' },
+  { value: 'openshift', label: 'OpenShift Internal Registry', url: 'image-registry.openshift-image-registry.svc:5000' },
   { value: 'quay', label: 'Quay.io', url: 'quay.io' },
   { value: 'dockerhub', label: 'Docker Hub', url: 'docker.io' },
   { value: 'github', label: 'GitHub Container Registry', url: 'ghcr.io' },


### PR DESCRIPTION
## Summary

- Add the missing "OpenShift Internal Registry" option to the Import Tool page's registry selector, matching the Import Agent page

## Problem

The Import Tool page was missing the OpenShift Internal Registry option (`image-registry.openshift-image-registry.svc:5000`) in its `REGISTRY_OPTIONS` array. Users on OpenShift could build agents from source using the internal registry, but not tools.

Closes #1632

## Test plan

- [ ] On OpenShift: Import Tool → Build from Source → verify "OpenShift Internal Registry" appears in registry dropdown
- [ ] On Kind: verify "Local Registry (In-Cluster)" still works for tools

Assisted-By: Claude Code