### PR TITLE
fix(skills): add --with-skills flag, fix image loading, and update docs

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -393,11 +393,16 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list"]
   # ConfigMaps: list/get for reads; create/update/patch for AuthBridge finalize
-  # (authbridge-config, envoy-config, spiffe-helper-config, authproxy-routes merge);
-  # delete required for skill deletion via the Skills API.
+  # (authbridge-config, envoy-config, spiffe-helper-config, authproxy-routes merge).
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "create", "update", "patch"]
+  {{- if .Values.featureFlags.skills }}
+  # Skills-specific: delete required for skill deletion via the Skills API.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["delete"]
+  {{- end }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -393,10 +393,11 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list"]
   # ConfigMaps: list/get for reads; create/update/patch for AuthBridge finalize
-  # (authbridge-config, envoy-config, spiffe-helper-config, authproxy-routes merge)
+  # (authbridge-config, envoy-config, spiffe-helper-config, authproxy-routes merge);
+  # delete required for skill deletion via the Skills API.
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "create", "update", "patch"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]

--- a/docs/demos/demo-generic-agent-skill.md
+++ b/docs/demos/demo-generic-agent-skill.md
@@ -2,8 +2,8 @@
 
 This guide explains how to use the Kagenti UI to:
 
-1. import the example [`summarizer`](../agent-examples/skills/summarizer) skill,
-2. import the example [`generic_agent`](../agent-examples/a2a/generic_agent) agent,
+1. import the example [`summarizer`](https://github.com/kagenti/agent-examples/tree/main/skills/summarizer) skill,
+2. import the example [`generic_agent`](https://github.com/kagenti/agent-examples/tree/main/a2a/generic_agent) agent,
 3. link the skill to the agent from the UI,
 4. and verify in chat that the skill is available and being used.
 
@@ -23,6 +23,8 @@ The example generic agent loads skill instructions and exposes them through its 
 Before starting, make sure:
 
 - Kagenti is installed and the UI is reachable, as described in [`docs/install.md`](../install.md)
+- **the Skills feature flag is enabled** — Skills are disabled by default and must be explicitly enabled during installation (see [Enabling Skills](../skills.md#enabling-skills))
+- **the build system is deployed** — Agent builds require Shipwright and the in-cluster registry (`registry.cr-system.svc.cluster.local:5000`). Deploy with `--with-builds` or the build push step will fail with `no such host`. If you need to add it to an existing cluster: `scripts/kind/setup-kagenti.sh --with-builds --skip-cluster`
 - you have access to a Kagenti-enabled namespace, for example `team1`
 - the cluster can build example agents from GitHub
 - you have LLM credentials ready for the generic agent
@@ -205,6 +207,41 @@ For a live demo, use this sequence:
 
 ## Troubleshooting
 
+### The Skills section is not visible in the UI
+
+The Skills feature is disabled by default. If the Skills navigation item or the **Import Skill** button is missing, the feature flag was not enabled at install time. See [Enabling Skills](../skills.md#enabling-skills) for how to enable it with the setup script (`--with-skills`) or how to enable it on an existing cluster with `helm upgrade` without a full redeploy.
+
+### The build fails with `no such host` when pushing the image
+
+The in-cluster registry was not deployed. Re-run setup with `--with-builds`:
+
+```bash
+scripts/kind/setup-kagenti.sh --with-backend --with-ui --with-skills --with-builds --build-images --skip-cluster
+```
+
+`--with-builds` deploys Shipwright and the container registry at `registry.cr-system.svc.cluster.local:5000` that agent builds push to.
+
+### The Linked Skills section is missing from the Import Agent form
+
+The Linked Skills section was added after the `v0.7.0-alpha.2` release. If the running UI image predates that, the section will not appear at all. Rebuild the UI from local source and reload it into Kind:
+
+```bash
+export KAGENTI_FEATURE_FLAG_SKILLS=true
+scripts/kind/setup-kagenti.sh --with-backend --with-ui --with-skills --build-images --skip-cluster
+```
+
+### "Agent already exists" error when reimporting after a failed build
+
+If a previous import attempt failed mid-way (for example, the build pod errored out), leftover Shipwright and Kubernetes resources remain in the namespace and block a fresh import. Delete them before retrying, replacing `<agent-name>` and `<namespace>` with your values:
+
+```bash
+kubectl delete buildrun -n <namespace> -l app=<agent-name>
+kubectl delete build <agent-name> -n <namespace>
+kubectl delete configmap <agent-name>-card-unsigned -n <namespace>
+```
+
+Then retry the import in the UI.
+
 ### The summarizer skill does not appear in the Linked Skills section
 
 Check that:
@@ -254,3 +291,4 @@ After the demo, delete the agent and skill from the Kagenti UI:
 - [`docs/demos/demo-generic-agent.md`](./demo-generic-agent.md)
 - [`docs/install.md`](../install.md)
 - [`docs/local-models.md`](../local-models.md)
+- [`docs/skills.md`](../skills.md) — Skills feature flag, enabling instructions, and troubleshooting

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -60,10 +60,29 @@ After enabling the feature flag and restarting/upgrading your deployment:
 2. **Look for Skills Section**: The Skills management interface should now be visible in the navigation menu
 3. **Verify Backend**: Check the backend logs to confirm skills routes are registered:
    ```bash
-   kubectl logs -n kagenti-system -l app=kagenti-backend | grep "skills routes registered"
+   kubectl logs -n kagenti-system -l app.kubernetes.io/name=kagenti-backend | grep "skills routes registered"
    ```
 
 Once enabled, the Skills management interface will be accessible through the UI, allowing you to configure and deploy skills for your agents.
+
+## Troubleshooting
+
+### Skills not appearing after setup
+
+If the skills feature was not enabled during initial setup (e.g., the `KAGENTI_FEATURE_FLAG_SKILLS` env var was set but `--with-skills` was not passed, or `--with-all` was used with an older script version), you can enable it without redeploying the full cluster:
+
+```bash
+helm upgrade kagenti charts/kagenti -n kagenti-system \
+  --set featureFlags.skills=true \
+  --set openshift=false \
+  -f charts/kagenti/values.yaml
+```
+
+This triggers a rolling restart of the backend and UI pods with the flag enabled. Verify afterwards:
+
+```bash
+kubectl logs -n kagenti-system -l app.kubernetes.io/name=kagenti-backend | grep "skills routes registered"
+```
 
 ## Accessing Skills via REST API
 

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -48,6 +48,7 @@ WITH_BUILDS=false
 WITH_KIALI=false
 WITH_KUADRANT=false
 WITH_AGENT_SANDBOX=false
+WITH_SKILLS=false
 WITH_ALL=false
 SKIP_CLUSTER=false
 SKIP_MLFLOW=false
@@ -84,6 +85,16 @@ run_cmd() {
   if $DRY_RUN; then echo "  [dry-run] $*"; else "$@"; fi
 }
 
+# Load a single image into the Kind node via docker save piped to ctr import.
+# Avoids 'kind load docker-image' failures (e.g. "failed to detect containerd
+# snapshotter") on WSL2 and Rancher Desktop.
+load_image_into_kind() {
+  local img="$1"
+  $CONTAINER_ENGINE save "$img" | \
+    $CONTAINER_ENGINE exec -i "${CLUSTER_NAME}-control-plane" \
+      ctr --namespace=k8s.io images import -
+}
+
 # ── Argument parsing ────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -98,6 +109,7 @@ while [[ $# -gt 0 ]]; do
     --with-builds)      WITH_BUILDS=true; shift ;;
     --with-kiali)       WITH_KIALI=true; shift ;;
     --with-agent-sandbox) WITH_AGENT_SANDBOX=true; shift ;;
+    --with-skills)      WITH_SKILLS=true; shift ;;
     --with-all)         WITH_ALL=true; shift ;;
     --skip-cluster)     SKIP_CLUSTER=true; shift ;;
     --skip-mlflow)      SKIP_MLFLOW=true; shift ;;
@@ -157,7 +169,7 @@ done
 if $WITH_ALL; then
   WITH_ISTIO=true; WITH_SPIRE=true; WITH_BACKEND=true; WITH_UI=true
   WITH_MCP_GATEWAY=true; WITH_OTEL=true; WITH_BUILDS=true; WITH_KIALI=true
-  WITH_AGENT_SANDBOX=true
+  WITH_AGENT_SANDBOX=true; WITH_SKILLS=true
   $SKIP_MLFLOW    || WITH_MLFLOW=true
   $SKIP_KUADRANT  || WITH_KUADRANT=true
 fi
@@ -206,7 +218,8 @@ echo "    OTel:          $WITH_OTEL"
 echo "    MLflow:        $WITH_MLFLOW"
 echo "    Builds:        $WITH_BUILDS"
 echo "    Kiali:         $WITH_KIALI"
-echo "    Agent Sandbox: $WITH_AGENT_SANDBOX"
+echo "    Agent Sandbox: $WITH_AGENT_SANDBOX
+    Skills:        $WITH_SKILLS"
 echo "    Skip cluster:  $SKIP_CLUSTER"
 echo "    Build images:  $BUILD_IMAGES"
 echo "    Preload imgs:  $PRELOAD_IMAGES"
@@ -583,7 +596,7 @@ log_success "kagenti-deps installed"
 echo ""
 
 # ── Configure Kind node to reach in-cluster container registry ──────────────
-if $WITH_BUILDS && ! $SKIP_CLUSTER; then
+if $WITH_BUILDS; then
   REGISTRY_NAME="registry"
   REGISTRY_NS="cr-system"
   REGISTRY_HOST="${REGISTRY_NAME}.${REGISTRY_NS}.svc.cluster.local"
@@ -594,9 +607,10 @@ if $WITH_BUILDS && ! $SKIP_CLUSTER; then
   if ! $DRY_RUN; then
     CLUSTER_IP=$(kubectl get svc "$REGISTRY_NAME" -n "$REGISTRY_NS" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
     if [ -n "$CLUSTER_IP" ]; then
-      # Add registry DNS to Kind node's /etc/hosts
+      # Upsert registry DNS in Kind node's /etc/hosts (replace stale entry if present).
+      # /etc/hosts is a bind mount so sed -i (rename) fails; use grep -v + cat > instead.
       $CONTAINER_ENGINE exec "${CLUSTER_NAME}-control-plane" \
-        sh -c "echo '${CLUSTER_IP} ${REGISTRY_HOST}' >> /etc/hosts"
+        sh -c "grep -v '${REGISTRY_HOST}' /etc/hosts > /tmp/hosts.tmp && cat /tmp/hosts.tmp > /etc/hosts && echo '${CLUSTER_IP} ${REGISTRY_HOST}' >> /etc/hosts"
 
       # Configure containerd registry mirror for insecure in-cluster registry
       $CONTAINER_ENGINE exec "${CLUSTER_NAME}-control-plane" sh -c "
@@ -936,11 +950,11 @@ EOF
   # Build and load spiffe-idp-setup image to ensure correct arch for Kind
   if $BUILD_IMAGES; then
     log_info "Building spiffe-idp-setup image for Kind..."
-    $CONTAINER_ENGINE build --load \
+    $CONTAINER_ENGINE buildx build --load \
       -t "$SPIFFE_IDP_IMAGE" \
       -f "$REPO_ROOT/kagenti/auth/spiffe-idp-setup/Dockerfile" \
       "$REPO_ROOT/kagenti"
-    kind load docker-image "$SPIFFE_IDP_IMAGE" --name "$CLUSTER_NAME"
+    load_image_into_kind "$SPIFFE_IDP_IMAGE"
   fi
 
   # Delete existing job (jobs are immutable)
@@ -1090,8 +1104,8 @@ if $BUILD_IMAGES && ! $DRY_RUN; then
   for spec in "${_BUILD_IMAGES[@]}"; do
     IFS='|' read -r img dockerfile <<< "$spec"
     log_info "  Building ${img}..."
-    $CONTAINER_ENGINE build --load -t "$img" -f "$BUILD_CONTEXT/$dockerfile" "$BUILD_CONTEXT"
-    kind load docker-image "$img" --name "$CLUSTER_NAME"
+    $CONTAINER_ENGINE buildx build --load -t "$img" -f "$BUILD_CONTEXT/$dockerfile" "$BUILD_CONTEXT"
+    load_image_into_kind "$img"
   done
   log_success "Platform images built and loaded into Kind"
 fi
@@ -1113,6 +1127,7 @@ KAGENTI_FLAGS=(
   --set "components.istio.enabled=${WITH_ISTIO}"
   --set "components.mcpGateway.enabled=${WITH_MCP_GATEWAY}"
   --set "featureFlags.agentSandbox=${WITH_AGENT_SANDBOX}"
+  --set "featureFlags.skills=${WITH_SKILLS}"
   --set "components.mlflow.enabled=${WITH_MLFLOW}"
   --set "ui.auth.enabled=$($WITH_SPIRE && echo true || echo false)"
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -218,8 +218,8 @@ echo "    OTel:          $WITH_OTEL"
 echo "    MLflow:        $WITH_MLFLOW"
 echo "    Builds:        $WITH_BUILDS"
 echo "    Kiali:         $WITH_KIALI"
-echo "    Agent Sandbox: $WITH_AGENT_SANDBOX
-    Skills:        $WITH_SKILLS"
+echo "    Agent Sandbox: $WITH_AGENT_SANDBOX"
+echo "    Skills:        $WITH_SKILLS"
 echo "    Skip cluster:  $SKIP_CLUSTER"
 echo "    Build images:  $BUILD_IMAGES"
 echo "    Preload imgs:  $PRELOAD_IMAGES"
@@ -610,7 +610,7 @@ if $WITH_BUILDS; then
       # Upsert registry DNS in Kind node's /etc/hosts (replace stale entry if present).
       # /etc/hosts is a bind mount so sed -i (rename) fails; use grep -v + cat > instead.
       $CONTAINER_ENGINE exec "${CLUSTER_NAME}-control-plane" \
-        sh -c "grep -v '${REGISTRY_HOST}' /etc/hosts > /tmp/hosts.tmp && cat /tmp/hosts.tmp > /etc/hosts && echo '${CLUSTER_IP} ${REGISTRY_HOST}' >> /etc/hosts"
+        sh -c "{ grep -v '${REGISTRY_HOST}' /etc/hosts || true; } > /tmp/hosts.tmp && cat /tmp/hosts.tmp > /etc/hosts && echo '${CLUSTER_IP} ${REGISTRY_HOST}' >> /etc/hosts"
 
       # Configure containerd registry mirror for insecure in-cluster registry
       $CONTAINER_ENGINE exec "${CLUSTER_NAME}-control-plane" sh -c "


### PR DESCRIPTION
Closes #1667.

## Summary

- Add `--with-skills` flag to `setup-kagenti.sh` and wire it to `featureFlags.skills` in Helm so the Skills feature flag actually reaches the backend (previously the env var export was silently ignored)
- Include `--with-skills` in `--with-all`
- Replace `docker build --load` with `docker buildx build --load` (`--load` is a buildx-only flag)
- Replace `kind load docker-image` with a `load_image_into_kind()` helper that uses `docker save | ctr import` — avoids "failed to detect containerd snapshotter" on WSL2
- Fix registry `/etc/hosts` upsert: run unconditionally (not only on fresh cluster), use `grep -v + cat >` instead of `sed -i` (bind-mount safe)
- Fix kubectl label selector in docs: `app=kagenti-backend` → `app.kubernetes.io/name=kagenti-backend`
- Add Troubleshooting sections to `docs/skills.md` and `docs/demos/demo-generic-agent-skill.md`

## Test plan

- [ ] `scripts/kind/setup-kagenti.sh --with-skills --skip-cluster` enables skills on existing cluster
- [ ] `--with-all` enables skills
- [ ] `--build-images` completes without `--load` or snapshotter errors on WSL2
- [ ] Re-running with `--with-builds --skip-cluster` correctly updates the registry hosts entry
- [ ] `kubectl logs -n kagenti-system -l app.kubernetes.io/name=kagenti-backend | grep "skills routes registered"` returns output when flag is on

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

Assisted-By: Claude Code