### PR TITLE
feat: add cleanup/uninstall scripts for OpenShell deployments

### DIFF
--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -261,6 +261,54 @@ export SSL_CERT_FILE=/tmp/ocp-ingress-ca.crt
 openshell gateway login
 ```
 
+## Uninstall
+
+To remove OpenShell resources from your cluster, use the cleanup scripts in
+`scripts/openshell/`.
+
+### Remove everything
+
+```bash
+scripts/openshell/cleanup-all.sh
+```
+
+This discovers all deployed tenants and removes them, then removes the shared
+infrastructure. Add `--delete-namespaces` to also delete tenant namespaces.
+
+### Remove a single tenant
+
+```bash
+scripts/openshell/cleanup-tenant.sh team1
+scripts/openshell/cleanup-tenant.sh team1 --delete-namespace
+```
+
+### Remove shared infrastructure only
+
+```bash
+scripts/openshell/cleanup-shared.sh
+```
+
+Skip specific components with `--skip-*` flags (mirrors `deploy-shared.sh`):
+
+```bash
+scripts/openshell/cleanup-shared.sh --skip-keycloak  # Keep the Keycloak realm
+scripts/openshell/cleanup-shared.sh --skip-backend   # Keep kagenti-backend + DB
+```
+
+### Dry run
+
+All cleanup scripts support `--dry-run` to preview what would be deleted:
+
+```bash
+scripts/openshell/cleanup-all.sh --dry-run
+```
+
+### Ordering
+
+Tenants must be cleaned up before shared infrastructure. `cleanup-all.sh`
+handles this automatically. If running scripts manually, always run
+`cleanup-tenant.sh` for each tenant first, then `cleanup-shared.sh`.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/scripts/openshell/cleanup-all.sh
+++ b/scripts/openshell/cleanup-all.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OPENSHELL FULL CLEANUP
+# ============================================================================
+# Convenience wrapper that removes ALL OpenShell resources:
+#   1. Discovers all tenants (by Helm releases or namespace labels)
+#   2. Calls cleanup-tenant.sh for each tenant
+#   3. Calls cleanup-shared.sh to remove shared infrastructure
+#
+# Usage:
+#   scripts/openshell/cleanup-all.sh
+#   scripts/openshell/cleanup-all.sh --delete-namespaces
+#   scripts/openshell/cleanup-all.sh --dry-run
+#   scripts/openshell/cleanup-all.sh --help
+#
+# Idempotent: safe to re-run if resources are already gone.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+DRY_RUN=false
+DELETE_NAMESPACES=false
+KEYCLOAK_NS="${KEYCLOAK_NS:-keycloak}"
+BACKEND_NS="${BACKEND_NS:-team1}"
+EXTRA_SHARED_ARGS=()
+
+# ── Colors & logging ────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_info()    { echo -e "${BLUE}→${NC} $1"; }
+log_success() { echo -e "${GREEN}✓${NC} $1"; }
+log_warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error()   { echo -e "${RED}✗${NC} $1"; }
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Remove ALL OpenShell resources (tenants + shared infrastructure).
+
+Options:
+  --help               Show this help message
+  --dry-run            Print commands without executing
+  --delete-namespaces  Also delete tenant namespaces (DESTRUCTIVE)
+  --keycloak-ns NS     Keycloak namespace (default: keycloak)
+  --backend-ns NS      Backend namespace (default: team1)
+  --skip-sandbox       Pass through to cleanup-shared.sh
+  --skip-gateway-api   Pass through to cleanup-shared.sh
+  --skip-tls           Pass through to cleanup-shared.sh
+  --skip-keycloak      Pass through to cleanup-shared.sh
+  --skip-litellm       Pass through to cleanup-shared.sh
+  --skip-backend       Pass through to cleanup-shared.sh
+  --skip-istio         Pass through to cleanup-shared.sh
+EOF
+  exit 0
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)              usage ;;
+    --dry-run)           DRY_RUN=true; shift ;;
+    --delete-namespaces) DELETE_NAMESPACES=true; shift ;;
+    --keycloak-ns)       KEYCLOAK_NS="$2"; shift 2 ;;
+    --backend-ns)        BACKEND_NS="$2"; shift 2 ;;
+    --skip-sandbox|--skip-gateway-api|--skip-tls|--skip-keycloak|--skip-litellm|--skip-backend|--skip-istio)
+      EXTRA_SHARED_ARGS+=("$1"); shift ;;
+    *)
+      log_error "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+echo ""
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║  OpenShell Full Cleanup                                      ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+echo "  Delete namespaces: $DELETE_NAMESPACES"
+echo "  Dry run:           $DRY_RUN"
+echo ""
+
+# ============================================================================
+# Step 1: Discover tenants
+# ============================================================================
+log_info "Step 1: Discovering OpenShell tenants..."
+
+TENANTS=()
+
+# Method 1: Find Helm releases with openshell- prefix
+HELM_TENANTS=$(helm list --all-namespaces --filter '^openshell-' -q 2>/dev/null | sed 's/^openshell-//' || true)
+for t in $HELM_TENANTS; do
+  TENANTS+=("$t")
+done
+
+# Method 2: Find namespaces with openshell.ai/tenant label
+LABELED_TENANTS=$(kubectl get namespaces -l "openshell.ai/tenant" -o jsonpath='{.items[*].metadata.labels.openshell\.ai/tenant}' 2>/dev/null || true)
+for t in $LABELED_TENANTS; do
+  # Avoid duplicates
+  if [[ ! " ${TENANTS[*]:-} " =~ " $t " ]]; then
+    TENANTS+=("$t")
+  fi
+done
+
+if [[ ${#TENANTS[@]} -eq 0 ]]; then
+  log_warn "No OpenShell tenants found"
+else
+  log_info "Found tenants: ${TENANTS[*]}"
+fi
+
+# ============================================================================
+# Step 2: Clean up each tenant
+# ============================================================================
+log_info "Step 2: Cleaning up tenants..."
+
+TENANT_ARGS=()
+if $DRY_RUN; then TENANT_ARGS+=(--dry-run); fi
+if $DELETE_NAMESPACES; then TENANT_ARGS+=(--delete-namespace); fi
+
+for tenant in "${TENANTS[@]}"; do
+  log_info "── Cleaning tenant: $tenant ──"
+  "$SCRIPT_DIR/cleanup-tenant.sh" "$tenant" "${TENANT_ARGS[@]}"
+  echo ""
+done
+
+# ============================================================================
+# Step 3: Clean up shared infrastructure
+# ============================================================================
+log_info "Step 3: Cleaning up shared infrastructure..."
+
+SHARED_ARGS=(--keycloak-ns "$KEYCLOAK_NS" --backend-ns "$BACKEND_NS")
+if $DRY_RUN; then SHARED_ARGS+=(--dry-run); fi
+SHARED_ARGS+=("${EXTRA_SHARED_ARGS[@]}")
+
+"$SCRIPT_DIR/cleanup-shared.sh" "${SHARED_ARGS[@]}"
+
+echo ""
+log_success "Full OpenShell cleanup complete"

--- a/scripts/openshell/cleanup-all.sh
+++ b/scripts/openshell/cleanup-all.sh
@@ -23,6 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ── Defaults ────────────────────────────────────────────────────────────────
 DRY_RUN=false
 DELETE_NAMESPACES=false
+CONFIRM=false
 KEYCLOAK_NS="${KEYCLOAK_NS:-keycloak}"
 BACKEND_NS="${BACKEND_NS:-team1}"
 EXTRA_SHARED_ARGS=()
@@ -43,6 +44,7 @@ Remove ALL OpenShell resources (tenants + shared infrastructure).
 Options:
   --help               Show this help message
   --dry-run            Print commands without executing
+  --yes                Skip confirmation prompt
   --delete-namespaces  Also delete tenant namespaces (DESTRUCTIVE)
   --keycloak-ns NS     Keycloak namespace (default: keycloak)
   --backend-ns NS      Backend namespace (default: team1)
@@ -62,6 +64,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --help)              usage ;;
     --dry-run)           DRY_RUN=true; shift ;;
+    --yes)               CONFIRM=true; shift ;;
     --delete-namespaces) DELETE_NAMESPACES=true; shift ;;
     --keycloak-ns)       KEYCLOAK_NS="$2"; shift 2 ;;
     --backend-ns)        BACKEND_NS="$2"; shift 2 ;;
@@ -82,6 +85,19 @@ echo ""
 echo "  Delete namespaces: $DELETE_NAMESPACES"
 echo "  Dry run:           $DRY_RUN"
 echo ""
+
+# ── Cluster context confirmation guard ──────────────────────────────────────
+if ! $DRY_RUN && ! $CONFIRM; then
+  CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "<unknown>")
+  log_warn "Target cluster context: $CURRENT_CONTEXT"
+  echo ""
+  read -r -p "This will delete OpenShell resources from the above cluster. Continue? [y/N] " response
+  case "$response" in
+    [yY][eE][sS]|[yY]) ;;
+    *) log_error "Aborted."; exit 1 ;;
+  esac
+  echo ""
+fi
 
 # ============================================================================
 # Step 1: Discover tenants
@@ -131,7 +147,7 @@ done
 # ============================================================================
 log_info "Step 3: Cleaning up shared infrastructure..."
 
-SHARED_ARGS=(--keycloak-ns "$KEYCLOAK_NS" --backend-ns "$BACKEND_NS")
+SHARED_ARGS=(--yes --keycloak-ns "$KEYCLOAK_NS" --backend-ns "$BACKEND_NS")
 if $DRY_RUN; then SHARED_ARGS+=(--dry-run); fi
 SHARED_ARGS+=("${EXTRA_SHARED_ARGS[@]}")
 

--- a/scripts/openshell/cleanup-all.sh
+++ b/scripts/openshell/cleanup-all.sh
@@ -115,10 +115,12 @@ done
 # Method 2: Find namespaces with openshell.ai/tenant label
 LABELED_TENANTS=$(kubectl get namespaces -l "openshell.ai/tenant" -o jsonpath='{.items[*].metadata.labels.openshell\.ai/tenant}' 2>/dev/null || true)
 for t in $LABELED_TENANTS; do
-  # Avoid duplicates
-  if [[ ! " ${TENANTS[*]:-} " =~ " $t " ]]; then
-    TENANTS+=("$t")
-  fi
+  # Avoid duplicates (exact match to prevent team1 matching team10)
+  found=false
+  for existing in "${TENANTS[@]:-}"; do
+    if [[ "$existing" == "$t" ]]; then found=true; break; fi
+  done
+  $found || TENANTS+=("$t")
 done
 
 if [[ ${#TENANTS[@]} -eq 0 ]]; then
@@ -136,11 +138,19 @@ TENANT_ARGS=()
 if $DRY_RUN; then TENANT_ARGS+=(--dry-run); fi
 if $DELETE_NAMESPACES; then TENANT_ARGS+=(--delete-namespace); fi
 
+TENANT_FAILURES=0
 for tenant in "${TENANTS[@]}"; do
   log_info "── Cleaning tenant: $tenant ──"
-  "$SCRIPT_DIR/cleanup-tenant.sh" "$tenant" "${TENANT_ARGS[@]}"
+  if ! "$SCRIPT_DIR/cleanup-tenant.sh" "$tenant" "${TENANT_ARGS[@]}"; then
+    log_warn "cleanup-tenant.sh failed for $tenant, continuing with remaining tenants"
+    TENANT_FAILURES=$((TENANT_FAILURES + 1))
+  fi
   echo ""
 done
+
+if [[ $TENANT_FAILURES -gt 0 ]]; then
+  log_warn "$TENANT_FAILURES tenant cleanup(s) failed — review output above"
+fi
 
 # ============================================================================
 # Step 3: Clean up shared infrastructure

--- a/scripts/openshell/cleanup-shared.sh
+++ b/scripts/openshell/cleanup-shared.sh
@@ -46,7 +46,9 @@ STEP_KEYCLOAK=true
 STEP_LITELLM=true
 STEP_BACKEND=true
 STEP_ISTIO=true
+DELETE_DATA=false
 DRY_RUN=false
+CONFIRM=false
 
 # ── Colors & logging ────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
@@ -74,8 +76,10 @@ Options:
   --skip-litellm      Skip LiteLLM proxy removal
   --skip-backend      Skip kagenti-backend + PostgreSQL removal
   --skip-istio        Skip Istio env var revert
+  --delete-data       Also delete PostgreSQL PVC (data loss, default: keep)
   --keycloak-ns NS    Keycloak namespace (default: keycloak)
   --backend-ns NS     Backend namespace (default: team1)
+  --yes               Skip confirmation prompt
   --dry-run           Print commands without executing
 EOF
   exit 0
@@ -85,6 +89,8 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --help)             usage ;;
+    --yes)              CONFIRM=true; shift ;;
+    --delete-data)      DELETE_DATA=true; shift ;;
     --skip-sandbox)     STEP_SANDBOX=false; shift ;;
     --skip-gateway-api) STEP_GATEWAY_API=false; shift ;;
     --skip-tls)         STEP_TLS=false; shift ;;
@@ -119,8 +125,22 @@ echo "  cert-manager CA:    $STEP_TLS"
 echo "  Istio env var:      $STEP_ISTIO"
 echo "  Gateway API CRDs:   $STEP_GATEWAY_API"
 echo "  Sandbox controller: $STEP_SANDBOX"
+echo "  Delete PVC data:    $DELETE_DATA"
 echo "  Dry run:            $DRY_RUN"
 echo ""
+
+# ── Cluster context confirmation guard ──────────────────────────────────────
+if ! $DRY_RUN && ! $CONFIRM; then
+  CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "<unknown>")
+  log_warn "Target cluster context: $CURRENT_CONTEXT"
+  echo ""
+  read -r -p "This will delete OpenShell shared infrastructure from the above cluster. Continue? [y/N] " response
+  case "$response" in
+    [yY][eE][sS]|[yY]) ;;
+    *) log_error "Aborted."; exit 1 ;;
+  esac
+  echo ""
+fi
 
 # ============================================================================
 # Step 1: Remove kagenti-backend + PostgreSQL
@@ -145,11 +165,15 @@ if $STEP_BACKEND; then
     run_cmd kubectl delete service postgres-sessions -n "$BACKEND_NS" --ignore-not-found
     run_cmd kubectl delete secret postgres-sessions-secret -n "$BACKEND_NS" --ignore-not-found
 
-    # PVC (warn: data loss)
+    # PVC (only deleted with --delete-data)
     PVC_NAME="postgres-data-postgres-sessions-0"
     if kubectl get pvc "$PVC_NAME" -n "$BACKEND_NS" &>/dev/null; then
-      log_warn "  Deleting PVC $PVC_NAME (PostgreSQL data will be lost)"
-      run_cmd kubectl delete pvc "$PVC_NAME" -n "$BACKEND_NS" --ignore-not-found
+      if $DELETE_DATA; then
+        log_warn "  Deleting PVC $PVC_NAME (PostgreSQL data will be lost)"
+        run_cmd kubectl delete pvc "$PVC_NAME" -n "$BACKEND_NS" --ignore-not-found
+      else
+        log_warn "  Keeping PVC $PVC_NAME (use --delete-data to remove)"
+      fi
     fi
 
     log_success "Backend + PostgreSQL removed"
@@ -187,7 +211,7 @@ if $STEP_KEYCLOAK; then
   log_info "Step 3: Removing Keycloak realm 'openshell'..."
 
   if kubectl get pod "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" &>/dev/null; then
-    # Check if realm exists
+    # Read-only probe (not wrapped in run_cmd) — needs live Keycloak even in dry-run
     REALM_EXISTS=$(kubectl exec "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" -- \
       "$KCADM" get realms/openshell --config "$KC_CONFIG" 2>/dev/null && echo "yes" || echo "no")
 
@@ -305,12 +329,12 @@ if $STEP_SANDBOX; then
   SANDBOX_BASE_URL="https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/refs/tags/${AGENT_SANDBOX_VERSION}"
 
   if kubectl get namespace agent-sandbox-system &>/dev/null; then
-    # Delete extensions first, then main manifest
+    # URL-based deletes use || true to tolerate network failures
     log_info "  Deleting extensions..."
-    run_cmd kubectl delete -f "${SANDBOX_BASE_URL}/config/extensions.yaml" --ignore-not-found 2>/dev/null || true
+    run_cmd kubectl delete -f "${SANDBOX_BASE_URL}/config/extensions.yaml" --ignore-not-found || true
 
     log_info "  Deleting controller..."
-    run_cmd kubectl delete -f "${SANDBOX_BASE_URL}/config/install.yaml" --ignore-not-found 2>/dev/null || true
+    run_cmd kubectl delete -f "${SANDBOX_BASE_URL}/config/install.yaml" --ignore-not-found || true
 
     log_success "agent-sandbox-controller removed"
   else
@@ -318,8 +342,8 @@ if $STEP_SANDBOX; then
     if kubectl get crd sandboxes.agents.x-k8s.io &>/dev/null; then
       log_info "  Namespace gone but CRD remains, cleaning up..."
       run_cmd kubectl delete crd sandboxes.agents.x-k8s.io --ignore-not-found
-      run_cmd kubectl delete crd sandboxclaims.agents.x-k8s.io --ignore-not-found 2>/dev/null || true
-      run_cmd kubectl delete crd sandboxtemplates.agents.x-k8s.io --ignore-not-found 2>/dev/null || true
+      run_cmd kubectl delete crd sandboxclaims.agents.x-k8s.io --ignore-not-found
+      run_cmd kubectl delete crd sandboxtemplates.agents.x-k8s.io --ignore-not-found
       log_success "Sandbox CRDs removed"
     else
       log_warn "agent-sandbox-controller not found, skipping"

--- a/scripts/openshell/cleanup-shared.sh
+++ b/scripts/openshell/cleanup-shared.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OPENSHELL SHARED INFRASTRUCTURE CLEANUP
+# ============================================================================
+# Removes cluster-wide shared infrastructure deployed by deploy-shared.sh:
+#   1. kagenti-backend + PostgreSQL sessions DB
+#   2. LiteLLM model proxy
+#   3. Keycloak realm (openshell)
+#   4. cert-manager CA chain (ClusterIssuers + CA Certificate)
+#   5. Shared TLS passthrough Gateway (Kind only)
+#   6. Revert Istio alpha Gateway API env var
+#   7. Gateway API experimental CRDs (Kind only)
+#   8. agent-sandbox-controller
+#
+# Idempotent: safe to re-run if resources are already gone.
+#
+# Usage:
+#   scripts/openshell/cleanup-shared.sh                  # Remove everything
+#   scripts/openshell/cleanup-shared.sh --skip-keycloak  # Keep Keycloak realm
+#   scripts/openshell/cleanup-shared.sh --dry-run        # Print commands only
+#   scripts/openshell/cleanup-shared.sh --help           # Show usage
+#
+# Prerequisites: kubectl, helm (for status checks)
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Versions (keep in sync with deploy-shared.sh) ─────────────────────────
+AGENT_SANDBOX_VERSION="v0.4.6"
+GATEWAY_API_VERSION="v1.4.0"
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+KEYCLOAK_NS="${KEYCLOAK_NS:-keycloak}"
+KEYCLOAK_POD="keycloak-0"
+KCADM="/opt/keycloak/bin/kcadm.sh"
+KC_CONFIG="/tmp/kc/kcadm.config"
+BACKEND_NS="${BACKEND_NS:-team1}"
+
+STEP_SANDBOX=true
+STEP_GATEWAY_API=true
+STEP_TLS=true
+STEP_KEYCLOAK=true
+STEP_LITELLM=true
+STEP_BACKEND=true
+STEP_ISTIO=true
+DRY_RUN=false
+
+# ── Colors & logging ────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_info()    { echo -e "${BLUE}→${NC} $1"; }
+log_success() { echo -e "${GREEN}✓${NC} $1"; }
+log_warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error()   { echo -e "${RED}✗${NC} $1"; }
+
+run_cmd() {
+  if $DRY_RUN; then echo "  [dry-run] $*"; else "$@"; fi
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Remove OpenShell shared infrastructure (idempotent).
+
+Options:
+  --help              Show this help message
+  --skip-sandbox      Skip agent-sandbox-controller removal
+  --skip-gateway-api  Skip experimental Gateway API CRD removal
+  --skip-tls          Skip cert-manager CA chain removal
+  --skip-keycloak     Skip Keycloak realm removal
+  --skip-litellm      Skip LiteLLM proxy removal
+  --skip-backend      Skip kagenti-backend + PostgreSQL removal
+  --skip-istio        Skip Istio env var revert
+  --keycloak-ns NS    Keycloak namespace (default: keycloak)
+  --backend-ns NS     Backend namespace (default: team1)
+  --dry-run           Print commands without executing
+EOF
+  exit 0
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)             usage ;;
+    --skip-sandbox)     STEP_SANDBOX=false; shift ;;
+    --skip-gateway-api) STEP_GATEWAY_API=false; shift ;;
+    --skip-tls)         STEP_TLS=false; shift ;;
+    --skip-keycloak)    STEP_KEYCLOAK=false; shift ;;
+    --skip-litellm)     STEP_LITELLM=false; shift ;;
+    --skip-backend)     STEP_BACKEND=false; shift ;;
+    --skip-istio)       STEP_ISTIO=false; shift ;;
+    --keycloak-ns)      KEYCLOAK_NS="$2"; shift 2 ;;
+    --backend-ns)       BACKEND_NS="$2"; shift 2 ;;
+    --dry-run)          DRY_RUN=true; shift ;;
+    *)
+      log_error "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# ── Helper: detect OpenShift ────────────────────────────────────────────────
+is_openshift() {
+  kubectl get clusterversion &>/dev/null
+}
+
+echo ""
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║  OpenShell Shared Infrastructure Cleanup                     ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+echo "  Backend + sessions: $STEP_BACKEND (namespace: $BACKEND_NS)"
+echo "  LiteLLM proxy:      $STEP_LITELLM"
+echo "  Keycloak realm:     $STEP_KEYCLOAK (namespace: $KEYCLOAK_NS)"
+echo "  cert-manager CA:    $STEP_TLS"
+echo "  Istio env var:      $STEP_ISTIO"
+echo "  Gateway API CRDs:   $STEP_GATEWAY_API"
+echo "  Sandbox controller: $STEP_SANDBOX"
+echo "  Dry run:            $DRY_RUN"
+echo ""
+
+# ============================================================================
+# Step 1: Remove kagenti-backend + PostgreSQL
+# ============================================================================
+if $STEP_BACKEND; then
+  log_info "Step 1: Removing kagenti-backend + PostgreSQL in namespace $BACKEND_NS..."
+
+  if kubectl get namespace "$BACKEND_NS" &>/dev/null; then
+    # Backend deployment and service
+    run_cmd kubectl delete deployment kagenti-backend -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete service kagenti-backend -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete serviceaccount kagenti-backend -n "$BACKEND_NS" --ignore-not-found
+
+    # Backend RBAC
+    run_cmd kubectl delete clusterrole kagenti-backend --ignore-not-found
+    run_cmd kubectl delete clusterrolebinding kagenti-backend --ignore-not-found
+    run_cmd kubectl delete role kagenti-backend-secrets -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete rolebinding kagenti-backend-secrets -n "$BACKEND_NS" --ignore-not-found
+
+    # PostgreSQL StatefulSet + PVC + Service + Secret
+    run_cmd kubectl delete statefulset postgres-sessions -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete service postgres-sessions -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete secret postgres-sessions-secret -n "$BACKEND_NS" --ignore-not-found
+
+    # PVC (warn: data loss)
+    PVC_NAME="postgres-data-postgres-sessions-0"
+    if kubectl get pvc "$PVC_NAME" -n "$BACKEND_NS" &>/dev/null; then
+      log_warn "  Deleting PVC $PVC_NAME (PostgreSQL data will be lost)"
+      run_cmd kubectl delete pvc "$PVC_NAME" -n "$BACKEND_NS" --ignore-not-found
+    fi
+
+    log_success "Backend + PostgreSQL removed"
+  else
+    log_warn "Namespace $BACKEND_NS does not exist, skipping backend cleanup"
+  fi
+else
+  log_info "Step 1: Skipping backend cleanup (--skip-backend)"
+fi
+
+# ============================================================================
+# Step 2: Remove LiteLLM proxy
+# ============================================================================
+if $STEP_LITELLM; then
+  log_info "Step 2: Removing LiteLLM proxy in namespace $BACKEND_NS..."
+
+  if kubectl get namespace "$BACKEND_NS" &>/dev/null; then
+    run_cmd kubectl delete deployment litellm-model-proxy -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete service litellm-model-proxy -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete configmap litellm-config -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete secret litemaas-credentials -n "$BACKEND_NS" --ignore-not-found
+    run_cmd kubectl delete secret litellm-virtual-keys -n "$BACKEND_NS" --ignore-not-found
+    log_success "LiteLLM proxy removed"
+  else
+    log_warn "Namespace $BACKEND_NS does not exist, skipping LiteLLM cleanup"
+  fi
+else
+  log_info "Step 2: Skipping LiteLLM cleanup (--skip-litellm)"
+fi
+
+# ============================================================================
+# Step 3: Remove Keycloak realm
+# ============================================================================
+if $STEP_KEYCLOAK; then
+  log_info "Step 3: Removing Keycloak realm 'openshell'..."
+
+  if kubectl get pod "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" &>/dev/null; then
+    # Check if realm exists
+    REALM_EXISTS=$(kubectl exec "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" -- \
+      "$KCADM" get realms/openshell --config "$KC_CONFIG" 2>/dev/null && echo "yes" || echo "no")
+
+    if [[ "$REALM_EXISTS" == "yes" ]]; then
+      log_info "  Deleting realm 'openshell'..."
+      run_cmd kubectl exec "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" -- \
+        "$KCADM" delete realms/openshell --config "$KC_CONFIG"
+      log_success "Keycloak realm 'openshell' deleted"
+    else
+      log_warn "Keycloak realm 'openshell' does not exist, skipping"
+    fi
+  else
+    log_warn "Keycloak pod not found in namespace $KEYCLOAK_NS, skipping realm deletion"
+  fi
+else
+  log_info "Step 3: Skipping Keycloak cleanup (--skip-keycloak)"
+fi
+
+# ============================================================================
+# Step 4: Remove cert-manager CA chain
+# ============================================================================
+if $STEP_TLS; then
+  log_info "Step 4: Removing cert-manager CA chain..."
+
+  # ClusterIssuers (cluster-scoped)
+  run_cmd kubectl delete clusterissuer openshell-ca-issuer --ignore-not-found
+  run_cmd kubectl delete clusterissuer openshell-selfsigned --ignore-not-found
+
+  # CA Certificate and Secret in cert-manager namespace
+  run_cmd kubectl delete certificate openshell-ca -n cert-manager --ignore-not-found
+  run_cmd kubectl delete secret openshell-ca-secret -n cert-manager --ignore-not-found
+
+  log_success "cert-manager CA chain removed"
+else
+  log_info "Step 4: Skipping TLS cleanup (--skip-tls)"
+fi
+
+# ============================================================================
+# Step 5: Remove shared TLS passthrough Gateway (Kind only)
+# ============================================================================
+if ! is_openshift; then
+  log_info "Step 5: Removing shared TLS passthrough Gateway..."
+
+  run_cmd kubectl delete gateway tls-passthrough -n kagenti-system --ignore-not-found
+  # The gateway controller creates a service automatically
+  run_cmd kubectl delete service tls-passthrough-istio -n kagenti-system --ignore-not-found
+
+  log_success "Shared Gateway removed"
+else
+  log_info "Step 5: OpenShift detected, no shared Gateway to remove"
+fi
+
+# ============================================================================
+# Step 6: Revert Istio alpha Gateway API env var
+# ============================================================================
+if $STEP_ISTIO; then
+  if ! is_openshift; then
+    log_info "Step 6: Reverting Istio PILOT_ENABLE_ALPHA_GATEWAY_API..."
+
+    ISTIOD_NS="istio-system"
+    if kubectl get deployment istiod -n "$ISTIOD_NS" &>/dev/null; then
+      # Remove the env var from the discovery container
+      CURRENT_ENV=$(kubectl get deployment istiod -n "$ISTIOD_NS" \
+        -o jsonpath='{.spec.template.spec.containers[?(@.name=="discovery")].env[?(@.name=="PILOT_ENABLE_ALPHA_GATEWAY_API")].value}' 2>/dev/null || true)
+
+      if [[ "$CURRENT_ENV" == "true" ]]; then
+        log_info "  Removing PILOT_ENABLE_ALPHA_GATEWAY_API from istiod..."
+        run_cmd kubectl set env deployment/istiod -n "$ISTIOD_NS" \
+          -c discovery PILOT_ENABLE_ALPHA_GATEWAY_API-
+        log_success "Istio env var reverted"
+      else
+        log_warn "PILOT_ENABLE_ALPHA_GATEWAY_API not set, skipping"
+      fi
+    else
+      log_warn "istiod deployment not found, skipping"
+    fi
+  else
+    log_info "Step 6: OpenShift detected, skipping Istio env var revert"
+  fi
+else
+  log_info "Step 6: Skipping Istio cleanup (--skip-istio)"
+fi
+
+# ============================================================================
+# Step 7: Remove Gateway API experimental CRDs (Kind only)
+# ============================================================================
+if $STEP_GATEWAY_API; then
+  if ! is_openshift; then
+    log_info "Step 7: Removing Gateway API experimental CRDs..."
+
+    # Only remove if they exist — these are cluster-scoped and may affect other workloads
+    if kubectl get crd tcproutes.gateway.networking.k8s.io &>/dev/null; then
+      log_warn "  Removing CRD tcproutes.gateway.networking.k8s.io"
+      run_cmd kubectl delete crd tcproutes.gateway.networking.k8s.io --ignore-not-found
+    fi
+    if kubectl get crd tlsroutes.gateway.networking.k8s.io &>/dev/null; then
+      log_warn "  Removing CRD tlsroutes.gateway.networking.k8s.io"
+      run_cmd kubectl delete crd tlsroutes.gateway.networking.k8s.io --ignore-not-found
+    fi
+
+    log_success "Gateway API experimental CRDs removed"
+  else
+    log_info "Step 7: OpenShift detected, no experimental CRDs to remove"
+  fi
+else
+  log_info "Step 7: Skipping Gateway API CRD cleanup (--skip-gateway-api)"
+fi
+
+# ============================================================================
+# Step 8: Remove agent-sandbox-controller
+# ============================================================================
+if $STEP_SANDBOX; then
+  log_info "Step 8: Removing agent-sandbox-controller..."
+
+  SANDBOX_BASE_URL="https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/refs/tags/${AGENT_SANDBOX_VERSION}"
+
+  if kubectl get namespace agent-sandbox-system &>/dev/null; then
+    # Delete extensions first, then main manifest
+    log_info "  Deleting extensions..."
+    run_cmd kubectl delete -f "${SANDBOX_BASE_URL}/config/extensions.yaml" --ignore-not-found 2>/dev/null || true
+
+    log_info "  Deleting controller..."
+    run_cmd kubectl delete -f "${SANDBOX_BASE_URL}/config/install.yaml" --ignore-not-found 2>/dev/null || true
+
+    log_success "agent-sandbox-controller removed"
+  else
+    # CRD might still exist even if namespace is gone
+    if kubectl get crd sandboxes.agents.x-k8s.io &>/dev/null; then
+      log_info "  Namespace gone but CRD remains, cleaning up..."
+      run_cmd kubectl delete crd sandboxes.agents.x-k8s.io --ignore-not-found
+      run_cmd kubectl delete crd sandboxclaims.agents.x-k8s.io --ignore-not-found 2>/dev/null || true
+      run_cmd kubectl delete crd sandboxtemplates.agents.x-k8s.io --ignore-not-found 2>/dev/null || true
+      log_success "Sandbox CRDs removed"
+    else
+      log_warn "agent-sandbox-controller not found, skipping"
+    fi
+  fi
+else
+  log_info "Step 8: Skipping sandbox controller cleanup (--skip-sandbox)"
+fi
+
+echo ""
+log_success "Shared infrastructure cleanup complete"

--- a/scripts/openshell/cleanup-shared.sh
+++ b/scripts/openshell/cleanup-shared.sh
@@ -212,16 +212,14 @@ if $STEP_KEYCLOAK; then
 
   if kubectl get pod "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" &>/dev/null; then
     # Read-only probe (not wrapped in run_cmd) — needs live Keycloak even in dry-run
-    REALM_EXISTS=$(kubectl exec "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" -- \
-      "$KCADM" get realms/openshell --config "$KC_CONFIG" 2>/dev/null && echo "yes" || echo "no")
-
-    if [[ "$REALM_EXISTS" == "yes" ]]; then
+    if kubectl exec "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" -- \
+         "$KCADM" get realms/openshell --config "$KC_CONFIG" >/dev/null 2>&1; then
       log_info "  Deleting realm 'openshell'..."
       run_cmd kubectl exec "$KEYCLOAK_POD" -n "$KEYCLOAK_NS" -- \
         "$KCADM" delete realms/openshell --config "$KC_CONFIG"
       log_success "Keycloak realm 'openshell' deleted"
     else
-      log_warn "Keycloak realm 'openshell' does not exist, skipping"
+      log_warn "Keycloak realm 'openshell' does not exist or kcadm not configured, skipping"
     fi
   else
     log_warn "Keycloak pod not found in namespace $KEYCLOAK_NS, skipping realm deletion"

--- a/scripts/openshell/cleanup-tenant.sh
+++ b/scripts/openshell/cleanup-tenant.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OPENSHELL PER-TENANT CLEANUP
+# ============================================================================
+# Removes a single tenant's OpenShell resources deployed by deploy-tenant.sh.
+#
+# Usage:
+#   scripts/openshell/cleanup-tenant.sh <team>
+#   scripts/openshell/cleanup-tenant.sh team1
+#   scripts/openshell/cleanup-tenant.sh team1 --delete-namespace
+#   scripts/openshell/cleanup-tenant.sh team1 --dry-run
+#   scripts/openshell/cleanup-tenant.sh --help
+#
+# Idempotent: safe to re-run if resources are already gone.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+DRY_RUN=false
+DELETE_NAMESPACE=false
+HELM_RELEASE_PREFIX="openshell"
+
+# ── Colors & logging ────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_info()    { echo -e "${BLUE}→${NC} $1"; }
+log_success() { echo -e "${GREEN}✓${NC} $1"; }
+log_warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error()   { echo -e "${RED}✗${NC} $1"; }
+
+run_cmd() {
+  if $DRY_RUN; then echo "  [dry-run] $*"; else "$@"; fi
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <team> [OPTIONS]
+
+Remove a tenant's OpenShell resources (idempotent).
+
+Arguments:
+  team                  Tenant name (e.g., team1, team2)
+
+Options:
+  --help               Show this help message
+  --dry-run            Print commands without executing
+  --delete-namespace   Also delete the tenant namespace (DESTRUCTIVE)
+EOF
+  exit 0
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+TENANT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)             usage ;;
+    --dry-run)          DRY_RUN=true; shift ;;
+    --delete-namespace) DELETE_NAMESPACE=true; shift ;;
+    -*)
+      log_error "Unknown option: $1"
+      usage
+      ;;
+    *)
+      if [[ -z "$TENANT" ]]; then
+        TENANT="$1"; shift
+      else
+        log_error "Unexpected argument: $1"
+        usage
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$TENANT" ]]; then
+  log_error "Tenant name is required. Usage: $(basename "$0") <team> [OPTIONS]"
+  exit 1
+fi
+
+# ── Helper: detect OpenShift ────────────────────────────────────────────────
+is_openshift() {
+  kubectl get clusterversion &>/dev/null
+}
+
+echo ""
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║  OpenShell Tenant Cleanup: $TENANT"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+echo "  Tenant:           $TENANT"
+echo "  Delete namespace: $DELETE_NAMESPACE"
+echo "  Dry run:          $DRY_RUN"
+echo ""
+
+# ============================================================================
+# Step 1: Remove agent deployments and related resources
+# ============================================================================
+log_info "Step 1: Removing agent resources in namespace $TENANT..."
+
+if kubectl get namespace "$TENANT" &>/dev/null; then
+  # Delete agent deployments
+  AGENT_DEPLOYMENTS=$(kubectl get deployments -n "$TENANT" -l "app.kubernetes.io/part-of=openshell-agents" -o name 2>/dev/null || true)
+  if [[ -n "$AGENT_DEPLOYMENTS" ]]; then
+    for dep in $AGENT_DEPLOYMENTS; do
+      log_info "  Deleting $dep"
+      run_cmd kubectl delete "$dep" -n "$TENANT" --ignore-not-found
+    done
+  fi
+
+  # Delete agent configmaps (policy-data)
+  AGENT_CMS=$(kubectl get configmaps -n "$TENANT" -l "app.kubernetes.io/part-of=openshell-agents" -o name 2>/dev/null || true)
+  if [[ -n "$AGENT_CMS" ]]; then
+    for cm in $AGENT_CMS; do
+      log_info "  Deleting $cm"
+      run_cmd kubectl delete "$cm" -n "$TENANT" --ignore-not-found
+    done
+  fi
+
+  # Delete skills configmap
+  if kubectl get configmap kagenti-skills -n "$TENANT" &>/dev/null; then
+    log_info "  Deleting configmap/kagenti-skills"
+    run_cmd kubectl delete configmap kagenti-skills -n "$TENANT" --ignore-not-found
+  fi
+
+  # Delete openshell-supervisor ServiceAccount
+  if kubectl get serviceaccount openshell-supervisor -n "$TENANT" &>/dev/null; then
+    log_info "  Deleting serviceaccount/openshell-supervisor"
+    run_cmd kubectl delete serviceaccount openshell-supervisor -n "$TENANT" --ignore-not-found
+  fi
+
+  log_success "Agent resources cleaned up"
+else
+  log_warn "Namespace $TENANT does not exist, skipping agent cleanup"
+fi
+
+# ============================================================================
+# Step 2: Remove OpenShift SCCs (if applicable)
+# ============================================================================
+if is_openshift; then
+  log_info "Step 2: Removing OpenShift SCC bindings..."
+
+  # Remove ClusterRoleBinding for sandbox SCC
+  CRB_NAME="${HELM_RELEASE_PREFIX}-sandbox-scc-${TENANT}"
+  if kubectl get clusterrolebinding "$CRB_NAME" &>/dev/null; then
+    log_info "  Deleting clusterrolebinding/$CRB_NAME"
+    run_cmd kubectl delete clusterrolebinding "$CRB_NAME" --ignore-not-found
+  fi
+
+  # Remove SCC policies granted during agent deployment
+  for SA in openshell-gateway openshell-supervisor; do
+    for SCC in anyuid privileged; do
+      run_cmd oc adm policy remove-scc-from-user "$SCC" \
+        -z "$SA" -n "$TENANT" 2>/dev/null || true
+    done
+  done
+
+  log_success "OpenShift SCCs cleaned up"
+else
+  log_info "Step 2: Not OpenShift, skipping SCC cleanup"
+fi
+
+# ============================================================================
+# Step 3: Helm uninstall
+# ============================================================================
+RELEASE_NAME="${HELM_RELEASE_PREFIX}-${TENANT}"
+log_info "Step 3: Uninstalling Helm release $RELEASE_NAME..."
+
+if helm status "$RELEASE_NAME" -n "$TENANT" &>/dev/null; then
+  run_cmd helm uninstall "$RELEASE_NAME" -n "$TENANT" --wait
+  log_success "Helm release $RELEASE_NAME uninstalled"
+else
+  log_warn "Helm release $RELEASE_NAME not found, skipping"
+fi
+
+# ============================================================================
+# Step 4: Remove namespace labels
+# ============================================================================
+if kubectl get namespace "$TENANT" &>/dev/null; then
+  log_info "Step 4: Removing namespace labels..."
+  run_cmd kubectl label namespace "$TENANT" shared-gateway-access- --overwrite 2>/dev/null || true
+  run_cmd kubectl label namespace "$TENANT" openshell.ai/tenant- --overwrite 2>/dev/null || true
+  log_success "Namespace labels removed"
+else
+  log_warn "Step 4: Namespace $TENANT does not exist, skipping label removal"
+fi
+
+# ============================================================================
+# Step 5: Delete namespace (optional)
+# ============================================================================
+if $DELETE_NAMESPACE; then
+  if kubectl get namespace "$TENANT" &>/dev/null; then
+    log_warn "Step 5: Deleting namespace $TENANT (this will remove ALL resources in it)..."
+    run_cmd kubectl delete namespace "$TENANT" --wait=true --timeout=120s
+    log_success "Namespace $TENANT deleted"
+  else
+    log_warn "Step 5: Namespace $TENANT already gone"
+  fi
+else
+  log_info "Step 5: Skipping namespace deletion (use --delete-namespace to remove)"
+fi
+
+echo ""
+log_success "Tenant cleanup complete for: $TENANT"

--- a/scripts/openshell/cleanup-tenant.sh
+++ b/scripts/openshell/cleanup-tenant.sh
@@ -101,8 +101,8 @@ echo ""
 log_info "Step 1: Removing agent resources in namespace $TENANT..."
 
 if kubectl get namespace "$TENANT" &>/dev/null; then
-  # Delete agent deployments
-  AGENT_DEPLOYMENTS=$(kubectl get deployments -n "$TENANT" -l "app.kubernetes.io/part-of=openshell-agents" -o name 2>/dev/null || true)
+  # Delete agent deployments (label matches deploy-tenant.sh)
+  AGENT_DEPLOYMENTS=$(kubectl get deployments -n "$TENANT" -l "kagenti.io/type=agent" -o name 2>/dev/null || true)
   if [[ -n "$AGENT_DEPLOYMENTS" ]]; then
     for dep in $AGENT_DEPLOYMENTS; do
       log_info "  Deleting $dep"
@@ -110,26 +110,20 @@ if kubectl get namespace "$TENANT" &>/dev/null; then
     done
   fi
 
-  # Delete agent configmaps (policy-data)
-  AGENT_CMS=$(kubectl get configmaps -n "$TENANT" -l "app.kubernetes.io/part-of=openshell-agents" -o name 2>/dev/null || true)
-  if [[ -n "$AGENT_CMS" ]]; then
-    for cm in $AGENT_CMS; do
-      log_info "  Deleting $cm"
-      run_cmd kubectl delete "$cm" -n "$TENANT" --ignore-not-found
+  # Delete agent policy configmaps (named ${agent_name}-policy by deploy-tenant.sh)
+  AGENT_DIR="$REPO_ROOT/deployments/openshell/agents"
+  if [[ -d "$AGENT_DIR" ]]; then
+    for agent_dir in "$AGENT_DIR"/*/; do
+      agent_name=$(basename "$agent_dir")
+      run_cmd kubectl delete configmap "${agent_name}-policy" -n "$TENANT" --ignore-not-found
     done
   fi
 
   # Delete skills configmap
-  if kubectl get configmap kagenti-skills -n "$TENANT" &>/dev/null; then
-    log_info "  Deleting configmap/kagenti-skills"
-    run_cmd kubectl delete configmap kagenti-skills -n "$TENANT" --ignore-not-found
-  fi
+  run_cmd kubectl delete configmap kagenti-skills -n "$TENANT" --ignore-not-found
 
   # Delete openshell-supervisor ServiceAccount
-  if kubectl get serviceaccount openshell-supervisor -n "$TENANT" &>/dev/null; then
-    log_info "  Deleting serviceaccount/openshell-supervisor"
-    run_cmd kubectl delete serviceaccount openshell-supervisor -n "$TENANT" --ignore-not-found
-  fi
+  run_cmd kubectl delete serviceaccount openshell-supervisor -n "$TENANT" --ignore-not-found
 
   log_success "Agent resources cleaned up"
 else
@@ -150,12 +144,12 @@ if is_openshift; then
   fi
 
   # Remove SCC policies granted during agent deployment
-  for SA in openshell-gateway openshell-supervisor; do
-    for SCC in anyuid privileged; do
-      run_cmd oc adm policy remove-scc-from-user "$SCC" \
-        -z "$SA" -n "$TENANT" 2>/dev/null || true
-    done
-  done
+  # deploy-tenant.sh grants anyuid to openshell-gateway in openshell-system,
+  # and privileged to openshell-supervisor in the tenant namespace
+  run_cmd oc adm policy remove-scc-from-user anyuid \
+    -z openshell-gateway -n openshell-system 2>/dev/null || true
+  run_cmd oc adm policy remove-scc-from-user privileged \
+    -z openshell-supervisor -n "$TENANT" 2>/dev/null || true
 
   log_success "OpenShift SCCs cleaned up"
 else
@@ -163,10 +157,21 @@ else
 fi
 
 # ============================================================================
-# Step 3: Helm uninstall
+# Step 3: Remove non-Helm resources that deploy-tenant.sh applies directly
+# ============================================================================
+if kubectl get namespace "$TENANT" &>/dev/null; then
+  # OpenShift trusted CA bundle ConfigMap (created via kubectl apply, not Helm)
+  if is_openshift; then
+    log_info "Step 3a: Removing openshell-trusted-ca ConfigMap..."
+    run_cmd kubectl delete configmap openshell-trusted-ca -n "$TENANT" --ignore-not-found
+  fi
+fi
+
+# ============================================================================
+# Step 4: Helm uninstall
 # ============================================================================
 RELEASE_NAME="${HELM_RELEASE_PREFIX}-${TENANT}"
-log_info "Step 3: Uninstalling Helm release $RELEASE_NAME..."
+log_info "Step 4: Uninstalling Helm release $RELEASE_NAME..."
 
 if helm status "$RELEASE_NAME" -n "$TENANT" &>/dev/null; then
   run_cmd helm uninstall "$RELEASE_NAME" -n "$TENANT" --wait
@@ -176,30 +181,30 @@ else
 fi
 
 # ============================================================================
-# Step 4: Remove namespace labels
+# Step 5: Remove namespace labels
 # ============================================================================
 if kubectl get namespace "$TENANT" &>/dev/null; then
-  log_info "Step 4: Removing namespace labels..."
+  log_info "Step 5: Removing namespace labels..."
   run_cmd kubectl label namespace "$TENANT" shared-gateway-access- --overwrite 2>/dev/null || true
   run_cmd kubectl label namespace "$TENANT" openshell.ai/tenant- --overwrite 2>/dev/null || true
   log_success "Namespace labels removed"
 else
-  log_warn "Step 4: Namespace $TENANT does not exist, skipping label removal"
+  log_warn "Step 5: Namespace $TENANT does not exist, skipping label removal"
 fi
 
 # ============================================================================
-# Step 5: Delete namespace (optional)
+# Step 6: Delete namespace (optional)
 # ============================================================================
 if $DELETE_NAMESPACE; then
   if kubectl get namespace "$TENANT" &>/dev/null; then
-    log_warn "Step 5: Deleting namespace $TENANT (this will remove ALL resources in it)..."
+    log_warn "Step 6: Deleting namespace $TENANT (this will remove ALL resources in it)..."
     run_cmd kubectl delete namespace "$TENANT" --wait=true --timeout=120s
     log_success "Namespace $TENANT deleted"
   else
-    log_warn "Step 5: Namespace $TENANT already gone"
+    log_warn "Step 6: Namespace $TENANT already gone"
   fi
 else
-  log_info "Step 5: Skipping namespace deletion (use --delete-namespace to remove)"
+  log_info "Step 6: Skipping namespace deletion (use --delete-namespace to remove)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds `scripts/openshell/cleanup-tenant.sh` to remove a single tenant's OpenShell resources (Helm release, agent deployments, namespace labels, OpenShift SCCs)
- Adds `scripts/openshell/cleanup-shared.sh` to remove shared infrastructure (backend, LiteLLM, Keycloak realm, cert-manager CA chain, Gateway, sandbox controller)
- Adds `scripts/openshell/cleanup-all.sh` as a convenience wrapper that discovers all tenants and removes everything
- Adds an "Uninstall" section to `docs/sandbox-guide.md`

All scripts are idempotent, support `--dry-run`, and handle both Kind and OpenShift environments.

## Test plan

- [ ] Run `cleanup-tenant.sh team1 --dry-run` and verify expected commands are printed
- [ ] Run `cleanup-all.sh --dry-run` on a cluster with OpenShell deployed
- [ ] Deploy OpenShell to Kind, then run `cleanup-all.sh` and verify all resources are removed
- [ ] Re-run `cleanup-all.sh` (idempotency check — should succeed with warnings)
- [ ] Verify `cleanup-shared.sh --skip-keycloak` preserves the Keycloak realm

Closes #1698

Assisted-By: Claude Code