### PR TITLE
:memo: docs: document feature flags in values.yaml

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -7,13 +7,30 @@ domain: localtest.me
 #  Feature flags: experimental features disabled by default
 # ------------------------------------------------------------------
 featureFlags:
+  # Sandbox runtime (session management, file browser, sidecars).
+  # NOT YET FULLY IMPLEMENTED — backend modules not merged. Do not enable.
+  # See 2026-04-21-agent-sandbox-workload-type-design.md
+  # See PR #996
   sandbox: false
+  # Third-party integration endpoints.
+  # (Currently undocumented)
   integrations: false
+  # Event-driven trigger system.
+  # See PR #996
   triggers: false
+  # kubernetes-sigs/agent-sandbox Sandbox workload type.
+  # Requires agent-sandbox CRDs (Enabled by `--with-agent-sandbox`).
+  # See docs/architecture/agent-sandbox.md
   agentSandbox: false
+  # Pluggable skills system.
+  # See PR #1344
   skills: false
-  externalSkills: false  # External skill registry references (skillberry-store, etc.)
+  # External skill registry references (skillberry-store, etc.)
+  externalSkills: false
+  # Enables AuthBridge tab on Agent details page
   authbridgeAPI: false
+  # Enables Platform Status card
+  # on http://kagenti-ui.localtest.me:8080/admin
   admin: false
 
 # ------------------------------------------------------------------

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -9,7 +9,6 @@ domain: localtest.me
 featureFlags:
   # Sandbox runtime (session management, file browser, sidecars).
   # NOT YET FULLY IMPLEMENTED — backend modules not merged. Do not enable.
-  # See 2026-04-21-agent-sandbox-workload-type-design.md
   # See PR #996
   sandbox: false
   # Third-party integration endpoints.
@@ -21,6 +20,7 @@ featureFlags:
   # kubernetes-sigs/agent-sandbox Sandbox workload type.
   # Requires agent-sandbox CRDs (Enabled by `--with-agent-sandbox`).
   # See docs/architecture/agent-sandbox.md
+  # See docs/superpowers/specs/2026-04-21-agent-sandbox-workload-type-design.md
   agentSandbox: false
   # Pluggable skills system.
   # See PR #1344


### PR DESCRIPTION
## Summary

- Add inline comments to every feature flag in `charts/kagenti/values.yaml` explaining what each flag controls, its current status, and relevant PRs
- Addresses confusion from #1764 where `sandbox` and `agentSandbox` flags were conflated

Fixes #1772

## Test plan

- [ ] `helm lint charts/kagenti` passes
- [ ] Comments are accurate and match current state of each feature

Assisted-By: Claude Code