### PR TITLE
fix(backend): clean up existing Build/BuildRun on re-import

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -122,7 +122,10 @@ from app.services.shipwright import (
     extract_buildrun_info,
     resolve_clone_secret,
 )
-from app.services.shipwright_builds import collect_kagenti_shipwright_builds
+from app.services.shipwright_builds import (
+    cleanup_existing_build,
+    collect_kagenti_shipwright_builds,
+)
 
 
 class OutboundRoute(BaseModel):
@@ -3390,6 +3393,9 @@ async def create_agent(
                     status_code=400,
                     detail="gitUrl is required for source deployment",
                 )
+
+            # Clean up any existing Build/BuildRuns to prevent 409 on re-import
+            cleanup_existing_build(kube, namespace=request.namespace, build_name=request.name)
 
             # Step 1: Create Shipwright Build CR
             clone_secret = resolve_clone_secret(kube.core_api, request.namespace)

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -68,7 +68,10 @@ from app.models.shipwright import (
     ShipwrightBuildListResponse,
 )
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
-from app.services.shipwright_builds import collect_kagenti_shipwright_builds
+from app.services.shipwright_builds import (
+    cleanup_existing_build,
+    collect_kagenti_shipwright_builds,
+)
 from app.services.shipwright import (
     build_shipwright_build_manifest,
     build_shipwright_buildrun_manifest,
@@ -1403,6 +1406,9 @@ async def create_tool(
                     status_code=400,
                     detail="gitUrl is required for source deployment",
                 )
+
+            # Clean up any existing Build/BuildRuns to prevent 409 on re-import
+            cleanup_existing_build(kube, namespace=request.namespace, build_name=request.name)
 
             # Step 1: Create Shipwright Build CR
             clone_secret = resolve_clone_secret(kube.core_api, request.namespace)

--- a/kagenti/backend/app/services/shipwright_builds.py
+++ b/kagenti/backend/app/services/shipwright_builds.py
@@ -17,9 +17,65 @@ from app.core.constants import (
     SHIPWRIGHT_CRD_GROUP,
     SHIPWRIGHT_CRD_VERSION,
     SHIPWRIGHT_BUILDS_PLURAL,
+    SHIPWRIGHT_BUILDRUNS_PLURAL,
 )
 from app.models.shipwright import ShipwrightBuildListItem
 from app.services.kubernetes import KubernetesService
+
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_existing_build(
+    kube: KubernetesService,
+    namespace: str,
+    build_name: str,
+) -> None:
+    """Delete an existing Shipwright Build and its BuildRuns (best-effort).
+
+    Called before creating a new Build to prevent 409 conflicts on re-import.
+    Silently handles 404s (resource already gone) and logs warnings for other errors.
+    """
+    # Delete BuildRuns first (they reference the Build)
+    try:
+        buildruns = kube.list_custom_resources(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace=namespace,
+            plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+            label_selector=f"kagenti.io/build-name={build_name}",
+        )
+        for buildrun in buildruns:
+            br_name = buildrun.get("metadata", {}).get("name")
+            if br_name:
+                try:
+                    kube.delete_custom_resource(
+                        group=SHIPWRIGHT_CRD_GROUP,
+                        version=SHIPWRIGHT_CRD_VERSION,
+                        namespace=namespace,
+                        plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+                        name=br_name,
+                    )
+                except ApiException as e:
+                    if e.status != 404:
+                        logger.warning("Failed to delete BuildRun '%s': %s", br_name, e.reason)
+    except ApiException as e:
+        if e.status != 404:
+            logger.warning("Failed to list BuildRuns for '%s': %s", build_name, e.reason)
+        return
+
+    # Delete the Build CR
+    try:
+        kube.delete_custom_resource(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace=namespace,
+            plural=SHIPWRIGHT_BUILDS_PLURAL,
+            name=build_name,
+        )
+    except ApiException as e:
+        if e.status != 404:
+            logger.warning("Failed to delete Shipwright Build '%s': %s", build_name, e.reason)
 
 
 def format_shipwright_build_timestamp(timestamp) -> Optional[str]:

--- a/kagenti/backend/app/services/shipwright_builds.py
+++ b/kagenti/backend/app/services/shipwright_builds.py
@@ -58,13 +58,12 @@ def cleanup_existing_build(
                     )
                 except ApiException as e:
                     if e.status != 404:
-                        logger.warning("Failed to delete BuildRun '%s': %s", br_name, e.reason)
+                        logger.warning("Failed to delete BuildRun: status=%d", e.status)
     except ApiException as e:
         if e.status != 404:
-            logger.warning("Failed to list BuildRuns for '%s': %s", build_name, e.reason)
-        return
+            logger.warning("Failed to list BuildRuns for cleanup: status=%d", e.status)
 
-    # Delete the Build CR
+    # Delete the Build CR (independent of BuildRun list success)
     try:
         kube.delete_custom_resource(
             group=SHIPWRIGHT_CRD_GROUP,
@@ -75,7 +74,7 @@ def cleanup_existing_build(
         )
     except ApiException as e:
         if e.status != 404:
-            logger.warning("Failed to delete Shipwright Build '%s': %s", build_name, e.reason)
+            logger.warning("Failed to delete Shipwright Build: status=%d", e.status)
 
 
 def format_shipwright_build_timestamp(timestamp) -> Optional[str]:

--- a/kagenti/backend/tests/test_build_cleanup.py
+++ b/kagenti/backend/tests/test_build_cleanup.py
@@ -1,0 +1,266 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for build cleanup on re-import (issue #1676).
+
+When re-importing an agent or tool that already has a Build/BuildRun,
+the backend must clean up existing resources before creating new ones
+to prevent 409 conflicts.
+"""
+
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from app.core.constants import (
+    SHIPWRIGHT_CRD_GROUP,
+    SHIPWRIGHT_CRD_VERSION,
+    SHIPWRIGHT_BUILDS_PLURAL,
+    SHIPWRIGHT_BUILDRUNS_PLURAL,
+)
+from app.services.shipwright_builds import cleanup_existing_build
+
+
+class TestCleanupExistingBuild:
+    """Tests for the cleanup_existing_build helper."""
+
+    def test_deletes_buildruns_and_build_when_they_exist(self):
+        """When a Build and its BuildRuns exist, all are deleted."""
+        kube = MagicMock()
+        kube.list_custom_resources.return_value = [
+            {"metadata": {"name": "my-agent-run-abc"}},
+            {"metadata": {"name": "my-agent-run-def"}},
+        ]
+
+        cleanup_existing_build(kube, namespace="team1", build_name="my-agent")
+
+        # Should list BuildRuns by label
+        kube.list_custom_resources.assert_called_once_with(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace="team1",
+            plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+            label_selector="kagenti.io/build-name=my-agent",
+        )
+
+        # Should delete each BuildRun
+        buildrun_delete_calls = [
+            call(
+                group=SHIPWRIGHT_CRD_GROUP,
+                version=SHIPWRIGHT_CRD_VERSION,
+                namespace="team1",
+                plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+                name="my-agent-run-abc",
+            ),
+            call(
+                group=SHIPWRIGHT_CRD_GROUP,
+                version=SHIPWRIGHT_CRD_VERSION,
+                namespace="team1",
+                plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+                name="my-agent-run-def",
+            ),
+        ]
+        # Should also delete the Build CR itself
+        build_delete_call = call(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace="team1",
+            plural=SHIPWRIGHT_BUILDS_PLURAL,
+            name="my-agent",
+        )
+        kube.delete_custom_resource.assert_has_calls(
+            buildrun_delete_calls + [build_delete_call], any_order=False
+        )
+
+    def test_no_op_when_build_does_not_exist(self):
+        """When no Build exists (404), cleanup is a no-op."""
+        kube = MagicMock()
+        kube.list_custom_resources.side_effect = ApiException(status=404)
+
+        # Should not raise
+        cleanup_existing_build(kube, namespace="team1", build_name="new-agent")
+
+        # Should not attempt to delete anything
+        kube.delete_custom_resource.assert_not_called()
+
+    def test_skips_buildrun_without_name(self):
+        """BuildRuns missing metadata.name are skipped."""
+        kube = MagicMock()
+        kube.list_custom_resources.return_value = [
+            {"metadata": {}},  # no name
+            {"metadata": {"name": "my-agent-run-abc"}},
+        ]
+
+        cleanup_existing_build(kube, namespace="team1", build_name="my-agent")
+
+        # Should only delete the one with a name, plus the Build
+        assert kube.delete_custom_resource.call_count == 2
+
+    def test_continues_on_individual_buildrun_delete_failure(self):
+        """If one BuildRun delete fails, others are still attempted."""
+        kube = MagicMock()
+        kube.list_custom_resources.return_value = [
+            {"metadata": {"name": "my-agent-run-abc"}},
+            {"metadata": {"name": "my-agent-run-def"}},
+        ]
+        # First delete fails, second succeeds, Build delete succeeds
+        kube.delete_custom_resource.side_effect = [
+            ApiException(status=500),
+            None,
+            None,
+        ]
+
+        # Should not raise
+        cleanup_existing_build(kube, namespace="team1", build_name="my-agent")
+
+        # All three deletes were attempted
+        assert kube.delete_custom_resource.call_count == 3
+
+    def test_handles_build_404_gracefully(self):
+        """If the Build itself is already gone (404), no error."""
+        kube = MagicMock()
+        kube.list_custom_resources.return_value = []
+        kube.delete_custom_resource.side_effect = ApiException(status=404)
+
+        cleanup_existing_build(kube, namespace="team1", build_name="my-agent")
+
+    def test_propagates_non_404_build_delete_error(self):
+        """Non-404 errors deleting the Build are logged but not raised."""
+        kube = MagicMock()
+        kube.list_custom_resources.return_value = []
+        kube.delete_custom_resource.side_effect = ApiException(status=500)
+
+        # Should not raise - cleanup is best-effort
+        cleanup_existing_build(kube, namespace="team1", build_name="my-agent")
+
+
+class TestAgentCreateCleanupIntegration:
+    """Integration tests: agent create endpoint cleans up existing builds."""
+
+    @pytest.fixture
+    def app_with_mocks(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from app.routers import agents
+        from app.services.kubernetes import get_kubernetes_service
+
+        app = FastAPI()
+        app.include_router(agents.router, prefix="/api/v1")
+
+        kube = MagicMock()
+        kube.list_custom_resources.return_value = [
+            {"metadata": {"name": "test-agent-run-old"}},
+        ]
+        kube.create_custom_resource.return_value = {"metadata": {"name": "test-agent-run-new"}}
+        # resolve_clone_secret needs core_api
+        kube.core_api = MagicMock()
+        kube.core_api.list_namespaced_secret.return_value = MagicMock(items=[])
+
+        def override_kube():
+            return kube
+
+        app.dependency_overrides[get_kubernetes_service] = override_kube
+
+        with patch("app.core.auth.settings") as mock_auth:
+            mock_auth.enable_auth = False
+            yield TestClient(app), kube
+
+        app.dependency_overrides.clear()
+
+    def test_create_agent_source_cleans_up_existing_build(self, app_with_mocks):
+        """POST /agents (source deploy) cleans up existing Build before creating new one."""
+        client, kube = app_with_mocks
+
+        response = client.post(
+            "/api/v1/agents",
+            json={
+                "name": "test-agent",
+                "namespace": "team1",
+                "protocol": "a2a",
+                "framework": "LangGraph",
+                "deploymentMethod": "source",
+                "gitUrl": "https://github.com/example/repo",
+                "gitBranch": "main",
+                "gitPath": ".",
+                "imageTag": "v1",
+            },
+        )
+
+        assert response.status_code == 200
+
+        # Verify cleanup was called (list + delete of old buildrun + delete of old build)
+        kube.list_custom_resources.assert_called_once_with(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace="team1",
+            plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+            label_selector="kagenti.io/build-name=test-agent",
+        )
+
+        # Should have: delete old buildrun, delete old build, create new build, create new buildrun
+        delete_calls = list(kube.delete_custom_resource.call_args_list)
+        assert len(delete_calls) >= 1  # at least old buildrun deleted
+
+
+class TestToolCreateCleanupIntegration:
+    """Integration tests: tool create endpoint cleans up existing builds."""
+
+    @pytest.fixture
+    def app_with_mocks(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from app.routers import tools
+        from app.services.kubernetes import get_kubernetes_service
+
+        app = FastAPI()
+        app.include_router(tools.router, prefix="/api/v1")
+
+        kube = MagicMock()
+        kube.list_custom_resources.return_value = [
+            {"metadata": {"name": "test-tool-run-old"}},
+        ]
+        kube.create_custom_resource.return_value = {"metadata": {"name": "test-tool-run-new"}}
+        kube.core_api = MagicMock()
+        kube.core_api.list_namespaced_secret.return_value = MagicMock(items=[])
+
+        def override_kube():
+            return kube
+
+        app.dependency_overrides[get_kubernetes_service] = override_kube
+
+        with patch("app.core.auth.settings") as mock_auth:
+            mock_auth.enable_auth = False
+            yield TestClient(app), kube
+
+        app.dependency_overrides.clear()
+
+    def test_create_tool_source_cleans_up_existing_build(self, app_with_mocks):
+        """POST /tools (source deploy) cleans up existing Build before creating new one."""
+        client, kube = app_with_mocks
+
+        response = client.post(
+            "/api/v1/tools",
+            json={
+                "name": "test-tool",
+                "namespace": "team1",
+                "protocol": "mcp",
+                "deploymentMethod": "source",
+                "gitUrl": "https://github.com/example/repo",
+                "gitBranch": "main",
+                "gitPath": ".",
+                "imageTag": "v1",
+            },
+        )
+
+        assert response.status_code == 200
+
+        # Verify cleanup was called
+        kube.list_custom_resources.assert_called_once_with(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace="team1",
+            plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+            label_selector="kagenti.io/build-name=test-tool",
+        )

--- a/kagenti/backend/tests/test_build_cleanup.py
+++ b/kagenti/backend/tests/test_build_cleanup.py
@@ -74,16 +74,23 @@ class TestCleanupExistingBuild:
             buildrun_delete_calls + [build_delete_call], any_order=False
         )
 
-    def test_no_op_when_build_does_not_exist(self):
-        """When no Build exists (404), cleanup is a no-op."""
+    def test_still_deletes_build_when_list_buildruns_returns_404(self):
+        """When listing BuildRuns returns 404, Build delete is still attempted."""
         kube = MagicMock()
         kube.list_custom_resources.side_effect = ApiException(status=404)
+        kube.delete_custom_resource.side_effect = ApiException(status=404)
 
         # Should not raise
         cleanup_existing_build(kube, namespace="team1", build_name="new-agent")
 
-        # Should not attempt to delete anything
-        kube.delete_custom_resource.assert_not_called()
+        # Build delete still attempted even though list returned 404
+        kube.delete_custom_resource.assert_called_once_with(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace="team1",
+            plural=SHIPWRIGHT_BUILDS_PLURAL,
+            name="new-agent",
+        )
 
     def test_skips_buildrun_without_name(self):
         """BuildRuns missing metadata.name are skipped."""
@@ -126,7 +133,7 @@ class TestCleanupExistingBuild:
 
         cleanup_existing_build(kube, namespace="team1", build_name="my-agent")
 
-    def test_propagates_non_404_build_delete_error(self):
+    def test_swallows_non_404_build_delete_error(self):
         """Non-404 errors deleting the Build are logged but not raised."""
         kube = MagicMock()
         kube.list_custom_resources.return_value = []
@@ -199,9 +206,24 @@ class TestAgentCreateCleanupIntegration:
             label_selector="kagenti.io/build-name=test-agent",
         )
 
-        # Should have: delete old buildrun, delete old build, create new build, create new buildrun
+        # Exact sequence: delete old BuildRun, then delete old Build
         delete_calls = list(kube.delete_custom_resource.call_args_list)
-        assert len(delete_calls) >= 1  # at least old buildrun deleted
+        assert delete_calls == [
+            call(
+                group=SHIPWRIGHT_CRD_GROUP,
+                version=SHIPWRIGHT_CRD_VERSION,
+                namespace="team1",
+                plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+                name="test-agent-run-old",
+            ),
+            call(
+                group=SHIPWRIGHT_CRD_GROUP,
+                version=SHIPWRIGHT_CRD_VERSION,
+                namespace="team1",
+                plural=SHIPWRIGHT_BUILDS_PLURAL,
+                name="test-agent",
+            ),
+        ]
 
 
 class TestToolCreateCleanupIntegration:
@@ -264,3 +286,22 @@ class TestToolCreateCleanupIntegration:
             plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
             label_selector="kagenti.io/build-name=test-tool",
         )
+
+        # Exact sequence: delete old BuildRun, then delete old Build
+        delete_calls = list(kube.delete_custom_resource.call_args_list)
+        assert delete_calls == [
+            call(
+                group=SHIPWRIGHT_CRD_GROUP,
+                version=SHIPWRIGHT_CRD_VERSION,
+                namespace="team1",
+                plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+                name="test-tool-run-old",
+            ),
+            call(
+                group=SHIPWRIGHT_CRD_GROUP,
+                version=SHIPWRIGHT_CRD_VERSION,
+                namespace="team1",
+                plural=SHIPWRIGHT_BUILDS_PLURAL,
+                name="test-tool",
+            ),
+        ]


### PR DESCRIPTION
## Summary

- Adds `cleanup_existing_build()` helper in `shipwright_builds` service that deletes existing Build + BuildRun resources before creating new ones
- Called in both agent and tool source-deploy paths to prevent 409 conflicts on re-import
- Best-effort cleanup: 404s are silently ignored, other errors are logged but don't block the new build

## Problem

When a build-from-source fails and the user tries to re-import the same agent/tool, the request fails with a 409 because the leftover Build CR still exists. The only workaround was manual `kubectl delete` or deleting the entire agent.

## Changes

| File | Change |
|------|--------|
| `app/services/shipwright_builds.py` | New `cleanup_existing_build()` — deletes BuildRuns by label, then the Build CR |
| `app/routers/agents.py` | Calls cleanup before Build creation in source-deploy path |
| `app/routers/tools.py` | Same cleanup for tools |
| `tests/test_build_cleanup.py` | 8 tests (6 unit + 2 integration) |

## Test plan

- [x] 8 new unit/integration tests pass
- [x] All 358 existing backend tests pass (no regressions)
- [x] Linter clean
- [x] Manually verified on Kind cluster — re-import succeeds after failed build

Closes #1676

Assisted-By: Claude Code