### PR TITLE
fix(backend): deduplicate env vars to prevent Sandbox creation failure

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2556,8 +2556,9 @@ def _build_env_vars(request: "CreateAgentRequest") -> List[dict]:
 
                 env_vars.append(env_entry)
 
-    # Deduplicate environment variables, keeping the last occurrence
-    # This allows user-provided envVars to override DEFAULT_ENV_VARS
+    # Deduplicate environment variables, keeping the last occurrence.
+    # Precedence (last wins): DEFAULT_ENV_VARS < AGENT_ENDPOINT/SKILL_FOLDERS < user envVars.
+    # User overrides of AGENT_ENDPOINT or SKILL_FOLDERS are intentional (advanced use).
     seen = {}
     for env in env_vars:
         seen[env["name"]] = env

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2555,7 +2555,13 @@ def _build_env_vars(request: "CreateAgentRequest") -> List[dict]:
                     }
 
                 env_vars.append(env_entry)
-    return env_vars
+
+    # Deduplicate environment variables, keeping the last occurrence
+    # This allows user-provided envVars to override DEFAULT_ENV_VARS
+    seen = {}
+    for env in env_vars:
+        seen[env["name"]] = env
+    return list(seen.values())
 
 
 def _build_common_labels(

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -388,7 +388,13 @@ def _build_tool_env_vars(
                     }
 
                 env_vars.append(env_entry)
-    return env_vars
+
+    # Deduplicate environment variables, keeping the last occurrence
+    # This allows user-provided envVars to override DEFAULT_ENV_VARS
+    seen = {}
+    for env in env_vars:
+        seen[env["name"]] = env
+    return list(seen.values())
 
 
 def _format_timestamp(timestamp) -> Optional[str]:

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -389,8 +389,8 @@ def _build_tool_env_vars(
 
                 env_vars.append(env_entry)
 
-    # Deduplicate environment variables, keeping the last occurrence
-    # This allows user-provided envVars to override DEFAULT_ENV_VARS
+    # Deduplicate environment variables, keeping the last occurrence.
+    # Precedence (last wins): DEFAULT_ENV_VARS (with service_ports override) < user envVars.
     seen = {}
     for env in env_vars:
         seen[env["name"]] = env

--- a/kagenti/backend/tests/test_sandbox_manifest.py
+++ b/kagenti/backend/tests/test_sandbox_manifest.py
@@ -84,6 +84,42 @@ class TestBuildSandboxManifest:
         container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
         assert container["ports"][0]["containerPort"] == 8888
 
+    def test_user_env_vars_override_defaults(self):
+        """User-provided envVars with the same name as DEFAULT_ENV_VARS should
+        override the default, not produce duplicates."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        ev = MagicMock()
+        ev.name = "PORT"
+        ev.value = "9000"
+        ev.valueFrom = None
+        request = _make_request(envVars=[ev])
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
+        port_entries = [e for e in container["env"] if e.get("name") == "PORT"]
+        assert len(port_entries) == 1
+        assert port_entries[0]["value"] == "9000"
+
+    def test_no_duplicate_env_vars(self):
+        """Env var list must never contain duplicate names."""
+        from app.routers.agents import _build_sandbox_manifest
+
+        ev1 = MagicMock()
+        ev1.name = "HOST"
+        ev1.value = "127.0.0.1"
+        ev1.valueFrom = None
+        ev2 = MagicMock()
+        ev2.name = "UV_CACHE_DIR"
+        ev2.value = "/tmp/uv"
+        ev2.valueFrom = None
+        request = _make_request(envVars=[ev1, ev2])
+        manifest = _build_sandbox_manifest(request=request, image="test:latest")
+
+        container = manifest["spec"]["podTemplate"]["spec"]["containers"][0]
+        names = [e["name"] for e in container["env"]]
+        assert len(names) == len(set(names)), f"Duplicate env vars found: {names}"
+
 
 class TestBuildSandboxManifestPVC:
     """Tests for PVC support in _build_sandbox_manifest."""

--- a/kagenti/backend/tests/test_tool_workloads.py
+++ b/kagenti/backend/tests/test_tool_workloads.py
@@ -740,3 +740,53 @@ def _build_tool_env_vars(env_var_list=None, service_ports=None):
         for ev in env_var_list:
             env_vars.append({"name": ev["name"], "value": ev["value"]})
     return env_vars
+
+
+class TestBuildToolEnvVarsDedup:
+    """Tests for env var deduplication in the real _build_tool_env_vars."""
+
+    def test_user_env_vars_override_defaults(self):
+        """User-provided envVars with the same name as DEFAULT_ENV_VARS should
+        override the default, not produce duplicates."""
+        from unittest.mock import MagicMock
+        from app.routers.tools import _build_tool_env_vars as real_build
+
+        ev = MagicMock()
+        ev.name = "PORT"
+        ev.value = "9000"
+        ev.valueFrom = None
+
+        result = real_build(env_var_list=[ev])
+        port_entries = [e for e in result if e.get("name") == "PORT"]
+        assert len(port_entries) == 1
+        assert port_entries[0]["value"] == "9000"
+
+    def test_no_duplicate_env_vars(self):
+        """Env var list must never contain duplicate names."""
+        from unittest.mock import MagicMock
+        from app.routers.tools import _build_tool_env_vars as real_build
+
+        ev = MagicMock()
+        ev.name = "HOST"
+        ev.value = "127.0.0.1"
+        ev.valueFrom = None
+
+        result = real_build(env_var_list=[ev])
+        names = [e["name"] for e in result]
+        assert len(names) == len(set(names)), f"Duplicate env vars found: {names}"
+
+    def test_service_ports_and_user_env_both_override(self):
+        """service_ports overrides PORT from defaults, user envVars can override further."""
+        from unittest.mock import MagicMock
+        from app.routers.tools import _build_tool_env_vars as real_build
+
+        ev = MagicMock()
+        ev.name = "PORT"
+        ev.value = "3000"
+        ev.valueFrom = None
+
+        service_ports = [{"name": "http", "port": 8080, "targetPort": 9090, "protocol": "TCP"}]
+        result = real_build(env_var_list=[ev], service_ports=service_ports)
+        port_entries = [e for e in result if e.get("name") == "PORT"]
+        assert len(port_entries) == 1
+        assert port_entries[0]["value"] == "3000"


### PR DESCRIPTION
## Summary

- Deduplicate environment variables in `_build_env_vars()` (agents) and `_build_tool_env_vars()` (tools), keeping the last occurrence so user-provided values override `DEFAULT_ENV_VARS`
- Adds unit tests verifying no duplicate env var names appear in Sandbox manifests
- Prevents Sandbox controller from failing when imported `.env` files contain variables already in platform defaults (e.g. `PORT`, `HOST`)

Fixes #1673

## Test plan

- [x] Existing sandbox manifest tests pass (20/20)
- [x] New tests verify: user env vars override defaults, no duplicates in final list
- [ ] Manual: import git-issue-agent with `.env.openai`, verify Sandbox pod starts

Assisted-By: Claude Code