### PR TITLE
chore(release): bump image pins to v0.6.0-alpha.4 / 0.3.0-alpha.2 / v0.7.0-alpha.2

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.3.0-alpha.1
-digest: sha256:a0a720de063f170860ed123257ab450f3a569bdb4e55864df33f47dc4bcb9add
-generated: "2026-05-15T09:55:06.320852-04:00"
+  version: 0.3.0-alpha.2
+digest: sha256:cc9a2ee16cfb5458455069f803e3b31dc21cd67876b78a09eddfe253ddc14b7a
+generated: "2026-05-23T09:39:55.373088-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kagenti
 description: A Helm chart for deploying the kagenti platform
 type: application
-version: 0.7.0-alpha.1
-appVersion: "0.7.0-alpha.1"
+version: 0.7.0-alpha.2
+appVersion: "0.7.0-alpha.2"
 
 dependencies:
 - name: kagenti-operator-chart

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,6 +7,6 @@ appVersion: "0.7.0-alpha.2"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.3.0-alpha.1
+  version: 0.3.0-alpha.2
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -77,7 +77,7 @@ ui:
   frontend:
     enabled: true
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.7.0-alpha.1
+    tag: v0.7.0-alpha.2
     resources:
       limits:
         cpu: 100m
@@ -91,7 +91,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.7.0-alpha.1
+    tag: v0.7.0-alpha.2
     # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
     defaultRegistryUrl: ""
     # Default Shipwright build strategy for internal registries
@@ -112,7 +112,7 @@ ui:
 # ------------------------------------------------------------------
 uiOAuthSecret:
   image: ghcr.io/kagenti/kagenti/ui-oauth-secret
-  tag: v0.7.0-alpha.1
+  tag: v0.7.0-alpha.2
   # When true, mount the in-cluster serviceaccount CA
   # into the ui-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -124,7 +124,7 @@ uiOAuthSecret:
 # ------------------------------------------------------------------
 agentOAuthSecret:
   image: ghcr.io/kagenti/kagenti/agent-oauth-secret
-  tag: v0.7.0-alpha.1
+  tag: v0.7.0-alpha.2
   # When true, mount the in-cluster serviceaccount CA
   # into the agent-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -142,7 +142,7 @@ agentOAuthSecret:
 apiOAuthSecret:
   enabled: false
   image: ghcr.io/kagenti/kagenti/api-oauth-secret
-  tag: v0.7.0-alpha.1
+  tag: v0.7.0-alpha.2
   # Client ID for the API service account
   clientId: kagenti-api
   # Name of the K8s secret to store credentials
@@ -214,7 +214,7 @@ authBridge:
 spiffeIdp:
   image:
     repository: ghcr.io/kagenti/kagenti/spiffe-idp-setup
-    tag: v0.7.0-alpha.1
+    tag: v0.7.0-alpha.2
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
@@ -298,7 +298,7 @@ phoenix:
 # ------------------------------------------------------------------
 phoenixOAuthSecret:
   image: ghcr.io/kagenti/kagenti/phoenix-oauth-secret
-  tag: v0.7.0-alpha.1
+  tag: v0.7.0-alpha.2
   # Keycloak client ID for Phoenix
   clientId: phoenix
   # Kubernetes secret name to store OAuth credentials
@@ -326,7 +326,7 @@ mlflow:
 # ------------------------------------------------------------------
 mlflowOAuthSecret:
   image: ghcr.io/kagenti/kagenti/mlflow-oauth-secret
-  tag: v0.7.0-alpha.1
+  tag: v0.7.0-alpha.2
   # Keycloak client ID for MLflow
   clientId: mlflow
   # Kubernetes secret name to store OAuth credentials

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -225,7 +225,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.3.0-alpha.1
+        tag: 0.3.0-alpha.2
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -264,10 +264,10 @@ kagenti-operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.3
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.3
-      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.3
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.3
+      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.4
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.4
+      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.4
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.4
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration


### PR DESCRIPTION
## What

Bumps every image and chart-dependency reference in the kagenti chart to the newest published versions across all three repos:

| Repo | Old | New | Why |
|---|---|---|---|
| kagenti-extensions sidecars (`authbridge`, `authbridge-envoy`, `authbridge-lite`, `proxy-init`) | `v0.6.0-alpha.3` | `v0.6.0-alpha.4` | Carries the spiffe-helper → in-process go-spiffe SDK migration ([kagenti-extensions#432](https://github.com/kagenti/kagenti-extensions/pull/432)) |
| kagenti-operator subchart dep + image | `0.3.0-alpha.1` | `0.3.0-alpha.2` | Carries the unused JWTAudience field cleanup ([kagenti-operator#373](https://github.com/kagenti/kagenti-operator/pull/373)) |
| kagenti self-images (ui-v2, backend, *-oauth-secret, spiffe-idp-setup) | `v0.7.0-alpha.1` | `v0.7.0-alpha.2` | Matches the chart's own tag bump |
| Chart `version` + `appVersion` | `0.7.0-alpha.1` | `0.7.0-alpha.2` | Track the bumped self-image references |

`Chart.lock` regenerated via `helm dep update` (pulled `oci://ghcr.io/kagenti/kagenti-operator/kagenti-operator-chart:0.3.0-alpha.2`, digest `sha256:8340c8e2...`).

## Verification

- [x] All upstream tags present: `kagenti-extensions/v0.6.0-alpha.4`, `kagenti-operator/v0.3.0-alpha.2`, `kagenti/v0.7.0-alpha.2`
- [x] Container images for each tag confirmed published to ghcr.io
- [x] kagenti-operator-chart at 0.3.0-alpha.2 confirmed pullable via `helm dep update`
- [x] `helm template charts/kagenti --set spire.enabled=true --set authBridge.clientAuthType=federated-jwt` renders cleanly with 51 references to the new tags
- [x] No stragglers — `grep -rn "v0\.6\.0-alpha\.3\|0\.3\.0-alpha\.1\|v0\.7\.0-alpha\.1" charts/kagenti/` returns nothing (excluding generated `charts/` subdir)

## Why now

These tags were cut earlier today. The chart needs to point at them for `helm install kagenti charts/kagenti` from `main` to actually pick up the new behavior.

Assisted-By: Claude Code
