### PR TITLE
fix(helm): restart otel-collector on config change

### DIFF
--- a/charts/kagenti-deps/templates/otel-collector.yaml
+++ b/charts/kagenti-deps/templates/otel-collector.yaml
@@ -46,6 +46,8 @@ spec:
       app: otel-collector
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include "kagenti.otel.collectorConfig" . | sha256sum }}
       labels:
         app: otel-collector
     spec:


### PR DESCRIPTION
## Summary

Add `checksum/config` annotation to the `otel-collector` Deployment pod template so that `helm upgrade` triggers a rolling restart whenever the rendered OTEL collector configuration changes.

Key changes:
- Add `checksum/config: {{ include "kagenti.otel.collectorConfig" . | sha256sum }}` annotation to the pod template metadata in `charts/kagenti-deps/templates/otel-collector.yaml`

**Root cause**: On a fresh OCP install with RHOAI MLflow, `setup-kagenti.sh` performs multiple Helm upgrades. The first upgrade deploys the OTEL collector with a config that only has the `debug` exporter (because `MLFLOW_TRACES_ENDPOINT` is not yet known). Subsequent upgrades update the ConfigMap to add the `otlphttp/mlflow` exporter, but without this annotation the pod never restarts — so it keeps running the initial config and silently drops all traces to MLflow.

The annotation ensures the pod spec changes whenever the config changes, triggering a Kubernetes rolling update automatically.

Assisted-By: Claude Code