### PR TITLE
fix(release): automate image tag pinning across both charts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,6 +176,7 @@ jobs:
           yq e ".uiOAuthSecret.tag = \"${REF_NAME}\"" -i values.yaml
           yq e ".agentOAuthSecret.tag = \"${REF_NAME}\"" -i values.yaml
           yq e ".apiOAuthSecret.tag = \"${REF_NAME}\"" -i values.yaml
+          yq e ".mlflowOAuthSecret.tag = \"${REF_NAME}\"" -i values.yaml
           helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
           helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}
 
@@ -189,5 +190,6 @@ jobs:
           cd ${{ env.CHARTS_PATH }}/kagenti-deps
           echo "Fetching Helm chart dependencies..."
           helm dependency update
+          yq e ".spiffeIdp.image.tag = \"${REF_NAME}\"" -i values.yaml
           helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
           helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}

--- a/docs/release-sop.md
+++ b/docs/release-sop.md
@@ -1,0 +1,288 @@
+# Release Management SOP
+
+Standard Operating Procedure for releasing Kagenti, aligned with CNCF project
+conventions (Kubernetes, Helm, ArgoCD).
+
+> **Related:** [docs/releasing.md](releasing.md) contains the procedural step-by-step
+> instructions. This document covers policy and governance.
+
+---
+
+## 1. Branching Strategy
+
+| Branch | Purpose | Lifetime |
+|--------|---------|----------|
+| `main` | Active development; all features merge here | Permanent |
+| `release-X.Y` | Stabilization and patches for a minor series | Permanent once created |
+
+### Rules
+
+- **`main` is always releasable.** CI must pass; broken builds are P0.
+- **Release branches are cut at RC time**, not before. Alpha releases tag directly from `main`.
+- **No direct commits to release branches.** All fixes land on `main` first and are cherry-picked back (exceptions: release-only metadata changes like version bumps).
+- **One active release branch per minor version.** Example: `release-0.6` covers `v0.6.0-rc.1` through all `v0.6.Z` patches.
+
+### When to Create a Release Branch
+
+```
+main ─────●────●────●────●────●────●─── (development continues)
+                              │
+                              └─── release-0.6 ─── rc.1 ─── rc.2 ─── v0.6.0 ─── v0.6.1
+```
+
+Create `release-X.Y` when cutting the **first RC**:
+
+```bash
+git checkout -b release-X.Y main
+git push origin release-X.Y
+```
+
+---
+
+## 2. Pre-release Lifecycle
+
+### 2.1 Alpha Releases
+
+**Purpose:** Milestone snapshots for early testing. May break between releases.
+
+**Naming:** `vX.Y.0-alpha.N` (e.g., `v0.7.0-alpha.1`, `v0.7.0-alpha.2`)
+
+**Criteria to tag:**
+- CI passes on `main`
+- No known data-loss or security issues in the tagged commit
+- All image tags in `values.yaml` pinned (no `latest`)
+
+**Cadence:** As needed during active development (typically every 1-2 weeks during a cycle).
+
+**Process:**
+
+```bash
+# Determine next alpha number
+git tag --list 'vX.Y.0-alpha.*' --sort=-v:refname | head -1
+
+# Tag (follow multi-repo dependency order - see Section 6)
+git tag -s vX.Y.0-alpha.N -m "vX.Y.0-alpha.N"
+git push origin vX.Y.0-alpha.N
+```
+
+### 2.2 Release Candidates
+
+**Purpose:** Feature-complete builds for validation. Code freeze in effect.
+
+**Naming:** `vX.Y.0-rc.N` (e.g., `v0.7.0-rc.1`, `v0.7.0-rc.2`)
+
+**Code freeze rules:**
+- Only bug fixes, test fixes, and documentation changes are allowed.
+- No new features, refactors, or dependency upgrades (unless fixing a security issue).
+- All changes go through the normal PR process targeting the release branch.
+
+**Entry criteria:**
+- [ ] All planned features for the milestone are merged to `main`
+- [ ] No open P0/P1 bugs against the milestone
+- [ ] Feature freeze declared on Slack/mailing list
+- [ ] Release branch created from `main`
+- [ ] All image tags pinned to RC version
+
+**Progression:**
+- If bugs are found during RC testing, fix on `main`, cherry-pick to release branch, bump to `rc.N+1`.
+- Maximum 3 RCs recommended. If more are needed, re-evaluate scope.
+
+---
+
+## 3. Stable (GA) Releases
+
+**Naming:** `vX.Y.0` (first GA of a minor series), `vX.Y.Z` (patches)
+
+**Promotion criteria:**
+- [ ] At least 1 RC validated with no release-blocking issues
+- [ ] Minimum 1-week soak since last RC (recommended)
+- [ ] At least one maintainer sign-off (not the person who tagged the RC)
+- [ ] E2E tests pass on Kind and OpenShift
+- [ ] Upgrade path from previous GA tested
+- [ ] Release notes written and reviewed
+
+**Process:**
+
+```bash
+# On the release branch
+git checkout release-X.Y
+
+# Verify the RC tag is the HEAD (or contains only release metadata commits)
+git log --oneline release-X.Y...vX.Y.0-rc.N  # should be empty or trivial
+
+# Tag GA
+git tag -s vX.Y.0 -m "vX.Y.0"
+git push origin vX.Y.0
+```
+
+**Post-release:**
+- Mark GitHub Release as "Latest"
+- Announce on Slack and mailing list
+- Update installation docs with new version
+
+---
+
+## 4. Maintenance and Patching
+
+### 4.1 Cherry-Pick Workflow
+
+All fixes land on `main` first. To backport to a release branch:
+
+```bash
+# 1. Identify the commit(s) to cherry-pick
+git log --oneline main | grep "<fix description>"
+
+# 2. Cherry-pick onto release branch
+git checkout release-X.Y
+git cherry-pick -x <commit-sha>  # -x adds "cherry picked from" reference
+
+# 3. Resolve conflicts if any, then push
+git push origin release-X.Y
+
+# 4. Tag the patch
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+The `-x` flag is mandatory — it creates traceability between main and the backport.
+
+### 4.2 Security Patches vs. Bug Fixes
+
+| Aspect | Security Patch | Bug Fix |
+|--------|---------------|---------|
+| Timeline | ASAP (24-72h target) | Next patch window |
+| Disclosure | Private fix, coordinated disclosure | Public PR on main |
+| RC required? | No (direct to patch tag) | Recommended for non-trivial fixes |
+| Backport scope | All supported release branches | Latest release branch only (unless critical) |
+| Communication | Security advisory + CVE | Release notes |
+
+**Security patch process:**
+1. Fix developed in a private fork or restricted branch
+2. Patch applied to all supported release branches simultaneously
+3. Tags pushed for all affected versions
+4. GitHub Security Advisory published
+5. Announce on mailing list with CVE reference
+
+### 4.3 Support Window
+
+| Policy | Scope |
+|--------|-------|
+| Active support | Current GA (N) — bug fixes and security patches |
+| Security-only | Previous GA (N-1) — security patches only |
+| End of life | N-2 and older — no further releases |
+
+---
+
+## 5. Multi-Repo Dependency Order
+
+Kagenti spans multiple repositories. Tags must be created in dependency order:
+
+```
+1. kagenti/kagenti-operator      →  tag, wait for CI
+2. kagenti/kagenti-extensions    →  tag, wait for CI
+3. kagenti/kagenti               →  update Chart.yaml + values.yaml, tag
+```
+
+**Between each step:** Verify container images and Helm charts are published before proceeding to the next repository.
+
+---
+
+## 6. Automation and Tooling
+
+### Release image pinning
+
+Installers use local charts from the repo checkout — they do NOT pull from OCI.
+Therefore image tags must be pinned in the committed `values.yaml` files before
+tagging.
+
+**Pin all images in one command:**
+
+```bash
+bash scripts/pin-release-tags.sh v0.6.0-rc.6
+```
+
+This updates tags across both `charts/kagenti/values.yaml` and
+`charts/kagenti-deps/values.yaml`. See [docs/releasing.md — Pinning Image
+Tags](releasing.md#pinning-image-tags-before-release) for details.
+
+**Validate before tagging:**
+
+```bash
+bash scripts/check-release-pins.sh
+```
+
+This validates both charts for `tag: latest` entries and detects tag drift
+between `kagenti-deps` and the main platform chart.
+
+### Currently Automated (via existing `build.yaml` workflows)
+
+| Step | Trigger | Output |
+|------|---------|--------|
+| Container image build + push | Tag push (`v*`) | Images on `ghcr.io/kagenti/` |
+| Helm chart package + push (with tag pinning) | Tag push (`v*`) | OCI charts on `ghcr.io/kagenti/` |
+| GitHub Release creation | Tag push (`v*`) | Release with auto-generated changelog |
+| Pre-release flag | GoReleaser `prerelease: auto` | `-alpha`/`-rc` tags marked as pre-release |
+| Pin validation (`ci-release-pins.yaml`) | PR touching `charts/` | Summary on all PRs; hard gate on `release/*` branches |
+
+### Recommended Additions
+
+| Automation | Trigger | Purpose | Priority |
+|-----------|---------|---------|----------|
+| **Release branch protection** | Branch creation matching `release-*` | Enforce PR reviews, required CI, no force push | P0 |
+| **Changelog generation** | Tag push | Generate structured changelog from conventional commits (e.g., `git-cliff`) | P1 |
+| **Cross-repo orchestration** | Manual workflow dispatch | Trigger dependency-ordered release across repos | P2 |
+| **Cosign image signing** | After image push | Sign images with Sigstore keyless signing | P2 |
+| **SBOM generation** | Tag push | Produce CycloneDX SBOM per image | P3 |
+
+---
+
+## 7. Release Checklist (Quick Reference)
+
+### Alpha
+
+- [ ] CI green on `main`
+- [ ] Tag dependency repos in order (operator → extensions)
+- [ ] Verify images/charts published for each
+- [ ] Update `Chart.yaml` + `values.yaml` in `kagenti/kagenti`
+- [ ] Pin all image tags (no `latest`)
+- [ ] Run `helm dependency update charts/kagenti/`
+- [ ] Tag `kagenti/kagenti`
+- [ ] Verify GitHub Release is Pre-release
+
+### RC
+
+- [ ] Feature freeze announced
+- [ ] All alpha checklist items
+- [ ] Release branch `release-X.Y` created
+- [ ] E2E tests pass
+- [ ] Testing checklist added to release notes
+
+### GA
+
+- [ ] All RC checklist items
+- [ ] 1-week soak since last RC
+- [ ] Maintainer sign-off
+- [ ] Upgrade from previous GA tested
+- [ ] Full release notes with component version table
+- [ ] Announcement drafted
+
+### Patch
+
+- [ ] Fix merged to `main` with tests
+- [ ] Cherry-picked to `release-X.Y` with `-x` flag
+- [ ] CI passes on release branch
+- [ ] Tag `vX.Y.Z`
+- [ ] Release notes describe the fix
+
+---
+
+## 8. Tooling
+
+| Tool | Role |
+|------|------|
+| `/release` skill | Interactive AI-assisted release workflow |
+| `gh` CLI | Tag management, release creation, CI status |
+| GoReleaser | Builds binaries, manages GitHub Releases |
+| Helm | Chart packaging and OCI registry push |
+| `git-cliff` (proposed) | Conventional-commit changelog generation |
+| Cosign (proposed) | Image signature verification |

--- a/scripts/check-release-pins.sh
+++ b/scripts/check-release-pins.sh
@@ -404,7 +404,7 @@ if [[ -f "$DEPS_VALUES_FILE" ]] && command -v yq >/dev/null 2>&1; then
 
         if [[ -n "$platform_tag" ]] && [[ "$platform_tag" != "null" ]] \
            && [[ "$spiffe_tag" != "$platform_tag" ]]; then
-            add_warning "charts/kagenti-deps/values.yaml" \
+            add_error "charts/kagenti-deps/values.yaml" \
                 "spiffeIdp.image.tag ($spiffe_tag) differs from platform tag ($platform_tag) — run scripts/pin-release-tags.sh"
         else
             add_ok "charts/kagenti-deps/values.yaml" \

--- a/scripts/check-release-pins.sh
+++ b/scripts/check-release-pins.sh
@@ -20,6 +20,9 @@ VALUES_FILE="$CHARTS_DIR/values.yaml"
 CHART_FILE="$CHARTS_DIR/Chart.yaml"
 TEMPLATES_DIR="$CHARTS_DIR/templates"
 
+DEPS_CHARTS_DIR="$REPO_ROOT/charts/kagenti-deps"
+DEPS_VALUES_FILE="$DEPS_CHARTS_DIR/values.yaml"
+
 # ---------------------------------------------------------------------------
 # Options
 # ---------------------------------------------------------------------------
@@ -363,7 +366,55 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Check 5 (optional): Verify pinned GHCR images exist in registry
+# Check 5: No "tag: latest" in kagenti-deps values.yaml
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "$DEPS_VALUES_FILE" ]]; then
+    add_warning "charts/kagenti-deps/values.yaml" "file not found (skipping)"
+else
+    matches=$(grep -Fn 'tag: latest' "$DEPS_VALUES_FILE" || true)
+
+    if [[ -z "$matches" ]]; then
+        add_ok "charts/kagenti-deps/values.yaml" "no tag: latest found"
+    else
+        while IFS= read -r match; do
+            if [[ -z "$match" ]]; then
+                continue
+            fi
+
+            line_number="${match%%:*}"
+            add_error "charts/kagenti-deps/values.yaml" "$line_number" "tag: latest"
+        done <<< "$matches"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 6: kagenti-deps images built by this repo are pinned consistently
+#
+# The spiffe-idp-setup image lives in kagenti-deps but is built by this repo.
+# Its tag must not drift from the main chart's platform image tags.
+# ---------------------------------------------------------------------------
+
+if [[ -f "$DEPS_VALUES_FILE" ]] && command -v yq >/dev/null 2>&1; then
+    spiffe_tag=$(yq eval '.spiffeIdp.image.tag' "$DEPS_VALUES_FILE" 2>/dev/null || echo "")
+
+    if [[ -n "$spiffe_tag" ]] && [[ "$spiffe_tag" != "null" ]]; then
+        # Compare against the first platform image tag in the main chart
+        platform_tag=$(yq eval '.ui.frontend.tag' "$VALUES_FILE" 2>/dev/null || echo "")
+
+        if [[ -n "$platform_tag" ]] && [[ "$platform_tag" != "null" ]] \
+           && [[ "$spiffe_tag" != "$platform_tag" ]]; then
+            add_warning "charts/kagenti-deps/values.yaml" \
+                "spiffeIdp.image.tag ($spiffe_tag) differs from platform tag ($platform_tag) — run scripts/pin-release-tags.sh"
+        else
+            add_ok "charts/kagenti-deps/values.yaml" \
+                "spiffeIdp.image.tag ($spiffe_tag) consistent with platform"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 7 (optional): Verify pinned GHCR images exist in registry
 #
 # Extract image: <ref> lines from values.yaml. Only GHCR is checked.
 # docker is required in this mode; fail with a clear message if missing.

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# pin-release-tags.sh — Pin all kagenti-built image tags to a release version.
+#
+# Updates image tags across both charts/kagenti/ and charts/kagenti-deps/ so
+# that a tagged release checkout always pulls the correct images when installed
+# from source (via the setup-kagenti.sh installers).
+#
+# Usage:
+#   ./scripts/pin-release-tags.sh v0.6.0-rc.6
+#   ./scripts/pin-release-tags.sh v0.7.0-alpha.2 --dry-run
+#   ./scripts/pin-release-tags.sh v0.6.0 --verify-images
+#
+# This script is idempotent — running it multiple times with the same version
+# produces the same result.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+KAGENTI_VALUES="$REPO_ROOT/charts/kagenti/values.yaml"
+KAGENTI_DEPS_VALUES="$REPO_ROOT/charts/kagenti-deps/values.yaml"
+KAGENTI_CHART="$REPO_ROOT/charts/kagenti/Chart.yaml"
+
+DRY_RUN=false
+VERIFY_IMAGES=false
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") VERSION [OPTIONS]
+
+Pin all kagenti-built container image tags to VERSION across both Helm charts.
+
+Arguments:
+  VERSION             The release version tag (e.g., v0.6.0-rc.6, v0.7.0-alpha.1)
+
+Options:
+  --dry-run           Show what would change without modifying files
+  --verify-images     Check that images exist in ghcr.io before pinning
+  --chart-version V   Also update Chart.yaml version (strip 'v' prefix automatically)
+  -h, --help          Show this help message
+
+Images pinned (charts/kagenti/values.yaml):
+  - ui.frontend.tag
+  - ui.backend.tag
+  - uiOAuthSecret.tag
+  - agentOAuthSecret.tag
+  - apiOAuthSecret.tag
+  - mlflowOAuthSecret.tag
+
+Images pinned (charts/kagenti-deps/values.yaml):
+  - spiffeIdp.image.tag
+
+EOF
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+VERSION=""
+CHART_VERSION=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)         DRY_RUN=true; shift ;;
+        --verify-images)   VERIFY_IMAGES=true; shift ;;
+        --chart-version)   CHART_VERSION="$2"; shift 2 ;;
+        -h|--help)         usage ;;
+        -*)                echo "Unknown option: $1" >&2; usage ;;
+        *)
+            if [[ -z "$VERSION" ]]; then
+                VERSION="$1"
+            else
+                echo "Unexpected argument: $1" >&2; usage
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "error: VERSION argument is required" >&2
+    echo "" >&2
+    usage
+fi
+
+# Validate version format (must start with v and contain at least major.minor.patch)
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "error: VERSION must match vX.Y.Z[-prerelease] (got: $VERSION)" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Check prerequisites
+# ---------------------------------------------------------------------------
+
+if ! command -v yq >/dev/null 2>&1; then
+    echo "error: yq is required but not installed" >&2
+    echo "  Install: brew install yq  (or see https://github.com/mikefarah/yq)" >&2
+    exit 2
+fi
+
+if [[ ! -f "$KAGENTI_VALUES" ]]; then
+    echo "error: $KAGENTI_VALUES not found (run from repo root)" >&2
+    exit 1
+fi
+
+if [[ ! -f "$KAGENTI_DEPS_VALUES" ]]; then
+    echo "error: $KAGENTI_DEPS_VALUES not found (run from repo root)" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Image registry and paths
+# ---------------------------------------------------------------------------
+
+REGISTRY="ghcr.io/kagenti/kagenti"
+
+# Map of yq paths to image names. These are ALL images built by this repo's
+# build.yaml CI workflow and must be kept in sync with the matrix there.
+#
+# Format: "values-file|yq-path|image-name"
+PINNABLE_IMAGES=(
+    "$KAGENTI_VALUES|.ui.frontend.tag|ui-v2"
+    "$KAGENTI_VALUES|.ui.backend.tag|backend"
+    "$KAGENTI_VALUES|.uiOAuthSecret.tag|ui-oauth-secret"
+    "$KAGENTI_VALUES|.agentOAuthSecret.tag|agent-oauth-secret"
+    "$KAGENTI_VALUES|.apiOAuthSecret.tag|api-oauth-secret"
+    "$KAGENTI_VALUES|.mlflowOAuthSecret.tag|mlflow-oauth-secret"
+    "$KAGENTI_DEPS_VALUES|.spiffeIdp.image.tag|spiffe-idp-setup"
+)
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+NC=$'\033[0m'
+
+# ---------------------------------------------------------------------------
+# Verify images exist (optional)
+# ---------------------------------------------------------------------------
+
+if [[ "$VERIFY_IMAGES" == "true" ]]; then
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "error: --verify-images requires docker" >&2
+        exit 2
+    fi
+
+    echo "Verifying images exist in registry..."
+    all_found=true
+
+    for entry in "${PINNABLE_IMAGES[@]}"; do
+        IFS='|' read -r _ _ image_name <<< "$entry"
+        full_ref="$REGISTRY/$image_name:$VERSION"
+
+        if docker manifest inspect "$full_ref" >/dev/null 2>&1; then
+            printf '%s[OK]%s   %s\n' "$GREEN" "$NC" "$full_ref"
+        else
+            printf '%s[MISS]%s %s\n' "$RED" "$NC" "$full_ref"
+            all_found=false
+        fi
+    done
+
+    if [[ "$all_found" != "true" ]]; then
+        echo ""
+        echo "${RED}error: Some images are missing. Build and push them before pinning.${NC}" >&2
+        exit 1
+    fi
+
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Pin image tags
+# ---------------------------------------------------------------------------
+
+echo "Pinning image tags to ${VERSION}..."
+echo ""
+
+for entry in "${PINNABLE_IMAGES[@]}"; do
+    IFS='|' read -r target_file yq_path image_name <<< "$entry"
+
+    # Get current value
+    current=$(yq eval "$yq_path" "$target_file" 2>/dev/null || echo "")
+    rel_path="${target_file#$REPO_ROOT/}"
+
+    if [[ "$current" == "$VERSION" ]]; then
+        printf '%s[SKIP]%s %s (%s) — already %s\n' "$GREEN" "$NC" "$image_name" "$rel_path" "$VERSION"
+        continue
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        printf '%s[DRY]%s  %s (%s): %s → %s\n' "$YELLOW" "$NC" "$image_name" "$rel_path" "$current" "$VERSION"
+    else
+        yq eval "$yq_path = \"$VERSION\"" -i "$target_file"
+        printf '%s[PIN]%s  %s (%s): %s → %s\n' "$GREEN" "$NC" "$image_name" "$rel_path" "$current" "$VERSION"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Pin Chart.yaml version (optional)
+# ---------------------------------------------------------------------------
+
+if [[ -n "$CHART_VERSION" ]]; then
+    echo ""
+    echo "Updating Chart.yaml version..."
+
+    # Strip 'v' prefix for chart version
+    chart_ver="${CHART_VERSION#v}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        current_chart_ver=$(yq eval '.version' "$KAGENTI_CHART")
+        printf '%s[DRY]%s  Chart.yaml version: %s → %s\n' "$YELLOW" "$NC" "$current_chart_ver" "$chart_ver"
+        printf '%s[DRY]%s  Chart.yaml appVersion: → %s\n' "$YELLOW" "$NC" "$chart_ver"
+    else
+        yq eval ".version = \"$chart_ver\"" -i "$KAGENTI_CHART"
+        yq eval ".appVersion = \"$chart_ver\"" -i "$KAGENTI_CHART"
+        printf '%s[PIN]%s  Chart.yaml version + appVersion → %s\n' "$GREEN" "$NC" "$chart_ver"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "${YELLOW}Dry run complete — no files were modified.${NC}"
+    echo "Remove --dry-run to apply changes."
+else
+    echo "${GREEN}All image tags pinned to ${VERSION}.${NC}"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Review changes:  git diff charts/"
+    echo "  2. Run validation:  bash scripts/check-release-pins.sh"
+    echo "  3. Commit:          git add charts/ && git commit -s -m \"chore(release): pin image tags for ${VERSION}\""
+fi

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -21,6 +21,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 KAGENTI_VALUES="$REPO_ROOT/charts/kagenti/values.yaml"
 KAGENTI_DEPS_VALUES="$REPO_ROOT/charts/kagenti-deps/values.yaml"
+# Only kagenti Chart.yaml is versioned here; kagenti-deps is a dependency chart
+# whose version is managed independently via its own release cadence.
 KAGENTI_CHART="$REPO_ROOT/charts/kagenti/Chart.yaml"
 
 DRY_RUN=false
@@ -92,7 +94,7 @@ if [[ -z "$VERSION" ]]; then
 fi
 
 # Validate version format (must start with v and contain at least major.minor.patch)
-if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
     echo "error: VERSION must match vX.Y.Z[-prerelease] (got: $VERSION)" >&2
     exit 1
 fi
@@ -141,10 +143,11 @@ PINNABLE_IMAGES=(
 # Colors
 # ---------------------------------------------------------------------------
 
-RED=$'\033[0;31m'
-GREEN=$'\033[0;32m'
-YELLOW=$'\033[1;33m'
-NC=$'\033[0m'
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; NC=$'\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; NC=''
+fi
 
 # ---------------------------------------------------------------------------
 # Verify images exist (optional)
@@ -190,9 +193,14 @@ echo ""
 for entry in "${PINNABLE_IMAGES[@]}"; do
     IFS='|' read -r target_file yq_path image_name <<< "$entry"
 
-    # Get current value
-    current=$(yq eval "$yq_path" "$target_file" 2>/dev/null || echo "")
+    # Get current value (yq returns literal "null" for missing paths)
+    current=$(yq eval "$yq_path // \"\"" "$target_file")
     rel_path="${target_file#$REPO_ROOT/}"
+
+    if [[ -z "$current" ]]; then
+        echo "error: yq path $yq_path not found in $rel_path" >&2
+        exit 1
+    fi
 
     if [[ "$current" == "$VERSION" ]]; then
         printf '%s[SKIP]%s %s (%s) — already %s\n' "$GREEN" "$NC" "$image_name" "$rel_path" "$VERSION"
@@ -202,7 +210,7 @@ for entry in "${PINNABLE_IMAGES[@]}"; do
     if [[ "$DRY_RUN" == "true" ]]; then
         printf '%s[DRY]%s  %s (%s): %s → %s\n' "$YELLOW" "$NC" "$image_name" "$rel_path" "$current" "$VERSION"
     else
-        yq eval "$yq_path = \"$VERSION\"" -i "$target_file"
+        yq eval --arg v "$VERSION" "$yq_path = \$v" -i "$target_file"
         printf '%s[PIN]%s  %s (%s): %s → %s\n' "$GREEN" "$NC" "$image_name" "$rel_path" "$current" "$VERSION"
     fi
 done
@@ -223,8 +231,8 @@ if [[ -n "$CHART_VERSION" ]]; then
         printf '%s[DRY]%s  Chart.yaml version: %s → %s\n' "$YELLOW" "$NC" "$current_chart_ver" "$chart_ver"
         printf '%s[DRY]%s  Chart.yaml appVersion: → %s\n' "$YELLOW" "$NC" "$chart_ver"
     else
-        yq eval ".version = \"$chart_ver\"" -i "$KAGENTI_CHART"
-        yq eval ".appVersion = \"$chart_ver\"" -i "$KAGENTI_CHART"
+        yq eval --arg v "$chart_ver" '.version = $v' -i "$KAGENTI_CHART"
+        yq eval --arg v "$chart_ver" '.appVersion = $v' -i "$KAGENTI_CHART"
         printf '%s[PIN]%s  Chart.yaml version + appVersion → %s\n' "$GREEN" "$NC" "$chart_ver"
     fi
 fi


### PR DESCRIPTION
## Summary

- Adds `scripts/pin-release-tags.sh` — a single command that pins all kagenti-built image tags across both `charts/kagenti/` and `charts/kagenti-deps/` values files
- Extends `scripts/check-release-pins.sh` to validate `kagenti-deps` and detect tag drift between the two charts  
- Fixes `build.yaml` to also pin `mlflow-oauth-secret` and `spiffe-idp-setup` at OCI chart-publish time
- Updates release documentation and the `/release` skill to reference the new automation

## Problem

The `spiffe-idp-setup` image tag in `charts/kagenti-deps/values.yaml` was pinned at `v0.6.0-rc.1` and never updated through rc.2–rc.5. Users testing rc.5 from a repo checkout (the standard install path) pulled the stale rc.1 image.

Root cause: The release pinning process was manual and only covered `charts/kagenti/values.yaml`. The `kagenti-deps` chart and the `mlflow-oauth-secret` image were missed by both:
1. The manual `chore(release): pin image tags` commits
2. The CI `build.yaml` chart-publish job

## How the pin script works

```bash
# Pin all images to a release version
bash scripts/pin-release-tags.sh v0.6.0-rc.6

# Preview without modifying
bash scripts/pin-release-tags.sh v0.6.0-rc.6 --dry-run

# Verify images exist before pinning
bash scripts/pin-release-tags.sh v0.6.0-rc.6 --verify-images
```

## Test plan

- [x] `pin-release-tags.sh --dry-run` shows correct before/after for all 7 images
- [x] `check-release-pins.sh` detects the existing drift (`spiffe-idp-setup` at rc.1 vs platform at alpha.1) 
- [x] Pre-commit hooks pass
- [ ] CI passes on this PR

Assisted-By: Claude Code