### PR TITLE
feat(kagenti-deps): Add Tekton and Shipwright support for vanilla Kubernetes

### DIFF
--- a/scripts/k8s/cleanup-kagenti.sh
+++ b/scripts/k8s/cleanup-kagenti.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# ============================================================================
+# KAGENTI CLEANUP FOR VANILLA KUBERNETES
+# ============================================================================
+# Reverses the install performed by scripts/k8s/setup-kagenti.sh: uninstalls
+# Helm releases, deletes namespaces, and clears stale Istio CA artifacts.
+# Does NOT delete the underlying cluster — that's the operator's call.
+#
+# Usage:
+#   scripts/k8s/cleanup-kagenti.sh
+#
+# Prerequisites: kubectl context pointing at the target cluster.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+KIND_CLEANUP="$REPO_ROOT/scripts/kind/cleanup-kagenti.sh"
+
+if [[ ! -x "$KIND_CLEANUP" ]]; then
+  echo "Error: $KIND_CLEANUP not found or not executable." >&2
+  exit 1
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Error: kubectl not found in PATH." >&2
+  exit 1
+fi
+if ! kubectl cluster-info >/dev/null 2>&1; then
+  echo "Error: kubectl cannot reach a cluster." >&2
+  exit 1
+fi
+
+# Reject the Kind-only flag explicitly so users don't get confused by silent
+# passthrough.
+for arg in "$@"; do
+  if [[ "$arg" == "--destroy-cluster" ]]; then
+    echo "Error: --destroy-cluster is Kind-only. Delete the cluster manually if needed." >&2
+    exit 1
+  fi
+done
+
+exec "$KIND_CLEANUP" "$@"

--- a/scripts/k8s/setup-kagenti.sh
+++ b/scripts/k8s/setup-kagenti.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# ============================================================================
+# KAGENTI PLATFORM SETUP FOR VANILLA KUBERNETES
+# ============================================================================
+# Installs the Kagenti stack onto a pre-existing Kubernetes cluster (K3s,
+# kubeadm, EKS, GKE, AKS, or any other distribution that exposes a working
+# kubectl context).
+#
+# Same component set as scripts/kind/setup-kagenti.sh — the only difference
+# is that cluster bring-up is the operator's responsibility, not this
+# script's. The shared installer logic lives in scripts/lib/install-deps.sh.
+#
+# Usage:
+#   scripts/k8s/setup-kagenti.sh                          # Core only
+#   scripts/k8s/setup-kagenti.sh --with-all               # Everything
+#   scripts/k8s/setup-kagenti.sh --with-builds            # Tekton + Shipwright
+#   scripts/k8s/setup-kagenti.sh --domain example.com     # Custom hostname domain
+#
+# Prerequisites:
+#   - kubectl context pointing at the target cluster
+#   - helm v3
+#   - cluster has enough capacity for the requested components
+#
+# Run scripts/k8s/setup-kagenti.sh --help for the full flag set.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+KIND_SETUP="$REPO_ROOT/scripts/kind/setup-kagenti.sh"
+
+if [[ ! -x "$KIND_SETUP" ]]; then
+  echo "Error: $KIND_SETUP not found or not executable." >&2
+  echo "       The Kubernetes entry point delegates installation to the shared" >&2
+  echo "       implementation in scripts/kind/setup-kagenti.sh + scripts/lib/install-deps.sh." >&2
+  exit 1
+fi
+
+# Verify a usable kubectl context before delegating. Fail fast with a clear
+# message rather than letting a missing kubeconfig bubble out of helm or
+# kubectl partway through the install.
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Error: kubectl not found in PATH." >&2
+  exit 1
+fi
+if ! kubectl cluster-info >/dev/null 2>&1; then
+  echo "Error: kubectl cannot reach a cluster." >&2
+  echo "       Set KUBECONFIG or run 'kubectl config use-context <name>' to point at" >&2
+  echo "       the target cluster, then re-run this script." >&2
+  exit 1
+fi
+
+# Reject Kind-only flags with a clear error rather than letting them fail
+# deep in the script when they hit a `docker exec <kind-container>` call.
+for arg in "$@"; do
+  case "$arg" in
+    --build-images|--preload-images)
+      echo "Error: $arg is Kind-only (loads images into the Kind node)." >&2
+      echo "       On vanilla Kubernetes, push images to your cluster's" >&2
+      echo "       registry and reference them by tag instead." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Forward the user's flags to the shared setup, but force --skip-cluster so
+# the Kind-specific create/preload steps are skipped. KAGENTI_SETUP_FLAVOR
+# changes the banner from "(Kind)" to "(Kubernetes)" so users running this
+# entry point see an accurate label, and gates the Kind-only registry-DNS
+# configuration block.
+KAGENTI_SETUP_FLAVOR=k8s exec "$KIND_SETUP" --skip-cluster "$@"

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -185,6 +185,11 @@ except Exception:
   fi
 }
 
+# ── Shared dependency installers (Tekton, Shipwright, build strategies) ─────
+# Sourced after log_*/run_cmd are defined; the lib reads DRY_RUN from this
+# scope and uses the helpers above.
+. "$REPO_ROOT/scripts/lib/install-deps.sh"
+
 # Load a single image into the Kind node via docker save piped to ctr import.
 # Avoids 'kind load docker-image' failures (e.g. "failed to detect containerd
 # snapshotter") on WSL2 and Rancher Desktop.
@@ -321,7 +326,10 @@ START_SECONDS=$SECONDS
 
 echo ""
 echo "============================================"
-echo "  Kagenti Platform Setup (Kind)"
+case "${KAGENTI_SETUP_FLAVOR:-kind}" in
+  k8s) echo "  Kagenti Platform Setup (Kubernetes)" ;;
+  *)   echo "  Kagenti Platform Setup (Kind)" ;;
+esac
 echo "============================================"
 echo ""
 echo "  Cluster:       $CLUSTER_NAME"
@@ -589,10 +597,7 @@ fi
 # ============================================================================
 if $WITH_BUILDS; then
   log_info "Step 3b: Tekton"
-  log_info "Installing Tekton ${TEKTON_VERSION}..."
-  run_cmd kubectl apply --server-side \
-    -f "https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml"
-  log_success "Tekton applied"
+  install_tekton "$TEKTON_VERSION"
   echo ""
 fi
 
@@ -741,7 +746,14 @@ log_success "kagenti-deps installed"
 echo ""
 
 # ── Configure Kind node to reach in-cluster container registry ──────────────
-if $WITH_BUILDS; then
+# Kind-only: writes /etc/hosts and /etc/containerd/certs.d on the Kind
+# control-plane container so kubelet can pull images from the in-cluster
+# registry by its cluster-DNS hostname. Vanilla Kubernetes operators need
+# to configure their nodes via the distribution's normal mechanism (e.g.
+# /etc/rancher/k3s/registries.yaml on K3s, /etc/containerd/config.toml +
+# restart on kubeadm); this script intentionally doesn't try to SSH into
+# nodes or guess the distro. Skip the block under the k8s flavor.
+if $WITH_BUILDS && [[ "${KAGENTI_SETUP_FLAVOR:-kind}" != "k8s" ]]; then
   REGISTRY_NAME="registry"
   REGISTRY_NS="cr-system"
   REGISTRY_HOST="${REGISTRY_NAME}.${REGISTRY_NS}.svc.cluster.local"
@@ -774,6 +786,14 @@ TOML
     fi
   fi
   echo ""
+elif $WITH_BUILDS; then
+  log_info "Skipping Kind registry-DNS step on vanilla Kubernetes."
+  log_info "  To pull images from the in-cluster registry by its cluster-DNS"
+  log_info "  hostname (registry.cr-system.svc.cluster.local:5000), configure"
+  log_info "  containerd on each node via your distribution's mechanism:"
+  log_info "    K3s:     /etc/rancher/k3s/registries.yaml + restart k3s/k3s-agent"
+  log_info "    kubeadm: /etc/containerd/config.toml + systemctl restart containerd"
+  echo ""
 fi
 
 # ============================================================================
@@ -781,165 +801,7 @@ fi
 # ============================================================================
 if $WITH_BUILDS; then
   log_info "Step 6b: Shipwright"
-
-  log_info "Installing Shipwright ${SHIPWRIGHT_VERSION}..."
-  run_cmd kubectl apply --server-side \
-    -f "https://github.com/shipwright-io/build/releases/download/${SHIPWRIGHT_VERSION}/release.yaml"
-
-  if ! $DRY_RUN; then
-    kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/shipwright-build --timeout=30s 2>/dev/null || true
-
-    # cert-manager resources for webhook TLS
-    kubectl apply -f - <<'EOF'
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: shipwright-selfsigned-issuer
-spec:
-  selfSigned: {}
-EOF
-    kubectl apply -f - <<EOF
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: shipwright-ca
-  namespace: shipwright-build
-spec:
-  isCA: true
-  commonName: shipwright-ca
-  secretName: shipwright-ca-secret
-  duration: 26280h
-  privateKey:
-    algorithm: ECDSA
-    size: 256
-  issuerRef:
-    name: shipwright-selfsigned-issuer
-    kind: ClusterIssuer
-EOF
-    kubectl wait --for=condition=Ready certificate/shipwright-ca \
-      -n shipwright-build --timeout=60s 2>/dev/null || true
-
-    kubectl apply -f - <<'EOF'
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: shipwright-ca-issuer
-  namespace: shipwright-build
-spec:
-  ca:
-    secretName: shipwright-ca-secret
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: shipwright-build-webhook-cert
-  namespace: shipwright-build
-spec:
-  secretName: shipwright-build-webhook-cert
-  duration: 8760h
-  renewBefore: 720h
-  dnsNames:
-    - shp-build-webhook
-    - shp-build-webhook.shipwright-build
-    - shp-build-webhook.shipwright-build.svc
-    - shp-build-webhook.shipwright-build.svc.cluster.local
-  issuerRef:
-    name: shipwright-ca-issuer
-    kind: Issuer
-EOF
-    kubectl wait --for=condition=Ready certificate/shipwright-build-webhook-cert \
-      -n shipwright-build --timeout=60s 2>/dev/null || true
-
-    # Annotate CRDs for CA injection
-    for crd in clusterbuildstrategies.shipwright.io buildstrategies.shipwright.io \
-               builds.shipwright.io buildruns.shipwright.io; do
-      kubectl annotate crd "$crd" \
-        cert-manager.io/inject-ca-from=shipwright-build/shipwright-build-webhook-cert \
-        --overwrite 2>/dev/null || true
-    done
-
-    # Restart webhook to pick up TLS
-    kubectl rollout restart deployment/shipwright-build-webhook -n shipwright-build 2>/dev/null || true
-    _wait_deployment_ready shipwright-build-webhook shipwright-build "Shipwright webhook"
-
-    # Install sample build strategies
-    kubectl apply --server-side \
-      -f "https://github.com/shipwright-io/build/releases/download/${SHIPWRIGHT_VERSION}/sample-strategies.yaml" \
-      2>/dev/null || true
-
-    # Install buildah-insecure-push strategy for in-cluster registry (no TLS)
-    log_info "Installing buildah-insecure-push ClusterBuildStrategy..."
-    kubectl apply -f - <<'STRATEGY_EOF'
-apiVersion: shipwright.io/v1beta1
-kind: ClusterBuildStrategy
-metadata:
-  name: buildah-insecure-push
-spec:
-  parameters:
-    - name: dockerfile
-      description: Path to the Dockerfile
-      type: string
-      default: Dockerfile
-    - name: build-args
-      description: Build arguments in KEY=VALUE format
-      type: array
-      defaults: []
-    - name: storage-driver
-      description: The storage driver to use (overlay or vfs)
-      type: string
-      default: vfs
-  securityContext:
-    runAsUser: 0
-    runAsGroup: 0
-  steps:
-    - name: build-and-push
-      image: quay.io/containers/buildah:v1.37.5
-      workingDir: $(params.shp-source-root)
-      securityContext:
-        capabilities:
-          add:
-            - SETFCAP
-      command:
-        - /bin/bash
-      args:
-        - -c
-        - |
-          set -euo pipefail
-
-          BUILD_ARGS=()
-          for arg in "$@"; do
-            if [[ "$arg" == "--build-arg="* ]]; then
-              BUILD_ARGS+=("--build-arg" "${arg#--build-arg=}")
-            fi
-          done
-
-          echo "Building image..."
-          buildah --storage-driver=$(params.storage-driver) bud \
-            "${BUILD_ARGS[@]}" \
-            -f "$(params.shp-source-context)/$(params.dockerfile)" \
-            -t "$(params.shp-output-image)" \
-            "$(params.shp-source-context)"
-
-          echo "Pushing image to $(params.shp-output-image)..."
-          buildah --storage-driver=$(params.storage-driver) push \
-            --tls-verify=false \
-            "$(params.shp-output-image)" \
-            "docker://$(params.shp-output-image)"
-
-          echo "Build and push completed successfully!"
-        - --
-        - $(params.build-args[*])
-      resources:
-        limits:
-          cpu: "1"
-          memory: 2Gi
-        requests:
-          cpu: 250m
-          memory: 256Mi
-STRATEGY_EOF
-  fi
-
-  log_success "Shipwright installed"
+  install_shipwright "$SHIPWRIGHT_VERSION"
   echo ""
 fi
 

--- a/scripts/lib/install-deps.sh
+++ b/scripts/lib/install-deps.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Shared Kagenti dependency installers
+# ============================================================================
+# Library of bash functions used by the Kind and vanilla-Kubernetes entry
+# points (scripts/kind/setup-kagenti.sh and scripts/k8s/setup-kagenti.sh).
+#
+# Functions install upstream third-party components onto an existing
+# Kubernetes cluster using kubectl/helm against the caller's KUBECONFIG.
+# They are NOT cluster-creators — Kind cluster bring-up stays in the Kind
+# entry point.
+#
+# The sourcing entry point is expected to provide:
+#   - log_info, log_success, log_warn, log_error  (output helpers)
+#   - run_cmd                                     (dry-run wrapper)
+#   - _wait_deployment_ready                      (rollout wait helper)
+#   - DRY_RUN                                     (boolean variable)
+#
+# Each install_* function declares its required pinned version constants
+# locally (with caller-overridable defaults) so this lib can be sourced
+# standalone without depending on a particular caller's variable layout.
+# ============================================================================
+
+# Guard against double-sourcing.
+if [[ "${__KAGENTI_INSTALL_DEPS_SH_SOURCED:-}" == "1" ]]; then
+  return 0
+fi
+__KAGENTI_INSTALL_DEPS_SH_SOURCED=1
+
+# ----------------------------------------------------------------------------
+# install_tekton
+# ----------------------------------------------------------------------------
+# Installs Tekton Pipelines from the upstream release manifest at a pinned
+# version. Idempotent — kubectl apply --server-side handles re-runs.
+#
+# Usage: install_tekton [version]
+#   version: Tekton release tag (default: $TEKTON_VERSION env, then v0.66.0)
+# ----------------------------------------------------------------------------
+install_tekton() {
+  local version="${1:-${TEKTON_VERSION:-v0.66.0}}"
+  log_info "Installing Tekton ${version}..."
+  run_cmd kubectl apply --server-side \
+    -f "https://storage.googleapis.com/tekton-releases/pipeline/previous/${version}/release.yaml"
+  log_success "Tekton applied"
+}
+
+# ----------------------------------------------------------------------------
+# install_shipwright
+# ----------------------------------------------------------------------------
+# Installs Shipwright Build Controller from the upstream release manifest at
+# a pinned version, configures cert-manager-issued TLS for the admission
+# webhook, and applies sample build strategies plus the buildah-insecure-push
+# strategy used for in-cluster registries.
+#
+# Prerequisites:
+#   - cert-manager installed and ready (a ClusterIssuer/Issuer is created
+#     by this function; cert-manager itself must already be running)
+#   - Tekton installed (Shipwright depends on Tekton)
+#
+# Usage: install_shipwright [version]
+#   version: Shipwright release tag (default: $SHIPWRIGHT_VERSION env, then v0.14.0)
+# ----------------------------------------------------------------------------
+install_shipwright() {
+  local version="${1:-${SHIPWRIGHT_VERSION:-v0.14.0}}"
+
+  log_info "Installing Shipwright ${version}..."
+  run_cmd kubectl apply --server-side \
+    -f "https://github.com/shipwright-io/build/releases/download/${version}/release.yaml"
+
+  if $DRY_RUN; then
+    log_success "Shipwright applied (dry-run)"
+    return 0
+  fi
+
+  kubectl wait --for=jsonpath='{.status.phase}'=Active namespace/shipwright-build --timeout=30s 2>/dev/null || true
+
+  configure_shipwright_webhook_tls
+
+  # Sample build strategies (best-effort).
+  kubectl apply --server-side \
+    -f "https://github.com/shipwright-io/build/releases/download/${version}/sample-strategies.yaml" \
+    2>/dev/null || true
+
+  install_buildah_insecure_push_strategy
+
+  log_success "Shipwright installed"
+}
+
+# ----------------------------------------------------------------------------
+# configure_shipwright_webhook_tls
+# ----------------------------------------------------------------------------
+# Wires up cert-manager to issue TLS for the Shipwright admission webhook:
+#   1. Create a self-signed ClusterIssuer
+#   2. Create a CA Certificate signed by the ClusterIssuer
+#   3. Create an Issuer that uses the CA
+#   4. Create a webhook Certificate with the right DNS SANs
+#   5. Annotate Shipwright CRDs for CA injection
+#   6. Restart the webhook to pick up the new TLS material
+#
+# Without this the Shipwright admission webhook will not have valid TLS and
+# Build/BuildRun resources will be rejected.
+# ----------------------------------------------------------------------------
+configure_shipwright_webhook_tls() {
+  if $DRY_RUN; then
+    log_info "[dry-run] would configure cert-manager TLS for Shipwright webhook"
+    return 0
+  fi
+
+  kubectl apply -f - <<'EOF'
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: shipwright-selfsigned-issuer
+spec:
+  selfSigned: {}
+EOF
+
+  kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: shipwright-ca
+  namespace: shipwright-build
+spec:
+  isCA: true
+  commonName: shipwright-ca
+  secretName: shipwright-ca-secret
+  duration: 26280h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: shipwright-selfsigned-issuer
+    kind: ClusterIssuer
+EOF
+  kubectl wait --for=condition=Ready certificate/shipwright-ca \
+    -n shipwright-build --timeout=60s 2>/dev/null || true
+
+  kubectl apply -f - <<'EOF'
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: shipwright-ca-issuer
+  namespace: shipwright-build
+spec:
+  ca:
+    secretName: shipwright-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: shipwright-build-webhook-cert
+  namespace: shipwright-build
+spec:
+  secretName: shipwright-build-webhook-cert
+  duration: 8760h
+  renewBefore: 720h
+  dnsNames:
+    - shp-build-webhook
+    - shp-build-webhook.shipwright-build
+    - shp-build-webhook.shipwright-build.svc
+    - shp-build-webhook.shipwright-build.svc.cluster.local
+  issuerRef:
+    name: shipwright-ca-issuer
+    kind: Issuer
+EOF
+  kubectl wait --for=condition=Ready certificate/shipwright-build-webhook-cert \
+    -n shipwright-build --timeout=60s 2>/dev/null || true
+
+  for crd in clusterbuildstrategies.shipwright.io buildstrategies.shipwright.io \
+             builds.shipwright.io buildruns.shipwright.io; do
+    kubectl annotate crd "$crd" \
+      cert-manager.io/inject-ca-from=shipwright-build/shipwright-build-webhook-cert \
+      --overwrite 2>/dev/null || true
+  done
+
+  kubectl rollout restart deployment/shipwright-build-webhook -n shipwright-build 2>/dev/null || true
+  _wait_deployment_ready shipwright-build-webhook shipwright-build "Shipwright webhook"
+}
+
+# ----------------------------------------------------------------------------
+# install_buildah_insecure_push_strategy
+# ----------------------------------------------------------------------------
+# Applies the buildah-insecure-push ClusterBuildStrategy used for pushing to
+# in-cluster HTTP registries (no TLS).
+# ----------------------------------------------------------------------------
+install_buildah_insecure_push_strategy() {
+  log_info "Installing buildah-insecure-push ClusterBuildStrategy..."
+  kubectl apply -f - <<'STRATEGY_EOF'
+apiVersion: shipwright.io/v1beta1
+kind: ClusterBuildStrategy
+metadata:
+  name: buildah-insecure-push
+spec:
+  parameters:
+    - name: dockerfile
+      description: Path to the Dockerfile
+      type: string
+      default: Dockerfile
+    - name: build-args
+      description: Build arguments in KEY=VALUE format
+      type: array
+      defaults: []
+    - name: storage-driver
+      description: The storage driver to use (overlay or vfs)
+      type: string
+      default: vfs
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  steps:
+    - name: build-and-push
+      image: quay.io/containers/buildah:v1.37.5
+      workingDir: $(params.shp-source-root)
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          set -euo pipefail
+
+          BUILD_ARGS=()
+          for arg in "$@"; do
+            if [[ "$arg" == "--build-arg="* ]]; then
+              BUILD_ARGS+=("--build-arg" "${arg#--build-arg=}")
+            fi
+          done
+
+          echo "Building image..."
+          buildah --storage-driver=$(params.storage-driver) bud \
+            "${BUILD_ARGS[@]}" \
+            -f "$(params.shp-source-context)/$(params.dockerfile)" \
+            -t "$(params.shp-output-image)" \
+            "$(params.shp-source-context)"
+
+          echo "Pushing image to $(params.shp-output-image)..."
+          buildah --storage-driver=$(params.storage-driver) push \
+            --tls-verify=false \
+            "$(params.shp-output-image)" \
+            "docker://$(params.shp-output-image)"
+
+          echo "Build and push completed successfully!"
+        - --
+        - $(params.build-args[*])
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: 250m
+          memory: 256Mi
+STRATEGY_EOF
+}


### PR DESCRIPTION
# Add vanilla-Kubernetes support for Tekton + Shipwright via shared bash library

## Summary

Adds support for installing Kagenti's optional Tekton + Shipwright build stack on **vanilla Kubernetes clusters** (K3s, kubeadm, EKS, GKE, AKS, IBM Cloud, etc.) — not just Kind or OpenShift. This unblocks Kagenti deployments on non-Kind, non-OCP environments without requiring users to reimplement the install logic out-of-band.

## Background

The first revision of this PR added Helm chart templates (`templates/tekton-pipelines.yaml`, `templates/shipwright-build.yaml`) that installed Tekton/Shipwright via in-cluster install Jobs when `openshift=false`. Reviewer @pdettori flagged six concerns ([review thread](https://github.com/kagenti/kagenti/pull/1779)):

1. **must-fix:** Conflict with the existing Kind installer (which already pins versions and disables the chart components).
2. **must-fix:** Unpinned `latest` versions are a reproducibility hazard.
3. **must-fix:** Bound to `cluster-admin` — overly broad.
4. **must-fix:** Missing cert-manager TLS setup for Shipwright webhook.
5. **suggestion:** `hook-succeeded` delete policy hurts debugging.
6. **suggestion:** No uninstall path.

In the discussion, @pdettori suggested **"extending the kind installer to work with vanilla (pre-existing) Kubernetes as well"** rather than adding a parallel install path inside the Helm chart. This commit takes that approach.

## Approach (Path A from review discussion)

Extract the Tekton/Shipwright install logic from `scripts/kind/setup-kagenti.sh` into a shared bash library, then add a thin vanilla-Kubernetes entry point that reuses it. The Helm chart templates added in the previous revision are removed.

### New layout

```
scripts/
├── lib/
│   └── install-deps.sh          # shared installer functions
├── kind/
│   ├── setup-kagenti.sh         # creates Kind cluster, sources lib
│   └── cleanup-kagenti.sh       # unchanged
└── k8s/
    ├── setup-kagenti.sh         # vanilla-k8s entry point (new)
    └── cleanup-kagenti.sh       # vanilla-k8s cleanup (new)
```

### Shared library functions

`scripts/lib/install-deps.sh` provides:

- `install_tekton [version]` — applies the upstream Tekton release manifest at a pinned version (default `v0.66.0`).
- `install_shipwright [version]` — applies the upstream Shipwright release manifest at a pinned version (default `v0.14.0`), then runs `configure_shipwright_webhook_tls`, applies sample build strategies, and installs `buildah-insecure-push`.
- `configure_shipwright_webhook_tls` — wires up cert-manager (self-signed ClusterIssuer → CA Certificate → Issuer → webhook Certificate with DNS SANs → CRD CA-injection annotations → webhook restart).
- `install_buildah_insecure_push_strategy` — applies the buildah-insecure-push ClusterBuildStrategy.

The lib is **stateless and dependency-injected**: it reads `DRY_RUN` from the caller's scope and uses the caller's `log_*`, `run_cmd`, and `_wait_deployment_ready` helpers. No globals defined in the lib itself.

### Kind entry point

`scripts/kind/setup-kagenti.sh` now:
- Sources `../lib/install-deps.sh` once at startup.
- Replaces the inline Tekton install (Step 3b) with `install_tekton "$TEKTON_VERSION"`.
- Replaces the inline Shipwright install + cert-manager TLS + build strategies (Step 6b, ~163 lines) with `install_shipwright "$SHIPWRIGHT_VERSION"`.
- Honors `KAGENTI_SETUP_FLAVOR` env var to relabel the banner when invoked via the k8s entry point.

Behavior is unchanged. Verified with `bash scripts/kind/setup-kagenti.sh --dry-run --skip-cluster --with-builds`.

### Vanilla-k8s entry point

`scripts/k8s/setup-kagenti.sh`:
- Verifies `kubectl` can reach a cluster (clear error if not).
- Sets `KAGENTI_SETUP_FLAVOR=k8s` so the banner reads "(Kubernetes)".
- `exec`s the Kind entry point with `--skip-cluster` forced.
- Forwards all other flags (`--with-*`, `--skip-*`, `--domain`, etc.) unchanged.

`scripts/k8s/cleanup-kagenti.sh`:
- Symmetric wrapper around `scripts/kind/cleanup-kagenti.sh`.
- Rejects `--destroy-cluster` with a clear error (Kind-only flag).

### Removed

- `charts/kagenti-deps/templates/tekton-pipelines.yaml`
- `charts/kagenti-deps/templates/shipwright-build.yaml`

## How this addresses each review comment

| # | Comment | Resolution |
|---|---------|-----------|
| 1 | Conflict with Kind installer | **Eliminated.** Single install path. Both Kind and k8s entry points call the same shared lib. The Kind installer's existing `--set components.tekton.enabled=false --set components.shipwright.enabled=false` is unchanged. No risk of double-install at different versions. |
| 2 | Unpinned `latest` | **Fixed.** Lib functions accept a version argument. Defaults match the Kind installer's existing pinned constants (`TEKTON_VERSION=v0.66.0`, `SHIPWRIGHT_VERSION=v0.14.0`). Callers can override per call. |
| 3 | `cluster-admin` overly broad | **Eliminated by removing in-cluster Jobs.** Bash scripts run with the operator's local kubectl credentials. No ServiceAccounts, ClusterRoleBindings, or third-party kubectl image with cluster-admin to compromise. |
| 4 | Missing cert-manager TLS | **Fixed.** `configure_shipwright_webhook_tls` is now part of `install_shipwright`. The vanilla-k8s entry point inherits it for free: self-signed ClusterIssuer → CA Certificate → Issuer → webhook Certificate with DNS SANs → CRD CA-injection annotations → webhook restart. Identical to what the Kind installer already does. |
| 5 | `hook-succeeded` debugging | **N/A.** No Helm hooks remain. Failures halt the script via `set -e` and the user sees them immediately on stderr. |
| 6 | No uninstall path | **Fixed.** `scripts/k8s/cleanup-kagenti.sh` mirrors `scripts/kind/cleanup-kagenti.sh`, providing symmetric uninstall: deletes CRs, uninstalls Helm releases, deletes PVCs, clears stale Istio CA artifacts, removes namespaces. |

## Testing

- ✅ `bash scripts/kind/setup-kagenti.sh --dry-run --skip-cluster --with-builds` — dry-run output unchanged from baseline; Tekton + Shipwright steps now flow through the lib.
- ✅ `bash scripts/k8s/setup-kagenti.sh --dry-run --with-builds` — banner says "(Kubernetes)", same install steps.
- ✅ Live install on a fresh Kind cluster via the **k8s entry point** with `--with-builds`. End-to-end result:
  - All Kagenti pods Running across `kagenti-system`, `keycloak`, `cert-manager`, `istio-system`, `gateway-system`, `cr-system`, `tekton-pipelines`, `shipwright-build`.
  - `tekton-pipelines-controller`, `tekton-pipelines-webhook`, `tekton-events-controller` Running.
  - `shipwright-build-controller`, `shipwright-build-webhook` Running with cert-manager-issued TLS.
  - All 9 ClusterBuildStrategies registered, including `buildah-insecure-push`.
  - "Skipping Kind registry-DNS step on vanilla Kubernetes" message confirmed; the Kind-only `docker exec <control-plane>` containerd config block is correctly bypassed.
- 📝 `bash -n` syntax check passes for all scripts and the lib.

## Optional follow-up: full lib extraction

This PR keeps the scope minimal — only Tekton, Shipwright, and the build-strategy install moved into the lib. The other cluster-agnostic install steps (cert-manager, Istio, SPIRE, Gateway API CRDs, Helm chart installs, MCP Gateway, Kuadrant) still live inline in `scripts/kind/setup-kagenti.sh` and are reachable from the k8s entry point via `--skip-cluster` passthrough.

If desired, a follow-up PR could extract those steps into the lib as well, leaving both entry points as thin orchestrators. Happy to do that here or in a follow-up — let me know which you'd prefer.

## Out of scope for this PR

- No changes to `scripts/ocp/setup-kagenti.sh`.
- No changes to any Helm chart values, templates, or behavior on OpenShift.
- No changes to component versions — the lib uses the same pinned versions the Kind installer already uses.

Closes #1778

Signed-off-by: Jeremy Cohn <jacohn1@gmail.com>
