### PR TITLE
fix(chart): add sandboxes/finalizers RBAC for operator on v0.6.x

### DIFF
--- a/charts/kagenti/templates/operator-sandbox-rbac.yaml
+++ b/charts/kagenti/templates/operator-sandbox-rbac.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.features.agentSandbox }}
+# Supplemental RBAC for kagenti-operator to manage ownerReferences on Sandbox CRs.
+# The operator's bundled ClusterRole (0.2.x) is missing sandboxes/finalizers,
+# which causes blockOwnerDeletion failures when creating keycloak client secrets
+# owned by a Sandbox resource. Fixed upstream in operator PR #363; this template
+# provides the same permission without requiring an operator image rebuild.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kagenti.fullname" . }}-operator-sandbox-finalizers
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - agents.x-k8s.io
+  resources:
+  - sandboxes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - agent.kagenti.dev
+  resources:
+  - agentcards/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kagenti.fullname" . }}-operator-sandbox-finalizers
+  labels:
+    {{- include "kagenti.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kagenti.fullname" . }}-operator-sandbox-finalizers
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Adds supplemental ClusterRole+Binding in the kagenti chart to grant the operator SA `sandboxes/finalizers` update permission
- Gated by `features.agentSandbox` — only installed when Sandbox CRDs are in use
- Fixes `blockOwnerDeletion` failures in the ClientRegistration controller when creating keycloak client credential secrets owned by Sandbox CRs

## Root Cause

The kagenti-operator `0.2.0-rc.5` ClusterRole (`kagenti-manager-role`) has `deployments/finalizers` and `statefulsets/finalizers` but is missing `sandboxes/finalizers`. When the operator tries to create a keycloak client credentials secret with an ownerReference to a Sandbox CR and `blockOwnerDeletion: true`, the API server rejects it:

```
secrets "kagenti-keycloak-client-credentials-..." is forbidden: cannot set
blockOwnerDeletion if an ownerReference refers to a resource you can't set
finalizers on
```

This causes pods to stay stuck in `ContainerCreating` waiting for the secret indefinitely.

## Why a chart-level fix

Fixed upstream in kagenti-operator PR #363, but the subsequent operator PRs (#361, #367, #369, #370) introduce architectural changes (authbridge mode flip, image consolidation) that are scoped for v0.7.0. Bumping the operator subchart to pick up #363 would pull in breaking changes.

This supplemental RBAC template provides the same permission without requiring an operator image rebuild — removable in v0.7.0 when the operator subchart catches up.

## Test plan

- [x] Verified on OCP cluster: patching the ClusterRole resolves the error
- [x] Operator successfully creates keycloak client credentials secrets after fix
- [ ] `helm template` with `features.agentSandbox=true` renders both resources
- [ ] `helm template` with `features.agentSandbox=false` renders nothing

Assisted-By: Claude Code