### PR TITLE
fix(openshell): use correct CLI subcommand to remove gateway registration

### DIFF
--- a/scripts/openshell/configure-cli.sh
+++ b/scripts/openshell/configure-cli.sh
@@ -144,7 +144,7 @@ if $DRY_RUN; then
 else
   if openshell gateway info --gateway "$GATEWAY_NAME" &>/dev/null; then
     log_warn "Gateway $GATEWAY_NAME already exists — removing to re-register"
-    openshell gateway destroy --name "$GATEWAY_NAME" 2>/dev/null || true
+    openshell gateway remove "$GATEWAY_NAME" 2>/dev/null || true
   fi
   openshell "${ADD_ARGS[@]}"
   log_success "Gateway registered"


### PR DESCRIPTION
## Summary

- Fix `configure-cli.sh` using non-existent `openshell gateway destroy --name` subcommand
- Replace with correct `openshell gateway remove <name>` (positional argument)
- Script is now idempotent on re-runs as originally intended

## Root Cause

The removal command `openshell gateway destroy --name "$GATEWAY_NAME"` silently failed (suppressed by `|| true`), so the gateway was never removed. The subsequent `gateway add` then failed with "Gateway already exists."

## Test plan

- [x] Run `scripts/openshell/configure-cli.sh team1` on a fresh CLI state — gateway registered successfully
- [x] Run it again — existing gateway removed and re-registered without error
- [x] Verified `openshell gateway remove --help` confirms the correct syntax

Fixes #1645

Assisted-By: Claude Code