### PR TITLE
fix(release): pin Chart.yaml version by default in release scripts

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -160,9 +160,10 @@ Alphas are tagged directly from `main`:
 
 - [ ] Confirm CI passes on `main` for each repo being tagged
 - [ ] Determine next alpha number
-- [ ] Pin all image tags (no `tag: latest` allowed, even for alphas):
+- [ ] Pin image tags and chart version (no `tag: latest` allowed, even for alphas):
 
 ```bash
+# Pins image tags AND updates Chart.yaml version/appVersion to match
 bash scripts/pin-release-tags.sh <version>
 bash scripts/check-release-pins.sh
 ```
@@ -220,7 +221,7 @@ The first RC marks feature freeze. This is when release branches are created.
 
 2. **Update kagenti/kagenti Chart.yaml** with new sub-chart RC versions
 
-3. **Pin all image tags:**
+3. **Pin image tags and chart version:**
 
    ```bash
    bash scripts/pin-release-tags.sh <version>
@@ -491,9 +492,10 @@ gh run list --repo kagenti/kagenti --branch release-X.Y --limit 3
 git tag --list 'vX.Y.0-rc.*' --sort=-v:refname | head -1
 ```
 
-**Pin image tags for the new RC:**
+**Pin image tags and chart version for the new RC:**
 
 ```bash
+# Pins image tags AND updates Chart.yaml version/appVersion to match
 bash scripts/pin-release-tags.sh <next-rc-version>
 bash scripts/check-release-pins.sh
 git add charts/
@@ -536,9 +538,10 @@ When the latest RC has soaked with no blocking issues.
 
 2. **Update kagenti Chart.yaml** with GA sub-chart versions
 
-3. **Pin image tags to GA version:**
+3. **Pin image tags and chart version to GA:**
 
    ```bash
+   # Pins image tags AND updates Chart.yaml version/appVersion to match
    bash scripts/pin-release-tags.sh vX.Y.0
    bash scripts/check-release-pins.sh
    git add charts/

--- a/scripts/check-release-pins.sh
+++ b/scripts/check-release-pins.sh
@@ -362,27 +362,32 @@ fi
 # appVersion should be 0.6.0-rc.11 (without the 'v' prefix).
 # ---------------------------------------------------------------------------
 
-if [[ -f "$CHART_FILE" ]] && [[ -f "$VALUES_FILE" ]] && command -v yq >/dev/null 2>&1; then
-    chart_version=$(yq eval '.version' "$CHART_FILE" 2>/dev/null || echo "")
-    chart_app_version=$(yq eval '.appVersion' "$CHART_FILE" 2>/dev/null || echo "")
-    platform_tag=$(yq eval '.ui.frontend.tag' "$VALUES_FILE" 2>/dev/null || echo "")
+if [[ -f "$CHART_FILE" ]] && [[ -f "$VALUES_FILE" ]]; then
+    if ! command -v yq >/dev/null 2>&1; then
+        add_warning "charts/kagenti/Chart.yaml" \
+            "yq not found — skipping Chart.yaml version/appVersion consistency check"
+    else
+        chart_version=$(yq eval '.version' "$CHART_FILE" 2>/dev/null || echo "")
+        chart_app_version=$(yq eval '.appVersion' "$CHART_FILE" 2>/dev/null || echo "")
+        platform_tag=$(yq eval '.ui.frontend.tag' "$VALUES_FILE" 2>/dev/null || echo "")
 
-    # Strip 'v' prefix from platform tag for comparison
-    platform_tag_stripped="${platform_tag#v}"
+        # Strip 'v' prefix from platform tag for comparison
+        platform_tag_stripped="${platform_tag#v}"
 
-    if [[ -n "$platform_tag_stripped" ]] && [[ "$platform_tag_stripped" != "null" ]]; then
-        if [[ "$chart_version" != "$platform_tag_stripped" ]]; then
-            add_error "charts/kagenti/Chart.yaml" 0 \
-                "version ($chart_version) does not match image tags ($platform_tag_stripped) — run scripts/pin-release-tags.sh"
-        else
-            add_ok "charts/kagenti/Chart.yaml" "version ($chart_version) matches image tags"
-        fi
+        if [[ -n "$platform_tag_stripped" ]] && [[ "$platform_tag_stripped" != "null" ]]; then
+            if [[ "$chart_version" != "$platform_tag_stripped" ]]; then
+                add_error "charts/kagenti/Chart.yaml" 0 \
+                    "version ($chart_version) does not match image tags ($platform_tag_stripped) — run scripts/pin-release-tags.sh"
+            else
+                add_ok "charts/kagenti/Chart.yaml" "version ($chart_version) matches image tags"
+            fi
 
-        if [[ "$chart_app_version" != "$platform_tag_stripped" ]]; then
-            add_error "charts/kagenti/Chart.yaml" 0 \
-                "appVersion ($chart_app_version) does not match image tags ($platform_tag_stripped) — run scripts/pin-release-tags.sh"
-        else
-            add_ok "charts/kagenti/Chart.yaml" "appVersion ($chart_app_version) matches image tags"
+            if [[ "$chart_app_version" != "$platform_tag_stripped" ]]; then
+                add_error "charts/kagenti/Chart.yaml" 0 \
+                    "appVersion ($chart_app_version) does not match image tags ($platform_tag_stripped) — run scripts/pin-release-tags.sh"
+            else
+                add_ok "charts/kagenti/Chart.yaml" "appVersion ($chart_app_version) matches image tags"
+            fi
         fi
     fi
 fi
@@ -428,20 +433,25 @@ fi
 # Its tag must not drift from the main chart's platform image tags.
 # ---------------------------------------------------------------------------
 
-if [[ -f "$DEPS_VALUES_FILE" ]] && command -v yq >/dev/null 2>&1; then
-    spiffe_tag=$(yq eval '.spiffeIdp.image.tag' "$DEPS_VALUES_FILE" 2>/dev/null || echo "")
+if [[ -f "$DEPS_VALUES_FILE" ]]; then
+    if ! command -v yq >/dev/null 2>&1; then
+        add_warning "charts/kagenti-deps/values.yaml" \
+            "yq not found — skipping spiffeIdp tag consistency check"
+    else
+        spiffe_tag=$(yq eval '.spiffeIdp.image.tag' "$DEPS_VALUES_FILE" 2>/dev/null || echo "")
 
-    if [[ -n "$spiffe_tag" ]] && [[ "$spiffe_tag" != "null" ]]; then
-        # Compare against the first platform image tag in the main chart
-        platform_tag=$(yq eval '.ui.frontend.tag' "$VALUES_FILE" 2>/dev/null || echo "")
+        if [[ -n "$spiffe_tag" ]] && [[ "$spiffe_tag" != "null" ]]; then
+            # Compare against the first platform image tag in the main chart
+            platform_tag=$(yq eval '.ui.frontend.tag' "$VALUES_FILE" 2>/dev/null || echo "")
 
-        if [[ -n "$platform_tag" ]] && [[ "$platform_tag" != "null" ]] \
-           && [[ "$spiffe_tag" != "$platform_tag" ]]; then
-            add_error "charts/kagenti-deps/values.yaml" 0 \
-                "spiffeIdp.image.tag ($spiffe_tag) differs from platform tag ($platform_tag) — run scripts/pin-release-tags.sh"
-        else
-            add_ok "charts/kagenti-deps/values.yaml" \
-                "spiffeIdp.image.tag ($spiffe_tag) consistent with platform"
+            if [[ -n "$platform_tag" ]] && [[ "$platform_tag" != "null" ]] \
+               && [[ "$spiffe_tag" != "$platform_tag" ]]; then
+                add_error "charts/kagenti-deps/values.yaml" 0 \
+                    "spiffeIdp.image.tag ($spiffe_tag) differs from platform tag ($platform_tag) — run scripts/pin-release-tags.sh"
+            else
+                add_ok "charts/kagenti-deps/values.yaml" \
+                    "spiffeIdp.image.tag ($spiffe_tag) consistent with platform"
+            fi
         fi
     fi
 fi

--- a/scripts/check-release-pins.sh
+++ b/scripts/check-release-pins.sh
@@ -355,6 +355,39 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Check 3b: Chart.yaml version and appVersion match image tags
+#
+# The chart version and appVersion should be consistent with the pinned image
+# tags. If image tags are pinned to e.g. v0.6.0-rc.11, the chart version and
+# appVersion should be 0.6.0-rc.11 (without the 'v' prefix).
+# ---------------------------------------------------------------------------
+
+if [[ -f "$CHART_FILE" ]] && [[ -f "$VALUES_FILE" ]] && command -v yq >/dev/null 2>&1; then
+    chart_version=$(yq eval '.version' "$CHART_FILE" 2>/dev/null || echo "")
+    chart_app_version=$(yq eval '.appVersion' "$CHART_FILE" 2>/dev/null || echo "")
+    platform_tag=$(yq eval '.ui.frontend.tag' "$VALUES_FILE" 2>/dev/null || echo "")
+
+    # Strip 'v' prefix from platform tag for comparison
+    platform_tag_stripped="${platform_tag#v}"
+
+    if [[ -n "$platform_tag_stripped" ]] && [[ "$platform_tag_stripped" != "null" ]]; then
+        if [[ "$chart_version" != "$platform_tag_stripped" ]]; then
+            add_error "charts/kagenti/Chart.yaml" 0 \
+                "version ($chart_version) does not match image tags ($platform_tag_stripped) — run scripts/pin-release-tags.sh"
+        else
+            add_ok "charts/kagenti/Chart.yaml" "version ($chart_version) matches image tags"
+        fi
+
+        if [[ "$chart_app_version" != "$platform_tag_stripped" ]]; then
+            add_error "charts/kagenti/Chart.yaml" 0 \
+                "appVersion ($chart_app_version) does not match image tags ($platform_tag_stripped) — run scripts/pin-release-tags.sh"
+        else
+            add_ok "charts/kagenti/Chart.yaml" "appVersion ($chart_app_version) matches image tags"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # Check 4 (soft warning): Chart.lock exists
 # ---------------------------------------------------------------------------
 
@@ -404,7 +437,7 @@ if [[ -f "$DEPS_VALUES_FILE" ]] && command -v yq >/dev/null 2>&1; then
 
         if [[ -n "$platform_tag" ]] && [[ "$platform_tag" != "null" ]] \
            && [[ "$spiffe_tag" != "$platform_tag" ]]; then
-            add_error "charts/kagenti-deps/values.yaml" \
+            add_error "charts/kagenti-deps/values.yaml" 0 \
                 "spiffeIdp.image.tag ($spiffe_tag) differs from platform tag ($platform_tag) — run scripts/pin-release-tags.sh"
         else
             add_ok "charts/kagenti-deps/values.yaml" \

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -42,10 +42,11 @@ Arguments:
   VERSION             The release version tag (e.g., v0.6.0-rc.6, v0.7.0-alpha.1)
 
 Options:
-  --dry-run           Show what would change without modifying files
-  --verify-images     Check that images exist in ghcr.io before pinning
-  --chart-version V   Also update Chart.yaml version (strip 'v' prefix automatically)
-  -h, --help          Show this help message
+  --dry-run              Show what would change without modifying files
+  --verify-images        Check that images exist in ghcr.io before pinning
+  --chart-version V      Override Chart.yaml version (default: derived from VERSION)
+  --skip-chart-version   Do NOT update Chart.yaml version/appVersion
+  -h, --help             Show this help message
 
 Images pinned (charts/kagenti/values.yaml):
   - ui.frontend.tag
@@ -68,14 +69,16 @@ EOF
 
 VERSION=""
 CHART_VERSION=""
+SKIP_CHART_VERSION=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --dry-run)         DRY_RUN=true; shift ;;
-        --verify-images)   VERIFY_IMAGES=true; shift ;;
-        --chart-version)   CHART_VERSION="$2"; shift 2 ;;
-        -h|--help)         usage ;;
-        -*)                echo "Unknown option: $1" >&2; usage ;;
+        --dry-run)             DRY_RUN=true; shift ;;
+        --verify-images)       VERIFY_IMAGES=true; shift ;;
+        --chart-version)       CHART_VERSION="$2"; shift 2 ;;
+        --skip-chart-version)  SKIP_CHART_VERSION=true; shift ;;
+        -h|--help)             usage ;;
+        -*)                    echo "Unknown option: $1" >&2; usage ;;
         *)
             if [[ -z "$VERSION" ]]; then
                 VERSION="$1"
@@ -216,10 +219,19 @@ for entry in "${PINNABLE_IMAGES[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
-# Pin Chart.yaml version (optional)
+# Pin Chart.yaml version
+#
+# By default, Chart.yaml version and appVersion are set to match VERSION
+# (strip 'v' prefix). Use --chart-version to override, or --skip-chart-version
+# to leave Chart.yaml untouched.
 # ---------------------------------------------------------------------------
 
-if [[ -n "$CHART_VERSION" ]]; then
+if [[ "$SKIP_CHART_VERSION" != "true" ]]; then
+    # Default to VERSION if --chart-version was not explicitly passed
+    if [[ -z "$CHART_VERSION" ]]; then
+        CHART_VERSION="$VERSION"
+    fi
+
     echo ""
     echo "Updating Chart.yaml version..."
 


### PR DESCRIPTION
## Summary

- `pin-release-tags.sh` now updates `Chart.yaml` version and appVersion to match the release VERSION argument **by default** — no need to pass `--chart-version` separately
- `check-release-pins.sh` gains a new Check 3b that validates Chart.yaml version/appVersion consistency with pinned image tags
- Release skill updated to reflect the new default behavior
- Fixes pre-existing bug in `check-release-pins.sh` spiffe check (missing line-number argument to `add_error`)

## Context

RC tags v0.6.0-rc.7 through rc.11 all shipped with `Chart.yaml version: 0.6.0-rc.6` and `appVersion: 0.6.0-rc.5` because the release workflow didn't pass `--chart-version` to `pin-release-tags.sh`. This change makes chart version pinning automatic so it can't drift again.

## Test plan

- [x] `pin-release-tags.sh v0.6.0-rc.12 --dry-run` — shows Chart.yaml version update
- [x] `pin-release-tags.sh v0.6.0-rc.12 --dry-run --skip-chart-version` — correctly skips Chart.yaml
- [x] `check-release-pins.sh` — new consistency check passes on main (version matches tags)
- [ ] Pre-commit hooks pass

Assisted-By: Claude Code