### PR TITLE
fix(ocp): MLflow integration gaps on RHOAI

### DIFF
--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -88,14 +88,11 @@ spec:
           volumeMounts:
             - name: otel-collector-config
               mountPath: /etc/otelcol-config
-            {{- $mlflowTLS := or (and $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled) (get (default dict $.Values.otel.mlflow) "enabled") }}
             {{- $mlflowOIDC := and $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled }}
-            {{- if and $.Values.openshift $mlflowTLS }}
+            {{- if and $.Values.openshift $mlflowOIDC }}
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
-            {{- end }}
-            {{- if and $.Values.openshift $mlflowOIDC }}
             - name: ingress-ca
               mountPath: /etc/pki/ingress-ca
               readOnly: true
@@ -114,10 +111,9 @@ spec:
         - name: otel-collector-config
           configMap:
             name: otel-collector-config
-        {{- if and $.Values.openshift $mlflowTLS }}
-        # OpenShift trusted CA bundle for MLflow TLS verification.
-        # The service-ca operator signs MLflow's serving cert; this bundle
-        # contains the CA so the collector can verify the upstream connection.
+        {{- if and $.Values.openshift $mlflowOIDC }}
+        # OpenShift trusted CA bundle for Keycloak TLS verification (self-managed MLflow OIDC path).
+        # RHOAI path uses SA-projected service-ca.crt instead.
         - name: trusted-ca
           configMap:
             name: config-trusted-cabundle
@@ -125,10 +121,7 @@ spec:
             items:
               - key: ca-bundle.crt
                 path: tls-ca-bundle.pem
-        {{- end }}
-        {{- if and $.Values.openshift $mlflowOIDC }}
         # OpenShift ingress CA for Keycloak JWKS verification via ingress route
-        # Copied from openshift-config-managed/default-ingress-cert by pre-install Job
         - name: ingress-ca
           configMap:
             name: otel-ingress-ca

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -88,10 +88,14 @@ spec:
           volumeMounts:
             - name: otel-collector-config
               mountPath: /etc/otelcol-config
-            {{- if and $.Values.openshift $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled }}
+            {{- $mlflowTLS := or (and $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled) (get (default dict $.Values.otel.mlflow) "enabled") }}
+            {{- $mlflowOIDC := and $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled }}
+            {{- if and $.Values.openshift $mlflowTLS }}
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
+            {{- end }}
+            {{- if and $.Values.openshift $mlflowOIDC }}
             - name: ingress-ca
               mountPath: /etc/pki/ingress-ca
               readOnly: true
@@ -110,9 +114,10 @@ spec:
         - name: otel-collector-config
           configMap:
             name: otel-collector-config
-        {{- if and $.Values.openshift $.Values.components.mlflow.enabled $.Values.mlflow.auth.enabled }}
-        # OpenShift trusted CA bundle — created by Tekton/platform operators.
-        # Optional so the pod starts while waiting for the ConfigMap to appear.
+        {{- if and $.Values.openshift $mlflowTLS }}
+        # OpenShift trusted CA bundle for MLflow TLS verification.
+        # The service-ca operator signs MLflow's serving cert; this bundle
+        # contains the CA so the collector can verify the upstream connection.
         - name: trusted-ca
           configMap:
             name: config-trusted-cabundle
@@ -120,6 +125,8 @@ spec:
             items:
               - key: ca-bundle.crt
                 path: tls-ca-bundle.pem
+        {{- end }}
+        {{- if and $.Values.openshift $mlflowOIDC }}
         # OpenShift ingress CA for Keycloak JWKS verification via ingress route
         # Copied from openshift-config-managed/default-ingress-cert by pre-install Job
         - name: ingress-ca

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -357,7 +357,7 @@ certManager:
 # ------------------------------------------------------------------
 rhoai:
   namespace: redhat-ods-operator
-  channel: fast-3.x
+  channel: stable-3.4
   installPlanApproval: Automatic
 
 # When true, skip servicemeshoperator3 Subscription creation (RHOAI provides it)

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -325,8 +325,11 @@ otel:
     rhoaiMlflowAuthConfig:
       exporters:
         otlphttp/mlflow:
+          compression: none
+          retry_on_failure:
+            enabled: false
           tls:
-            ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
       extensions:
         bearertokenauth/mlflow:
           filename: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -323,6 +323,10 @@ otel:
     # Uses the collector's ServiceAccount token for authentication against
     # RHOAI MLflow's Kubernetes authorization plugin.
     rhoaiMlflowAuthConfig:
+      exporters:
+        otlphttp/mlflow:
+          tls:
+            ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
       extensions:
         bearertokenauth/mlflow:
           filename: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/docs/ocp/openshift-install.md
+++ b/docs/ocp/openshift-install.md
@@ -307,6 +307,84 @@ The cleanup script removes:
 - Namespaces: `kagenti-system`, `mcp-system`, `gateway-system`, `keycloak`, `istio-cni`, `istio-system`, `istio-ztunnel`, `openshift-builds`, `zero-trust-workload-identity-manager`, `cert-manager-operator`, `cert-manager`, `team1`, `team2`
 - Istio shared-trust ClusterIssuers and Certificates
 
+## RHOAI MLflow Integration
+
+When Red Hat OpenShift AI (RHOAI) is installed, Kagenti can use RHOAI's managed
+MLflow instance for LLM trace collection instead of deploying its own.
+
+### Enabling RHOAI MLflow
+
+Enable the integration by passing these values to `setup-kagenti.sh` (or the
+equivalent Helm overrides):
+
+```yaml
+components:
+  mlflow:
+    enabled: false        # do NOT deploy standalone MLflow
+  rhoai:
+    enabled: true         # install RHOAI operator + DSC
+
+otel:
+  mlflow:
+    enabled: true         # wire OTEL collector → RHOAI MLflow
+    workspace: "team1"    # RHOAI workspace namespace
+    experimentId: "1"     # target experiment (created automatically)
+```
+
+The installer (`scripts/ocp/setup-kagenti.sh`) automatically:
+
+1. Waits for the RHOAI MLflow CR to become ready
+2. Grants the OTEL collector ServiceAccount `mlflow-edit` in the workspace namespace
+3. Creates the target experiment via the MLflow REST API
+4. Deploys an OAuth proxy with browser SSO for the MLflow dashboard
+5. Adds a "MLflow" link to the Kagenti UI sidebar
+
+### Authentication
+
+The OTEL collector authenticates to RHOAI MLflow using its projected
+ServiceAccount token (`/var/run/secrets/kubernetes.io/serviceaccount/token`).
+MLflow's `kubernetes-auth` plugin validates this token via Kubernetes
+SubjectAccessReview against the workspace namespace.
+
+TLS is verified using the OpenShift service-ca certificate
+(`/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`), which is
+automatically available in every pod.
+
+### RHOAI Version Requirements
+
+RHOAI **3.4.0+** (channel `stable-3.4`) is required for full trace rendering.
+It ships MLflow 3.10.1 which includes the fix for OTEL-ingested trace display.
+
+Earlier versions (RHOAI 3.3.x on channel `fast-3.x`) ship MLflow 3.6.x which
+has a client-side JavaScript bug where clicking a trace shows "Trace failed to
+render" due to a `num_spans` metadata mismatch. The fix landed in upstream
+[MLflow PR #20596](https://github.com/mlflow/mlflow/pull/20596) (v3.10.0).
+
+If you are on RHOAI 3.3.x, switch to the `stable-3.4` channel:
+
+```shell
+oc patch subscription rhods-operator -n redhat-ods-operator --type=merge \
+  -p '{"spec":{"channel":"stable-3.4"}}'
+```
+
+After the operator upgrades, the MLflow deployment will be updated automatically.
+
+### OTEL Collector Configuration
+
+The RHOAI MLflow pipeline differs from the standalone MLflow pipeline:
+
+| Setting | Standalone | RHOAI |
+|---------|-----------|-------|
+| Authentication | OAuth2 client credentials | ServiceAccount bearer token |
+| TLS CA | System CAs / ingress-ca | service-ca.crt (projected volume) |
+| Compression | gzip (default) | none (RHOAI incompatibility) |
+| Retry | enabled (5s→30s backoff) | disabled (response parsing bug) |
+| Endpoint | `http://mlflow:5000/v1/traces` | `https://mlflow.<ns>.svc:8443/v1/traces` |
+
+The retry is disabled because RHOAI MLflow returns a JSON body with
+`Content-Type: application/x-protobuf`, which the OTEL collector cannot parse,
+triggering infinite retries even though traces are successfully ingested.
+
 ## Troubleshooting
 
 ### Pre-flight Validation

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -441,7 +441,6 @@ _mlflow_grant_otel_rbac() {
         break
       fi
     done
-    [ -n "$cr_name" ] && break
     tries=$((tries + 1))
     if [ $tries -ge 24 ]; then
       log_warn "No MLflow ClusterRole found (tried: ${candidates[*]}) after 2m — MLflow OTEL RBAC skipped"
@@ -1147,9 +1146,15 @@ EOF
   # SubjectAccessReview.
   log_info "Ensuring MLflow OAuth proxy exists for browser access..."
   if ! $KUBECTL get deployment mlflow-oauth-proxy -n "$MLFLOW_NAMESPACE" &>/dev/null; then
+    local oauth_proxy_image
+    oauth_proxy_image=$(oc adm release info --image-for=oauth-proxy 2>/dev/null)
+    if [ -z "$oauth_proxy_image" ]; then
+      log_warn "Could not resolve oauth-proxy image — skipping MLflow OAuth proxy"
+      return 0
+    fi
     # Cookie secret for oauth-proxy session encryption
     local cookie_secret
-    cookie_secret=$(openssl rand -base64 32 | tr -d '\n' | head -c 32 | base64)
+    cookie_secret=$(head -c 32 /dev/urandom | base64 | tr -d '\n')
     $KUBECTL apply -f - <<OAUTH_EOF
 apiVersion: v1
 kind: ServiceAccount
@@ -1186,7 +1191,7 @@ spec:
       serviceAccountName: mlflow-oauth-proxy
       containers:
       - name: oauth-proxy
-        image: $(oc adm release info --image-for=oauth-proxy 2>/dev/null)
+        image: ${oauth_proxy_image}
         args:
         - --https-address=:8443
         - --provider=openshift
@@ -1426,12 +1431,13 @@ else
     if [ -n "$_EXP_TOKEN" ]; then
       _EXP_RESP=$($KUBECTL run mlflow-exp-create --rm -i --restart=Never \
         --image=curlimages/curl -n kagenti-system \
-        -- curl -sk -X POST \
-        -H "Authorization: Bearer $_EXP_TOKEN" \
-        -H "x-mlflow-workspace: $_EXP_WS" \
+        --env="TOK=$_EXP_TOKEN" \
+        -- sh -c 'curl -sk -X POST \
+        -H "Authorization: Bearer $TOK" \
+        -H "x-mlflow-workspace: '"$_EXP_WS"'" \
         -H "Content-Type: application/json" \
-        -d "{\"name\":\"$_EXP_NAME\"}" \
-        "https://mlflow.${MLFLOW_NAMESPACE}.svc.cluster.local:8443/api/2.0/mlflow/experiments/create" 2>/dev/null)
+        -d "{\"name\":\"'"$_EXP_NAME"'\"}" \
+        "https://mlflow.'"${MLFLOW_NAMESPACE}"'.svc.cluster.local:8443/api/2.0/mlflow/experiments/create"' 2>/dev/null)
       if echo "$_EXP_RESP" | grep -q "experiment_id"; then
         _EXP_ID=$(echo "$_EXP_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['experiment_id'])" 2>/dev/null)
         log_success "Created MLflow experiment '$_EXP_NAME' (id=$_EXP_ID) in workspace $_EXP_WS"

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1414,6 +1414,34 @@ if [ "$SKIP_MLFLOW" = true ]; then
   log_success "Skipping MLflow RBAC grant (--skip-mlflow)"
 else
   _mlflow_grant_otel_rbac
+
+  # Create default MLflow experiment in the workspace namespace.
+  # The otel-collector sends traces with x-mlflow-experiment-id header; the experiment
+  # must exist or MLflow will reject the traces.
+  # Uses kubectl run with a curl pod since the installer runs outside the cluster.
+  if ! $DRY_RUN; then
+    _EXP_WS="${MLFLOW_WORKSPACE:-team1}"
+    _EXP_NAME="kagenti-traces"
+    _EXP_TOKEN=$($KUBECTL create token otel-collector -n kagenti-system --duration=600s 2>/dev/null)
+    if [ -n "$_EXP_TOKEN" ]; then
+      _EXP_RESP=$($KUBECTL run mlflow-exp-create --rm -i --restart=Never \
+        --image=curlimages/curl -n kagenti-system \
+        -- curl -sk -X POST \
+        -H "Authorization: Bearer $_EXP_TOKEN" \
+        -H "x-mlflow-workspace: $_EXP_WS" \
+        -H "Content-Type: application/json" \
+        -d "{\"name\":\"$_EXP_NAME\"}" \
+        "https://mlflow.${MLFLOW_NAMESPACE}.svc.cluster.local:8443/api/2.0/mlflow/experiments/create" 2>/dev/null)
+      if echo "$_EXP_RESP" | grep -q "experiment_id"; then
+        _EXP_ID=$(echo "$_EXP_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['experiment_id'])" 2>/dev/null)
+        log_success "Created MLflow experiment '$_EXP_NAME' (id=$_EXP_ID) in workspace $_EXP_WS"
+      elif echo "$_EXP_RESP" | grep -q "RESOURCE_ALREADY_EXISTS"; then
+        log_success "MLflow experiment '$_EXP_NAME' already exists in workspace $_EXP_WS"
+      else
+        log_warn "Failed to create MLflow experiment: $_EXP_RESP"
+      fi
+    fi
+  fi
 fi
 echo ""
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -377,9 +377,28 @@ _mlflow_wait_ready() {
     sleep 5
   done
 
-  # Resolve the gateway URL from the MLflow CR status.url (mirrors the
-  # kagenti-operator's resolveTrackingURI logic). TLS is verified via the
-  # container's system CA pool (Let's Encrypt trusted by default).
+  # Check if the CR reports Available status — RHOAI MLflow operator sets this
+  # condition but never populates status.url (no Route/Ingress is created).
+  local cr_available=""
+  cr_available=$($KUBECTL get mlflow "$MLFLOW_INSTANCE_NAME" -n "$MLFLOW_NAMESPACE" \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "")
+
+  if [ "$cr_available" = "True" ]; then
+    log_success "MLflow CR reports Available — skipping status.url wait"
+    # Resolve the service port from the actual Service object
+    local svc_port
+    svc_port=$($KUBECTL get service "$MLFLOW_INSTANCE_NAME" -n "$MLFLOW_NAMESPACE" \
+      -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || echo "8443")
+    local proto="https"
+    if [ "$svc_port" = "80" ] || [ "$svc_port" = "5000" ] || [ "$svc_port" = "8080" ]; then
+      proto="http"
+    fi
+    MLFLOW_TRACES_ENDPOINT="${proto}://${MLFLOW_INSTANCE_NAME}.${MLFLOW_NAMESPACE}.svc.cluster.local:${svc_port}/v1/traces"
+    log_success "MLflow traces endpoint (in-cluster): $MLFLOW_TRACES_ENDPOINT"
+    return 0
+  fi
+
+  # Fall back to waiting for status.url (non-RHOAI operators may populate this).
   log_info "Waiting for MLflow gateway URL (status.url)..."
   local gateway_url=""
   tries=0
@@ -390,7 +409,14 @@ _mlflow_wait_ready() {
     tries=$((tries + 1))
     if [ $tries -ge 60 ]; then
       log_warn "MLflow CR status.url not populated after 5m — using in-cluster endpoint"
-      MLFLOW_TRACES_ENDPOINT="http://${MLFLOW_INSTANCE_NAME}.${MLFLOW_NAMESPACE}.svc.cluster.local:5000/v1/traces"
+      local svc_port
+      svc_port=$($KUBECTL get service "$MLFLOW_INSTANCE_NAME" -n "$MLFLOW_NAMESPACE" \
+        -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || echo "8443")
+      local proto="https"
+      if [ "$svc_port" = "80" ] || [ "$svc_port" = "5000" ] || [ "$svc_port" = "8080" ]; then
+        proto="http"
+      fi
+      MLFLOW_TRACES_ENDPOINT="${proto}://${MLFLOW_INSTANCE_NAME}.${MLFLOW_NAMESPACE}.svc.cluster.local:${svc_port}/v1/traces"
       log_success "MLflow traces endpoint (in-cluster): $MLFLOW_TRACES_ENDPOINT"
       return 0
     fi
@@ -401,16 +427,24 @@ _mlflow_wait_ready() {
 }
 
 _mlflow_grant_otel_rbac() {
-  # The RHOAI MLflow operator creates the mlflow-operator-mlflow-integration ClusterRole
-  # with pseudo-resources (mlflow.kubeflow.org/*) checked via SubjectAccessReview.
+  # The RHOAI MLflow operator creates ClusterRoles for MLflow access control.
   # The otel-collector SA needs a RoleBinding in each agent namespace (workspace)
   # so the collector can send traces with the correct workspace context.
-  local cr_name="mlflow-operator-mlflow-integration"
+  # Prefer mlflow-operator-mlflow-edit (read+write), fall back to older name.
+  local cr_name=""
+  local candidates=("mlflow-operator-mlflow-edit" "mlflow-operator-mlflow-integration")
   local tries=0
-  while ! $KUBECTL get clusterrole "$cr_name" &>/dev/null; do
+  while [ -z "$cr_name" ]; do
+    for candidate in "${candidates[@]}"; do
+      if $KUBECTL get clusterrole "$candidate" &>/dev/null; then
+        cr_name="$candidate"
+        break
+      fi
+    done
+    [ -n "$cr_name" ] && break
     tries=$((tries + 1))
     if [ $tries -ge 24 ]; then
-      log_warn "ClusterRole '$cr_name' not found after 2m — MLflow OTEL RBAC skipped"
+      log_warn "No MLflow ClusterRole found (tried: ${candidates[*]}) after 2m — MLflow OTEL RBAC skipped"
       return 0
     fi
     sleep 5
@@ -1088,9 +1122,9 @@ otel:
           traces_endpoint: "${MLFLOW_TRACES_ENDPOINT}"
 EOF
     helm upgrade kagenti-deps "$KAGENTI_REPO/charts/kagenti-deps/" \
-      -n kagenti-system \
       -f "$_mlflow_vals_file" \
-      --reuse-values --no-hooks
+      --reset-values \
+      "${KAGENTI_DEPS_HELM_ARGS[@]}"
     rm -f "$_mlflow_vals_file"
     log_success "kagenti-deps upgraded with MLflow OTEL endpoint"
   fi

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1128,6 +1128,139 @@ EOF
     rm -f "$_mlflow_vals_file"
     log_success "kagenti-deps upgraded with MLflow OTEL endpoint"
   fi
+
+  # Expose MLflow UI via an OpenShift OAuth proxy so browser users can
+  # authenticate through OpenShift SSO. The proxy injects the user's token
+  # as a bearer token which MLflow's kubernetes-auth plugin validates via
+  # SubjectAccessReview.
+  log_info "Ensuring MLflow OAuth proxy exists for browser access..."
+  if ! $KUBECTL get deployment mlflow-oauth-proxy -n "$MLFLOW_NAMESPACE" &>/dev/null; then
+    # Cookie secret for oauth-proxy session encryption
+    local cookie_secret
+    cookie_secret=$(openssl rand -base64 32 | tr -d '\n' | head -c 32 | base64)
+    $KUBECTL apply -f - <<OAUTH_EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mlflow-oauth-proxy
+  namespace: ${MLFLOW_NAMESPACE}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"mlflow"}}'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlflow-oauth-proxy-cookie
+  namespace: ${MLFLOW_NAMESPACE}
+type: Opaque
+data:
+  cookie-secret: ${cookie_secret}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mlflow-oauth-proxy
+  namespace: ${MLFLOW_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mlflow-oauth-proxy
+  template:
+    metadata:
+      labels:
+        app: mlflow-oauth-proxy
+    spec:
+      serviceAccountName: mlflow-oauth-proxy
+      containers:
+      - name: oauth-proxy
+        image: $(oc adm release info --image-for=oauth-proxy 2>/dev/null)
+        args:
+        - --https-address=:8443
+        - --provider=openshift
+        - --openshift-service-account=mlflow-oauth-proxy
+        - --upstream=https://${MLFLOW_INSTANCE_NAME}.${MLFLOW_NAMESPACE}.svc.cluster.local:8443
+        - --upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --cookie-secret-file=/etc/oauth/cookie-secret
+        - --pass-access-token=true
+        - --pass-user-bearer-token=true
+        ports:
+        - containerPort: 8443
+          name: https
+        volumeMounts:
+        - name: tls
+          mountPath: /etc/tls/private
+          readOnly: true
+        - name: cookie-secret
+          mountPath: /etc/oauth
+          readOnly: true
+      volumes:
+      - name: tls
+        secret:
+          secretName: mlflow-oauth-proxy-tls
+      - name: cookie-secret
+        secret:
+          secretName: mlflow-oauth-proxy-cookie
+          items:
+          - key: cookie-secret
+            path: cookie-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mlflow-oauth-proxy
+  namespace: ${MLFLOW_NAMESPACE}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: mlflow-oauth-proxy-tls
+spec:
+  selector:
+    app: mlflow-oauth-proxy
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: mlflow
+  namespace: ${MLFLOW_NAMESPACE}
+spec:
+  to:
+    kind: Service
+    name: mlflow-oauth-proxy
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+OAUTH_EOF
+  fi
+
+  # Wait for the oauth-proxy to become ready
+  local tries=0
+  while ! $KUBECTL get pods -n "$MLFLOW_NAMESPACE" \
+    -l app=mlflow-oauth-proxy -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running; do
+    tries=$((tries + 1))
+    if [ $tries -ge 24 ]; then
+      log_warn "MLflow OAuth proxy not ready after 2m — dashboard link may not work"
+      break
+    fi
+    sleep 5
+  done
+
+  local mlflow_host=""
+  mlflow_host=$($KUBECTL get route mlflow -n "$MLFLOW_NAMESPACE" \
+    -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+  if [ -n "$mlflow_host" ]; then
+    local mlflow_url="https://${mlflow_host}/mlflow/"
+    $KUBECTL patch configmap kagenti-ui-config -n kagenti-system \
+      --type merge -p "{\"data\":{\"MLFLOW_DASHBOARD_URL\":\"${mlflow_url}\"}}" 2>/dev/null || true
+    log_success "MLflow dashboard URL: $mlflow_url"
+  else
+    log_warn "Could not resolve MLflow Route host — UI link will be empty"
+  fi
 }
 log_info "Step 3d: MLflow provisioning (deferred)"
 _deferred_mlflow

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -460,6 +460,18 @@ for ns in v.get('agentNamespaces', ['team1', 'team2']):
     print(ns)
 " 2>/dev/null || echo -e "team1\nteam2")
 
+  # Grant in MLflow namespace (authentication: SA must be permitted to access MLflow)
+  log_info "Creating MLflow RBAC for otel-collector in $MLFLOW_NAMESPACE..."
+  if ! $DRY_RUN; then
+    $KUBECTL create rolebinding otel-collector-mlflow \
+      --clusterrole="$cr_name" \
+      --serviceaccount=kagenti-system:otel-collector \
+      -n "$MLFLOW_NAMESPACE" \
+      --dry-run=client -o yaml | $KUBECTL apply -f -
+  fi
+  log_success "RoleBinding otel-collector-mlflow created in $MLFLOW_NAMESPACE"
+
+  # Grant in each agent namespace (workspace authorization)
   while IFS= read -r ns; do
     [ -z "$ns" ] && continue
     log_info "Creating MLflow RBAC for otel-collector in $ns..."


### PR DESCRIPTION
## Summary

Resolves multiple issues with the RHOAI MLflow integration on OpenShift:

- **Fix installer wait logic**: Detect `Available` condition on the MLflow CR early — RHOAI never populates `status.url` (no Route/Ingress created), eliminating a 5-minute timeout
- **Fix ClusterRole name mismatch**: Try `mlflow-operator-mlflow-edit` (actual RHOAI name) before falling back to `mlflow-operator-mlflow-integration`
- **Wire OTEL MLflow exporter**: Pass `otel.mlflow.enabled=true` and the resolved traces endpoint during `helm upgrade --reset-values`
- **Fix TLS verification**: Mount `service-ca.crt` for RHOAI MLflow TLS, add `bearertokenauth/mlflow` extension using projected SA token
- **Fix trace rendering**: Upgrade RHOAI subscription channel from `fast-3.x` (3.3.1, ships MLflow 3.6.x) to `stable-3.4` (3.4.0, ships MLflow 3.10.1) which includes the fix for the "Trace failed to render" UI bug ([MLflow PR #20596](https://github.com/mlflow/mlflow/pull/20596))
- **Expose MLflow UI**: Deploy OAuth proxy route for browser access to the MLflow dashboard
- **Add RHOAI MLflow docs**: Document the integration setup, authentication flow, version requirements, and OTEL collector configuration differences

### Root cause of trace rendering failure

RHOAI 3.3.x ships MLflow 3.6.x which has a client-side JavaScript bug: the trace detail view enters an infinite fetch loop when `num_spans` metadata (set by the OTLP ingestion path) does not match what the trace viewer JS expects. All API calls return 200 OK — the data is served correctly, but the JS fails to parse the span tree. Fixed in MLflow 3.10.0.

### OTEL collector to RHOAI MLflow authentication

The collector uses its projected ServiceAccount token with `bearertokenauth` extension. MLflow `kubernetes-auth` plugin validates the token via Kubernetes SubjectAccessReview. TLS is verified using the OpenShift `service-ca.crt` (auto-injected into pods). Compression is disabled (RHOAI incompatibility) and retry is disabled (RHOAI returns JSON body with `Content-Type: application/x-protobuf`, causing parse errors on retry).

Fixes #1637

## Test plan

- [x] Run installer with --with-mlflow on RHOAI cluster — no 5-min stall
- [x] OTEL collector configmap includes otlphttp/mlflow exporter with bearertokenauth
- [x] RoleBinding references mlflow-operator-mlflow-edit ClusterRole
- [x] Traces ingested via OTEL collector land in MLflow (POST /v1/traces 200 OK)
- [x] MLflow 3.10.1 running after RHOAI 3.4.0 upgrade
- [x] Trace detail view renders correctly in MLflow UI (user verification)

Assisted-By: Claude Code