### PR TITLE
fix: Update HyperShift PR workflow to use 4.20.11

### DIFF
--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -16,7 +16,7 @@
 #   - Label serves as visual indicator of approval status
 #   - New commits require re-approval (TOCTOU protection)
 #
-name: E2E OCP 4.20.21 (HyperShift PR)
+name: E2E OCP 4.20.11 (HyperShift PR)
 
 on:
   issue_comment:
@@ -27,7 +27,7 @@ permissions: {}
 
 # Version tracking - keep workflow name in sync with OCP_VERSION
 env:
-  OCP_VERSION: '4.20.21'  # Update workflow name when changing default
+  OCP_VERSION: '4.20.11'  # Update workflow name when changing default
   MAX_SLOTS: '6'
   SLOT_TIMEOUT: '60'
 


### PR DESCRIPTION
## Problem
Previous PR only updated the create-cluster.sh script but not the workflow file.
The workflow env var OCP_VERSION was still 4.20.21, overriding the script's default.

## Fix
Update workflow to use 4.20.11 to match the script.

## Changes
- Workflow name: E2E OCP 4.20.21 → 4.20.11
- env.OCP_VERSION: 4.20.21 → 4.20.11