### PR TITLE
fix(ocp-installer): upgrade MCP Gateway to v0.6.0 and fix hostname routing

### DIFF
--- a/charts/kagenti/templates/mcp-gateway.yaml
+++ b/charts/kagenti/templates/mcp-gateway.yaml
@@ -20,6 +20,9 @@ spec:
   listeners:
     - name: mcp
       {{- if .Values.openshift }}
+      {{- if not .Values.mcpGateway.openshiftDomain }}
+      {{- fail "mcpGateway.openshiftDomain is required on OpenShift (set by scripts/ocp/setup-kagenti.sh)" }}
+      {{- end }}
       hostname: "mcp-gateway-{{ .Values.mcpGateway.namespaces.gatewaySystem }}.{{ .Values.mcpGateway.openshiftDomain }}"
       {{- else }}
       hostname: "{{ .Values.mcpGateway.hostname }}"

--- a/charts/kagenti/templates/mcp-gateway.yaml
+++ b/charts/kagenti/templates/mcp-gateway.yaml
@@ -19,7 +19,11 @@ spec:
   gatewayClassName: istio
   listeners:
     - name: mcp
+      {{- if .Values.openshift }}
+      hostname: "mcp-gateway-{{ .Values.mcpGateway.namespaces.gatewaySystem }}.{{ .Values.mcpGateway.openshiftDomain }}"
+      {{- else }}
       hostname: "{{ .Values.mcpGateway.hostname }}"
+      {{- end }}
       port: 8080
       protocol: HTTP
       allowedRoutes:

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -284,11 +284,11 @@ mcpGateway:
   namespaces:
     mcpSystem: mcp-system
     gatewaySystem: gateway-system
-  # TODO: Investigate why only the hostname 'mcp.127-0-0-1.sslip.io' works for MCP Gateway.
-  # Observed behavior: When using this hostname, the MCP Gateway is accessible and functions as expected.
-  # Other values tried:  'mcp.localtest.me', and 'mcp.sslip.io' were tested but failed to route traffic correctly.
-  # Expected behavior: The MCP Gateway should work with any valid hostname or IP address configured for local development.
+  # Hostname used for the Gateway listener on non-OpenShift (Kind) clusters.
   hostname: 'mcp.127-0-0-1.sslip.io'
+  # On OpenShift, the Gateway listener hostname is auto-constructed from this
+  # domain to match the auto-generated Route hostname. Override in ocp_values.yaml.
+  openshiftDomain: ''
 
 # ------------------------------------------------------------------
 #  Phoenix Configuration

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -110,6 +110,9 @@ charts:
         useServiceAccountCA: true
       keycloak:
         url: http://keycloak-service.keycloak:8080
+      # mcpGateway.openshiftDomain is set dynamically by the installer
+      # (scripts/ocp/setup-kagenti.sh) using the detected apps domain.
+      # Example: apps.kagenti1.kubestellar.org
       agentNamespaces:
         - team1
         - team2

--- a/deployments/envs/ocp_values.yaml
+++ b/deployments/envs/ocp_values.yaml
@@ -110,9 +110,9 @@ charts:
         useServiceAccountCA: true
       keycloak:
         url: http://keycloak-service.keycloak:8080
-      # mcpGateway.openshiftDomain is set dynamically by the installer
-      # (scripts/ocp/setup-kagenti.sh) using the detected apps domain.
-      # Example: apps.kagenti1.kubestellar.org
+      # mcpGateway.openshiftDomain is set dynamically by the installer via:
+      #   --set "mcpGateway.openshiftDomain=${DOMAIN}"
+      # See scripts/ocp/setup-kagenti.sh. Example: apps.kagenti1.kubestellar.org
       agentNamespaces:
         - team1
         - team2

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -55,7 +55,7 @@ SKIP_MCP_GATEWAY=true
 SKIP_UI=false
 SKIP_MLFLOW=false
 SHOW_SECRETS=false
-MCP_GATEWAY_VERSION="0.5.1"
+MCP_GATEWAY_VERSION="0.6.0"
 OPERATOR_REPO=""
 OPERATOR_IMAGE=""
 DRY_RUN=false
@@ -1443,6 +1443,7 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set mlflow.auth.enabled=false \
   --set "keycloak.publicUrl=${KEYCLOAK_PUBLIC_URL}" \
   --set "keycloak.realm=${KC_REALM}" \
+  --set "mcpGateway.openshiftDomain=${DOMAIN}" \
   --set "components.mlflow.enabled=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)" \
   --set "components.mlflow.routeNamespace=${MLFLOW_NAMESPACE}" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)" \
@@ -1534,10 +1535,15 @@ if $SKIP_MCP_GATEWAY; then
 elif helm status mcp-gateway -n mcp-system &>/dev/null; then
   log_info "MCP Gateway already installed — skipping"
 else
-  log_info "Installing MCP Gateway v${MCP_GATEWAY_VERSION}..."
+  MCP_GW_PUBLIC_HOST="mcp-gateway-gateway-system.${DOMAIN}"
+  log_info "Installing MCP Gateway v${MCP_GATEWAY_VERSION} (publicHost=${MCP_GW_PUBLIC_HOST})..."
   run_cmd helm install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
-    --create-namespace --namespace mcp-system --version "$MCP_GATEWAY_VERSION"
+    --create-namespace --namespace mcp-system --version "$MCP_GATEWAY_VERSION" \
+    --set "gateway.publicHost=${MCP_GW_PUBLIC_HOST}"
   log_success "MCP Gateway installed"
+
+  log_info "Waiting for MCP Gateway broker-router deployment..."
+  _wait_deployment_ready mcp-gateway mcp-system "MCP Gateway broker-router"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

- Upgrades MCP Gateway chart from v0.5.1 to v0.6.0 on OpenShift installer, fixing a bug where the controller pod was included in the `mcp-gateway` Service endpoints (causing ext_proc gRPC to connect to the wrong pod ~50% of the time)
- Fixes Gateway listener hostname mismatch on OpenShift — the listener now uses the detected apps domain to match the auto-generated Route hostname
- Adds `mcpGateway.openshiftDomain` value so the kagenti Helm chart can construct the correct Gateway listener hostname on OCP

## Root Cause

Chart v0.5.1 labels the controller pod with `app.kubernetes.io/name: mcp-gateway` (same as the broker-router). The Service selector `{name: mcp-gateway}` matches both pods, so the Istio gateway's ext_proc gRPC randomly connects to the controller (which doesn't serve on port 50051) → connection reset → HTTP 500. Chart v0.6.0 fixes this by labeling the controller `mcp-gateway-controller`.

## Test plan

- [x] Verified on OCP cluster: `curl -X POST https://mcp-gateway-gateway-system.apps.kagenti1.kubestellar.org/mcp` returns valid MCP initialize response
- [x] Verified internal cluster path works (Inspector proxy → Istio Gateway → MCP Gateway)
- [ ] Run OCP installer from scratch on a clean cluster
- [ ] Verify Kind install still works (no regression — Kind already uses v0.6.0)

Assisted-By: Claude Code