### PR TITLE
fix(ocp): use mlflow-integration role for OTel collector RBAC

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -435,9 +435,10 @@ _mlflow_grant_otel_rbac() {
   # The RHOAI MLflow operator creates ClusterRoles for MLflow access control.
   # The otel-collector SA needs a RoleBinding in each agent namespace (workspace)
   # so the collector can send traces with the correct workspace context.
-  # Prefer mlflow-operator-mlflow-edit (read+write), fall back to older name.
+  # Prefer mlflow-operator-mlflow-integration (has get/list/create/update on
+  # experiments — required by the /v1/traces OTLP endpoint), fall back to edit.
   local cr_name=""
-  local candidates=("mlflow-operator-mlflow-edit" "mlflow-operator-mlflow-integration")
+  local candidates=("mlflow-operator-mlflow-integration" "mlflow-operator-mlflow-edit")
   local tries=0
   while [ -z "$cr_name" ]; do
     for candidate in "${candidates[@]}"; do


### PR DESCRIPTION
## Summary

- Swap ClusterRole candidate order in `_mlflow_grant_otel_rbac()` to prefer `mlflow-operator-mlflow-integration` over `mlflow-operator-mlflow-edit`
- The `mlflow-integration` role includes get/list/create/update on experiments, which the MLflow `/v1/traces` OTLP endpoint requires to resolve the experiment by name before writing spans
- The `mlflow-edit` role only has create/update (no get/list), causing 400 Bad Request responses from the trace ingest endpoint

## Test plan

- [ ] Deploy with `--with-all` on OCP cluster with RHOAI MLflow installed
- [ ] Run an agent (e.g. weather agent) and verify traces appear in MLflow under the `kagenti-traces` experiment
- [ ] Confirm `otel-collector` logs show successful 2xx responses to MLflow

Assisted-By: Claude Code