### PR TITLE
fix(otel): remove span filter processors that cause orphaned traces

### DIFF
--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -231,16 +231,6 @@ otel:
           tls:
             insecure: true
       processors:
-        filter/phoenix:
-          traces:
-            span:
-              - 'IsMatch(name, "^a2a\\..*")'
-              - 'attributes["http.method"] != nil'
-              - 'attributes["openinference.span.kind"] != nil'
-              - 'attributes["mcp.method.name"] == "initialize"'
-              - 'attributes["mcp.method.name"] == "notifications/initialized"'
-              - 'attributes["mcp.method.name"] == "notifications/cancelled"'
-              - 'attributes["mcp.method.name"] == "tools/list"'
         transform/genai_to_openinference:
           trace_statements:
             - context: span
@@ -276,7 +266,7 @@ otel:
         pipelines:
           traces/phoenix:
             receivers: [otlp]
-            processors: [memory_limiter, filter/phoenix, transform/genai_to_openinference, batch]
+            processors: [memory_limiter, transform/genai_to_openinference, batch]
             exporters: [otlp/phoenix]
     mlflowConfig:
       exporters:
@@ -299,23 +289,11 @@ otel:
             enabled: true
             num_consumers: 2
             queue_size: 1000
-      processors:
-        filter/mlflow:
-          traces:
-            span:
-              - 'IsMatch(name, "^a2a\\..*")'
-              - 'attributes["http.method"] != nil and IsMatch(name, "^(POST|GET|DELETE)$")'
-              - 'IsMatch(name, "^mcp-router\\..*") and (attributes["http.method"] == "GET" or attributes["http.method"] == "DELETE")'
-              - 'attributes["openinference.span.kind"] != nil'
-              - 'attributes["mcp.method.name"] == "initialize"'
-              - 'attributes["mcp.method.name"] == "notifications/initialized"'
-              - 'attributes["mcp.method.name"] == "notifications/cancelled"'
-              - 'attributes["mcp.method.name"] == "tools/list"'
       service:
         pipelines:
           traces/mlflow:
             receivers: [otlp]
-            processors: [memory_limiter, filter/mlflow, batch]
+            processors: [memory_limiter, batch]
             exporters: [debug, otlphttp/mlflow]
     # MLflow OAuth extension config - auto-merged when mlflow.auth.enabled
     mlflowAuthConfig:


### PR DESCRIPTION
## Summary

- Remove `filter/phoenix` and `filter/mlflow` OTel Collector processors that drop intermediate spans (A2A protocol, HTTP-attributed, MCP lifecycle spans)
- These filters break parent-child span hierarchy — child spans referencing a dropped parent appear detached from their actual ancestor, connecting only to the trace root
- Traces now preserve complete span trees for accurate debugging and observability

Closes #1606

## Test plan

- [ ] Deploy to Kind cluster and verify OTel collector starts without errors
- [ ] Send agent requests and confirm trace views in Phoenix show complete span hierarchies
- [ ] Verify MLflow trace ingestion shows full parent-child relationships
- [ ] Confirm no orphaned/detached spans appear in trace visualizations

Assisted-By: Claude Code