### PR TITLE
:bug: fix(ui): render in-cluster URLs as non-clickable text

### DIFF
--- a/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
@@ -483,9 +483,13 @@ export const ToolDetailPage: React.FC = () => {
                       <DescriptionListGroup>
                         <DescriptionListTerm>MCP Server URL</DescriptionListTerm>
                         <DescriptionListDescription>
-                          <a href={toolExternalUrl} target="_blank" rel="noopener noreferrer">
-                            {toolExternalUrl}
-                          </a>
+                          {hasRoute ? (
+                            <a href={toolExternalUrl} target="_blank" rel="noopener noreferrer">
+                              {toolExternalUrl}
+                            </a>
+                          ) : (
+                            <code>{toolExternalUrl}</code>
+                          )}
                         </DescriptionListDescription>
                       </DescriptionListGroup>
                     </DescriptionList>
@@ -846,9 +850,7 @@ export const ToolDetailPage: React.FC = () => {
                   <DescriptionListGroup>
                     <DescriptionListTerm>MCP Server URL (in-cluster)</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <a href={mcpInClusterUrl} target="_blank" rel="noopener noreferrer">
-                        {mcpInClusterUrl}
-                      </a>
+                      <code>{mcpInClusterUrl}</code>
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                   <DescriptionListGroup>


### PR DESCRIPTION
## Summary

- In-cluster MCP server URLs (`http://<svc>.<ns>.svc.cluster.local:...`) on the MCP Tools detail page were rendered as clickable hyperlinks, leading users to a "site can't be reached" error when clicked.
- The MCP Inspector tab's in-cluster URL is now rendered as `<code>` (never clickable — these URLs are only reachable from inside the cluster).
- The MCP Server URL field on the Overview tab now conditionally renders: clickable `<a>` when an external route exists, non-clickable `<code>` when it doesn't.

<img width="1146" height="650" alt="image" src="https://github.com/user-attachments/assets/1744bcf8-c3a5-4d13-8596-cf1bab5bb9da" />

Fixes #1716

## Test plan

- [x] Navigate to MCP Tools → select a tool → Overview tab: verify the MCP Server URL renders as plain `<code>` text when no external route exists
- [x] Navigate to MCP Tools → select a tool → MCP Inspector tab: verify the in-cluster URL renders as non-clickable `<code>` text
- [x] If an external route exists, verify the Overview tab URL is still a clickable link

Assisted-By: Claude Code