### PR TITLE
fix(ocp): use local chart tag when --kagenti-repo is a local path

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1337,8 +1337,15 @@ elif [ -z "$KAGENTI_REPO_ORIGINAL" ]; then
   KAGENTI_UI_FLAGS+=(--set "ui.frontend.tag=v${LATEST_TAG}")
   KAGENTI_UI_FLAGS+=(--set "ui.backend.tag=v${LATEST_TAG}")
 else
-  # Local or explicit repo: trust the chart's pinned image tags
-  log_info "Using image tags from chart values (--kagenti-repo provided)"
+  # Local or explicit repo: read ui.frontend.tag from the chart (all component tags share the same release version)
+  LATEST_TAG=$(grep -A4 'frontend:' "$KAGENTI_REPO/charts/kagenti/values.yaml" | grep -m1 'tag:' | awk '{print $2}')
+  if [ -n "$LATEST_TAG" ]; then
+    log_success "Using tag from local chart: ${LATEST_TAG}"
+    KAGENTI_UI_FLAGS+=(--set "ui.frontend.tag=${LATEST_TAG}")
+    KAGENTI_UI_FLAGS+=(--set "ui.backend.tag=${LATEST_TAG}")
+  else
+    log_info "Using image tags from chart values (--kagenti-repo provided)"
+  fi
 fi
 
 # Override operator chart dependency with local repo if provided


### PR DESCRIPTION
## Summary

- When the OCP installer is run with `--kagenti-repo .` (local path), it was still querying GitHub for the latest tag and overriding image tags. This defeated `--reset-values` and local chart pins.
- Now reads the tag from the local chart's `values.yaml` instead of querying GitHub when a local repo path is provided.

## Root Cause

The installer always ran `git ls-remote --tags` against GitHub to determine the image tag, regardless of whether a local repo was specified. The latest GitHub tag (`v0.7.0-alpha.1`) overrode the chart's pinned `v0.6.0-rc.5` tags.

## Test plan

- [ ] Run `./scripts/ocp/setup-kagenti.sh --kagenti-repo . --with-all --skip-mlflow` from a checkout on `release-0.6` — should use `v0.6.0-rc.5`
- [ ] Run without `--kagenti-repo` — should still fetch latest tag from GitHub (existing behavior)

Assisted-By: Claude Code