### PR TITLE
feat: gate OTel Helm resources for operator-managed bootstrap

### DIFF
--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -155,6 +155,7 @@ spec:
       port: 8335
       targetPort: 8335
   type: ClusterIP
+{{- if not .Values.otelBootstrap.operatorManaged }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -166,6 +167,7 @@ metadata:
 data:
   base.yaml: |
     {{- include "kagenti.otel.collectorConfig" . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- if and .Values.components.otel.enabled (.Capabilities.APIVersions.Has "security.istio.io/v1") }}
 ---

--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -155,6 +155,8 @@ spec:
       port: 8335
       targetPort: 8335
   type: ClusterIP
+{{- /* ConfigMap is operator-managed when otelBootstrap.operatorManaged=true;
+       Service and Deployment above remain Helm-managed in all modes. */}}
 {{- if not .Values.otelBootstrap.operatorManaged }}
 ---
 apiVersion: v1

--- a/charts/kagenti-deps/templates/otel-ingress-ca-job.yaml
+++ b/charts/kagenti-deps/templates/otel-ingress-ca-job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.openshift .Values.components.otel.enabled .Values.components.mlflow.enabled .Values.mlflow.auth.enabled }}
+{{- if and (not .Values.otelBootstrap.operatorManaged) .Values.openshift .Values.components.otel.enabled .Values.components.mlflow.enabled .Values.mlflow.auth.enabled }}
 # Copy OpenShift ingress CA certificate for OTEL collector OAuth2 client
 # The ingress CA is needed to verify TLS when connecting to external Keycloak URL
 ---

--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -1,5 +1,12 @@
 # Global settings
 openshift: true
+
+# When true, the kagenti-operator handles OTel collector bootstrap (ingress CA
+# trust and ConfigMap assembly) at startup via its OtelBootstrapRunnable. The
+# Helm-based otel-ingress-ca-job and inline otel-collector-config ConfigMap are
+# skipped. Set to true when the operator chart has otelBootstrap.enable: true.
+otelBootstrap:
+  operatorManaged: false
 # OpenShift version (e.g., "4.20.8") - if provided, skips cluster lookup for version detection
 # This is useful when helm diff/template can't access the cluster for lookups
 ocpVersion: ""

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -23,6 +23,7 @@
 #   ./scripts/ocp/setup-kagenti.sh --skip-ovn-patch             # Skip OVN gateway patch
 #   ./scripts/ocp/setup-kagenti.sh --skip-mcp-gateway           # Skip MCP Gateway install
 #   ./scripts/ocp/setup-kagenti.sh --skip-mlflow                # Disable Kagenti-Operator <-> MLflow integration
+#   ./scripts/ocp/setup-kagenti.sh --otel-operator-managed      # Let the operator handle OTel collector config
 #   ./scripts/ocp/setup-kagenti.sh --operator-repo ~/kagenti-operator  # Use local operator chart
 #   ./scripts/ocp/setup-kagenti.sh --operator-image quay.io/user/kagenti-operator:dev  # Custom operator image
 #   ./scripts/ocp/setup-kagenti.sh --operator-repo ~/kagenti-operator --operator-image quay.io/user/op:dev  # Both
@@ -66,6 +67,7 @@ KUADRANT_VERSION="1.4.2"
 MLFLOW_NAMESPACE="redhat-ods-applications"
 MLFLOW_INSTANCE_NAME="mlflow"
 MLFLOW_TRACES_ENDPOINT=""
+OTEL_OPERATOR_MANAGED=false
 
 # Colors
 RED='\033[0;31m'
@@ -89,6 +91,7 @@ while [[ $# -gt 0 ]]; do
     --skip-mcp-gateway)   SKIP_MCP_GATEWAY=true; shift ;;
     --skip-ui)            SKIP_UI=true; shift ;;
     --skip-mlflow)        SKIP_MLFLOW=true; shift ;;
+    --otel-operator-managed) OTEL_OPERATOR_MANAGED=true; shift ;;
     --show-secrets)       SHOW_SECRETS=true; shift ;;
     --operator-repo)      OPERATOR_REPO="$2"; shift 2 ;;
     --operator-image)     OPERATOR_IMAGE="$2"; shift 2 ;;
@@ -110,6 +113,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --skip-mcp-gateway        Skip MCP Gateway installation"
       echo "  --skip-ui                 Skip Kagenti UI and backend installation"
       echo "  --skip-mlflow             Skip MLflow integration (OTel traces + operator auto-config)"
+      echo "  --otel-operator-managed   Let the kagenti-operator handle OTel collector config (skip Helm OTel wiring)"
       echo "  --show-secrets            Print Keycloak admin credentials to stdout (omitted by default for CI safety)"
       echo "  --with-kiali              Enable Kiali + Prometheus (user workload monitoring)"
       echo "  --with-builds             Enable Tekton + OpenShift Builds (Shipwright)"
@@ -667,8 +671,12 @@ _helm_kagenti_deps() {
   done
 
   # Build MLflow OTEL flags: enable the pipeline and point it at the DSC-managed endpoint.
+  # When --otel-operator-managed is set, the operator handles ConfigMap assembly
+  # and MLflow endpoint discovery at startup, so we skip injecting OTel values.
   KAGENTI_DEPS_MLFLOW_VALS_FILE=""
-  if [ -n "$MLFLOW_TRACES_ENDPOINT" ]; then
+  if [ "$OTEL_OPERATOR_MANAGED" = true ]; then
+    log_info "OTel collector config managed by kagenti-operator — skipping Helm OTel MLflow values"
+  elif [ -n "$MLFLOW_TRACES_ENDPOINT" ]; then
     KAGENTI_DEPS_MLFLOW_VALS_FILE=$(mktemp /tmp/kagenti-mlflow-vals-XXXXXX.yaml)
     cat > "$KAGENTI_DEPS_MLFLOW_VALS_FILE" <<EOF
 otel:
@@ -701,6 +709,9 @@ EOF
     ${KAGENTI_DEPS_MLFLOW_VALS_FILE:+-f "$KAGENTI_DEPS_MLFLOW_VALS_FILE"}
     --no-hooks
   )
+  if [ "$OTEL_OPERATOR_MANAGED" = true ]; then
+    KAGENTI_DEPS_HELM_ARGS+=(--set otelBootstrap.operatorManaged=true)
+  fi
 
   if helm status kagenti-deps -n kagenti-system &>/dev/null; then
     # Upgrade path: skip hooks (the kiali hook will fail on any cluster where
@@ -1109,8 +1120,12 @@ DSCEOF
     return 0
   fi
 
-  # Upgrade kagenti-deps to wire OTEL collector to the MLflow endpoint
-  if [ -n "$MLFLOW_TRACES_ENDPOINT" ]; then
+  # Upgrade kagenti-deps to wire OTEL collector to the MLflow endpoint.
+  # When --otel-operator-managed, the operator discovers the endpoint from the
+  # MLflow CR at startup and assembles the ConfigMap — no Helm upgrade needed.
+  if [ "$OTEL_OPERATOR_MANAGED" = true ]; then
+    log_info "OTel collector config managed by kagenti-operator — skipping Helm OTEL endpoint upgrade"
+  elif [ -n "$MLFLOW_TRACES_ENDPOINT" ]; then
     log_info "Upgrading kagenti-deps with MLflow OTEL endpoint..."
 
     # Adopt cert-manager resources created by _ensure_rhoai_shared_trust (Step 3b)

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -675,6 +675,8 @@ _helm_kagenti_deps() {
   # and MLflow endpoint discovery at startup, so we skip injecting OTel values.
   KAGENTI_DEPS_MLFLOW_VALS_FILE=""
   if [ "$OTEL_OPERATOR_MANAGED" = true ]; then
+    [ -n "$MLFLOW_TRACES_ENDPOINT" ] && \
+      log_warn "--otel-operator-managed set; ignoring MLFLOW_TRACES_ENDPOINT=$MLFLOW_TRACES_ENDPOINT"
     log_info "OTel collector config managed by kagenti-operator — skipping Helm OTel MLflow values"
   elif [ -n "$MLFLOW_TRACES_ENDPOINT" ]; then
     KAGENTI_DEPS_MLFLOW_VALS_FILE=$(mktemp /tmp/kagenti-mlflow-vals-XXXXXX.yaml)


### PR DESCRIPTION
> **Merge after:** https://github.com/kagenti/kagenti-operator/pull/376

## Summary

Adds an `otelBootstrap.operatorManaged` toggle to the `kagenti-deps` Helm chart and an `--otel-operator-managed` flag to the OCP setup script. When enabled, the Helm chart defers OTel collector ConfigMap assembly and ingress CA trust to the kagenti-operator's bootstrap runnable instead of rendering them itself.

## Changes

- **`charts/kagenti-deps/values.yaml`** — new `otelBootstrap.operatorManaged` flag (default `false`)
- **`charts/kagenti-deps/templates/otel-collector.yaml`** — gate the `otel-collector-config` ConfigMap behind `{{- if not .Values.otelBootstrap.operatorManaged }}`
- **`charts/kagenti-deps/templates/otel-ingress-ca-job.yaml`** — gate the entire Job behind the same toggle
- **`scripts/ocp/setup-kagenti.sh`** — new `--otel-operator-managed` flag that:
  - Skips injecting MLflow OTel values into the Helm args
  - Passes `--set otelBootstrap.operatorManaged=true` to `kagenti-deps`
  - Skips the deferred `helm upgrade` for OTel endpoint wiring
  - MLflow provisioning (DSC, CR, RBAC) remains unchanged

## Test Plan

- [x] `helm template` renders ConfigMap and Job when `otelBootstrap.operatorManaged` is unset
- [x] `helm template` omits ConfigMap and Job when `otelBootstrap.operatorManaged=true`
- [x] `setup-kagenti.sh --otel-operator-managed` logs skip messages and passes the flag to Helm
- [x] Full end-to-end: setup script + operator with `otelBootstrap.enable=true` on OCP cluster

Made with [Cursor](https://cursor.com)