### PR TITLE
docs: reference operator NetworkReady condition for OVN routingViaHost

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -246,7 +246,7 @@ Common options:
 |------|-------------|
 | `--kagenti-repo PATH\|URL` | Local path or GitHub URL to the repo (default: clones `main` to `~/.cache/kagenti`) |
 | `--realm REALM` | Keycloak realm (default: `kagenti`) |
-| `--skip-ovn-patch` | Skip OVN gateway routing patch |
+| `--skip-ovn-patch` | Skip OVN gateway routing patch (operator logs a warning at startup if not applied) |
 | `--skip-mcp-gateway` | Skip MCP Gateway installation |
 | `--skip-ui` | Skip Kagenti UI and backend installation |
 | `--skip-mlflow` | Skip MLflow integration |

--- a/docs/ocp/openshift-install.md
+++ b/docs/ocp/openshift-install.md
@@ -90,7 +90,7 @@ Preview what commands would execute without running them:
 | `--kagenti-repo PATH\|URL` | Local path or GitHub URL (default: auto-clone `main`) |
 | `--realm REALM` | Keycloak realm (default: `kagenti`) |
 | `--keycloak-namespace NS` | Keycloak namespace (default: `keycloak`) |
-| `--skip-ovn-patch` | Skip OVN gateway routing patch |
+| `--skip-ovn-patch` | Skip OVN gateway routing patch (operator logs a warning at startup if not applied) |
 | `--skip-mcp-gateway` | Skip MCP Gateway |
 | `--skip-ui` | Skip UI and backend |
 | `--skip-mlflow` | Skip MLflow integration |

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -111,7 +111,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --kagenti-repo PATH|URL   Local path or GitHub URL to kagenti repo (default: clone main to ~/.cache/kagenti)"
       echo "  --realm REALM             Keycloak realm (default: kagenti, or \$KEYCLOAK_REALM)"
       echo "  --keycloak-namespace NS   Keycloak namespace (default: keycloak, or \$KEYCLOAK_NAMESPACE)"
-      echo "  --skip-ovn-patch          Skip OVN gateway routing patch"
+      echo "  --skip-ovn-patch          Skip OVN gateway routing patch (operator logs warning at startup)"
       echo "  --skip-mcp-gateway        Skip MCP Gateway (ignored when --with-kuadrant is set)"
       echo "  --skip-ui                 Skip Kagenti UI and backend installation"
       echo "  --skip-mlflow             Skip MLflow integration (OTel traces + operator auto-config)"
@@ -260,6 +260,7 @@ log_info "Step 1: OVN Gateway Patch"
 
 if $SKIP_OVN_PATCH; then
   log_info "Skipped (--skip-ovn-patch)"
+  log_warn "The kagenti-operator will log a warning at startup if routingViaHost is not enabled"
 else
   # Check if this is an OVNKubernetes cluster
   NETWORK_TYPE=$($KUBECTL get network.operator.openshift.io cluster -o jsonpath='{.spec.defaultNetwork.type}' 2>/dev/null || echo "unknown")


### PR DESCRIPTION
> **Merge ordering:** This PR should not be merged until [kagenti-operator#386](https://github.com/kagenti/kagenti-operator/pull/386) is merged first — that PR adds the startup network check this documentation references.

## Summary

Updates the OCP setup script and installation docs to inform users that the kagenti-operator now checks OVN `routingViaHost` configuration at startup and logs a warning if it's not enabled. When `--skip-ovn-patch` is used, the script warns that the operator will flag the misconfiguration in its logs.

## Changes

- **`scripts/ocp/setup-kagenti.sh`** — added warning when `--skip-ovn-patch` is used about operator startup check; updated success message after patch; updated help text
- **`docs/install.md`** — updated `--skip-ovn-patch` flag description
- **`docs/ocp/openshift-install.md`** — same

## Test Plan

- [ ] Verify `--skip-ovn-patch` help text renders correctly: `scripts/ocp/setup-kagenti.sh --help`
- [ ] Review log output when running with `--skip-ovn-patch` on an OVN cluster