### PR TITLE
fix(ui): show descriptive error on agent chat 403

### DIFF
--- a/kagenti/ui-v2/src/components/AgentChat.tsx
+++ b/kagenti/ui-v2/src/components/AgentChat.tsx
@@ -192,7 +192,9 @@ export const AgentChat: React.FC<AgentChatProps> = ({ namespace, name }) => {
         }
 
         if (!response.ok) {
-          throw new Error(`HTTP error: ${response.status}`);
+          const errorData = await response.json().catch(() => ({}));
+          const detail = typeof errorData.detail === 'string' ? errorData.detail : '';
+          throw new Error(detail || `HTTP error: ${response.status}`);
         }
 
         const reader = response.body?.getReader();


### PR DESCRIPTION
## Summary

- Parse the JSON response body on non-2xx responses in the Agent Chat streaming handler
- Display the backend's `detail` message (e.g., "Required role(s): kagenti-operator") instead of the raw "HTTP error: 403"
- Falls back to status code if body parsing fails or no detail is present

Closes #1721

## Before / After

| Before | After |
|--------|-------|
| `Error: HTTP error: 403` | `Error: Required role(s): kagenti-operator` |

## Test plan

- [ ] Log in as non-admin user (e.g., "bob") without kagenti-operator role
- [ ] Navigate to an agent's Chat tab
- [ ] Send a message — verify the error now shows "Required role(s): kagenti-operator"
- [ ] Log in as admin user — verify chat still works normally
- [ ] Test with network error (agent down) — verify generic error still appears

Assisted-By: Claude Code