### PR TITLE
fix(kind): remove stale UI password display from setup script

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1320,17 +1320,8 @@ if [ -n "$KC_ADMIN_PASS" ]; then
 else
   echo "    Keycloak admin console: (pending — secret keycloak-initial-admin not ready)"
 fi
-if $WITH_UI; then
-  UI_USER=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
-  UI_PASS=$(kubectl get secret kagenti-test-user -n keycloak -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
-  if [ -n "$UI_PASS" ]; then
-    echo "    Kagenti UI login:       ${UI_USER} / ${UI_PASS}"
-  else
-    echo "    Kagenti UI login:       (pending — run show-services.sh once platform is ready)"
-  fi
-fi
 echo ""
-echo "  For full service URLs and credentials, run:"
+echo "  For service URLs and credentials (including UI login), run:"
 echo "    .github/scripts/local-setup/show-services.sh"
 echo ""
 


### PR DESCRIPTION
## Summary

- Remove the unreliable UI credential display from `scripts/kind/setup-kagenti.sh`
- Direct users to `show-services.sh` as the single source of truth for credentials

On re-runs, the `kagenti-test-user` secret may not reflect the actual Keycloak password, causing the displayed credentials to fail at login. The `show-services.sh` script always reads the correct state.

Fixes #1725

## Test plan

- [ ] Run `scripts/kind/setup-kagenti.sh --with-ui` on a fresh cluster — verify it points to `show-services.sh`
- [ ] Re-run the script — verify no stale password is shown
- [ ] Run `.github/scripts/local-setup/show-services.sh` — verify correct credentials

Assisted-By: Claude Code