### PR TITLE
fix(backend): skip Service creation for Sandbox agents

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2687,23 +2687,13 @@ def _create_or_replace_service(
     service_manifest: dict,
     workload_type: str,
 ) -> None:
-    """Create the Service for an agent / tool, with the Sandbox-controller-race
-    handling that kagenti#1581 introduced.
+    """Create the Service for an agent / tool.
 
-    Returns silently for ``WORKLOAD_TYPE_JOB`` since Jobs don't need a Service
-    (the operator's `AgentCardReconciler` doesn't reconcile Jobs).
-
-    For ``WORKLOAD_TYPE_SANDBOX`` an existing Service may have been created by
-    the agent-sandbox controller before our admission window — kagenti#1581
-    handles that 409 by deleting the controller's short-lived Service and
-    replacing it with the backend-managed ClusterIP shape. Other workload
-    types (Deployment, StatefulSet) re-raise on 409.
-
-    Used by both the image-based create flow (kagenti#1581) and the
-    source-build / Shipwright finalize flow (kagenti#1593) so the two paths
-    can't drift again.
+    Returns silently for ``WORKLOAD_TYPE_JOB`` and ``WORKLOAD_TYPE_SANDBOX``
+    since Jobs don't need a Service and the Sandbox controller manages its own
+    headless Service (ClusterIP=None).
     """
-    if workload_type == WORKLOAD_TYPE_JOB:
+    if workload_type in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
         return
     # Strip CR/LF before logging — name and namespace come from the FastAPI
     # request body. Kubernetes will reject non-DNS-1123 names so this is
@@ -2711,21 +2701,8 @@ def _create_or_replace_service(
     # py/log-injection taint analysis on the user-input → log-sink flow.
     safe_name = name.replace("\n", "").replace("\r", "")
     safe_namespace = namespace.replace("\n", "").replace("\r", "")
-    try:
-        kube.create_service(namespace=namespace, body=service_manifest)
-        logger.info("Created Service '%s' in namespace '%s'", safe_name, safe_namespace)
-    except ApiException as e:
-        if e.status == 409 and workload_type == WORKLOAD_TYPE_SANDBOX:
-            logger.warning(
-                "Service '%s' already exists (Sandbox controller race); "
-                "replacing with backend-managed ClusterIP Service",
-                safe_name,
-            )
-            kube.delete_service(namespace=namespace, name=name)
-            kube.create_service(namespace=namespace, body=service_manifest)
-            logger.info("Replaced Service '%s' in namespace '%s'", safe_name, safe_namespace)
-        else:
-            raise
+    kube.create_service(namespace=namespace, body=service_manifest)
+    logger.info("Created Service '%s' in namespace '%s'", safe_name, safe_namespace)
 
 
 def _build_service_manifest(request: "CreateAgentRequest") -> dict:
@@ -3209,16 +3186,17 @@ async def create_agent(
                 )
                 logger.info(f"Created Sandbox '{request.name}' in namespace '{request.namespace}'")
 
-            # Create Service (not needed for Jobs — Sandbox uses backend-managed
-            # Service, see _create_or_replace_service for the full rationale).
-            service_manifest = _build_service_manifest(request)
-            _create_or_replace_service(
-                kube,
-                request.namespace,
-                request.name,
-                service_manifest,
-                request.workloadType,
-            )
+            # Create Service (not needed for Jobs or Sandboxes — the Sandbox
+            # controller manages its own headless Service with ClusterIP=None).
+            if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+                service_manifest = _build_service_manifest(request)
+                _create_or_replace_service(
+                    kube,
+                    request.namespace,
+                    request.name,
+                    service_manifest,
+                    request.workloadType,
+                )
 
             # Create AgentRuntime CR so the webhook injects sidecars on pod rollout
             if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -192,10 +192,7 @@ class TestBuildServiceManifestForSandbox:
 class TestCreateOrReplaceService:
     """Tests for `_create_or_replace_service` — the shared helper used by both
     the image-based agent-create flow and the source-build / Shipwright finalize
-    flow. Covers the workload-type gate (Job → skip) and the Sandbox controller
-    409-race recovery (delete+recreate). Pre-`kagenti#1581` / `#1593` the two
-    call sites had divergent inline copies of this logic; the helper exists to
-    keep them from drifting again, and these tests pin the contract."""
+    flow. Covers the workload-type gate (Job and Sandbox → skip, others → create)."""
 
     def _service_manifest(self, name="test-agent"):
         # The helper doesn't inspect the manifest content, just passes it
@@ -219,17 +216,16 @@ class TestCreateOrReplaceService:
         kube.create_service.assert_not_called()
         kube.delete_service.assert_not_called()
 
-    def test_sandbox_creates_service(self):
-        """Sandbox must NOT be skipped — pre-`kagenti#1581` it was, breaking the
-        operator's AgentCardReconciler. This test would have caught both that
-        regression and the source-build path's parallel bug fixed by `#1593`."""
+    def test_sandbox_skips_service_creation(self):
+        """Sandbox agents don't get a backend-managed Service — the Sandbox
+        controller manages its own headless Service (ClusterIP=None)."""
         from app.routers.agents import _create_or_replace_service
 
         kube = MagicMock()
         manifest = self._service_manifest("sb")
         _create_or_replace_service(kube, "team1", "sb", manifest, WORKLOAD_TYPE_SANDBOX)
 
-        kube.create_service.assert_called_once_with(namespace="team1", body=manifest)
+        kube.create_service.assert_not_called()
         kube.delete_service.assert_not_called()
 
     def test_deployment_creates_service(self):
@@ -243,22 +239,18 @@ class TestCreateOrReplaceService:
         kube.create_service.assert_called_once_with(namespace="team1", body=manifest)
         kube.delete_service.assert_not_called()
 
-    def test_sandbox_409_replaces_existing_service(self):
-        """The agent-sandbox controller can race us by creating its own
-        short-lived Service. On 409 we delete it and recreate with our
-        backend-managed shape (kagenti#1581's pattern)."""
+    def test_sandbox_409_not_applicable(self):
+        """Sandbox workloads are skipped entirely — no race handling needed
+        since the backend never creates a Service for Sandbox agents."""
         from app.routers.agents import _create_or_replace_service
-        from kubernetes.client import ApiException
 
         kube = MagicMock()
-        # First create_service raises 409; second succeeds (after delete).
-        kube.create_service.side_effect = [ApiException(status=409), None]
         manifest = self._service_manifest("sb")
 
         _create_or_replace_service(kube, "team1", "sb", manifest, WORKLOAD_TYPE_SANDBOX)
 
-        assert kube.create_service.call_count == 2
-        kube.delete_service.assert_called_once_with(namespace="team1", name="sb")
+        kube.create_service.assert_not_called()
+        kube.delete_service.assert_not_called()
 
     def test_deployment_409_propagates(self):
         """Deployment workloads do not have a controller-race recovery — a 409
@@ -278,9 +270,9 @@ class TestCreateOrReplaceService:
         assert exc_info.value.status == 409
         kube.delete_service.assert_not_called()
 
-    def test_non_409_propagates_for_sandbox(self):
-        """Even on Sandbox, only a 409 triggers the replace path. Other API
-        errors (403, 500, etc.) propagate so callers can see real failures."""
+    def test_non_409_propagates_for_deployment(self):
+        """Non-409 errors propagate for Deployment workloads so callers can
+        see real failures (403, 500, etc.)."""
         from app.routers.agents import _create_or_replace_service
         from kubernetes.client import ApiException
         import pytest
@@ -290,7 +282,7 @@ class TestCreateOrReplaceService:
 
         with pytest.raises(ApiException) as exc_info:
             _create_or_replace_service(
-                kube, "team1", "sb", self._service_manifest("sb"), WORKLOAD_TYPE_SANDBOX
+                kube, "team1", "dep", self._service_manifest("dep"), "deployment"
             )
         assert exc_info.value.status == 500
         kube.delete_service.assert_not_called()


### PR DESCRIPTION
## Summary

- Remove backend-managed ClusterIP Service creation for Sandbox workload types
- The Sandbox controller manages its own headless Service (`ClusterIP=None`); the backend creating a regular ClusterIP Service caused an immutable field conflict that blocked the Sandbox from reaching Ready
- Simplify `_create_or_replace_service` to early-return for both Job and Sandbox workloads

## Root Cause

When the backend created a Sandbox CR, it also created a regular `ClusterIP` Service with the same name. The Sandbox controller then tried to adopt/create its own headless Service (`ClusterIP: None`), but Kubernetes rejected the mutation because `spec.clusterIP` is immutable. This left the Sandbox permanently stuck in `ReconcilerError` state.

## Test plan

- [ ] Deploy agent with workload type `sandbox` on OpenShift — verify Sandbox reaches Ready
- [ ] Verify no ClusterIP Service is created by the backend for sandbox agents
- [ ] Verify the Sandbox controller creates its own headless Service
- [ ] Verify non-sandbox agents (Deployment, StatefulSet) still get their Service created normally
- [ ] Kind e2e tests pass (existing Sandbox test coverage)

Assisted-By: Claude Code