### PR TITLE
docs: Fix broken AuthBridge Binary README links

### DIFF
--- a/docs/authbridge/README.md
+++ b/docs/authbridge/README.md
@@ -140,7 +140,7 @@ For a progressive walkthrough: [Demos](demos.md)
 
 For deep implementation details:
 
-- [AuthBridge Binary README](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/authbridge/README.md) — modes, YAML config, logging
+- [AuthBridge Binary README](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/README.md) — modes, YAML config, logging
 - [AuthBridge Architecture](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/README.md) — sequence diagrams, protocol flows
 - [AuthBridge Demos](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/README.md) — step-by-step demo instructions
 - [Identity Guide](../identity-guide.md) — platform-level SPIFFE/SPIRE and Keycloak architecture

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -259,5 +259,5 @@ injects defaults that can be overridden via Helm values.
 
 ## Further Reading
 
-- [AuthBridge Binary README](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/authbridge/README.md) — full YAML config reference, all listener modes
+- [AuthBridge Binary README](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/README.md) — full YAML config reference, all listener modes
 - [AuthBridge Architecture](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/README.md) — sequence diagrams, protocol details


### PR DESCRIPTION
## Summary

Two doc files linked to `https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/authbridge/README.md`, which 404s — that file does not exist in kagenti-extensions. The AuthBridge binaries README lives at [`authbridge/cmd/README.md`](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/README.md) (title *"AuthBridge Binaries"*), which covers modes, YAML config, and per-binary deployment shapes — matching the existing anchor text *"modes, YAML config, logging"*.

Files changed:
- `docs/authbridge/README.md:143`
- `docs/authbridge/deployment-guide.md:262`

Both lines now point at `…/authbridge/cmd/README.md`.

Closes #1615

## Test plan

- [x] Manually verified `https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/README.md` resolves on `main`
- [x] Confirmed the original `…/cmd/authbridge/README.md` path returns 404
- [x] No other lowercase-`authbridge/...` URL references in the repo are broken (the rest resolve against current kagenti-extensions `main`)

Assisted-By: Claude Code