### PR TITLE
Fix: Update ose-cli image from v4.17 to v4.15

### DIFF
--- a/charts/kagenti/templates/ui-routes-job.yaml
+++ b/charts/kagenti/templates/ui-routes-job.yaml
@@ -194,7 +194,7 @@ spec:
       serviceAccountName: {{ include "kagenti.fullname" . }}-route-processor-sa
       containers:
       - name: script-runner
-        image: {{ .Values.common.oseCLIImage | default "registry.redhat.io/openshift4/ose-cli:v4.17" }}
+        image: {{ .Values.common.oseCLIImage | default "registry.redhat.io/openshift4/ose-cli:v4.15" }}
         command: ["/bin/bash", "-c", "/scripts/process_routes.sh"]
         volumeMounts:
         - name: script-volume

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -48,7 +48,7 @@ secrets:
 
 common:
   kubectlImage: "quay.io/kubestellar/kubectl:1.30.14"
-  oseCLIImage: "registry.redhat.io/openshift4/ose-cli:v4.17"
+  oseCLIImage: "registry.redhat.io/openshift4/ose-cli:v4.15"
 
 # ------------------------------------------------------------------
 #  Components Configurations


### PR DESCRIPTION
The kagenti-process-routes-job Helm hook fails on OpenShift 4.20.23 because registry.redhat.io/openshift4/ose-cli:v4.17 does not exist. The latest available tag is v4.15.

Changes:
- charts/kagenti/values.yaml: Update common.oseCLIImage default
- charts/kagenti/templates/ui-routes-job.yaml: Update inline fallback

Assisted-By: Claude Code

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary
Current workflows are targeting a non existent image tag. This is a small fix for it.
## Related issue(s)

## (Optional) Testing Instructions

Fixes #1713 
