### PR TITLE
fix(ocp): set components.mlflow.enabled in kagenti chart install

### DIFF
--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -236,6 +236,7 @@ otel:
             span:
               - 'IsMatch(name, "^a2a\\..*")'
               - 'attributes["http.method"] != nil'
+              - 'attributes["openinference.span.kind"] != nil'
               - 'attributes["mcp.method.name"] == "initialize"'
               - 'attributes["mcp.method.name"] == "notifications/initialized"'
               - 'attributes["mcp.method.name"] == "notifications/cancelled"'
@@ -305,6 +306,7 @@ otel:
               - 'IsMatch(name, "^a2a\\..*")'
               - 'attributes["http.method"] != nil and IsMatch(name, "^(POST|GET|DELETE)$")'
               - 'IsMatch(name, "^mcp-router\\..*") and (attributes["http.method"] == "GET" or attributes["http.method"] == "DELETE")'
+              - 'attributes["openinference.span.kind"] != nil'
               - 'attributes["mcp.method.name"] == "initialize"'
               - 'attributes["mcp.method.name"] == "notifications/initialized"'
               - 'attributes["mcp.method.name"] == "notifications/cancelled"'

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1438,6 +1438,7 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set mlflow.auth.enabled=false \
   --set "keycloak.publicUrl=${KEYCLOAK_PUBLIC_URL}" \
   --set "keycloak.realm=${KC_REALM}" \
+  --set "components.mlflow.enabled=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)" \
   --set "featureFlags.agentSandbox=${WITH_AGENT_SANDBOX}"
 


### PR DESCRIPTION
## Summary

- The OCP installer provisions MLflow via RHOAI (Step 3d) but never passes `components.mlflow.enabled=true` to the main kagenti Helm chart (Step 4)
- The `ui-routes-job` helm hook renders its route discovery list gated on `components.mlflow.enabled`, so the MLflow route is excluded from the `kagenti-ui-config` ConfigMap
- This causes the UI observability page to hide the MLflow card (conditional render: `{mlflowUrl && (...)}`)
- Fix: add `--set components.mlflow.enabled=...` based on `SKIP_MLFLOW`, matching the existing pattern for `kagenti-operator-chart.mlflow.enable`

## Test plan

- [ ] Deploy on OCP with `./scripts/ocp/setup-kagenti.sh --kagenti-repo . --with-all`
- [ ] Verify `kubectl get configmap kagenti-ui-config -n kagenti-system -o yaml` contains `MLFLOW_DASHBOARD_URL` with a valid route URL
- [ ] Verify MLflow card appears on the observability page
- [ ] Deploy with `--skip-mlflow` and verify MLflow card does NOT appear

Assisted-By: Claude Code