### PR TITLE
Remove unused framework selector from UI

### DIFF
--- a/kagenti/ui-v2/src/components/BuildProgressView.tsx
+++ b/kagenti/ui-v2/src/components/BuildProgressView.tsx
@@ -317,12 +317,6 @@ export const BuildProgressView: React.FC<BuildProgressViewProps> = ({
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
-                <DescriptionListTerm>Framework</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <Label color="purple">{resourceConfig.framework}</Label>
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
                 <DescriptionListTerm>External Access</DescriptionListTerm>
                 <DescriptionListDescription>
                   {resourceConfig.createHttpRoute ? (

--- a/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentCatalogPage.tsx
@@ -138,7 +138,7 @@ export const AgentCatalogPage: React.FC = () => {
   };
 
   const renderLabels = (agent: Agent) => {
-    const labels = [];
+    const labels: React.ReactNode[] = [];
     if (agent.labels.protocol) {
       agent.labels.protocol.forEach((p) => {
         labels.push(
@@ -147,13 +147,6 @@ export const AgentCatalogPage: React.FC = () => {
           </Label>
         );
       });
-    }
-    if (agent.labels.framework) {
-      labels.push(
-        <Label key="framework" color="purple" isCompact>
-          {agent.labels.framework}
-        </Label>
-      );
     }
     return <LabelGroup>{labels}</LabelGroup>;
   };

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -402,11 +402,6 @@ export const AgentDetailPage: React.FC = () => {
                   </FlexItem>
                 ));
               })()}
-              {labels['kagenti.io/framework'] && (
-                <FlexItem>
-                  <Label color="purple">{labels['kagenti.io/framework']}</Label>
-                </FlexItem>
-              )}
               <FlexItem>
                 <Dropdown
                   isOpen={actionsMenuOpen}

--- a/kagenti/ui-v2/src/pages/BuildProgressPage.tsx
+++ b/kagenti/ui-v2/src/pages/BuildProgressPage.tsx
@@ -379,12 +379,6 @@ export const BuildProgressPage: React.FC = () => {
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Framework</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <Label color="purple">{buildInfo.agentConfig.framework}</Label>
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
                   <DescriptionListTerm>External Access</DescriptionListTerm>
                   <DescriptionListDescription>
                     {buildInfo.agentConfig.createHttpRoute ? (

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -63,12 +63,6 @@ const AGENT_EXAMPLES = [
   { value: 'a2a/weather_service', label: 'Weather Service Agent' },
 ];
 
-const FRAMEWORKS = [
-  { value: 'LangGraph', label: 'LangGraph' },
-  { value: 'CrewAI', label: 'CrewAI' },
-  { value: 'AG2', label: 'AG2' },
-  { value: 'Python', label: 'Python (Custom)' },
-];
 
 const REGISTRY_OPTIONS = [
   { value: 'local', label: 'Local Registry (In-Cluster)', url: 'registry.cr-system.svc.cluster.local:5000' },
@@ -121,7 +115,6 @@ export const ImportAgentPage: React.FC = () => {
   const [namespace, setNamespace] = useState('team1');
   const [name, setName] = useState('');
   const [protocol, setProtocol] = useState('a2a');
-  const [framework, setFramework] = useState('LangGraph');
 
   // Build from source state
   const [gitUrl, setGitUrl] = useState(DEFAULT_REPO_URL);
@@ -510,7 +503,7 @@ export const ImportAgentPage: React.FC = () => {
         gitBranch,
         imageTag: 'v0.0.1',
         protocol,
-        framework,
+        framework: 'LangGraph',
         envVars: envVars.filter((ev) => ev.name && (ev.value || ev.valueFrom)),
         skills: selectedSkills.length > 0 ? selectedSkills : undefined,
         // Workload type
@@ -550,7 +543,7 @@ export const ImportAgentPage: React.FC = () => {
         gitBranch: '',
         imageTag,
         protocol,
-        framework,
+        framework: 'LangGraph',
         envVars: envVars.filter((ev) => ev.name && (ev.value || ev.valueFrom)),
         skills: selectedSkills.length > 0 ? selectedSkills : undefined,
         // Workload type
@@ -1021,18 +1014,6 @@ export const ImportAgentPage: React.FC = () => {
                 </FormHelperText>
               </FormGroup>
 
-              {/* Framework Selection */}
-              <FormGroup label="Framework" fieldId="framework">
-                <FormSelect
-                  id="framework"
-                  value={framework}
-                  onChange={(_e, value) => setFramework(value)}
-                >
-                  {FRAMEWORKS.map((fw) => (
-                    <FormSelectOption key={fw.value} value={fw.value} label={fw.label} />
-                  ))}
-                </FormSelect>
-              </FormGroup>
 
               <FormGroup label="Linked Skills" fieldId="linkedSkills">
                 {availableSkills.length === 0 ? (

--- a/kagenti/ui-v2/src/pages/ToolBuildProgressPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolBuildProgressPage.tsx
@@ -390,12 +390,6 @@ export const ToolBuildProgressPage: React.FC = () => {
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Framework</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <Label color="purple">{buildInfo.toolConfig.framework}</Label>
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
                   <DescriptionListTerm>External Access</DescriptionListTerm>
                   <DescriptionListDescription>
                     {buildInfo.toolConfig.createHttpRoute ? (

--- a/kagenti/ui-v2/src/pages/ToolCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolCatalogPage.tsx
@@ -120,7 +120,7 @@ export const ToolCatalogPage: React.FC = () => {
   };
 
   const renderLabels = (tool: Tool) => {
-    const labels = [];
+    const labels: React.ReactNode[] = [];
     if (tool.labels.protocol) {
       tool.labels.protocol.forEach((p) => {
         labels.push(
@@ -129,13 +129,6 @@ export const ToolCatalogPage: React.FC = () => {
           </Label>
         );
       });
-    }
-    if (tool.labels.framework) {
-      labels.push(
-        <Label key="framework" color="purple" isCompact>
-          {tool.labels.framework}
-        </Label>
-      );
     }
     if (tool.workloadType) {
       labels.push(


### PR DESCRIPTION
## Summary

- Removes the framework dropdown from the agent import page (was LangGraph/CrewAI/AG2/Python options)
- Removes framework purple label display from agent catalog, tool catalog, agent detail, and build progress pages
- Backend still stores `kagenti.io/framework` label on K8s resources (hardcoded to `LangGraph` default) — plumbing preserved for future use

## Rationale

The framework field was purely cosmetic — no backend logic branched on its value. It confused users by implying framework-specific behavior that doesn't exist. See #1678 for discussion.

## Files changed (7)

| File | Change |
|------|--------|
| `ImportAgentPage.tsx` | Remove FRAMEWORKS const, state var, FormSelect dropdown; hardcode default |
| `AgentCatalogPage.tsx` | Remove purple framework label from card |
| `ToolCatalogPage.tsx` | Remove purple framework label from card |
| `AgentDetailPage.tsx` | Remove purple framework label from header |
| `BuildProgressPage.tsx` | Remove framework row from build config display |
| `ToolBuildProgressPage.tsx` | Remove framework row from build config display |
| `BuildProgressView.tsx` | Remove framework row from build config display |

## Test plan

- [ ] Import an agent — verify no framework dropdown appears
- [ ] Check agent catalog page — no purple framework labels on cards
- [ ] Check agent detail page — no purple framework label in header
- [ ] Check build progress page — no "Framework" row in config summary
- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit` passes)

Closes #1678

Assisted-By: Claude Code