### PR TITLE
Fix/setup kagenti mapfile portability

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -303,7 +303,10 @@ if $PRELOAD_IMAGES && ! $DRY_RUN; then
     exit 1
   fi
 
-  mapfile -t PRELOAD_LIST < <(grep -v '^\s*#' "$PRELOAD_FILE" | grep -v '^\s*$')
+  PRELOAD_LIST=()
+  while IFS= read -r line; do
+    PRELOAD_LIST+=("$line")
+  done < <(grep -v '^[[:space:]]*#' "$PRELOAD_FILE" | grep -v '^[[:space:]]*$')
   if [ ${#PRELOAD_LIST[@]} -eq 0 ]; then
     log_warn "Preload images file is empty — skipping"
   else


### PR DESCRIPTION
## Summary

  - Replaces the Bash 4+ `mapfile` builtin in `scripts/kind/setup-kagenti.sh` with a portable `while IFS= read` loop so `--preload-images` works on macOS's default `/bin/bash`
  (3.2.57).
  - Switches the accompanying `grep` patterns from `\s` (GNU-only) to POSIX `[[:space:]]` for BSD grep compatibility.

  Fixes #1709.

  ## Background

  On a stock macOS, running:

  ```sh
  ./scripts/kind/setup-kagenti.sh --preload-images

  fails with:

  scripts/kind/setup-kagenti.sh: line 306: mapfile: command not found

  The script's shebang is #!/usr/bin/env bash, which resolves to system Bash 3.2 unless the user has Homebrew bash earlier on PATH. mapfile was introduced in Bash 4.