### PR TITLE
docs: fix OpenClaw platform link

### DIFF
--- a/docs/agentic-runtime/agents/nemoclaw-openclaw.md
+++ b/docs/agentic-runtime/agents/nemoclaw-openclaw.md
@@ -11,7 +11,7 @@
 
 ## 1. Overview
 
-OpenClaw is the default agent from the [OpenClaw](https://openclaw.ai) platform,
+OpenClaw is the default agent from the [OpenClaw](https://github.com/openclaw/openclaw) platform,
 integrated via [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw). It provides
 a gateway-based AI assistant with a plugin ecosystem, workspace management, and
 extension support.


### PR DESCRIPTION
## Problem
Issue #1612 reports that the OpenClaw platform link in `docs/agentic-runtime/agents/nemoclaw-openclaw.md` points to `https://openclaw.ai/`, which the link-health scan reports as unreachable.

## Solution
Update the platform link to the active OpenClaw GitHub repository (`https://github.com/openclaw/openclaw`) while leaving the surrounding integration documentation unchanged.

## Validation
- `git diff --check`
- Verified `https://github.com/openclaw/openclaw` returns HTTP 200

## Confidence
82/100 — lower-risk docs/broken-link fix. The broken URL and replacement are directly verifiable, and no duplicate PR for this specific link was found.

Closes #1612