### PR TITLE
fix(installer): handle stale MCPGatewayExtension stuck in deletion

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1221,6 +1221,28 @@ if $WITH_MCP_GATEWAY; then
   kubectl create namespace mcp-system --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null || true
   kubectl create namespace gateway-system --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null || true
 
+  # Clean up any MCPGatewayExtension stuck in deletion (e.g. leftover from a prior
+  # version that used a different API group). A stuck finalizer prevents the controller
+  # from creating the broker-router deployment on reinstall.
+  for _crd_group in mcp.kuadrant.io mcp.kagenti.com; do
+    _stuck=$(kubectl get mcpgatewayextensions.${_crd_group} -n mcp-system -o json 2>/dev/null \
+      | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data.get('items', []):
+    if item.get('metadata', {}).get('deletionTimestamp'):
+        print(item['metadata']['name'])
+" 2>/dev/null || echo "")
+    if [ -n "$_stuck" ]; then
+      echo "$_stuck" | while read -r _name; do
+        log_warn "Removing stuck finalizer from MCPGatewayExtension/${_name} (${_crd_group})"
+        kubectl patch "mcpgatewayextensions.${_crd_group}/${_name}" -n mcp-system \
+          --type=json -p '[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+      done
+      sleep 2
+    fi
+  done
+
   log_info "Installing MCP Gateway v${MCP_GATEWAY_VERSION}..."
   run_cmd helm upgrade --install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
     -n mcp-system --create-namespace --version "$MCP_GATEWAY_VERSION" \

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1532,12 +1532,34 @@ log_info "Step 5b: Install MCP Gateway"
 
 if $SKIP_MCP_GATEWAY; then
   log_info "Skipped (--skip-mcp-gateway)"
-elif helm status mcp-gateway -n mcp-system &>/dev/null; then
-  log_info "MCP Gateway already installed — skipping"
 else
+  # Clean up any MCPGatewayExtension stuck in deletion (e.g. leftover from a prior
+  # version that used a different API group). A stuck finalizer prevents the controller
+  # from creating the broker-router deployment on reinstall.
+  if ! $DRY_RUN; then
+    for _crd_group in mcp.kuadrant.io mcp.kagenti.com; do
+      _stuck=$($KUBECTL get mcpgatewayextensions.${_crd_group} -n mcp-system -o json 2>/dev/null \
+        | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data.get('items', []):
+    if item.get('metadata', {}).get('deletionTimestamp'):
+        print(item['metadata']['name'])
+" 2>/dev/null || echo "")
+      if [ -n "$_stuck" ]; then
+        echo "$_stuck" | while read -r _name; do
+          log_warn "Removing stuck finalizer from MCPGatewayExtension/${_name} (${_crd_group})"
+          $KUBECTL patch "mcpgatewayextensions.${_crd_group}/${_name}" -n mcp-system \
+            --type=json -p '[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+        done
+        sleep 2
+      fi
+    done
+  fi
+
   MCP_GW_PUBLIC_HOST="mcp-gateway-gateway-system.${DOMAIN}"
   log_info "Installing MCP Gateway v${MCP_GATEWAY_VERSION} (publicHost=${MCP_GW_PUBLIC_HOST})..."
-  run_cmd helm install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
+  run_cmd helm upgrade --install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
     --create-namespace --namespace mcp-system --version "$MCP_GATEWAY_VERSION" \
     --set "gateway.publicHost=${MCP_GW_PUBLIC_HOST}"
   log_success "MCP Gateway installed"


### PR DESCRIPTION
## Summary

- Fixes MCP Gateway installer failure when a stale `MCPGatewayExtension` from a prior version is stuck in deletion with a finalizer the old controller can no longer process
- Before installing, detects resources with `deletionTimestamp` under both `mcp.kuadrant.io` and `mcp.kagenti.com` API groups and strips their finalizers
- Switches OCP installer from `helm install` to `helm upgrade --install` for idempotent re-runs (matches Kind installer)

## Context

When upgrading from MCP Gateway v0.5.x (API group `mcp.kagenti.com/v1alpha1`) to v0.6.0 (`mcp.kuadrant.io/v1alpha1`), a previously-deleted MCPGatewayExtension gets stuck because:
1. The old controller is gone and can't process the finalizer
2. The new controller sees `deletionTimestamp` and runs cleanup logic instead of creating the broker-router
3. The installer waits 5 minutes for a deployment that will never appear

## Test plan

- [x] Verified fix on OpenShift cluster with stuck MCPGatewayExtension (finalizer removal + helm upgrade recreates broker-router in <10s)
- [ ] Re-run OCP installer on cluster with existing healthy MCP Gateway (idempotent upgrade path)
- [ ] Run Kind installer with `--with-mcp-gateway` on fresh cluster

Assisted-By: Claude Code