### PR TITLE
fix(ocp-installer): prevent set -e exit on token creation failure

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1463,7 +1463,7 @@ else
   if ! $DRY_RUN; then
     _EXP_WS="${MLFLOW_WORKSPACE:-team1}"
     _EXP_NAME="kagenti-traces"
-    _EXP_TOKEN=$($KUBECTL create token otel-collector -n kagenti-system --duration=600s 2>/dev/null)
+    _EXP_TOKEN=$($KUBECTL create token otel-collector -n kagenti-system --duration=600s 2>/dev/null || true)
     if [ -n "$_EXP_TOKEN" ]; then
       _EXP_RESP=$($KUBECTL run mlflow-exp-create --rm -i --restart=Never \
         --image=curlimages/curl -n kagenti-system \


### PR DESCRIPTION
## Summary

- Fix silent script exit during OCP install that skips MCP Gateway installation
- The `kubectl create token` command substitution triggers `set -e` on failure, killing the script before Steps 5/5b/6 (Kuadrant + MCP Gateway)
- Add `|| true` since the failure is already guarded by `if [ -n "$_EXP_TOKEN" ]`

## Root Cause

With `set -euo pipefail`, this line:
```bash
_EXP_TOKEN=$($KUBECTL create token otel-collector -n kagenti-system --duration=600s 2>/dev/null)
```
exits the script if the token request fails (e.g., SA not ready). The `2>/dev/null` suppresses the error message but NOT the exit code in a variable assignment under `set -e`.

## Test plan

- [ ] Run `scripts/ocp/setup-kagenti.sh --with-all` on a fresh cluster
- [ ] Verify Steps 5, 5b, and 6 execute (MCP Gateway gets installed)
- [ ] Verify MLflow experiment creation still works when token succeeds

Closes #1743

Assisted-By: Claude Code