### PR TITLE
feat: align kagenti with kagenti-extensions go-spiffe SDK migration

### DIFF
--- a/charts/kagenti/templates/_helpers.tpl
+++ b/charts/kagenti/templates/_helpers.tpl
@@ -71,3 +71,19 @@ It will be enabled if:
 {{- define "kagenti.istio.communityCharts.enabled" -}}
 {{- tpl "{{ and .Values.components.istio.enabled (not .Values.openshift) }}" . | toString -}}
 {{- end -}}
+
+{{/*
+Validate that authBridge.clientAuthType=federated-jwt is only used when
+SPIRE is enabled. The federated-jwt path mints a JWT-SVID via the
+in-process SPIFFE provider, which is only constructed when spire.enabled
+gates a top-level `spiffe:` block into the rendered authbridge config.
+Without that, the new authbridge image fails to Configure with
+"spiffe identity requires a SPIFFE provider to be injected" at boot.
+Failing here at helm template time gives a clearer message than a
+CrashLoopBackOff. See kagenti-extensions#332.
+*/}}
+{{- define "kagenti.authBridge.validateSpiffeIdentity" -}}
+{{- if and (eq .Values.authBridge.clientAuthType "federated-jwt") (not .Values.spire.enabled) -}}
+{{- fail "authBridge.clientAuthType=federated-jwt requires spire.enabled=true (the in-process SPIFFE provider is needed to mint JWT-SVID client assertions)" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -110,7 +110,7 @@ data:
 #  ConfigMap for AuthBridge in Namespace: {{ . }}
 #  Consolidated config consumed by the kagenti-operator and injected sidecars:
 #  - kagenti-operator: Client registration controller (reads KEYCLOAK_URL, KEYCLOAK_REALM)
-#  - kagenti-webhook: Injects CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS, JWT_AUDIENCE
+#  - kagenti-webhook: Injects CLIENT_AUTH_TYPE, SPIFFE_IDP_ALIAS
 #  - authbridge sidecars: Read ISSUER, EXPECTED_AUDIENCE for inbound JWT validation
 #
 #  NOTE: KEYCLOAK_NAMESPACE is only used by Helm-hook Jobs (spiffe-idp-setup, agent-oauth-secret)
@@ -139,7 +139,6 @@ data:
   # Authentication configuration (used by operator and webhook injector)
   CLIENT_AUTH_TYPE: "{{ $root.Values.authBridge.clientAuthType }}"
   SPIFFE_IDP_ALIAS: "{{ $root.Values.authBridge.spiffeIdpAlias }}"
-  JWT_AUDIENCE: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
   # EXPECTED_AUDIENCE: Read by authbridge-unified ext_proc (envoy-proxy sidecar)
   # for inbound JWT "aud" claim validation. Must match the audience mapper value
   # configured in Keycloak (kagenti-platform-audience scope).
@@ -342,6 +341,14 @@ data:
   # No top-level `mode:` — see the matching template-configmap in
   # authbridge-template-configmaps.yaml for the rationale.
   config.yaml: |
+    {{- if $root.Values.spire.enabled }}
+    # Empty spiffe block signals authbridge to construct an in-process
+    # SPIFFE provider (X.509 source for mTLS + lazy JWT source for
+    # tokenexchange). All fields default: socket points at the standard
+    # SPIRE agent socket, mirror writes /opt/svid*.pem on rotation. The
+    # JWT audience is per-tokenexchange (see identity.jwt_audience below).
+    spiffe: {}
+    {{- end }}
     pipeline:
       inbound:
         plugins:
@@ -372,6 +379,12 @@ data:
                 #   "client-secret"  → "client-secret" (traditional)
                 #   "federated-jwt"  → "spiffe" (SPIFFE JWT-SVID authentication)
                 type: {{ eq $root.Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" $root.Values.authBridge.clientAuthType | quote }}
+                {{- if eq $root.Values.authBridge.clientAuthType "federated-jwt" }}
+                # Audience the JWT-SVID client assertion is minted with —
+                # must equal the audience Keycloak's SPIFFE IdP expects
+                # (the realm issuer URL). Only meaningful when type=spiffe.
+                jwt_audience: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
+                {{- end }}
 ---
 {{- if $.Values.openshift }}
 # ——————————————————————————————————————————————————————————————————————————————

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -1,6 +1,7 @@
 # This template configures the agent namespaces based on the list provided in values.yaml.
 # For each namespace, it creates the namespace itself, applies necessary labels,
 # and creates secrets for GitHub, OpenAI, and Slack.
+{{- include "kagenti.authBridge.validateSpiffeIdentity" . -}}
 {{- if .Values.agentNamespaces }}
 {{- $root := . }}
 {{- range $root.Values.agentNamespaces }}

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -10,6 +10,7 @@
 
   See: https://github.com/kagenti/kagenti/issues/1336
 */ -}}
+{{- include "kagenti.authBridge.validateSpiffeIdentity" . -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -26,7 +26,6 @@ data:
   SPIRE_ENABLED: {{ if .Values.spire.enabled }}"true"{{ else }}"false"{{ end }}
   CLIENT_AUTH_TYPE: "{{ .Values.authBridge.clientAuthType }}"
   SPIFFE_IDP_ALIAS: "{{ .Values.authBridge.spiffeIdpAlias }}"
-  JWT_AUDIENCE: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
   EXPECTED_AUDIENCE: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
   CREDENTIAL_WAIT_TIMEOUT: {{ .Values.authBridge.credentialWaitTimeout | quote }}
 ---
@@ -52,6 +51,14 @@ data:
   # default (proxy-sidecar) wins by default, and a namespace-level
   # override can still be added later by editing this ConfigMap.
   config.yaml: |
+    {{- if .Values.spire.enabled }}
+    # Empty spiffe block signals authbridge to construct an in-process
+    # SPIFFE provider (X.509 source for mTLS + lazy JWT source for
+    # tokenexchange). All fields default: socket points at the standard
+    # SPIRE agent socket, mirror writes /opt/svid*.pem on rotation. The
+    # JWT audience is per-tokenexchange (see identity.jwt_audience below).
+    spiffe: {}
+    {{- end }}
     pipeline:
       inbound:
         plugins:
@@ -78,6 +85,12 @@ data:
               default_policy: "passthrough"
               identity:
                 type: {{ eq .Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" .Values.authBridge.clientAuthType | quote }}
+                {{- if eq .Values.authBridge.clientAuthType "federated-jwt" }}
+                # Audience the JWT-SVID client assertion is minted with —
+                # must equal the audience Keycloak's SPIFFE IdP expects
+                # (the realm issuer URL). Only meaningful when type=spiffe.
+                jwt_audience: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+                {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2085,33 +2085,46 @@ def _build_authbridge_runtime_yaml(
     # AgentRuntime.Spec.AuthBridgeMode → namespace ConfigMap →
     # cluster default (proxy-sidecar). Hardcoding it here would pin
     # every backend-rendered ConfigMap to one shape regardless of CR.
-    config = {
-        "pipeline": {
-            "inbound": {
-                "plugins": [
-                    {
-                        "name": "jwt-validation",
-                        "config": {
-                            "issuer": issuer,
-                            "keycloak_url": keycloak_url,
-                            "keycloak_realm": realm,
-                        },
-                    }
-                ]
-            },
-            "outbound": {
-                "plugins": [
-                    {
-                        "name": "token-exchange",
-                        "config": {
-                            "keycloak_url": keycloak_url,
-                            "keycloak_realm": realm,
-                            "default_policy": "passthrough",
-                            "identity": {"type": identity_type},
-                        },
-                    }
-                ]
-            },
+    identity: dict[str, str] = {"type": identity_type}
+    if identity_type == "spiffe":
+        # JWT-SVID client-assertion audience — must match what Keycloak's
+        # SPIFFE IdP expects (the realm issuer URL). Required by
+        # authbridge's token-exchange plugin in the spiffe identity path.
+        # See kagenti-extensions#332.
+        identity["jwt_audience"] = issuer
+    config: dict[str, object] = {}
+    if spire_enabled:
+        # Empty spiffe block signals authbridge to construct the in-process
+        # SPIFFE provider (X.509 source for mTLS + lazy JWT source for
+        # tokenexchange). All fields default: socket points at the standard
+        # SPIRE agent socket, mirror writes /opt/svid*.pem on rotation.
+        # The JWT audience lives per-tokenexchange (under identity above).
+        config["spiffe"] = {}
+    config["pipeline"] = {
+        "inbound": {
+            "plugins": [
+                {
+                    "name": "jwt-validation",
+                    "config": {
+                        "issuer": issuer,
+                        "keycloak_url": keycloak_url,
+                        "keycloak_realm": realm,
+                    },
+                }
+            ]
+        },
+        "outbound": {
+            "plugins": [
+                {
+                    "name": "token-exchange",
+                    "config": {
+                        "keycloak_url": keycloak_url,
+                        "keycloak_realm": realm,
+                        "default_policy": "passthrough",
+                        "identity": identity,
+                    },
+                }
+            ]
         },
     }
 

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -62,6 +62,12 @@ def test_build_authbridge_runtime_yaml_client_secret():
     assert tok["keycloak_realm"] == "kagenti"
     assert tok["default_policy"] == "passthrough"
     assert tok["identity"]["type"] == "client-secret"
+    # Without SPIRE, no top-level spiffe block is emitted; authbridge
+    # leaves the in-process Provider unbuilt.
+    assert "spiffe" not in cfg
+    # client-secret identity has no JWT-SVID assertion path; jwt_audience
+    # must NOT be emitted (it would be ignored but is misleading config).
+    assert "jwt_audience" not in tok["identity"]
 
     # Plugin defaults are applied by the authbridge binary, not
     # emitted here. Asserting absence keeps the contract honest.
@@ -72,7 +78,7 @@ def test_build_authbridge_runtime_yaml_client_secret():
 
 
 def test_build_authbridge_runtime_yaml_spire_enabled():
-    """SPIRE-enabled config maps to spiffe identity."""
+    """SPIRE-enabled config maps to spiffe identity with jwt_audience."""
     from app.routers.agents import _build_authbridge_runtime_yaml
 
     result = _build_authbridge_runtime_yaml(
@@ -83,8 +89,16 @@ def test_build_authbridge_runtime_yaml_spire_enabled():
     )
     cfg = yaml.safe_load(result)
 
+    # Top-level spiffe block (empty mapping) signals authbridge to
+    # construct the in-process SPIFFE provider. All fields default.
+    assert "spiffe" in cfg
+    assert cfg["spiffe"] == {} or cfg["spiffe"] is None  # yaml.safe_load may surface either
+
     tok = _plugin_config(cfg, "outbound", "token-exchange")
     assert tok["identity"]["type"] == "spiffe"
+    # JWT-SVID client-assertion audience — must equal the realm issuer
+    # URL Keycloak's SPIFFE IdP expects. See kagenti-extensions#332.
+    assert tok["identity"]["jwt_audience"] == "http://keycloak.example.com/realms/kagenti"
     # jwt_svid_path is not emitted — the plugin applies
     # /opt/jwt_svid.token as its default when identity.type is spiffe.
     assert "jwt_svid_path" not in tok["identity"]

--- a/kagenti/backend/tests/test_authbridge_runtime_config.py
+++ b/kagenti/backend/tests/test_authbridge_runtime_config.py
@@ -92,7 +92,7 @@ def test_build_authbridge_runtime_yaml_spire_enabled():
     # Top-level spiffe block (empty mapping) signals authbridge to
     # construct the in-process SPIFFE provider. All fields default.
     assert "spiffe" in cfg
-    assert cfg["spiffe"] == {} or cfg["spiffe"] is None  # yaml.safe_load may surface either
+    assert cfg["spiffe"] == {}
 
     tok = _plugin_config(cfg, "outbound", "token-exchange")
     assert tok["identity"]["type"] == "spiffe"

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -493,6 +493,11 @@ export interface TokenExchangePluginConfig {
 
 export interface IdentityConfig {
   type: string; // "spiffe" | "client-secret"
+  // jwt_audience is required when type === "spiffe": authbridge mints
+  // a JWT-SVID with this audience and sends it as the OAuth client_assertion
+  // to Keycloak. Must match Keycloak's SPIFFE IdP expected audience
+  // (typically the realm issuer URL). Omitted when type === "client-secret".
+  jwt_audience?: string;
 }
 
 export interface AuthBridgeStats {


### PR DESCRIPTION
Companion to [kagenti-extensions#432](https://github.com/kagenti/kagenti-extensions/pull/432).

## Why

The new authbridge image (PR #432) replaces the bundled `spiffe-helper` binary with an in-process `go-spiffe` SDK integration. That changes the authbridge config schema in two ways:

- A top-level `spiffe:` block signals the framework to build the in-process Provider (X.509 source for mTLS + lazy JWT source for tokenexchange).
- A per-plugin `tokenexchange.identity.jwt_audience` field carries the JWT-SVID client-assertion audience that previously lived in `helper.conf`.

Without these chart updates, the new image fails to boot in SPIRE-enabled deployments — either skipping Provider construction (no mTLS, spiffe identity unwired) or failing Configure with `identity.type=spiffe requires identity.jwt_audience to be set`.

## What

Two code paths emit authbridge config in this repo. Both are updated:

| Source | What changed |
|---|---|
| `charts/kagenti/templates/authbridge-template-configmaps.yaml` and `charts/kagenti/templates/agent-namespaces.yaml` | Render `spiffe: {}` (when `spire.enabled=true`) and `tokenexchange.identity.jwt_audience` (when `clientAuthType=federated-jwt`). Drop the unused `JWT_AUDIENCE` env var from `authbridge-config` ConfigMap. |
| `kagenti/backend/app/routers/agents.py` (`_build_authbridge_runtime_yaml`) + tests | Same schema change for backend-API-created agents. |
| `kagenti/ui-v2/src/types/index.ts` (`IdentityConfig`) | Add optional `jwt_audience` field for type-safety in the UI form/validation surface. |

## Sequencing / backward compatibility

This PR is **safe to land before** kagenti-extensions#432:

- New `spiffe:` block + `jwt_audience` field are additive. The OLD authbridge image's YAML decoder silently drops unknown keys, so deployments still running the old image keep working with the updated chart.
- `JWT_AUDIENCE` env var being removed has no consumer (verified across kagenti, kagenti-extensions, and kagenti-operator — only the operator parsed it into a struct field that nothing reads). Old image unaffected.
- `spiffe-helper-config` ConfigMap and the legacy `helper.conf` rendering are intentionally LEFT in place. They're no-ops against the new image (no spiffe-helper binary to read them) and required by the old image during a phased rollout. Cleanup can land in a follow-up PR after all old-image deployments are gone.

## Test plan

- [ ] `cd kagenti/backend && uv run pytest tests/test_authbridge_runtime_config.py -v` passes
- [ ] `helm template charts/kagenti --set spire.enabled=true --set authBridge.clientAuthType=federated-jwt` renders `spiffe: {}` and `tokenexchange.identity.jwt_audience` in both `agent-namespaces.yaml` and `authbridge-template-configmaps.yaml` outputs
- [ ] `helm template charts/kagenti --set spire.enabled=true --set authBridge.clientAuthType=client-secret` does NOT render `jwt_audience` (only `type: client-secret`)
- [ ] `helm template charts/kagenti --set spire.enabled=false` does NOT render the top-level `spiffe:` block
- [ ] Local Kind: deploy + chat with weather-agent in federated-jwt mode succeeds (verified)

Assisted-By: Claude Code
