### PR TITLE
feat(installer): add --skip-mlflow and --skip-kuadrant to Kind installer

### DIFF
--- a/.github/scripts/local-setup/kind-full-test.sh
+++ b/.github/scripts/local-setup/kind-full-test.sh
@@ -28,6 +28,8 @@
 #     --skip-test                  Skip running E2E tests
 #     --skip-kagenti-uninstall     Skip Kagenti uninstall (default: skipped)
 #     --skip-cluster-destroy       Skip cluster destruction (keep for debugging)
+#     --skip-mlflow                Skip MLflow deployment (saves ~2 GB memory)
+#     --skip-kuadrant              Skip Kuadrant deployment (saves ~1 GB memory)
 #
 #   Other options:
 #     --clean-kagenti    Uninstall Kagenti before installing (fresh install)
@@ -45,6 +47,9 @@
 #
 #   # Fresh kagenti on existing cluster
 #   ./.github/scripts/local-setup/kind-full-test.sh --skip-cluster-create --clean-kagenti --skip-cluster-destroy
+#
+#   # Lightweight install (4 vCPU / 12-16 GB VM)
+#   ./.github/scripts/local-setup/kind-full-test.sh --skip-mlflow --skip-kuadrant --skip-cluster-destroy
 #
 #   # Final cleanup - only destroy
 #   ./.github/scripts/local-setup/kind-full-test.sh --include-cluster-destroy
@@ -80,6 +85,8 @@ SKIP_AGENTS=false
 SKIP_TEST=false
 SKIP_KAGENTI_UNINSTALL=false
 SKIP_DESTROY=false
+SKIP_MLFLOW=false
+SKIP_KUADRANT=false
 INCLUDE_KAGENTI_UNINSTALL=false
 CLEAN_KAGENTI=false
 KAGENTI_ENV="${KAGENTI_ENV:-dev}"
@@ -142,6 +149,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-cluster-destroy)
             SKIP_DESTROY=true
+            shift
+            ;;
+        --skip-mlflow)
+            SKIP_MLFLOW=true
+            shift
+            ;;
+        --skip-kuadrant)
+            SKIP_KUADRANT=true
             shift
             ;;
         --clean-kagenti)
@@ -247,7 +262,10 @@ if [ "$RUN_INSTALL" = "true" ]; then
     ./.github/scripts/common/20-create-secrets.sh
 
     log_step "Running Kagenti installer..."
-    ./scripts/kind/setup-kagenti.sh --with-all --skip-cluster --build-images --cluster-name "$CLUSTER_NAME"
+    SETUP_ARGS=(--with-all --skip-cluster --build-images --cluster-name "$CLUSTER_NAME")
+    [ "$SKIP_MLFLOW" = "true" ] && SETUP_ARGS+=(--skip-mlflow)
+    [ "$SKIP_KUADRANT" = "true" ] && SETUP_ARGS+=(--skip-kuadrant)
+    ./scripts/kind/setup-kagenti.sh "${SETUP_ARGS[@]}"
 
     log_step "Waiting for platform to be ready..."
     ./.github/scripts/common/40-wait-platform-ready.sh

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -48,7 +48,10 @@ WITH_BUILDS=false
 WITH_KIALI=false
 WITH_KUADRANT=false
 WITH_AGENT_SANDBOX=false
+WITH_ALL=false
 SKIP_CLUSTER=false
+SKIP_MLFLOW=false
+SKIP_KUADRANT=false
 BUILD_IMAGES=false
 PRELOAD_IMAGES=false
 DRY_RUN=false
@@ -95,15 +98,10 @@ while [[ $# -gt 0 ]]; do
     --with-builds)      WITH_BUILDS=true; shift ;;
     --with-kiali)       WITH_KIALI=true; shift ;;
     --with-agent-sandbox) WITH_AGENT_SANDBOX=true; shift ;;
-    --with-all)
-      WITH_ISTIO=true; WITH_SPIRE=true; WITH_BACKEND=true; WITH_UI=true
-      WITH_MCP_GATEWAY=true; WITH_KUADRANT=true; WITH_OTEL=true
-      WITH_MLFLOW=true; WITH_BUILDS=true; WITH_KIALI=true
-      WITH_AGENT_SANDBOX=true
-      shift ;;
+    --with-all)         WITH_ALL=true; shift ;;
     --skip-cluster)     SKIP_CLUSTER=true; shift ;;
-    --skip-mlflow)      WITH_MLFLOW=false; shift ;;
-    --skip-kuadrant)    WITH_KUADRANT=false; shift ;;
+    --skip-mlflow)      SKIP_MLFLOW=true; shift ;;
+    --skip-kuadrant)    SKIP_KUADRANT=true; shift ;;
     --build-images)     BUILD_IMAGES=true; shift ;;
     --preload-images)   PRELOAD_IMAGES=true; shift ;;
     --secrets-file)     SECRETS_FILE_ARG="$2"; shift 2 ;;
@@ -154,6 +152,15 @@ while [[ $# -gt 0 ]]; do
     *) log_error "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+# ── Expand --with-all (deferred so --skip-* flags are order-independent) ───
+if $WITH_ALL; then
+  WITH_ISTIO=true; WITH_SPIRE=true; WITH_BACKEND=true; WITH_UI=true
+  WITH_MCP_GATEWAY=true; WITH_OTEL=true; WITH_BUILDS=true; WITH_KIALI=true
+  WITH_AGENT_SANDBOX=true
+  $SKIP_MLFLOW    || WITH_MLFLOW=true
+  $SKIP_KUADRANT  || WITH_KUADRANT=true
+fi
 
 # ── Flag dependencies ──────────────────────────────────────────────────────
 # UI requires backend API

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -19,6 +19,7 @@
 #   scripts/kind/setup-kagenti.sh                          # Core only
 #   scripts/kind/setup-kagenti.sh --with-all               # Everything
 #   scripts/kind/setup-kagenti.sh --with-istio --with-ui   # Core + Istio + UI
+#   scripts/kind/setup-kagenti.sh --with-all --skip-mlflow --skip-kuadrant  # Lightweight
 #   scripts/kind/setup-kagenti.sh --skip-cluster           # Reuse existing cluster
 #   scripts/kind/setup-kagenti.sh --cluster-name my-test   # Custom cluster name
 #
@@ -101,6 +102,8 @@ while [[ $# -gt 0 ]]; do
       WITH_AGENT_SANDBOX=true
       shift ;;
     --skip-cluster)     SKIP_CLUSTER=true; shift ;;
+    --skip-mlflow)      WITH_MLFLOW=false; shift ;;
+    --skip-kuadrant)    WITH_KUADRANT=false; shift ;;
     --build-images)     BUILD_IMAGES=true; shift ;;
     --preload-images)   PRELOAD_IMAGES=true; shift ;;
     --secrets-file)     SECRETS_FILE_ARG="$2"; shift 2 ;;
@@ -126,6 +129,10 @@ while [[ $# -gt 0 ]]; do
       echo "  --with-kiali        Install Kiali + Prometheus (auto-enables Istio)"
       echo "  --with-agent-sandbox Install agent-sandbox controller (kubernetes-sigs)"
       echo "  --with-all          Enable all optional components"
+      echo ""
+      echo "Skip flags (override --with-all for resource-constrained environments):"
+      echo "  --skip-mlflow       Exclude MLflow even when --with-all is used (~2 GB saved)"
+      echo "  --skip-kuadrant     Exclude Kuadrant even when --with-all is used (~1 GB saved)"
       echo ""
       echo "Other options:"
       echo "  --skip-cluster      Don't create Kind cluster (reuse existing)"


### PR DESCRIPTION
## Summary

- Adds `--skip-mlflow` and `--skip-kuadrant` flags to both `setup-kagenti.sh` and `kind-full-test.sh`
- `--with-all` expansion is deferred until after argument parsing, making `--skip-*` flags order-independent
- Enables lightweight local dev on 4 vCPU / 12–16 GB VMs

## Changes

- `scripts/kind/setup-kagenti.sh`: new `--skip-mlflow` / `--skip-kuadrant` flags; deferred `--with-all` expansion so skip flags work in any position
- `.github/scripts/local-setup/kind-full-test.sh`: passes skip flags through to `setup-kagenti.sh`

## Usage

```bash
# Direct usage (setup-kagenti.sh) — flags are order-independent
scripts/kind/setup-kagenti.sh --with-all --skip-mlflow --skip-kuadrant
scripts/kind/setup-kagenti.sh --skip-mlflow --with-all   # same result

# Via kind-full-test.sh wrapper
./.github/scripts/local-setup/kind-full-test.sh --skip-mlflow --skip-kuadrant --skip-cluster-destroy

# Skip only MLflow
./.github/scripts/local-setup/kind-full-test.sh --skip-mlflow --skip-cluster-destroy

# Full install (unchanged default behavior)
./.github/scripts/local-setup/kind-full-test.sh --skip-cluster-destroy
```

## Test plan

- [x] `bash -n` syntax check passes
- [ ] `--skip-mlflow --skip-kuadrant` installs without MLflow/Kuadrant pods
- [ ] Default (no skip flags) still deploys all components via `--with-all`
- [ ] Flags combine with existing `--skip-cluster-create`, `--skip-cluster-destroy`
- [x] `--skip-*` flags work regardless of position relative to `--with-all`

Closes #1670

Assisted-By: Claude Code