### PR TITLE
docs: add Rong Chang and update Varsha's maintainer responsibilities

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,8 +16,9 @@ The current Maintainers Group for the Kagenti Project consists of:
 | [Mariusz Sabath](https://github.com/mrsabath) | IBM | Project Technical Lead, Workload Identity, Security |
 | [Morgan Foster](https://github.com/usize) | Red Hat | Workload Identity and Security |
 | [Paolo Dettori](https://github.com/pdettori) | IBM | Project Technical Lead, Agent Lifecycle Management |
+| [Rong Chang](https://github.com/webchang) | IBM | Identity, Attestation, Authorization and Policy Management |
 | [Ryan Jenkins](https://github.com/RyanJenkins99) | Red Hat | Automation, HyperShift CI |
-| [Varsha Prasad Narsing](https://github.com/varshaprasad96) | Red Hat | |
+| [Varsha Prasad Narsing](https://github.com/varshaprasad96) | Red Hat | Agent Runtime |
 
 ## Contact
 


### PR DESCRIPTION
## Summary
- Add Rong Chang (@webchang, IBM) as a maintainer with responsibilities for Identity, Attestation, Authorization and Policy Management
- Update Varsha Prasad Narsing's responsibilities to Agent Runtime

## Test plan
- [x] Verified `MAINTAINERS.md` table formatting and alphabetical ordering
- [ ] Maintainer team review and acknowledgment per [GOVERNANCE.md](https://github.com/kagenti/kagenti/blob/main/GOVERNANCE.md)
