### PR TITLE
fix(ocp-installer): guard MLflow kubectl-run from set -e exit

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1473,9 +1473,9 @@ else
         -H "x-mlflow-workspace: '"$_EXP_WS"'" \
         -H "Content-Type: application/json" \
         -d "{\"name\":\"'"$_EXP_NAME"'\"}" \
-        "https://mlflow.'"${MLFLOW_NAMESPACE}"'.svc.cluster.local:8443/api/2.0/mlflow/experiments/create"' 2>/dev/null)
+        "https://mlflow.'"${MLFLOW_NAMESPACE}"'.svc.cluster.local:8443/api/2.0/mlflow/experiments/create"' 2>/dev/null || true)
       if echo "$_EXP_RESP" | grep -q "experiment_id"; then
-        _EXP_ID=$(echo "$_EXP_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['experiment_id'])" 2>/dev/null)
+        _EXP_ID=$(echo "$_EXP_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['experiment_id'])" 2>/dev/null || true)
         log_success "Created MLflow experiment '$_EXP_NAME' (id=$_EXP_ID) in workspace $_EXP_WS"
       elif echo "$_EXP_RESP" | grep -q "RESOURCE_ALREADY_EXISTS"; then
         log_success "MLflow experiment '$_EXP_NAME' already exists in workspace $_EXP_WS"


### PR DESCRIPTION
## Summary

- Guard `kubectl run mlflow-exp-create` command substitution with `|| true` to prevent `set -e` from killing the script when the curl pod exits non-zero
- Guard the `python3` JSON parse on the same path for belt-and-suspenders
- PR #1754 fixed the token creation line but missed these two lines — same root cause, same fix pattern

## Root Cause

With `set -euo pipefail`, this line:
```bash
_EXP_RESP=$(kubectl run mlflow-exp-create --rm -i ... 2>/dev/null)
```
exits the script when the pod returns non-zero (MLflow not ready, network timeout, image pull failure). The `2>/dev/null` suppresses stderr but NOT the exit code in a variable assignment under `set -e`. Steps 5, 5b, and 6 (Kuadrant, MCP Gateway, verification) are silently skipped.

## Test plan

- [ ] Run `scripts/ocp/setup-kagenti.sh --with-all` on OpenShift
- [ ] Verify Steps 5b and 6 execute (MCP Gateway gets installed)
- [ ] Verify MLflow experiment creation still succeeds on healthy clusters

Closes #1743 (follow-up to #1754)

Assisted-By: Claude Code