### PR TITLE
fix(kagenti): trigger pod rollouts on config changes via checksum/config

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -56,6 +56,11 @@ spec:
       app.kubernetes.io/name: kagenti-backend
   template:
     metadata:
+      annotations:
+        # Force pod restart whenever the in-chart ConfigMap or OAuth-secret inputs change.
+        # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/config: {{ printf "%s|%s|%s|%s|%s|%t|%t" .Values.ui.domainName .Values.ui.api.hostname .Values.ui.namespace .Values.ui.configmap .Values.keycloak.realm .Values.components.phoenix.enabled .Values.components.mlflow.enabled | sha256sum }}
+        checksum/oauth-config: {{ printf "%s|%s|%s|%s" .Values.keycloak.url .Values.keycloak.publicUrl .Values.keycloak.realm .Values.ui.namespace | sha256sum }}
       labels:
         app.kubernetes.io/name: kagenti-backend
         app.kubernetes.io/component: backend
@@ -300,6 +305,11 @@ spec:
       app.kubernetes.io/name: kagenti-ui
   template:
     metadata:
+      annotations:
+        # Force pod restart whenever the in-chart ConfigMap or OAuth-secret inputs change.
+        # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/config: {{ printf "%s|%s|%s|%s|%s|%t|%t" .Values.ui.domainName .Values.ui.api.hostname .Values.ui.namespace .Values.ui.configmap .Values.keycloak.realm .Values.components.phoenix.enabled .Values.components.mlflow.enabled | sha256sum }}
+        checksum/oauth-config: {{ printf "%s|%s|%s|%s" .Values.keycloak.url .Values.keycloak.publicUrl .Values.keycloak.realm .Values.ui.namespace | sha256sum }}
       labels:
         app.kubernetes.io/name: kagenti-ui
         app.kubernetes.io/component: frontend


### PR DESCRIPTION
Closes #1773.

## Summary

Adds `checksum/config` annotations to the `kagenti-backend` and `kagenti-ui` Deployments so that `helm upgrade` triggers a rollout whenever the in-chart `kagenti-ui-config` ConfigMap or the inputs that determine the runtime-generated `kagenti-ui-oauth-secret` Secret change.

Today, those Deployments' pod templates have no annotations block. Since their env vars come from a referenced ConfigMap and Secret (not embedded directly in the pod template), Kubernetes sees a byte-identical pod template across `helm upgrade` revisions and doesn't roll out new pods. The result is that values like `keycloak.publicUrl`, `keycloak.realm`, and dashboard URLs land in the cluster but the running pods keep their old configuration cached in-process. `/api/v1/auth/config` then serves stale URLs and login breaks.

This is the standard Helm "automatically roll deployments" pattern (see [Helm chart tips](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)).

## Before / after rendered manifest

`helm template kagenti --set ui.domainName=example.com --set openshift=false` (relevant fragment for the `kagenti-backend` Deployment):

Before:
```yaml
spec:
  template:
    metadata:
      labels:
        app.kubernetes.io/name: kagenti-backend
        ...
    spec:
      containers: ...
```

After:
```yaml
spec:
  template:
    metadata:
      annotations:
        checksum/config: 307e5279e5dcccc276a43e63f2c3dd21fad8b9eb62149e0f97cf954eac66df31
        checksum/oauth-config: 5f1a650fad76b3719d9bd6c332eb702d294209563eaa494d32a7ccde606740da
      labels:
        app.kubernetes.io/name: kagenti-backend
        ...
    spec:
      containers: ...
```

Re-rendering with `--set ui.domainName=other.example.com` produces different `checksum/config` values, so the pod template now differs across upgrades that touch the domain (or any other ConfigMap/Secret input).

## Test plan

- [x] `helm template` twice with identical values → identical `checksum/*` values (idempotent).
- [x] `helm template` with two different `ui.domainName` values → different `checksum/config` (sensitive to relevant changes).
- [ ] Live cluster:
  - Install kagenti at domain A. Log in. Confirm `/api/v1/auth/config` returns A's URLs.
  - `helm upgrade --reuse-values -f domain-B.yaml` (domain change only).
  - Without manual intervention, `kubectl get pods` shows new `kagenti-backend` and `kagenti-ui` pods (recently created), and `/api/v1/auth/config` returns B's URLs.
  - Login through the UI completes successfully against the new Keycloak hostname.
- [ ] Confirm no spurious rollouts when running `helm upgrade --reuse-values` with no value changes.

## Notes

- `checksum/config` hashes the values that flow into the `kagenti-ui-config` ConfigMap (`ui.domainName`, `ui.api.hostname`, `ui.namespace`, `ui.configmap`, `keycloak.realm`, and the phoenix/mlflow component toggles). A self-`include` of `ui.yaml` would have been an even tighter "hash the rendered ConfigMap" approach, but Helm's template engine treats that as recursion when the file also contains the Deployment doing the include — hashing the inputs avoids that and is what the official chart-tips example does for ConfigMaps in the same template file.
- `checksum/oauth-config` hashes the values that determine what `ui-oauth-secret-job.yaml` writes into `kagenti-ui-oauth-secret`. We can't directly hash a Secret that doesn't exist yet at install time, so we hash the inputs.
- Other workloads (AuthBridge sidecars, agent namespaces) consume similar config from ConfigMaps and would benefit from the same pattern. Out of scope here; this PR matches the user-observable workaround (`kubectl rollout restart deploy/kagenti-backend deploy/kagenti-ui`).
