### PR TITLE
fix(istio): enable ambient control-plane flag for istiod

### DIFF
--- a/charts/kagenti-deps/templates/istio-operand.yaml
+++ b/charts/kagenti-deps/templates/istio-operand.yaml
@@ -13,6 +13,10 @@ spec:
   namespace:  "{{ .Values.istio.namespace }}"
   values:
     pilot:
+      # Required by ztunnel in ambient mode; without this, ztunnel fails XDS
+      # with "ztunnel requires PILOT_ENABLE_AMBIENT=true".
+      env:
+        PILOT_ENABLE_AMBIENT: "true"
       trustedZtunnelNamespace: "{{ .Values.istio.ztunnel.namespace }}"
       # Reduce default resource requests to fit on resource-constrained
       # dev clusters with limited CPUs.


### PR DESCRIPTION
## Summary
On my cluster, an Istio upgrade left `istiod` without `PILOT_ENABLE_AMBIENT=true`, which the ambient dataplane (`ztunnel`) requires. The result was networking instability and Kagenti pod crashloops.

## Background
Kagenti uses Istio **ambient networking** — Istio's sidecar-less mode. Instead of injecting an Envoy proxy into every pod, traffic is handled by a per-node agent (`ztunnel`) for L4 and mTLS, with optional `waypoint` proxies for L7. Lower overhead, no pod restarts to enroll workloads, but the data plane is split across two layers that must stay in sync.

Ambient mode needs two sides aligned:

1. `istiod` (control plane) publishes ambient config.
2. `ztunnel` (dataplane) enforces it on each node.

If `istiod` doesn't have ambient enabled, `ztunnel` can't get the config it needs — even when `ztunnel` itself is running fine.

## Problem observed
After upgrading Istio on my cluster:

1. `istiod` came up without `PILOT_ENABLE_AMBIENT=true`.
2. `ztunnel` logged: `ztunnel requires PILOT_ENABLE_AMBIENT=true`.
3. Kagenti workloads became unstable, including crashloops in core pods.

Root cause: control-plane / dataplane config drift after the upgrade, not a Kagenti app bug.

## What this PR changes
Declare ambient enablement explicitly in our managed chart:

- `charts/kagenti-deps/templates/istio-operand.yaml` under `spec.values.pilot.env`:
  - `PILOT_ENABLE_AMBIENT: "true"`

## Why this helps
1. Survives future Istio upgrades and reconciles.
2. Turns a manual runtime fix into versioned config.
3. Keeps ambient control-plane and dataplane aligned.

## Scope
This code change updates the OpenShift/Sail-managed Istio operand template path in this repo.

## Testing
- Confirmed template render includes `PILOT_ENABLE_AMBIENT: "true"` in the Istio operand.
- During incident recovery, confirmed that setting this flag on live `istiod` removed `ztunnel requires PILOT_ENABLE_AMBIENT=true` errors and restored stability.

Assisted-By: Codex
