### PR TITLE
fix(ocp): skip remote tag detection when --kagenti-repo is provided

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,11 @@ updates:
         update-types: [minor, patch]
       major:
         update-types: [major]
+    ignore:
+      # cryptography 47+ crashes with SIGILL on ARM64 Kind clusters.
+      # Pin is intentional — block all bumps above the current upper bound.
+      - dependency-name: "cryptography"
+        update-types: [version-update:semver-major, version-update:semver-minor]
 
   # npm (UI) — React frontend dependencies
   - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,7 @@ updates:
     ignore:
       # cryptography 47+ crashes with SIGILL on ARM64 Kind clusters.
       # Pin is intentional — block all bumps above the current upper bound.
+      # Effect: only patch bumps allowed until the SIGILL is resolved upstream.
       - dependency-name: "cryptography"
         update-types: [version-update:semver-major, version-update:semver-minor]
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -221,6 +221,7 @@ _clone_kagenti() {
 }
 
 KAGENTI_SOURCE=""
+KAGENTI_REPO_ORIGINAL="$KAGENTI_REPO"
 if [ -z "$KAGENTI_REPO" ]; then
   # No --kagenti-repo given: always clone fresh from upstream main
   KAGENTI_SOURCE="$KAGENTI_GITHUB_URL"
@@ -1307,7 +1308,8 @@ KAGENTI_UI_FLAGS=()
 if $SKIP_UI; then
   log_info "Kagenti UI: skipped (--skip-ui)"
   KAGENTI_UI_FLAGS+=(--set components.ui.enabled=false)
-else
+elif [ -z "$KAGENTI_REPO_ORIGINAL" ]; then
+  # No --kagenti-repo provided: detect latest release tag from remote
   log_info "Detecting latest kagenti release tag..."
   LATEST_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/kagenti/kagenti.git | tail -n1 | sed 's|.*refs/tags/v||; s/\^{}//')
   if [ -z "$LATEST_TAG" ]; then
@@ -1317,6 +1319,9 @@ else
   log_success "Using tag: v${LATEST_TAG}"
   KAGENTI_UI_FLAGS+=(--set "ui.frontend.tag=v${LATEST_TAG}")
   KAGENTI_UI_FLAGS+=(--set "ui.backend.tag=v${LATEST_TAG}")
+else
+  # Local or explicit repo: trust the chart's pinned image tags
+  log_info "Using image tags from chart values (--kagenti-repo provided)"
 fi
 
 # Override operator chart dependency with local repo if provided


### PR DESCRIPTION
## Summary

- Fixes the OCP setup script overriding chart-pinned image tags with the latest remote tag when `--kagenti-repo` is explicitly provided
- Remote tag detection now only runs when no repo is specified (using upstream main)
- When a local repo is passed, the chart's `values.yaml` image tags are used as-is

Fixes #1654

## Test plan

- [ ] Run `./scripts/ocp/setup-kagenti.sh --kagenti-repo . --with-all` on OCP — verify UI shows the version pinned in chart values
- [ ] Run `./scripts/ocp/setup-kagenti.sh` (no `--kagenti-repo`) — verify it still detects and uses the latest remote tag
- [ ] Kind install continues to work as before (unaffected code path)

Assisted-By: Claude Code