### PR TITLE
fix(backend): restore backend-managed Service for Sandbox agents

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -866,7 +866,7 @@ async def get_agent(
 
     # Try to get the associated Service (not applicable for Jobs)
     service = None
-    if workload_type not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+    if workload_type != WORKLOAD_TYPE_JOB:
         try:
             service = kube.get_service(namespace=namespace, name=name)
         except ApiException as e:
@@ -2807,11 +2807,12 @@ def _create_or_replace_service(
 ) -> None:
     """Create the Service for an agent / tool.
 
-    Returns silently for ``WORKLOAD_TYPE_JOB`` and ``WORKLOAD_TYPE_SANDBOX``
-    since Jobs don't need a Service and the Sandbox controller manages its own
-    headless Service (ClusterIP=None).
+    Returns silently for ``WORKLOAD_TYPE_JOB`` since Jobs don't need a Service.
+    Sandbox agents get a backend-managed ClusterIP Service for port translation
+    (8080→8000); the agent-sandbox controller's own Service is suppressed via
+    ``spec.service: false`` on the Sandbox CR (v0.4.6+).
     """
-    if workload_type in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+    if workload_type == WORKLOAD_TYPE_JOB:
         return
     # Strip CR/LF before logging — name and namespace come from the FastAPI
     # request body. Kubernetes will reject non-DNS-1123 names so this is
@@ -3124,6 +3125,7 @@ def _build_sandbox_manifest(
         },
         "spec": {
             "replicas": 1,
+            "service": False,
             "podTemplate": {
                 "metadata": {
                     "labels": {
@@ -3332,9 +3334,8 @@ async def create_agent(
                 )
                 logger.info(f"Created Sandbox '{request.name}' in namespace '{request.namespace}'")
 
-            # Create Service (not needed for Jobs or Sandboxes — the Sandbox
-            # controller manages its own headless Service with ClusterIP=None).
-            if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+            # Create Service (not needed for Jobs).
+            if request.workloadType != WORKLOAD_TYPE_JOB:
                 service_manifest = _build_service_manifest(request)
                 _create_or_replace_service(
                     kube,
@@ -3910,9 +3911,8 @@ async def finalize_shipwright_build(
             kube.create_sandbox(namespace=namespace, body=sandbox_manifest)
             logger.info(f"Created Sandbox '{name}' in namespace '{namespace}' from build")
 
-        # Create Service via the shared _create_or_replace_service helper —
-        # gates on workload_type and handles the Sandbox controller race the
-        # same way the image-based create flow does.
+        # Create Service via the shared _create_or_replace_service helper
+        # (skips only for Job workloads).
         service_manifest = _build_service_manifest(agent_request)
         # Carry forward build-time kagenti.io/* labels onto the Service so
         # downstream label-based selectors / queries match. Use

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -59,14 +59,15 @@ class TestBuildSandboxManifest:
         port_env = next(ev for ev in container["env"] if ev.get("name") == "PORT")
         assert port_env["value"] == str(DEFAULT_IN_CLUSTER_PORT)
 
-    def test_no_service_field_in_spec(self):
-        """Sandbox spec must NOT include a service field (unsupported in released CRD)."""
+    def test_service_false_in_spec(self):
+        """Sandbox spec sets service: false to prevent agent-sandbox controller
+        from creating a conflicting headless Service (v0.4.6+ opt-in behavior)."""
         from app.routers.agents import _build_sandbox_manifest
 
         request = _make_request()
         manifest = _build_sandbox_manifest(request=request, image="test:latest")
 
-        assert "service" not in manifest["spec"]
+        assert manifest["spec"]["service"] is False
 
     def test_custom_service_ports_override_container_port(self):
         """When servicePorts are provided, containerPort uses targetPort from first entry."""
@@ -193,7 +194,7 @@ class TestBuildServiceManifestForSandbox:
 class TestCreateOrReplaceService:
     """Tests for `_create_or_replace_service` — the shared helper used by both
     the image-based agent-create flow and the source-build / Shipwright finalize
-    flow. Covers the workload-type gate (Job and Sandbox → skip, others → create)."""
+    flow. Covers the workload-type gate (Job → skip, others → create)."""
 
     def _service_manifest(self, name="test-agent"):
         # The helper doesn't inspect the manifest content, just passes it
@@ -217,17 +218,17 @@ class TestCreateOrReplaceService:
         kube.create_service.assert_not_called()
         kube.delete_service.assert_not_called()
 
-    def test_sandbox_skips_service_creation(self):
-        """Sandbox agents don't get a backend-managed Service — the Sandbox
-        controller manages its own headless Service (ClusterIP=None)."""
+    def test_sandbox_creates_service(self):
+        """Sandbox agents get a backend-managed ClusterIP Service for port
+        translation (8080→8000). The agent-sandbox controller's headless
+        Service is suppressed via spec.service: false on the Sandbox CR."""
         from app.routers.agents import _create_or_replace_service
 
         kube = MagicMock()
         manifest = self._service_manifest("sb")
         _create_or_replace_service(kube, "team1", "sb", manifest, WORKLOAD_TYPE_SANDBOX)
 
-        kube.create_service.assert_not_called()
-        kube.delete_service.assert_not_called()
+        kube.create_service.assert_called_once_with(namespace="team1", body=manifest)
 
     def test_deployment_creates_service(self):
         """Deployment workloads always get a Service — the most common path."""
@@ -240,18 +241,19 @@ class TestCreateOrReplaceService:
         kube.create_service.assert_called_once_with(namespace="team1", body=manifest)
         kube.delete_service.assert_not_called()
 
-    def test_sandbox_409_not_applicable(self):
-        """Sandbox workloads are skipped entirely — no race handling needed
-        since the backend never creates a Service for Sandbox agents."""
+    def test_sandbox_409_propagates(self):
+        """Sandbox workloads now create a Service — a 409 is a real conflict
+        and must propagate (same as Deployment workloads)."""
         from app.routers.agents import _create_or_replace_service
+        from kubernetes.client import ApiException
+        import pytest
 
         kube = MagicMock()
+        kube.create_service.side_effect = ApiException(status=409)
         manifest = self._service_manifest("sb")
 
-        _create_or_replace_service(kube, "team1", "sb", manifest, WORKLOAD_TYPE_SANDBOX)
-
-        kube.create_service.assert_not_called()
-        kube.delete_service.assert_not_called()
+        with pytest.raises(ApiException):
+            _create_or_replace_service(kube, "team1", "sb", manifest, WORKLOAD_TYPE_SANDBOX)
 
     def test_deployment_409_propagates(self):
         """Deployment workloads do not have a controller-race recovery — a 409

--- a/scripts/openshell/deploy-shared.sh
+++ b/scripts/openshell/deploy-shared.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # ── Versions (keep in sync with scripts/kind/setup-kagenti.sh) ──────────────
-AGENT_SANDBOX_VERSION="v0.3.10"
+AGENT_SANDBOX_VERSION="v0.4.6"
 GATEWAY_API_VERSION="v1.4.0"
 
 # ── Defaults ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Reverts the PR #1661 skip logic that removed Service creation for Sandbox workloads
- Backend now creates a ClusterIP Service (port 8080→8000) for Sandbox agents, restoring the port translation needed by the platform
- Sets `spec.service: false` on the Sandbox CR to suppress the agent-sandbox controller's conflicting headless Service (v0.4.6+ behavior)
- Aligns `scripts/openshell/deploy-shared.sh` to agent-sandbox v0.4.6 (matching `kind/setup-kagenti.sh` and `ocp/setup-kagenti.sh`)
- Also fixes the GET agent path to correctly fetch Service info for Sandbox agents

## Context

The agent-sandbox controller creates a headless Service (`ClusterIP=None`) which cannot perform port translation—kube-proxy is not in the path for headless Services. Kagenti agents listen on port 8000 but the platform addresses them at port 8080, requiring a ClusterIP Service for the 8080→8000 translation.

With agent-sandbox v0.4.6 ([PR #775](https://github.com/kubernetes-sigs/agent-sandbox/pull/775), [PR #800](https://github.com/kubernetes-sigs/agent-sandbox/pull/800)), Service creation became opt-in via `spec.service: true`. Setting `spec.service: false` explicitly suppresses it, preventing conflicts with the backend-managed Service.

## Test plan

- [x] Unit tests pass (18/18 in `test_sandbox_manifest.py`)
- [ ] Kind: deploy contact-extractor agent, verify agent card fetchable at port 8080
- [ ] OpenShift: same verification with agent-sandbox v0.4.6

Assisted-By: Claude Code