### PR TITLE
fix(istio): keep gateway pods out of ambient capture

### DIFF
--- a/charts/kagenti-deps/templates/ingress-gateway.yaml
+++ b/charts/kagenti-deps/templates/ingress-gateway.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: http
   labels:
+    # Keep generated gateway pods out of ambient capture.
+    istio.io/dataplane-mode: none
     {{- include "kagenti.labels" . | nindent 4 }}
   annotations:
     networking.istio.io/service-type: ClusterIP

--- a/charts/kagenti/templates/mcp-gateway.yaml
+++ b/charts/kagenti/templates/mcp-gateway.yaml
@@ -12,6 +12,8 @@ metadata:
   labels:
     gateway.io/name: mcp-gateway
     istio: ingressgateway
+    # Keep generated gateway pods out of ambient capture.
+    istio.io/dataplane-mode: none
     {{- include "kagenti.labels" . | nindent 4 }}
 spec:
   gatewayClassName: istio


### PR DESCRIPTION
## Summary
This PR hardens Kagenti's gateway resources for Istio ambient environments by explicitly opting the generated gateway pods out of ambient capture.

In practice: we add `istio.io/dataplane-mode: none` to the Gateway resource metadata for both Kagenti gateways so the controller-generated gateway pods consistently inherit the intended mode.

## Background
Kagenti namespaces are labeled for Istio ambient (`istio.io/dataplane-mode=ambient`). That is correct for most workloads.

Gateway pods (`http-istio`, `mcp-gateway-istio`) are different: they are infrastructure entrypoints managed by the Gateway API controller. They should run in non-ambient dataplane mode (`none`) rather than being ambient-captured.

When that opt-out is not applied consistently at the source Gateway object, replacements can come up with ambient redirection and become unstable.

## Problem observed
On `agentic-cloud` (agentic-node cluster), gateway replicas intermittently came up as ambient-captured and entered `CrashLoopBackOff` in `istio-proxy`.

Healthy vs failing pattern observed:
- healthy gateway pods had `istio.io/dataplane-mode=none` and no ambient redirection annotation
- failing gateway pods lacked `dataplane-mode=none` and showed ambient redirection

This created rollout-dependent behavior where some replicas were stable and others crashed.

## What this PR changes
Set explicit gateway opt-out labels on the Gateway resources that drive generated pods:

- `charts/kagenti-deps/templates/ingress-gateway.yaml`
  - add `metadata.labels.istio.io/dataplane-mode: none` to `Gateway/http`
- `charts/kagenti/templates/mcp-gateway.yaml`
  - add `metadata.labels.istio.io/dataplane-mode: none` to `Gateway/mcp-gateway`

## Why this helps
1. Makes desired gateway dataplane mode declarative in chart source.
2. Prevents rollout-time drift where newly generated gateway pods are ambient-captured.
3. Stabilizes gateway deployments across restarts/reconciliations.

## Validation
- `helm lint ./charts/kagenti-deps --set openshift=false --set components.spire.enabled=false --set components.ingressGateway.enabled=true`
- `helm lint ./charts/kagenti`
- Rendered manifests include `istio.io/dataplane-mode: none` on both Gateway resources.
- Live cluster validation on `agentic-cloud`:
  - applied equivalent Gateway labels and rolled out `mcp-gateway-istio` + `http-istio`
  - monitored for 30 minutes (6 x 5-minute checkpoints)
  - both gateways remained healthy throughout with no CrashLoop recurrence

## Scope
This change is limited to gateway template metadata labels and does not alter workload ambient defaults for agent namespaces.

Assisted-By: Codex
