### PR TITLE
fix: wait for SPIRE OIDC provider readiness before IdP setup job

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -826,6 +826,13 @@ json.dump(cm, sys.stdout)
     fi
   fi
 
+  # Wait for OIDC discovery provider to be fully ready before starting IdP setup
+  log_info "Waiting for OIDC discovery provider to be ready..."
+  kubectl wait --for=condition=Available deployment/spire-spiffe-oidc-discovery-provider \
+    -n "$SPIRE_SERVER_NS" --timeout=300s 2>/dev/null \
+    && log_success "OIDC discovery provider ready" \
+    || log_warn "OIDC discovery provider not ready after 5m — IdP setup may fail"
+
   # 7b: Run SPIFFE IdP setup job (configures Keycloak with SPIRE identity provider)
   log_info "Setting up SPIFFE IdP..."
 


### PR DESCRIPTION
## Summary

- Adds `kubectl wait --for=condition=Available` (300s timeout) for the SPIRE OIDC discovery provider deployment before launching the SPIFFE IdP setup job
- Prevents the IdP job from timing out on fresh Kind clusters where SPIRE server is still initializing trust bundles

## Root Cause

After patching the OIDC ConfigMap and restarting the deployment (Step 7), the script immediately launches the IdP setup job (Step 7b) without waiting for the new pod to pass readiness probes. The OIDC pod has 3 containers and depends on SPIRE server having initialized its trust bundles — on fresh clusters this takes longer than the 120s rollout timeout, causing the downstream IdP job to fail.

## Test plan

- [ ] `kind delete cluster --name kagenti && scripts/kind/setup-kagenti.sh --with-spire --with-ui --with-builds --with-agent-sandbox`
- [ ] Verify "OIDC discovery provider ready" appears in output before IdP setup starts
- [ ] Verify SPIFFE IdP setup job completes without the 5m timeout warning

Assisted-By: Claude Code