### PR TITLE
fix(e2e): skip MCP CRD validation when gateway not installed

### DIFF
--- a/.github/scripts/kagenti-operator/41-wait-crds.sh
+++ b/.github/scripts/kagenti-operator/41-wait-crds.sh
@@ -7,48 +7,56 @@ source "$SCRIPT_DIR/../lib/k8s-utils.sh"
 
 log_step "41" "Waiting for Kagenti Operator CRDs"
 
-# NOTE: agents.agent.kagenti.dev is NOT required for E2E tests since we now
-# deploy agents using standard Kubernetes Deployments + Services directly.
-# Only keeping CRDs that are still actively used in CI.
-#
-# MCP gateway v0.6.0 renamed the CRD group from mcp.kuadrant.io to
-# mcp.kagenti.com. Kind CI still uses the old version; HyperShift uses the new.
-# Detect which domain is present, then wait for those CRDs.
-MCP_RESOURCES=(
-    "mcpserverregistrations"
-    "mcpvirtualservers"
-    "mcpgatewayextensions"
-)
-
-# Detect which MCP CRD domain is installed.
-# Retry up to 60s since operators may still be registering CRDs.
-MCP_DOMAIN=""
-for i in $(seq 1 12); do
-    if kubectl get crd "mcpserverregistrations.mcp.kagenti.com" &>/dev/null; then
-        MCP_DOMAIN="mcp.kagenti.com"
-        break
-    elif kubectl get crd "mcpserverregistrations.mcp.kuadrant.io" &>/dev/null; then
-        MCP_DOMAIN="mcp.kuadrant.io"
-        break
-    fi
-    log_info "MCP CRDs not yet available, retrying ($i/12)..."
-    sleep 5
-done
-if [ -z "$MCP_DOMAIN" ]; then
-    MCP_DOMAIN="mcp.kagenti.com"
-    log_info "Defaulting to $MCP_DOMAIN (neither domain detected after 60s)"
+# Check if MCP Gateway is installed before waiting for its CRDs.
+# The mcp-gateway chart is optional (requires --with-mcp-gateway or --with-all
+# on Kind, and is skipped by default on HyperShift/OCP).
+MCP_GATEWAY_INSTALLED=false
+if helm list -n mcp-system -q 2>/dev/null | grep -q "^mcp-gateway$"; then
+    MCP_GATEWAY_INSTALLED=true
+elif kubectl get namespace mcp-system &>/dev/null && \
+     kubectl get crds 2>/dev/null | grep -q "mcp\.\(kuadrant\.io\|kagenti\.com\)"; then
+    MCP_GATEWAY_INSTALLED=true
 fi
-log_info "MCP CRD domain: $MCP_DOMAIN"
 
-for resource in "${MCP_RESOURCES[@]}"; do
-    crd="${resource}.${MCP_DOMAIN}"
-    log_info "Waiting for CRD: $crd"
-    wait_for_crd "$crd" || {
-        log_error "CRD $crd not found"
-        kubectl get crds | grep -E 'kagenti|mcp' || echo "No kagenti/mcp CRDs found"
-        kubectl get pods -n kagenti-system
-        exit 1
-    }
-done
+if [ "$MCP_GATEWAY_INSTALLED" = "false" ]; then
+    log_info "MCP Gateway not installed — skipping MCP CRD validation"
+else
+    MCP_RESOURCES=(
+        "mcpserverregistrations"
+        "mcpvirtualservers"
+        "mcpgatewayextensions"
+    )
+
+    # Detect which MCP CRD domain is installed.
+    # Retry up to 60s since operators may still be registering CRDs.
+    MCP_DOMAIN=""
+    for i in $(seq 1 12); do
+        if kubectl get crd "mcpserverregistrations.mcp.kuadrant.io" &>/dev/null; then
+            MCP_DOMAIN="mcp.kuadrant.io"
+            break
+        elif kubectl get crd "mcpserverregistrations.mcp.kagenti.com" &>/dev/null; then
+            MCP_DOMAIN="mcp.kagenti.com"
+            break
+        fi
+        log_info "MCP CRDs not yet available, retrying ($i/12)..."
+        sleep 5
+    done
+    if [ -z "$MCP_DOMAIN" ]; then
+        MCP_DOMAIN="mcp.kuadrant.io"
+        log_info "Defaulting to $MCP_DOMAIN (neither domain detected after 60s)"
+    fi
+    log_info "MCP CRD domain: $MCP_DOMAIN"
+
+    for resource in "${MCP_RESOURCES[@]}"; do
+        crd="${resource}.${MCP_DOMAIN}"
+        log_info "Waiting for CRD: $crd"
+        wait_for_crd "$crd" || {
+            log_error "CRD $crd not found"
+            kubectl get crds | grep -E 'kagenti|mcp' || echo "No kagenti/mcp CRDs found"
+            kubectl get pods -n kagenti-system
+            exit 1
+        }
+    done
+fi
 
 log_success "All Kagenti Operator CRDs established"


### PR DESCRIPTION
## Summary

- Skip MCP Gateway CRD validation in `41-wait-crds.sh` when MCP Gateway is not installed
- Fix domain detection order: try `mcp.kuadrant.io` first (actual v0.6.0 group), then `mcp.kagenti.com`
- Update fallback default to `mcp.kuadrant.io`

## Root Cause

The HyperShift E2E job in the RC Release Validation workflow fails because `41-wait-crds.sh` unconditionally waits for MCP Gateway CRDs. On HyperShift/OCP, the MCP Gateway chart is optional (`SKIP_MCP_GATEWAY=true` by default in `setup-kagenti.sh`), so CRDs are never registered — causing a 60s timeout followed by a hard failure.

## Fix

Check for the `mcp-gateway` Helm release in `mcp-system` (or existing MCP CRDs) before entering the wait loop. If MCP Gateway is not installed, log a skip message and continue.

Closes #1785

## Test plan

- [ ] RC Release Validation workflow passes (HyperShift E2E no longer fails on missing MCP CRDs)
- [ ] Kind E2E with `--with-all` still validates MCP CRDs correctly

Assisted-By: Claude Code