### PR TITLE
fix(ui): show real MCP Gateway status instead of hardcoded Running

### DIFF
--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -230,3 +230,22 @@ async def get_platform_status(
     )
 
     return PlatformStatusResponse(components=components, registry=registry)
+
+
+class MCPGatewayStatusResponse(BaseModel):
+    """Status of the MCP Gateway component."""
+
+    status: Literal["Ready", "Degraded", "Missing"]
+
+
+@router.get(
+    "/mcp-gateway-status",
+    response_model=MCPGatewayStatusResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def get_mcp_gateway_status(
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> MCPGatewayStatusResponse:
+    """Return the health status of the MCP Gateway deployment."""
+    status = _check_deployment_ready(kube, "gateway-system", "mcp-gateway-istio")
+    return MCPGatewayStatusResponse(status=status)

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -247,5 +247,6 @@ async def get_mcp_gateway_status(
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> MCPGatewayStatusResponse:
     """Return the health status of the MCP Gateway deployment."""
+    # TODO: parameterize namespace/deployment if install location ever varies
     status = _check_deployment_ready(kube, "gateway-system", "mcp-gateway-istio")
     return MCPGatewayStatusResponse(status=status)

--- a/kagenti/backend/tests/test_mcp_gateway_status.py
+++ b/kagenti/backend/tests/test_mcp_gateway_status.py
@@ -1,0 +1,92 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for MCP Gateway status endpoint.
+
+Validates that GET /config/mcp-gateway-status correctly reports the
+MCP Gateway deployment state as Ready, Degraded, or Missing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers.config import router
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+
+
+@pytest.fixture
+def mock_kube():
+    """Create a mock KubernetesService."""
+    return MagicMock(spec=KubernetesService)
+
+
+@pytest.fixture
+def client(mock_kube):
+    """Create a test client with DI override for KubernetesService."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_kubernetes_service] = lambda: mock_kube
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+class TestMCPGatewayStatus:
+    """Test /config/mcp-gateway-status endpoint."""
+
+    def test_gateway_ready(self, client, mock_kube):
+        """When mcp-gateway-istio deployment is ready, returns Ready."""
+        mock_deployment = MagicMock()
+        mock_deployment.spec.replicas = 1
+        mock_deployment.status.ready_replicas = 1
+        mock_kube.apps_api.read_namespaced_deployment.return_value = mock_deployment
+
+        with patch("app.core.auth.settings") as mock_auth_settings:
+            mock_auth_settings.enable_auth = False
+            response = client.get("/api/v1/config/mcp-gateway-status")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "Ready"}
+        mock_kube.apps_api.read_namespaced_deployment.assert_called_once_with(
+            name="mcp-gateway-istio", namespace="gateway-system"
+        )
+
+    def test_gateway_missing(self, client, mock_kube):
+        """When gateway-system namespace or deployment doesn't exist, returns Missing."""
+        mock_kube.apps_api.read_namespaced_deployment.side_effect = ApiException(status=404)
+
+        with patch("app.core.auth.settings") as mock_auth_settings:
+            mock_auth_settings.enable_auth = False
+            response = client.get("/api/v1/config/mcp-gateway-status")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "Missing"}
+
+    def test_gateway_degraded(self, client, mock_kube):
+        """When deployment exists but replicas aren't ready, returns Degraded."""
+        mock_deployment = MagicMock()
+        mock_deployment.spec.replicas = 2
+        mock_deployment.status.ready_replicas = 1
+        mock_kube.apps_api.read_namespaced_deployment.return_value = mock_deployment
+
+        with patch("app.core.auth.settings") as mock_auth_settings:
+            mock_auth_settings.enable_auth = False
+            response = client.get("/api/v1/config/mcp-gateway-status")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "Degraded"}
+
+    def test_gateway_degraded_on_api_error(self, client, mock_kube):
+        """When K8s API returns non-404 error, returns Degraded."""
+        mock_kube.apps_api.read_namespaced_deployment.side_effect = ApiException(status=503)
+
+        with patch("app.core.auth.settings") as mock_auth_settings:
+            mock_auth_settings.enable_auth = False
+            response = client.get("/api/v1/config/mcp-gateway-status")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "Degraded"}

--- a/kagenti/ui-v2/src/pages/MCPGatewayPage.tsx
+++ b/kagenti/ui-v2/src/pages/MCPGatewayPage.tsx
@@ -34,14 +34,9 @@ import { useQuery } from '@tanstack/react-query';
 import { configService } from '@/services/api';
 
 export const MCPGatewayPage: React.FC = () => {
-  // Placeholder query - will be replaced with actual API call
-  const { isLoading } = useQuery({
+  const { data: gatewayStatus, isLoading } = useQuery({
     queryKey: ['mcp-gateway-status'],
-    queryFn: async () => {
-      // Placeholder - return mock data for now
-      return { status: 'running', tools: 12, uptime: '5d 12h' };
-    },
-    enabled: false, // Disabled until API is ready
+    queryFn: () => configService.getMCPGatewayStatus(),
   });
 
   // Fetch dashboard config for MCP Inspector URL
@@ -103,7 +98,15 @@ export const MCPGatewayPage: React.FC = () => {
                     <DescriptionListGroup>
                       <DescriptionListTerm>Status</DescriptionListTerm>
                       <DescriptionListDescription>
-                        <Label color="green">Running</Label>
+                        {gatewayStatus?.status === 'Ready' && (
+                          <Label color="green">Running</Label>
+                        )}
+                        {gatewayStatus?.status === 'Degraded' && (
+                          <Label color="orange">Degraded</Label>
+                        )}
+                        {(gatewayStatus?.status === 'Missing' || !gatewayStatus) && (
+                          <Label color="grey">Not Installed</Label>
+                        )}
                       </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>

--- a/kagenti/ui-v2/src/pages/MCPGatewayPage.tsx
+++ b/kagenti/ui-v2/src/pages/MCPGatewayPage.tsx
@@ -34,7 +34,7 @@ import { useQuery } from '@tanstack/react-query';
 import { configService } from '@/services/api';
 
 export const MCPGatewayPage: React.FC = () => {
-  const { data: gatewayStatus, isLoading } = useQuery({
+  const { data: gatewayStatus, isLoading, isError } = useQuery({
     queryKey: ['mcp-gateway-status'],
     queryFn: () => configService.getMCPGatewayStatus(),
   });
@@ -98,13 +98,14 @@ export const MCPGatewayPage: React.FC = () => {
                     <DescriptionListGroup>
                       <DescriptionListTerm>Status</DescriptionListTerm>
                       <DescriptionListDescription>
+                        {isError && <Label color="red">Status unknown</Label>}
                         {gatewayStatus?.status === 'Ready' && (
                           <Label color="green">Running</Label>
                         )}
                         {gatewayStatus?.status === 'Degraded' && (
                           <Label color="orange">Degraded</Label>
                         )}
-                        {(gatewayStatus?.status === 'Missing' || !gatewayStatus) && (
+                        {gatewayStatus?.status === 'Missing' && (
                           <Label color="grey">Not Installed</Label>
                         )}
                       </DescriptionListDescription>

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -737,6 +737,10 @@ export interface PlatformStatusResponse {
 /**
  * Config service
  */
+export interface MCPGatewayStatusResponse {
+  status: 'Ready' | 'Degraded' | 'Missing';
+}
+
 export const configService = {
   async getDashboards(): Promise<DashboardConfig> {
     return apiFetch('/config/dashboards');
@@ -744,6 +748,10 @@ export const configService = {
 
   async getPlatformStatus(): Promise<PlatformStatusResponse> {
     return apiFetch('/config/platform-status');
+  },
+
+  async getMCPGatewayStatus(): Promise<MCPGatewayStatusResponse> {
+    return apiFetch('/config/mcp-gateway-status');
   },
 };
 


### PR DESCRIPTION
## Summary

- Add backend `GET /config/mcp-gateway-status` endpoint that checks the `mcp-gateway-istio` deployment in `gateway-system` namespace
- Replace hardcoded green "Running" label in the MCP Gateway page with a real API call
- Display "Running" (green), "Degraded" (orange), or "Not Installed" (grey) based on actual cluster state

Closes #1720

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/test_mcp_gateway_status.py -v` (4 tests covering Ready/Degraded/Missing/API-error)
- [ ] Deploy to Kind without MCP Gateway → page shows "Not Installed"
- [ ] Deploy to Kind with MCP Gateway → page shows "Running"
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

Assisted-By: Claude Code