### PR TITLE
fix(mlflow): redirect to root after OIDC login instead of user profile

### DIFF
--- a/charts/kagenti-deps/templates/mlflow.yaml
+++ b/charts/kagenti-deps/templates/mlflow.yaml
@@ -397,6 +397,8 @@ spec:
           value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/mlflow"
         - name: OIDC_ALEMBIC_VERSION_TABLE
           value: "mlflow_oidc_alembic_version"
+        - name: DEFAULT_LANDING_PAGE_IS_PERMISSIONS
+          value: "false"
         {{- end }}
         ports:
         - containerPort: 5000

--- a/kagenti/auth/mlflow-oauth-secret/mlflow_oauth_secret.py
+++ b/kagenti/auth/mlflow-oauth-secret/mlflow_oauth_secret.py
@@ -390,6 +390,7 @@ def main() -> None:
             "OIDC_REDIRECT_URI": redirect_uri,
             "OIDC_SCOPE": "openid email profile",
             "OIDC_GROUPS_CLAIM": "groups",
+            "DEFAULT_LANDING_PAGE_IS_PERMISSIONS": "false",
         }
 
         create_or_update_k8s_resource(


### PR DESCRIPTION
## Summary

- Set `DEFAULT_LANDING_PAGE_IS_PERMISSIONS=false` in the MLflow OAuth secret generator and Helm template
- This configures `mlflow-oidc-auth` to redirect to `/` (experiments view) after Keycloak login, instead of `/oidc/ui/user` (permissions/profile page)

## Root Cause

The `mlflow-oidc-auth` plugin defaults `DEFAULT_LANDING_PAGE_IS_PERMISSIONS` to `true` ([source](https://github.com/mlflow-oidc/mlflow-oidc-auth/blob/main/mlflow_oidc_auth/config.py#L131)). When true, the OIDC callback handler redirects to the user profile page (`/oidc/ui/user`) instead of the originally requested path or root.

## Fix

Two-layer fix for robustness:
1. **Secret generator** (`mlflow_oauth_secret.py`): adds the key to the generated K8s secret so new deployments get it automatically
2. **Helm template** (`mlflow.yaml`): sets it as a direct env var, ensuring it takes effect even if the secret was created before this change

## Test plan

- [ ] CI passes (no behavioral change for Kind since MLflow auth is disabled)
- [ ] Verify on OpenShift cluster with MLflow OIDC auth enabled: clicking MLFlow link from Observability page should land on experiments view (`/`), not `/oidc/ui/user`

Closes #1752

Assisted-By: Claude Code