### PR TITLE
feat(ui): gate Skills UI behind feature flag

### DIFF
--- a/kagenti/ui-v2/src/components/AppLayout.tsx
+++ b/kagenti/ui-v2/src/components/AppLayout.tsx
@@ -340,13 +340,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, features }) => {
                   >
                     Tools
                   </NavItem>
-                  <NavItem
-                    itemId="skills"
-                    isActive={isNavItemActive('/skills')}
-                    onClick={() => handleNavSelect('/skills')}
-                  >
-                    Skills
-                  </NavItem>
+                  {features?.skills && (
+                    <NavItem
+                      itemId="skills"
+                      isActive={isNavItemActive('/skills')}
+                      onClick={() => handleNavSelect('/skills')}
+                    >
+                      Skills
+                    </NavItem>
+                  )}
                   {features?.sandbox && (
                     <>
                       <NavItem

--- a/kagenti/ui-v2/src/pages/HomePage.tsx
+++ b/kagenti/ui-v2/src/pages/HomePage.tsx
@@ -273,17 +273,19 @@ export const HomePage: React.FC = () => {
               isLoading={toolsLoading}
             />
           </GridItem>
-          <GridItem md={6} lg={3}>
-            <QuickLinkCard
-              title="Skill Catalog"
-              description="Browse and manage reusable skills for your agents."
-              icon={<CogIcon />}
-              path="/skills"
-              buttonText="View Skills"
-              count={skills.length}
-              isLoading={skillsLoading}
-            />
-          </GridItem>
+          {features.skills && (
+            <GridItem md={6} lg={3}>
+              <QuickLinkCard
+                title="Skill Catalog"
+                description="Browse and manage reusable skills for your agents."
+                icon={<CogIcon />}
+                path="/skills"
+                buttonText="View Skills"
+                count={skills.length}
+                isLoading={skillsLoading}
+              />
+            </GridItem>
+          )}
           <GridItem md={6} lg={3}>
             <QuickLinkCard
               title="Observability"
@@ -324,15 +326,17 @@ export const HomePage: React.FC = () => {
               Import New Tool
             </Button>
           </FlexItem>
-          <FlexItem>
-            <Button
-              variant="primary"
-              icon={<PlusCircleIcon />}
-              onClick={() => navigate('/skills/import')}
-            >
-              Import New Skill
-            </Button>
-          </FlexItem>
+          {features.skills && (
+            <FlexItem>
+              <Button
+                variant="primary"
+                icon={<PlusCircleIcon />}
+                onClick={() => navigate('/skills/import')}
+              >
+                Import New Skill
+              </Button>
+            </FlexItem>
+          )}
         </Flex>
 
         <Alert


### PR DESCRIPTION
## Summary

- Wraps the Skills navigation item in `AppLayout.tsx` behind `features?.skills`
- Wraps the Skill Catalog card and "Import New Skill" button in `HomePage.tsx` behind `features.skills`
- Routes in `App.tsx` and backend router in `main.py` were already gated — this closes the remaining UI gaps

The `kagenti_feature_flag_skills` config value (default: `False`) now fully controls visibility of the Skills feature across both backend and frontend.

Closes #1638

## Test plan

- [ ] Start with `KAGENTI_FEATURE_FLAG_SKILLS=false` (default) — verify Skills nav item, homepage card, and import button are hidden
- [ ] Set `KAGENTI_FEATURE_FLAG_SKILLS=true` — verify all Skills UI surfaces appear
- [ ] Confirm agent detail page still shows A2A agent-card skills (those are protocol metadata, not the Skills feature)

Assisted-By: Claude Code