### PR TITLE
fix(kagenti-deps): derive KC_HOSTNAME from keycloak.publicUrl when set

### DIFF
--- a/charts/kagenti-deps/templates/keycloak-k8s.yaml
+++ b/charts/kagenti-deps/templates/keycloak-k8s.yaml
@@ -239,7 +239,7 @@ extraEnvVars with the same name override these defaults.
 - name: KC_HOSTNAME_STRICT
   value: "false"
 - name: KC_HOSTNAME
-  value: {{ printf "http://keycloak.%s:8080/" .Values.domain | quote }}
+  value: {{ .Values.keycloak.publicUrl | default (printf "http://keycloak.%s:8080/" .Values.domain) | quote }}
 - name: KC_HOSTNAME_BACKCHANNEL_DYNAMIC
   value: "true"
 - name: KC_HEALTH_ENABLED

--- a/charts/kagenti-deps/tests/keycloak-k8s_test.yaml
+++ b/charts/kagenti-deps/tests/keycloak-k8s_test.yaml
@@ -31,7 +31,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: KC_HOSTNAME
-            value: "http://keycloak.localtest.me:8080/"
+            value: "http://keycloak.localtest.me:8080"
         documentIndex: 2
       - contains:
           path: spec.template.spec.containers[0].env
@@ -112,7 +112,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: KC_HOSTNAME
-            value: "http://keycloak.localtest.me:8080/"
+            value: "http://keycloak.localtest.me:8080"
         documentIndex: 2
 
   - it: appends new env var from extraEnvVars


### PR DESCRIPTION
Closes #1770.

## Summary

The `kagenti-deps` chart's Keycloak StatefulSet (non-OpenShift path) hardcoded `KC_HOSTNAME` to `http://keycloak.<domain>:8080/` regardless of `keycloak.publicUrl`. Every other consumer of `publicUrl` in the chart already honors it; only `KC_HOSTNAME` itself did not. As a result, Keycloak's OIDC discovery advertised `http://...:8080/...` URLs that browsers couldn't reach externally, breaking login on any cluster where Keycloak is fronted by an HTTPS ingress on a different host/port.

This change has the chart use `keycloak.publicUrl` when set, with the previous `http://keycloak.<domain>:8080/` as the fallback for users who don't set it.

## Before / after rendered manifest

`helm template kagenti-deps --set domain=example.com --set openshift=false --set keycloak.publicUrl=https://keycloak.example.com`:

Before:
```yaml
- name: KC_HOSTNAME
  value: "http://keycloak.example.com:8080/"
```

After:
```yaml
- name: KC_HOSTNAME
  value: "https://keycloak.example.com"
```

When `keycloak.publicUrl` is unset, output is identical to today (`http://keycloak.<domain>:8080/`).

## Test plan

- [x] `helm template` with `keycloak.publicUrl` set; `KC_HOSTNAME` is the HTTPS public URL.
- [x] `helm template` with `keycloak.publicUrl` unset; `KC_HOSTNAME` matches previous behavior.
- [x] `helm template --set openshift=true`; `keycloak-k8s.yaml` does not render (operand path unaffected).
- [ ] Live cluster (verified by issue reporter on a Kind-class cluster fronted by an HTTPS ALB): `kubectl get sts -n keycloak keycloak ... KC_HOSTNAME ...` returns the HTTPS URL; OIDC discovery's `authorization_endpoint` is `https://...`; end-to-end login flow through the kagenti UI completes without `ERR_CONNECTION_TIMED_OUT`.

## Scope

Non-OpenShift k8s StatefulSet path (`keycloak-k8s.yaml`, gated `if (not .Values.openshift)`). The OpenShift RHBK-operator path is unaffected — it uses `hostname.strict: false` with no explicit `hostname.hostname` and relies on the Route's hostname plus `KC_PROXY_HEADERS=forwarded` for issuer derivation. Different mechanism, no fix needed there.
