### PR TITLE
:bug: fix(ui): make Enter key invoke tool in MCP dialog

### DIFF
--- a/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
@@ -953,7 +953,12 @@ export const ToolDetailPage: React.FC = () => {
               </p>
             )}
 
-            <Form>
+            <Form onSubmit={(e) => {
+              e.preventDefault();
+              if (!invokeMutation.isPending) {
+                handleInvoke();
+              }
+            }}>
               {selectedTool.input_schema?.properties &&
               Object.keys(selectedTool.input_schema.properties).length > 0 ? (
                 Object.entries(selectedTool.input_schema.properties).map(([key, prop]) => {


### PR DESCRIPTION
## Summary

- Pressing `Enter` after typing a tool argument in the MCP Tools invoke dialog unexpectedly closed the dialog instead of invoking the tool.
- Root cause: the `<Form>` element had no `onSubmit` handler, so the browser's default form submission fired and dismissed the modal.
- Added `onSubmit` handler that calls `preventDefault()` and triggers `handleInvoke()`, making Enter submit the form as users expect.

<img width="1574" height="884" alt="image" src="https://github.com/user-attachments/assets/63e50542-de0a-40a1-917d-f331ed2b53fa" />


Fixes #1715

## Test plan

- [ ] Navigate to MCP Tools → select a tool → **Invoke Tool**
- [ ] Type a value in the argument field and press `Enter`
- [ ] Verify the tool is invoked (same as clicking the **Invoke** button)
- [ ] Verify the dialog stays open and shows the result
- [ ] Verify clicking **Close** still dismisses the dialog normally

Assisted-By: Claude Code