### PR TITLE
fix(ci): use uv run pytest in token-exchange test script

### DIFF
--- a/.github/scripts/token-exchange/80-run-tests.sh
+++ b/.github/scripts/token-exchange/80-run-tests.sh
@@ -58,14 +58,14 @@ PYTEST_ARGS=(-v --tb=short --junitxml="$REPO_ROOT/test-results/token-exchange-${
 if [[ "$KEYCLOAK_PROVIDER" == "rhbk" ]]; then
   log_info "Running tests against RHBK (non-fatal)"
   # --no-header to reduce noise; failures are warnings not errors
-  python -m pytest "$TEST_DIR" "${PYTEST_ARGS[@]}" || {
+  uv run pytest "$TEST_DIR" "${PYTEST_ARGS[@]}" || {
     RC=$?
     log_warn "RHBK tests failed (exit code $RC) — non-fatal as per policy"
     exit 0  # Non-fatal
   }
 else
   log_info "Running tests against community Keycloak (fatal)"
-  python -m pytest "$TEST_DIR" "${PYTEST_ARGS[@]}"
+  uv run pytest "$TEST_DIR" "${PYTEST_ARGS[@]}"
 fi
 
 log_success "Token exchange E2E tests passed ($KEYCLOAK_PROVIDER)"


### PR DESCRIPTION
## Summary

- Fix `No module named pytest` failure in e2e-kind workflow by replacing bare `python -m pytest` with `uv run pytest` in `.github/scripts/token-exchange/80-run-tests.sh`

## Root Cause

The token-exchange test script called `python -m pytest` directly, but CI installs test dependencies via `uv sync --extra test` into a virtual environment. The system Python at `/opt/hostedtoolcache/Python/3.11.15/x64/bin/python` doesn't have pytest installed.

## Test plan

- [ ] e2e-kind workflow passes the "Run token exchange E2E tests" step

Fixes #1696

Assisted-By: Claude Code