### PR TITLE
Feat: UI verbiage simplification and outbound table for AuthBridge

### DIFF
--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -203,13 +203,19 @@ export const ImportAgentPage: React.FC = () => {
   });
   const [outboundRoutes, setOutboundRoutes] = useState<RouteRow[]>([makeEmptyRoute()]);
   const isEmptyRoute = (r: RouteRow) => !r.host && !r.target_audience;
+  const isCommittedRoute = (r: RouteRow) => !!r.host && !!r.target_audience;
   const removeRoute = (i: number) => setOutboundRoutes((prev) => prev.filter((_, idx) => idx !== i));
   const updateRoute = (i: number, field: 'host' | 'target_audience' | 'token_scopes', value: string) =>
     setOutboundRoutes((prev) => {
       const updated = [...prev];
       updated[i] = { ...updated[i], [field]: value };
-      // If the user edited the trailing empty row, append a fresh empty row.
-      if (i === prev.length - 1 && (value || updated[i].host || updated[i].target_audience)) {
+      // Once the trailing row has both Host Pattern and Target OIDC Audience
+      // filled in, promote it by appending a fresh empty row below.
+      if (
+        i === prev.length - 1 &&
+        updated[i].host &&
+        updated[i].target_audience
+      ) {
         updated.push(makeEmptyRoute());
       }
       return updated;
@@ -1179,13 +1185,13 @@ export const ImportAgentPage: React.FC = () => {
               <ExpandableSection
                 toggleText={(() => {
                   const n = outboundRoutes.filter((r) => !isEmptyRoute(r)).length;
-                  return `Outbound Authorization header control (${n} route${n !== 1 ? 's' : ''})`;
+                  return `Outbound OIDC token exchange rules (${n} route${n !== 1 ? 's' : ''})`;
                 })()}
                 isExpanded={showOutboundRouting}
                 onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
               >
                 <Text component="p" style={{ marginBottom: '8px' }}>
-                  RFC 8693 / OAuth 2.0 Token Exchange - Restrict outbound to certain hosts and OIDC audiences and scopes.
+                  RFC 8693 / OAuth 2.0 Token Exchange - Restrict outbound to certain hosts, OIDC audiences, and scopes.
                 </Text>
                 <Table aria-label="Outbound routes" variant="compact">
                   <Thead>
@@ -1198,7 +1204,7 @@ export const ImportAgentPage: React.FC = () => {
                   </Thead>
                   <Tbody>
                     {outboundRoutes.map((route, index) => {
-                      const isTrailingEmpty = isEmptyRoute(route) && index === outboundRoutes.length - 1;
+                      const showRemove = isCommittedRoute(route);
                       return (
                         <Tr key={route.id}>
                           <Td>
@@ -1226,7 +1232,7 @@ export const ImportAgentPage: React.FC = () => {
                             />
                           </Td>
                           <Td>
-                            {!isTrailingEmpty && (
+                            {showRemove && (
                               <Button variant="link" onClick={() => removeRoute(index)}>
                                 Remove
                               </Button>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -35,6 +35,7 @@ import {
   Checkbox,
 } from '@patternfly/react-core';
 import { TrashIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { agentService, ShipwrightBuildConfig, skillService } from '@/services/api';
@@ -1147,7 +1148,7 @@ export const ImportAgentPage: React.FC = () => {
               </FormGroup>
 
               {authBridgeEnabled && (
-                <div style={{ marginLeft: '24px' }}>
+                <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
                   <Checkbox
                     id="useEnvoyMode"
                     label="Sandbox networking with Envoy proxy"
@@ -1155,7 +1156,7 @@ export const ImportAgentPage: React.FC = () => {
                     onChange={(_e, checked) => setUseEnvoyMode(checked)}
                     description="AuthBridge secures agent with iptables and Envoy proxy"
                   />
-                </div>
+                </FormGroup>
               )}
 
               {/* SPIRE Identity */}
@@ -1179,93 +1180,86 @@ export const ImportAgentPage: React.FC = () => {
                   RFC 8693 / OAuth 2.0 Token Exchange -
                   Restrict outbound to certain hosts and OIDC audiences and scopes.
                 </Text>
-                <div style={{ border: '1px solid var(--pf-v5-global--BorderColor--100)', marginBottom: '8px' }}>
-                  <Grid style={{ background: 'var(--pf-v5-global--BackgroundColor--200)', fontWeight: 'bold', fontSize: '0.85em', textTransform: 'uppercase' }}>
-                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>Host Pattern</GridItem>
-                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>Target OIDC Audience</GridItem>
-                    <GridItem span={4} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>OIDC Token Scopes</GridItem>
-                    <GridItem span={2} style={{ padding: '8px' }}></GridItem>
-                  </Grid>
-                  {outboundRoutes.map((route, index) => (
-                    <Grid key={route.id} style={{ borderTop: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
-                      <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                <Table aria-label="Outbound routes" variant="compact">
+                  <Thead>
+                    <Tr>
+                      <Th width={25}>Host Pattern</Th>
+                      <Th width={25}>Target OIDC Audience</Th>
+                      <Th width={30}>OIDC Token Scopes</Th>
+                      <Th width={20} screenReaderText="Actions" />
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {outboundRoutes.map((route, index) => (
+                      <Tr key={route.id}>
+                        <Td>
+                          <TextInput
+                            aria-label="Host pattern"
+                            value={route.host}
+                            onChange={(_e, v) => updateRoute(index, 'host', v)}
+                            placeholder="e.g. github-tool-mcp"
+                          />
+                        </Td>
+                        <Td>
+                          <TextInput
+                            aria-label="Target audience"
+                            value={route.target_audience}
+                            onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
+                            placeholder="e.g. github-tool"
+                          />
+                        </Td>
+                        <Td>
+                          <TextInput
+                            aria-label="Token scopes"
+                            value={route.token_scopes}
+                            onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
+                            placeholder="openid"
+                          />
+                        </Td>
+                        <Td>
+                          <Button variant="link" onClick={() => removeRoute(index)}>
+                            Remove
+                          </Button>
+                        </Td>
+                      </Tr>
+                    ))}
+                    <Tr>
+                      <Td>
                         <TextInput
                           aria-label="Host pattern"
-                          value={route.host}
-                          onChange={(_e, v) => updateRoute(index, 'host', v)}
+                          value={draftRoute.host}
+                          onChange={(_e, v) => updateDraftRoute('host', v)}
                           placeholder="e.g. github-tool-mcp"
                         />
-                      </GridItem>
-                      <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                      </Td>
+                      <Td>
                         <TextInput
                           aria-label="Target audience"
-                          value={route.target_audience}
-                          onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
+                          value={draftRoute.target_audience}
+                          onChange={(_e, v) => updateDraftRoute('target_audience', v)}
                           placeholder="e.g. github-tool"
                         />
-                      </GridItem>
-                      <GridItem span={4} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                      </Td>
+                      <Td>
                         <TextInput
                           aria-label="Token scopes"
-                          value={route.token_scopes}
-                          onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
-                          placeholder="openid scope1 scope2"
+                          value={draftRoute.token_scopes}
+                          onChange={(_e, v) => updateDraftRoute('token_scopes', v)}
+                          placeholder="openid"
                         />
-                      </GridItem>
-                      <GridItem span={2} style={{ padding: '8px' }}>
-                        <Button variant="plain" onClick={() => removeRoute(index)}>
-                          Remove
+                      </Td>
+                      <Td>
+                        <Button
+                          variant="link"
+                          isDisabled={!draftRoute.host || !draftRoute.target_audience || !draftRoute.token_scopes}
+                          onClick={addRoute}
+                        >
+                          Add Route
                         </Button>
-                      </GridItem>
-                    </Grid>
-                  ))}
-                  <Grid style={{ borderTop: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
-                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
-                      <TextInput
-                        aria-label="Host pattern"
-                        value={draftRoute.host}
-                        onChange={(_e, v) => updateDraftRoute('host', v)}
-                        placeholder="e.g. github-tool-mcp"
-                      />
-                    </GridItem>
-                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
-                      <TextInput
-                        aria-label="Target audience"
-                        value={draftRoute.target_audience}
-                        onChange={(_e, v) => updateDraftRoute('target_audience', v)}
-                        placeholder="e.g. github-tool"
-                      />
-                    </GridItem>
-                    <GridItem span={4} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
-                      <TextInput
-                        aria-label="Token scopes"
-                        value={draftRoute.token_scopes}
-                        onChange={(_e, v) => updateDraftRoute('token_scopes', v)}
-                        placeholder="openid scope1 scope2"
-                      />
-                    </GridItem>
-                    <GridItem span={2} style={{ padding: '8px' }}>
-                      {(() => {
-                        const canAdd = !!(draftRoute.host && draftRoute.target_audience && draftRoute.token_scopes);
-                        return (
-                          <Button
-                            variant="plain"
-                            onClick={(e) => {
-                              if (canAdd) {
-                                addRoute();
-                              }
-                              (e.currentTarget as HTMLButtonElement).blur();
-                            }}
-                            style={!canAdd ? { color: 'var(--pf-v5-global--disabled-color--100)', cursor: 'not-allowed' } : undefined}
-                            aria-disabled={!canAdd}
-                          >
-                            Add Route
-                          </Button>
-                        );
-                      })()}
-                    </GridItem>
-                  </Grid>
-                </div>
+                      </Td>
+                    </Tr>
+                  </Tbody>
+                </Table>
               </ExpandableSection>
               )}
 

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -192,17 +192,26 @@ export const ImportAgentPage: React.FC = () => {
 
   // Outbound routing rules
   const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
-  const addRoute = () =>
+  const [draftRoute, setDraftRoute] = useState<{ host: string; target_audience: string; token_scopes: string }>({
+    host: '',
+    target_audience: '',
+    token_scopes: 'openid',
+  });
+  const addRoute = () => {
     setOutboundRoutes((prev) => [
       ...prev,
-      { id: newRouteRowId(), host: '', target_audience: '', token_scopes: 'openid' },
+      { id: newRouteRowId(), ...draftRoute },
     ]);
+    setDraftRoute({ host: '', target_audience: '', token_scopes: 'openid' });
+  };
   const removeRoute = (i: number) => setOutboundRoutes(outboundRoutes.filter((_, idx) => idx !== i));
   const updateRoute = (i: number, field: string, value: string) => {
     const updated = [...outboundRoutes];
     updated[i] = { ...updated[i], [field]: value };
     setOutboundRoutes(updated);
   };
+  const updateDraftRoute = (field: 'host' | 'target_audience' | 'token_scopes', value: string) =>
+    setDraftRoute((prev) => ({ ...prev, [field]: value }));
 
   // Port exclusion annotations
   const [outboundPortsExclude, setOutboundPortsExclude] = useState('');
@@ -1125,7 +1134,7 @@ export const ImportAgentPage: React.FC = () => {
               <FormGroup fieldId="authBridgeEnabled">
                 <Checkbox
                   id="authBridgeEnabled"
-                  label="Enable AuthBridge sidecar injection"
+                  label="Secure with AuthBridge"
                   isChecked={authBridgeEnabled}
                   onChange={(_e, checked) => {
                     setAuthBridgeEnabled(checked);
@@ -1133,20 +1142,20 @@ export const ImportAgentPage: React.FC = () => {
                       setUseEnvoyMode(false);
                     }
                   }}
-                  description="When enabled, the operator injects a combined AuthBridge sidecar for inbound JWT validation and outbound token exchange. Defaults to proxy-sidecar mode (HTTP_PROXY)."
+                  description="When enabled, the agent will reject inbound messages without valid Authorization JWT"
               />
               </FormGroup>
 
               {authBridgeEnabled && (
-                <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
+                <div style={{ marginLeft: '24px' }}>
                   <Checkbox
                     id="useEnvoyMode"
-                    label="Use envoy-sidecar mode"
+                    label="Sandbox networking with Envoy proxy"
                     isChecked={useEnvoyMode}
                     onChange={(_e, checked) => setUseEnvoyMode(checked)}
-                    description="Switch from proxy-sidecar (default) to envoy-sidecar mode (Envoy + ext_proc + iptables interception)."
+                    description="AuthBridge secures agent with iptables and Envoy proxy"
                   />
-                </FormGroup>
+                </div>
               )}
 
               {/* SPIRE Identity */}
@@ -1162,49 +1171,101 @@ export const ImportAgentPage: React.FC = () => {
 
               {authBridgeEnabled && (
               <ExpandableSection
-                toggleText={`Outbound Routing Rules (${outboundRoutes.length} route${outboundRoutes.length !== 1 ? 's' : ''})`}
+                toggleText={`Outbound Authorization header control (${outboundRoutes.length} route${outboundRoutes.length !== 1 ? 's' : ''})`}
                 isExpanded={showOutboundRouting}
                 onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
               >
                 <Text component="p" style={{ marginBottom: '8px' }}>
-                  Configure token exchange rules for outbound HTTP requests. Each route matches a service host and specifies the target audience and OAuth scopes for the exchanged token.
+                  RFC 8693 / OAuth 2.0 Token Exchange -
+                  Restrict outbound to certain hosts and OIDC audiences and scopes.
                 </Text>
-                {outboundRoutes.map((route, index) => (
-                  <Grid hasGutter key={route.id} style={{ marginBottom: '8px' }}>
-                    <GridItem span={3}>
+                <div style={{ border: '1px solid var(--pf-v5-global--BorderColor--100)', marginBottom: '8px' }}>
+                  <Grid style={{ background: 'var(--pf-v5-global--BackgroundColor--200)', fontWeight: 'bold', fontSize: '0.85em', textTransform: 'uppercase' }}>
+                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>Host Pattern</GridItem>
+                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>Target OIDC Audience</GridItem>
+                    <GridItem span={4} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>OIDC Token Scopes</GridItem>
+                    <GridItem span={2} style={{ padding: '8px' }}></GridItem>
+                  </Grid>
+                  {outboundRoutes.map((route, index) => (
+                    <Grid key={route.id} style={{ borderTop: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                      <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                        <TextInput
+                          aria-label="Host pattern"
+                          value={route.host}
+                          onChange={(_e, v) => updateRoute(index, 'host', v)}
+                          placeholder="e.g. github-tool-mcp"
+                        />
+                      </GridItem>
+                      <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                        <TextInput
+                          aria-label="Target audience"
+                          value={route.target_audience}
+                          onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
+                          placeholder="e.g. github-tool"
+                        />
+                      </GridItem>
+                      <GridItem span={4} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                        <TextInput
+                          aria-label="Token scopes"
+                          value={route.token_scopes}
+                          onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
+                          placeholder="openid scope1 scope2"
+                        />
+                      </GridItem>
+                      <GridItem span={2} style={{ padding: '8px' }}>
+                        <Button variant="plain" onClick={() => removeRoute(index)}>
+                          Remove
+                        </Button>
+                      </GridItem>
+                    </Grid>
+                  ))}
+                  <Grid style={{ borderTop: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
+                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
                       <TextInput
                         aria-label="Host pattern"
-                        value={route.host}
-                        onChange={(_e, v) => updateRoute(index, 'host', v)}
+                        value={draftRoute.host}
+                        onChange={(_e, v) => updateDraftRoute('host', v)}
                         placeholder="e.g. github-tool-mcp"
                       />
                     </GridItem>
-                    <GridItem span={3}>
+                    <GridItem span={3} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
                       <TextInput
                         aria-label="Target audience"
-                        value={route.target_audience}
-                        onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
+                        value={draftRoute.target_audience}
+                        onChange={(_e, v) => updateDraftRoute('target_audience', v)}
                         placeholder="e.g. github-tool"
                       />
                     </GridItem>
-                    <GridItem span={4}>
+                    <GridItem span={4} style={{ padding: '8px', borderRight: '1px solid var(--pf-v5-global--BorderColor--100)' }}>
                       <TextInput
                         aria-label="Token scopes"
-                        value={route.token_scopes}
-                        onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
+                        value={draftRoute.token_scopes}
+                        onChange={(_e, v) => updateDraftRoute('token_scopes', v)}
                         placeholder="openid scope1 scope2"
                       />
                     </GridItem>
-                    <GridItem span={2}>
-                      <Button variant="plain" onClick={() => removeRoute(index)}>
-                        Remove
-                      </Button>
+                    <GridItem span={2} style={{ padding: '8px' }}>
+                      {(() => {
+                        const canAdd = !!(draftRoute.host && draftRoute.target_audience && draftRoute.token_scopes);
+                        return (
+                          <Button
+                            variant="plain"
+                            onClick={(e) => {
+                              if (canAdd) {
+                                addRoute();
+                              }
+                              (e.currentTarget as HTMLButtonElement).blur();
+                            }}
+                            style={!canAdd ? { color: 'var(--pf-v5-global--disabled-color--100)', cursor: 'not-allowed' } : undefined}
+                            aria-disabled={!canAdd}
+                          >
+                            Add Route
+                          </Button>
+                        );
+                      })()}
                     </GridItem>
                   </Grid>
-                ))}
-                <Button variant="link" onClick={addRoute}>
-                  Add Route
-                </Button>
+                </div>
               </ExpandableSection>
               )}
 
@@ -1213,7 +1274,7 @@ export const ImportAgentPage: React.FC = () => {
               <ExpandableSection
                 toggleText="AuthBridge Advanced Configuration"
               >
-                <FormGroup label="Outbound Ports to Exclude" fieldId="outboundPortsExclude">
+                <FormGroup label="Disable outbound security for some ports" fieldId="outboundPortsExclude">
                   <TextInput
                     id="outboundPortsExclude"
                     value={outboundPortsExclude}
@@ -1222,11 +1283,11 @@ export const ImportAgentPage: React.FC = () => {
                   />
                   <FormHelperText>
                     <HelperText>
-                      <HelperTextItem>Comma-separated ports to bypass outbound proxy interception.</HelperTextItem>
+                      <HelperTextItem>Comma-separated TCP ports.</HelperTextItem>
                     </HelperText>
                   </FormHelperText>
                 </FormGroup>
-                <FormGroup label="Inbound Ports to Exclude" fieldId="inboundPortsExclude">
+                <FormGroup label="Disable inbound security on ports" fieldId="inboundPortsExclude">
                   <TextInput
                     id="inboundPortsExclude"
                     value={inboundPortsExclude}
@@ -1235,7 +1296,7 @@ export const ImportAgentPage: React.FC = () => {
                   />
                   <FormHelperText>
                     <HelperText>
-                      <HelperTextItem>Comma-separated ports to bypass inbound proxy interception.</HelperTextItem>
+                      <HelperTextItem>Comma-separated TCP ports.</HelperTextItem>
                     </HelperText>
                   </FormHelperText>
                 </FormGroup>
@@ -1247,10 +1308,10 @@ export const ImportAgentPage: React.FC = () => {
                     aria-label="Default outbound policy"
                   >
                     <FormSelectOption key="passthrough" value="passthrough" label="passthrough — pass traffic through unchanged (default)" />
-                    <FormSelectOption key="exchange" value="exchange" label="exchange — require token exchange for all outbound traffic" />
+                    <FormSelectOption key="exchange" value="exchange" label="exchange — require RFC 8693 / OAuth 2.0 Token Exchange exchange for all outbound traffic" />
                   </FormSelect>
                 </FormGroup>
-                <FormGroup label="mTLS" fieldId="mtlsMode">
+                <FormGroup label="Mutual TLS (mTLS)" fieldId="mtlsMode">
                   <FormSelect
                     id="mtlsMode"
                     value={mtlsMode}
@@ -1258,9 +1319,9 @@ export const ImportAgentPage: React.FC = () => {
                     aria-label="mTLS mode"
                     isDisabled={!spireEnabled}
                   >
-                    <FormSelectOption key="disabled" value="disabled" label="disabled — no mTLS between sidecars (default)" />
-                    <FormSelectOption key="permissive" value="permissive" label="permissive — allow non-mTLS peers (rollout-friendly)" />
-                    <FormSelectOption key="strict" value="strict" label="strict — require mTLS, fail closed" />
+                    <FormSelectOption key="disabled" value="disabled" label="disabled — don't use mTLS between sidecars (default)" />
+                    <FormSelectOption key="permissive" value="permissive" label="permissive — use, but allow non-mTLS peers (rollout-friendly)" />
+                    <FormSelectOption key="strict" value="strict" label="strict — require mTLS, fail without" />
                   </FormSelect>
                   {!spireEnabled && (
                     <FormHelperText>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -202,7 +202,6 @@ export const ImportAgentPage: React.FC = () => {
     token_scopes: 'openid',
   });
   const [outboundRoutes, setOutboundRoutes] = useState<RouteRow[]>([makeEmptyRoute()]);
-  const isEmptyRoute = (r: RouteRow) => !r.host && !r.target_audience;
   const isCommittedRoute = (r: RouteRow) => !!r.host && !!r.target_audience;
   const removeRoute = (i: number) => setOutboundRoutes((prev) => prev.filter((_, idx) => idx !== i));
   const updateRoute = (i: number, field: 'host' | 'target_audience' | 'token_scopes', value: string) =>
@@ -211,6 +210,8 @@ export const ImportAgentPage: React.FC = () => {
       updated[i] = { ...updated[i], [field]: value };
       // Once the trailing row has both Host Pattern and Target OIDC Audience
       // filled in, promote it by appending a fresh empty row below.
+      // (Promotion runs on every per-field onChange; both fields are read fresh
+      // inside the setter so order doesn't matter.)
       if (
         i === prev.length - 1 &&
         updated[i].host &&
@@ -542,8 +543,8 @@ export const ImportAgentPage: React.FC = () => {
         // and envoy-sidecar support the full disabled/permissive/strict
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
-        outboundRoutes: authBridgeEnabled && outboundRoutes.some((r) => !isEmptyRoute(r))
-          ? outboundRoutes.filter((r) => !isEmptyRoute(r)).map(({ id, ...r }) => r)
+        outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
+          ? outboundRoutes.filter(isCommittedRoute).map(({ id, ...r }) => r)
           : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -584,8 +585,8 @@ export const ImportAgentPage: React.FC = () => {
         // and envoy-sidecar support the full disabled/permissive/strict
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
-        outboundRoutes: authBridgeEnabled && outboundRoutes.some((r) => !isEmptyRoute(r))
-          ? outboundRoutes.filter((r) => !isEmptyRoute(r)).map(({ id, ...r }) => r)
+        outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
+          ? outboundRoutes.filter(isCommittedRoute).map(({ id, ...r }) => r)
           : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -1184,7 +1185,7 @@ export const ImportAgentPage: React.FC = () => {
               {authBridgeEnabled && (
               <ExpandableSection
                 toggleText={(() => {
-                  const n = outboundRoutes.filter((r) => !isEmptyRoute(r)).length;
+                  const n = outboundRoutes.filter(isCommittedRoute).length;
                   return `Outbound OIDC token exchange rules (${n} route${n !== 1 ? 's' : ''})`;
                 })()}
                 isExpanded={showOutboundRouting}
@@ -1251,7 +1252,7 @@ export const ImportAgentPage: React.FC = () => {
               <ExpandableSection
                 toggleText="AuthBridge Advanced Configuration"
               >
-                <FormGroup label="Disable outbound security for some ports" fieldId="outboundPortsExclude">
+                <FormGroup label="Bypass AuthBridge on these outbound ports" fieldId="outboundPortsExclude">
                   <TextInput
                     id="outboundPortsExclude"
                     value={outboundPortsExclude}
@@ -1264,7 +1265,7 @@ export const ImportAgentPage: React.FC = () => {
                     </HelperText>
                   </FormHelperText>
                 </FormGroup>
-                <FormGroup label="Disable AuthBridge inbound security on ports" fieldId="inboundPortsExclude">
+                <FormGroup label="Bypass AuthBridge on some inbound ports" fieldId="inboundPortsExclude">
                   <TextInput
                     id="inboundPortsExclude"
                     value={inboundPortsExclude}

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -191,28 +191,29 @@ export const ImportAgentPage: React.FC = () => {
   // Use envoy-sidecar mode (false = proxy-sidecar, the default)
   const [useEnvoyMode, setUseEnvoyMode] = useState(false);
 
-  // Outbound routing rules
-  const [outboundRoutes, setOutboundRoutes] = useState<Array<{ id: string; host: string; target_audience: string; token_scopes: string }>>([]);
-  const [draftRoute, setDraftRoute] = useState<{ host: string; target_audience: string; token_scopes: string }>({
+  // Outbound routing rules. The table always renders a trailing empty row
+  // (host='', target_audience='', token_scopes='openid'). Editing any field
+  // commits that row to state and a fresh empty row appears below it.
+  type RouteRow = { id: string; host: string; target_audience: string; token_scopes: string };
+  const makeEmptyRoute = (): RouteRow => ({
+    id: newRouteRowId(),
     host: '',
     target_audience: '',
     token_scopes: 'openid',
   });
-  const addRoute = () => {
-    setOutboundRoutes((prev) => [
-      ...prev,
-      { id: newRouteRowId(), ...draftRoute },
-    ]);
-    setDraftRoute({ host: '', target_audience: '', token_scopes: 'openid' });
-  };
-  const removeRoute = (i: number) => setOutboundRoutes(outboundRoutes.filter((_, idx) => idx !== i));
-  const updateRoute = (i: number, field: string, value: string) => {
-    const updated = [...outboundRoutes];
-    updated[i] = { ...updated[i], [field]: value };
-    setOutboundRoutes(updated);
-  };
-  const updateDraftRoute = (field: 'host' | 'target_audience' | 'token_scopes', value: string) =>
-    setDraftRoute((prev) => ({ ...prev, [field]: value }));
+  const [outboundRoutes, setOutboundRoutes] = useState<RouteRow[]>([makeEmptyRoute()]);
+  const isEmptyRoute = (r: RouteRow) => !r.host && !r.target_audience;
+  const removeRoute = (i: number) => setOutboundRoutes((prev) => prev.filter((_, idx) => idx !== i));
+  const updateRoute = (i: number, field: 'host' | 'target_audience' | 'token_scopes', value: string) =>
+    setOutboundRoutes((prev) => {
+      const updated = [...prev];
+      updated[i] = { ...updated[i], [field]: value };
+      // If the user edited the trailing empty row, append a fresh empty row.
+      if (i === prev.length - 1 && (value || updated[i].host || updated[i].target_audience)) {
+        updated.push(makeEmptyRoute());
+      }
+      return updated;
+    });
 
   // Port exclusion annotations
   const [outboundPortsExclude, setOutboundPortsExclude] = useState('');
@@ -535,7 +536,9 @@ export const ImportAgentPage: React.FC = () => {
         // and envoy-sidecar support the full disabled/permissive/strict
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
-        outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
+        outboundRoutes: authBridgeEnabled && outboundRoutes.some((r) => !isEmptyRoute(r))
+          ? outboundRoutes.filter((r) => !isEmptyRoute(r)).map(({ id, ...r }) => r)
+          : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
@@ -575,7 +578,9 @@ export const ImportAgentPage: React.FC = () => {
         // and envoy-sidecar support the full disabled/permissive/strict
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
-        outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
+        outboundRoutes: authBridgeEnabled && outboundRoutes.some((r) => !isEmptyRoute(r))
+          ? outboundRoutes.filter((r) => !isEmptyRoute(r)).map(({ id, ...r }) => r)
+          : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
@@ -1154,7 +1159,7 @@ export const ImportAgentPage: React.FC = () => {
                     label="Use Envoy + iptables interception"
                     isChecked={useEnvoyMode}
                     onChange={(_e, checked) => setUseEnvoyMode(checked)}
-                    description="AuthBridge secures agent with iptables and Envoy proxy"
+                    description="Enforce transparent outbound interception (vs HTTP_PROXY env vars)"
                   />
                 </FormGroup>
               )}
@@ -1172,7 +1177,10 @@ export const ImportAgentPage: React.FC = () => {
 
               {authBridgeEnabled && (
               <ExpandableSection
-                toggleText={`Outbound Authorization header control (${outboundRoutes.length} route${outboundRoutes.length !== 1 ? 's' : ''})`}
+                toggleText={(() => {
+                  const n = outboundRoutes.filter((r) => !isEmptyRoute(r)).length;
+                  return `Outbound Authorization header control (${n} route${n !== 1 ? 's' : ''})`;
+                })()}
                 isExpanded={showOutboundRouting}
                 onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
               >
@@ -1189,74 +1197,44 @@ export const ImportAgentPage: React.FC = () => {
                     </Tr>
                   </Thead>
                   <Tbody>
-                    {outboundRoutes.map((route, index) => (
-                      <Tr key={route.id}>
-                        <Td>
-                          <TextInput
-                            aria-label="Host pattern"
-                            value={route.host}
-                            onChange={(_e, v) => updateRoute(index, 'host', v)}
-                            placeholder="e.g. github-tool-mcp"
-                          />
-                        </Td>
-                        <Td>
-                          <TextInput
-                            aria-label="Target audience"
-                            value={route.target_audience}
-                            onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
-                            placeholder="e.g. github-tool"
-                          />
-                        </Td>
-                        <Td>
-                          <TextInput
-                            aria-label="Token scopes"
-                            value={route.token_scopes}
-                            onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
-                            placeholder="openid"
-                          />
-                        </Td>
-                        <Td>
-                          <Button variant="link" onClick={() => removeRoute(index)}>
-                            Remove
-                          </Button>
-                        </Td>
-                      </Tr>
-                    ))}
-                    <Tr>
-                      <Td>
-                        <TextInput
-                          aria-label="Host pattern"
-                          value={draftRoute.host}
-                          onChange={(_e, v) => updateDraftRoute('host', v)}
-                          placeholder="e.g. github-tool-mcp"
-                        />
-                      </Td>
-                      <Td>
-                        <TextInput
-                          aria-label="Target audience"
-                          value={draftRoute.target_audience}
-                          onChange={(_e, v) => updateDraftRoute('target_audience', v)}
-                          placeholder="e.g. github-tool"
-                        />
-                      </Td>
-                      <Td>
-                        <TextInput
-                          aria-label="Token scopes"
-                          value={draftRoute.token_scopes}
-                          onChange={(_e, v) => updateDraftRoute('token_scopes', v)}
-                          placeholder="openid"
-                        />
-                      </Td>
-                      <Td>
-                        <Button
-                          variant="link"
-                          isDisabled={!draftRoute.host || !draftRoute.target_audience }
-                          onClick={addRoute}
-                        >
-                          Add Route
-                        </Button>
-                      </Td>
-                    </Tr>
+                    {outboundRoutes.map((route, index) => {
+                      const isTrailingEmpty = isEmptyRoute(route) && index === outboundRoutes.length - 1;
+                      return (
+                        <Tr key={route.id}>
+                          <Td>
+                            <TextInput
+                              aria-label="Host pattern"
+                              value={route.host}
+                              onChange={(_e, v) => updateRoute(index, 'host', v)}
+                              placeholder="e.g. github-tool-mcp"
+                            />
+                          </Td>
+                          <Td>
+                            <TextInput
+                              aria-label="Target audience"
+                              value={route.target_audience}
+                              onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
+                              placeholder="e.g. github-tool"
+                            />
+                          </Td>
+                          <Td>
+                            <TextInput
+                              aria-label="Token scopes"
+                              value={route.token_scopes}
+                              onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
+                              placeholder="openid"
+                            />
+                          </Td>
+                          <Td>
+                            {!isTrailingEmpty && (
+                              <Button variant="link" onClick={() => removeRoute(index)}>
+                                Remove
+                              </Button>
+                            )}
+                          </Td>
+                        </Tr>
+                      );
+                    })}
                   </Tbody>
                 </Table>
               </ExpandableSection>
@@ -1280,7 +1258,7 @@ export const ImportAgentPage: React.FC = () => {
                     </HelperText>
                   </FormHelperText>
                 </FormGroup>
-                <FormGroup label="Disable inbound security on ports" fieldId="inboundPortsExclude">
+                <FormGroup label="Disable AuthBridge inbound security on ports" fieldId="inboundPortsExclude">
                   <TextInput
                     id="inboundPortsExclude"
                     value={inboundPortsExclude}

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -203,6 +203,10 @@ export const ImportAgentPage: React.FC = () => {
   });
   const [outboundRoutes, setOutboundRoutes] = useState<RouteRow[]>([makeEmptyRoute()]);
   const isCommittedRoute = (r: RouteRow) => !!r.host && !!r.target_audience;
+  const serializeRoute = ({ id, token_scopes, ...r }: RouteRow) => ({
+    ...r,
+    token_scopes: token_scopes || 'openid',
+  });
   const removeRoute = (i: number) => setOutboundRoutes((prev) => prev.filter((_, idx) => idx !== i));
   const updateRoute = (i: number, field: 'host' | 'target_audience' | 'token_scopes', value: string) =>
     setOutboundRoutes((prev) => {
@@ -544,10 +548,7 @@ export const ImportAgentPage: React.FC = () => {
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
-          ? outboundRoutes.filter(isCommittedRoute).map(({ id, token_scopes, ...r }) => ({
-              ...r,
-              token_scopes: token_scopes || 'openid',
-            }))
+          ? outboundRoutes.filter(isCommittedRoute).map(serializeRoute)
           : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -589,10 +590,7 @@ export const ImportAgentPage: React.FC = () => {
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
-          ? outboundRoutes.filter(isCommittedRoute).map(({ id, token_scopes, ...r }) => ({
-              ...r,
-              token_scopes: token_scopes || 'openid',
-            }))
+          ? outboundRoutes.filter(isCommittedRoute).map(serializeRoute)
           : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -1198,7 +1196,7 @@ export const ImportAgentPage: React.FC = () => {
                 onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
               >
                 <Text component="p" style={{ marginBottom: '8px' }}>
-                  RFC 8693 / OAuth 2.0 Token Exchange - Restrict outbound to certain hosts, OIDC audiences, and scopes.
+                  RFC 8693 / OAuth 2.0 Token Exchange — Restrict outbound to certain hosts, OIDC audiences, and scopes.
                 </Text>
                 <Table aria-label="Outbound routes" variant="compact">
                   <Thead>
@@ -1211,7 +1209,7 @@ export const ImportAgentPage: React.FC = () => {
                   </Thead>
                   <Tbody>
                     {outboundRoutes.map((route, index) => {
-                      const showRemove = isCommittedRoute(route);
+                      const showRemove = index < outboundRoutes.length - 1;
                       return (
                         <Tr key={route.id}>
                           <Td>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -544,7 +544,10 @@ export const ImportAgentPage: React.FC = () => {
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
-          ? outboundRoutes.filter(isCommittedRoute).map(({ id, ...r }) => r)
+          ? outboundRoutes.filter(isCommittedRoute).map(({ id, token_scopes, ...r }) => ({
+              ...r,
+              token_scopes: token_scopes || 'openid',
+            }))
           : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -586,7 +589,10 @@ export const ImportAgentPage: React.FC = () => {
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
         outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
-          ? outboundRoutes.filter(isCommittedRoute).map(({ id, ...r }) => r)
+          ? outboundRoutes.filter(isCommittedRoute).map(({ id, token_scopes, ...r }) => ({
+              ...r,
+              token_scopes: token_scopes || 'openid',
+            }))
           : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
@@ -1265,7 +1271,7 @@ export const ImportAgentPage: React.FC = () => {
                     </HelperText>
                   </FormHelperText>
                 </FormGroup>
-                <FormGroup label="Bypass AuthBridge on some inbound ports" fieldId="inboundPortsExclude">
+                <FormGroup label="Bypass AuthBridge on these inbound ports" fieldId="inboundPortsExclude">
                   <TextInput
                     id="inboundPortsExclude"
                     value={inboundPortsExclude}

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1235,7 +1235,7 @@ export const ImportAgentPage: React.FC = () => {
                               aria-label="Token scopes"
                               value={route.token_scopes}
                               onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
-                              placeholder="openid"
+                              placeholder="openid scope1 scope2"
                             />
                           </Td>
                           <Td>
@@ -1303,7 +1303,7 @@ export const ImportAgentPage: React.FC = () => {
                     aria-label="mTLS mode"
                     isDisabled={!spireEnabled}
                   >
-                    <FormSelectOption key="disabled" value="disabled" label="disabled — don't use mTLS between sidecars (default)" />
+                    <FormSelectOption key="disabled" value="disabled" label="disabled — no mTLS between sidecars (default)" />
                     <FormSelectOption key="permissive" value="permissive" label="permissive — use, but allow non-mTLS peers (rollout-friendly)" />
                     <FormSelectOption key="strict" value="strict" label="strict — require mTLS, fail without" />
                   </FormSelect>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1177,8 +1177,7 @@ export const ImportAgentPage: React.FC = () => {
                 onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
               >
                 <Text component="p" style={{ marginBottom: '8px' }}>
-                  RFC 8693 / OAuth 2.0 Token Exchange -
-                  Restrict outbound to certain hosts and OIDC audiences and scopes.
+                  RFC 8693 / OAuth 2.0 Token Exchange - Restrict outbound to certain hosts and OIDC audiences and scopes.
                 </Text>
                 <Table aria-label="Outbound routes" variant="compact">
                   <Thead>
@@ -1302,7 +1301,7 @@ export const ImportAgentPage: React.FC = () => {
                     aria-label="Default outbound policy"
                   >
                     <FormSelectOption key="passthrough" value="passthrough" label="passthrough — pass traffic through unchanged (default)" />
-                    <FormSelectOption key="exchange" value="exchange" label="exchange — require RFC 8693 / OAuth 2.0 Token Exchange exchange for all outbound traffic" />
+                    <FormSelectOption key="exchange" value="exchange" label="exchange — require RFC 8693 / OAuth 2.0 Token Exchange for all outbound traffic" />
                   </FormSelect>
                 </FormGroup>
                 <FormGroup label="Mutual TLS (mTLS)" fieldId="mtlsMode">

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1135,7 +1135,7 @@ export const ImportAgentPage: React.FC = () => {
               <FormGroup fieldId="authBridgeEnabled">
                 <Checkbox
                   id="authBridgeEnabled"
-                  label="Secure with AuthBridge"
+                  label="Secure with Kagenti AuthBridge"
                   isChecked={authBridgeEnabled}
                   onChange={(_e, checked) => {
                     setAuthBridgeEnabled(checked);
@@ -1143,7 +1143,7 @@ export const ImportAgentPage: React.FC = () => {
                       setUseEnvoyMode(false);
                     }
                   }}
-                  description="When enabled, the agent will reject inbound messages without valid Authorization JWT"
+                  description="When enabled, the agent will reject inbound messages without valid JWT and can perform outbound token exchange."
               />
               </FormGroup>
 
@@ -1151,7 +1151,7 @@ export const ImportAgentPage: React.FC = () => {
                 <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
                   <Checkbox
                     id="useEnvoyMode"
-                    label="Sandbox networking with Envoy proxy"
+                    label="Use Envoy + iptables interception"
                     isChecked={useEnvoyMode}
                     onChange={(_e, checked) => setUseEnvoyMode(checked)}
                     description="AuthBridge secures agent with iptables and Envoy proxy"
@@ -1250,7 +1250,7 @@ export const ImportAgentPage: React.FC = () => {
                       <Td>
                         <Button
                           variant="link"
-                          isDisabled={!draftRoute.host || !draftRoute.target_audience || !draftRoute.token_scopes}
+                          isDisabled={!draftRoute.host || !draftRoute.target_audience }
                           onClick={addRoute}
                         >
                           Add Route


### PR DESCRIPTION
## Summary

Resolves #1309

In addition to simplifying verbiage, this PR tries to make it easier to understand the three components of outbound route rules, and make the UI behave more like similar UIs for table editing.

## (Optional) Testing Instructions

The usual -- check out this PR, then

```bash
make build-load-ui-frontend &&
  UI_TAG=$(docker images | grep kagenti-ui-v2 | tail -n 1 | awk 'END {print $2}') &&
  echo UI_TAG is $UI_TAG &&
  oc -n kagenti-system set image deployment/kagenti-ui frontend=ghcr.io/kagenti/kagenti-ui-v2:${UI_TAG} &&
  kubectl -n kagenti-system rollout status deployment kagenti-ui
```
