### PR TITLE
fix: hide registry secret field for OpenShift Internal Registry

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -130,11 +130,12 @@ export const ImportAgentPage: React.FC = () => {
   const [registrySecret, setRegistrySecret] = useState('');
 
   // Update registry secret default when registry type changes
+  // OpenShift internal registry doesn't require credentials (uses service account)
   React.useEffect(() => {
-    if (registryType !== 'local') {
-      setRegistrySecret(`${registryType}-registry-secret`);
-    } else {
+    if (registryType === 'local' || registryType === 'openshift') {
       setRegistrySecret('');
+    } else {
+      setRegistrySecret(`${registryType}-registry-secret`);
     }
   }, [registryType]);
 
@@ -755,28 +756,30 @@ export const ImportAgentPage: React.FC = () => {
                   </FormGroup>
 
                   {registryType !== 'local' && (
-                    <>
-                      <FormGroup
-                        label="Registry Namespace/Organization"
-                        isRequired
-                        fieldId="registryNamespace"
-                      >
-                        <TextInput
-                          id="registryNamespace"
-                          value={registryNamespace}
-                          onChange={(_e, value) => setRegistryNamespace(value)}
-                          placeholder="your-org-name"
-                          validated={validated.registryNamespace}
-                        />
-                        <FormHelperText>
-                          <HelperText>
-                            <HelperTextItem>
-                              Your organization or namespace in the registry
-                            </HelperTextItem>
-                          </HelperText>
-                        </FormHelperText>
-                      </FormGroup>
+                    <FormGroup
+                      label="Registry Namespace/Organization"
+                      isRequired
+                      fieldId="registryNamespace"
+                    >
+                      <TextInput
+                        id="registryNamespace"
+                        value={registryNamespace}
+                        onChange={(_e, value) => setRegistryNamespace(value)}
+                        placeholder="your-org-name"
+                        validated={validated.registryNamespace}
+                      />
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem>
+                            Your organization or namespace in the registry
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    </FormGroup>
+                  )}
 
+                  {registryType !== 'local' && registryType !== 'openshift' && (
+                    <>
                       <FormGroup label="Registry Secret Name" fieldId="registrySecret">
                         <TextInput
                           id="registrySecret"

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -114,11 +114,12 @@ export const ImportToolPage: React.FC = () => {
   const [imageTag, setImageTag] = useState('v0.0.1');
 
   // Update registry secret default when registry type changes
+  // OpenShift internal registry doesn't require credentials (uses service account)
   React.useEffect(() => {
-    if (registryType !== 'local') {
-      setRegistrySecret(`${registryType}-registry-secret`);
-    } else {
+    if (registryType === 'local' || registryType === 'openshift') {
       setRegistrySecret('');
+    } else {
+      setRegistrySecret(`${registryType}-registry-secret`);
     }
   }, [registryType]);
 
@@ -722,21 +723,23 @@ export const ImportToolPage: React.FC = () => {
                     </FormGroup>
                   )}
 
-                  <FormGroup label="Registry Secret" fieldId="registrySecret">
-                    <TextInput
-                      id="registrySecret"
-                      value={registrySecret}
-                      onChange={(_e, value) => setRegistrySecret(value)}
-                      placeholder="Leave empty for public registries"
-                    />
-                    <FormHelperText>
-                      <HelperText>
-                        <HelperTextItem>
-                          Kubernetes secret containing registry credentials
-                        </HelperTextItem>
-                      </HelperText>
-                    </FormHelperText>
-                  </FormGroup>
+                  {registryType !== 'local' && registryType !== 'openshift' && (
+                    <FormGroup label="Registry Secret" fieldId="registrySecret">
+                      <TextInput
+                        id="registrySecret"
+                        value={registrySecret}
+                        onChange={(_e, value) => setRegistrySecret(value)}
+                        placeholder="Leave empty for public registries"
+                      />
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem>
+                            Kubernetes secret containing registry credentials
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    </FormGroup>
+                  )}
 
                   <FormGroup label="Image Tag" fieldId="imageTag">
                     <TextInput


### PR DESCRIPTION
## Summary

- Hide the "Registry Secret Name" field and "Authentication Required" alert when OpenShift Internal Registry is selected for builds
- The OpenShift internal registry uses service account authentication, not a separate registry secret
- Applies to both Import Agent and Import Tool pages

Fixes #1683

## Test plan

- [x] Select "OpenShift Internal Registry" → verify registry secret field is hidden
- [x] Select "Quay.io" or "Docker Hub" → verify registry secret field still appears with default value
- [x] Select "Local Registry" → verify registry secret field is hidden (existing behavior preserved)
- [ ] Verify registry namespace field still appears for OpenShift (needed for project name)

Assisted-By: Claude Code