### PR TITLE
Single source of truth for AuthBridge Config + Envoy Config Fix

### DIFF
--- a/charts/kagenti/templates/_helpers.tpl
+++ b/charts/kagenti/templates/_helpers.tpl
@@ -87,3 +87,17 @@ CrashLoopBackOff. See kagenti-extensions#332.
 {{- fail "authBridge.clientAuthType=federated-jwt requires spire.enabled=true (the in-process SPIFFE provider is needed to mint JWT-SVID client assertions)" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+AuthBridge runtime config YAML (config.yaml content for authbridge-runtime-config ConfigMap).
+Single source of truth: evaluates authBridge.pipeline from values.yaml via tpl(),
+prepends the conditional spiffe block when SPIRE is enabled.
+Both authbridge-template-configmaps.yaml and agent-namespaces.yaml include this.
+*/}}
+{{- define "kagenti.authbridge-runtime-config-yaml" -}}
+{{- if .Values.spire.enabled }}
+spiffe: {}
+{{- end }}
+pipeline:
+{{ tpl .Values.authBridge.pipeline . | indent 2 }}
+{{- end -}}

--- a/charts/kagenti/templates/agent-namespaces.yaml
+++ b/charts/kagenti/templates/agent-namespaces.yaml
@@ -216,6 +216,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  message_timeout: 310s
                   allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
@@ -281,6 +282,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  message_timeout: 310s
                   allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
@@ -342,50 +344,7 @@ data:
   # No top-level `mode:` — see the matching template-configmap in
   # authbridge-template-configmaps.yaml for the rationale.
   config.yaml: |
-    {{- if $root.Values.spire.enabled }}
-    # Empty spiffe block signals authbridge to construct an in-process
-    # SPIFFE provider (X.509 source for mTLS + lazy JWT source for
-    # tokenexchange). All fields default: socket points at the standard
-    # SPIRE agent socket, mirror writes /opt/svid*.pem on rotation. The
-    # JWT audience is per-tokenexchange (see identity.jwt_audience below).
-    spiffe: {}
-    {{- end }}
-    pipeline:
-      inbound:
-        plugins:
-          - name: jwt-validation
-            config:
-              # `issuer` carries the PUBLIC Keycloak URL because that is what
-              # Keycloak stamps into the `iss` claim of issued tokens (must
-              # match bit-for-bit for validation to pass).
-              issuer: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
-              # `keycloak_url` + `keycloak_realm` let jwt-validation derive
-              # `jwks_url` from the INTERNAL Keycloak URL — the sidecar
-              # actually fetches JWKS from inside the cluster, and the
-              # public hostname (in `issuer`) typically resolves to
-              # 127.0.0.1 via the localtest.me wildcard. Mirrors the pair
-              # already passed to token-exchange below. See
-              # kagenti-extensions#383.
-              keycloak_url: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
-              keycloak_realm: {{ $root.Values.keycloak.realm | quote }}
-      outbound:
-        plugins:
-          - name: token-exchange
-            config:
-              keycloak_url: "http://keycloak-service.{{ $root.Values.keycloak.namespace }}.svc:8080"
-              keycloak_realm: {{ $root.Values.keycloak.realm | quote }}
-              default_policy: "passthrough"
-              identity:
-                # Map Helm clientAuthType to authbridge identity.type:
-                #   "client-secret"  → "client-secret" (traditional)
-                #   "federated-jwt"  → "spiffe" (SPIFFE JWT-SVID authentication)
-                type: {{ eq $root.Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" $root.Values.authBridge.clientAuthType | quote }}
-                {{- if eq $root.Values.authBridge.clientAuthType "federated-jwt" }}
-                # Audience the JWT-SVID client assertion is minted with —
-                # must equal the audience Keycloak's SPIFFE IdP expects
-                # (the realm issuer URL). Only meaningful when type=spiffe.
-                jwt_audience: "{{ $root.Values.keycloak.publicUrl }}/realms/{{ $root.Values.keycloak.realm }}"
-                {{- end }}
+    {{- include "kagenti.authbridge-runtime-config-yaml" $root | nindent 4 }}
 ---
 {{- if $.Values.openshift }}
 # ——————————————————————————————————————————————————————————————————————————————

--- a/charts/kagenti/templates/authbridge-template-configmaps.yaml
+++ b/charts/kagenti/templates/authbridge-template-configmaps.yaml
@@ -52,46 +52,7 @@ data:
   # default (proxy-sidecar) wins by default, and a namespace-level
   # override can still be added later by editing this ConfigMap.
   config.yaml: |
-    {{- if .Values.spire.enabled }}
-    # Empty spiffe block signals authbridge to construct an in-process
-    # SPIFFE provider (X.509 source for mTLS + lazy JWT source for
-    # tokenexchange). All fields default: socket points at the standard
-    # SPIRE agent socket, mirror writes /opt/svid*.pem on rotation. The
-    # JWT audience is per-tokenexchange (see identity.jwt_audience below).
-    spiffe: {}
-    {{- end }}
-    pipeline:
-      inbound:
-        plugins:
-          - name: jwt-validation
-            config:
-              # `issuer` carries the PUBLIC Keycloak URL because that is what
-              # Keycloak stamps into the `iss` claim of issued tokens (must
-              # match bit-for-bit for validation to pass).
-              issuer: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
-              # `keycloak_url` + `keycloak_realm` let jwt-validation derive
-              # `jwks_url` from the INTERNAL Keycloak URL — the sidecar
-              # fetches JWKS from inside the cluster, and the public
-              # hostname in `issuer` isn't reachable from inside the pod.
-              # Mirrors the pair already passed to token-exchange below.
-              # See kagenti-extensions#383.
-              keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
-              keycloak_realm: {{ .Values.keycloak.realm | quote }}
-      outbound:
-        plugins:
-          - name: token-exchange
-            config:
-              keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
-              keycloak_realm: {{ .Values.keycloak.realm | quote }}
-              default_policy: "passthrough"
-              identity:
-                type: {{ eq .Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" .Values.authBridge.clientAuthType | quote }}
-                {{- if eq .Values.authBridge.clientAuthType "federated-jwt" }}
-                # Audience the JWT-SVID client assertion is minted with —
-                # must equal the audience Keycloak's SPIFFE IdP expects
-                # (the realm issuer URL). Only meaningful when type=spiffe.
-                jwt_audience: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
-                {{- end }}
+    {{- include "kagenti.authbridge-runtime-config-yaml" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -160,6 +121,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  message_timeout: 310s
                   allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND
@@ -213,6 +175,7 @@ data:
                     envoy_grpc:
                       cluster_name: ext_proc_cluster
                     timeout: 300s
+                  message_timeout: 310s
                   allow_mode_override: true
                   processing_mode:
                     request_header_mode: SEND

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -64,6 +64,8 @@ spec:
       labels:
         app.kubernetes.io/name: kagenti-backend
         app.kubernetes.io/component: backend
+      annotations:
+        checksum/authbridge-runtime-config: {{ include "kagenti.authbridge-runtime-config-yaml" . | sha256sum }}
     spec:
       serviceAccountName: kagenti-backend
       {{- if .Values.ui.auth.enabled }}
@@ -257,6 +259,9 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: authbridge-runtime-config
+              mountPath: /etc/kagenti/authbridge
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
@@ -266,6 +271,9 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: authbridge-runtime-config
+          configMap:
+            name: authbridge-runtime-config
 ---
 # Backend Service
 apiVersion: v1

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -214,6 +214,30 @@ authBridge:
   spiffeIdpAlias: "spire-spiffe"
   # How long AuthBridge fast-polls for credential files before switching to backoff
   credentialWaitTimeout: "120s"
+  # Full authbridge pipeline configuration (single source of truth).
+  # SREs modify this block to change inbound/outbound plugins.
+  # Helm template expressions ({{ .Values.* }}) are supported — they are
+  # evaluated at render time via tpl().
+  pipeline: |
+    inbound:
+      plugins:
+        - name: jwt-validation
+          config:
+            issuer: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+            keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
+            keycloak_realm: {{ .Values.keycloak.realm | quote }}
+    outbound:
+      plugins:
+        - name: token-exchange
+          config:
+            keycloak_url: "http://keycloak-service.{{ .Values.keycloak.namespace }}.svc:8080"
+            keycloak_realm: {{ .Values.keycloak.realm | quote }}
+            default_policy: "passthrough"
+            identity:
+              type: {{ eq .Values.authBridge.clientAuthType "federated-jwt" | ternary "spiffe" .Values.authBridge.clientAuthType | quote }}
+              {{- if eq .Values.authBridge.clientAuthType "federated-jwt" }}
+              jwt_audience: "{{ .Values.keycloak.publicUrl }}/realms/{{ .Values.keycloak.realm }}"
+              {{- end }}
 
 # ------------------------------------------------------------------
 #  SPIFFE Identity Provider Setup Job Configuration

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -82,6 +82,9 @@ class Settings(BaseSettings):
     )
     kagenti_feature_flag_acp: bool = False  # ACP WebSocket protocol gateway
 
+    # AuthBridge runtime config (mounted from Helm-managed ConfigMap)
+    authbridge_runtime_config_path: str = "/etc/kagenti/authbridge/config.yaml"
+
     # Label settings
     kagenti_label_prefix: str = "kagenti.io/"
     enabled_namespace_label_key: str = "kagenti-enabled"

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -250,6 +250,7 @@ static_resources:
                 envoy_grpc:
                   cluster_name: ext_proc_cluster
                 timeout: 300s
+              message_timeout: 310s
               processing_mode:
                 request_header_mode: SEND
                 response_header_mode: SKIP
@@ -311,6 +312,7 @@ static_resources:
                 envoy_grpc:
                   cluster_name: ext_proc_cluster
                 timeout: 300s
+              message_timeout: 310s
               processing_mode:
                 request_header_mode: SEND
                 response_header_mode: SKIP

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2072,54 +2072,118 @@ async def get_shipwright_build_info(
         raise HTTPException(status_code=e.status, detail=str(e.reason))
 
 
+def _get_authbridge_runtime_yaml() -> str:
+    """Read the authbridge runtime config from the Helm-managed ConfigMap.
+
+    The pipeline configuration is defined in values.yaml (authBridge.pipeline),
+    rendered by the Helm chart into the authbridge-runtime-config ConfigMap,
+    and mounted into the backend pod. This is the single source of truth.
+
+    Falls back to legacy in-memory construction when the file does not
+    exist (e.g. local development outside the cluster).
+    """
+    config_path = settings.authbridge_runtime_config_path
+    try:
+        with open(config_path, "r") as f:
+            content = f.read()
+        if content.strip():
+            return content
+    except FileNotFoundError:
+        logger.warning(
+            "AuthBridge runtime config not found at %s; "
+            "falling back to legacy in-memory construction",
+            config_path,
+        )
+    except OSError as e:
+        logger.warning(
+            "Failed to read AuthBridge runtime config from %s: %s; "
+            "falling back to legacy construction",
+            config_path,
+            e,
+        )
+
+    return _build_authbridge_runtime_yaml_fallback()
+
+
 def _build_authbridge_runtime_yaml(
     keycloak_url: str,
     realm: str,
     issuer: str,
-    spire_enabled: bool,
+    spire_enabled: bool = False,
 ) -> str:
-    """Build the YAML config for the unified authbridge binary.
+    """Build authbridge runtime config YAML with explicit parameters.
 
-    The operator reads this as the base for per-agent ConfigMap generation,
-    merging in mode and listener addresses at injection time. The Helm chart
-    creates an equivalent ConfigMap for pre-declared namespaces
-    (see charts/kagenti/templates/agent-namespaces.yaml).
+    This function is used by tests to generate authbridge configuration
+    with specific parameters, independent of the settings object.
 
-    Emits the per-plugin schema: every plugin-specific setting lives under
-    its own `config:` block inside pipeline.inbound.plugins[] or
-    pipeline.outbound.plugins[]. Plugin-level defaults (audience_file,
-    bypass_paths, identity file paths) are intentionally omitted — the
-    authbridge binary applies them from its own convention layer
-    (see authbridge/authlib/plugins/CONVENTIONS.md). Leaving them out
-    here keeps the backend-generated ConfigMap minimal and the schema
-    source-of-truth in one place.
+    Args:
+        keycloak_url: Internal Keycloak URL for JWKS and token exchange
+        realm: Keycloak realm name
+        issuer: Public issuer URL (must match JWT "iss" claim)
+        spire_enabled: Whether to enable SPIFFE/SPIRE identity
+
+    Returns:
+        YAML string containing the authbridge runtime configuration
     """
     identity_type = "spiffe" if spire_enabled else "client-secret"
-    # jwt-validation receives keycloak_url + keycloak_realm so it can
-    # derive jwks_url from the INTERNAL keycloak URL rather than the
-    # public `issuer`. Required for split-horizon deployments where
-    # `issuer` isn't reachable from inside the pod. See
-    # kagenti-extensions#383.
-    # Note: Remember to keep AuthBridgeConfig in kagenti/ui-v2/src/types/index.ts
-    # in sync with this YAML runtime configuration.
-    # No top-level `mode:` — the operator resolves it per workload from
-    # AgentRuntime.Spec.AuthBridgeMode → namespace ConfigMap →
-    # cluster default (proxy-sidecar). Hardcoding it here would pin
-    # every backend-rendered ConfigMap to one shape regardless of CR.
     identity: dict[str, str] = {"type": identity_type}
     if identity_type == "spiffe":
-        # JWT-SVID client-assertion audience — must match what Keycloak's
-        # SPIFFE IdP expects (the realm issuer URL). Required by
-        # authbridge's token-exchange plugin in the spiffe identity path.
-        # See kagenti-extensions#332.
+        identity["jwt_audience"] = issuer
+
+    config: dict[str, object] = {}
+    if spire_enabled:
+        config["spiffe"] = {}
+
+    config["pipeline"] = {
+        "inbound": {
+            "plugins": [
+                {
+                    "name": "jwt-validation",
+                    "config": {
+                        "issuer": issuer,
+                        "keycloak_url": keycloak_url,
+                        "keycloak_realm": realm,
+                    },
+                }
+            ]
+        },
+        "outbound": {
+            "plugins": [
+                {
+                    "name": "token-exchange",
+                    "config": {
+                        "keycloak_url": keycloak_url,
+                        "keycloak_realm": realm,
+                        "default_policy": "passthrough",
+                        "identity": identity,
+                    },
+                }
+            ]
+        },
+    }
+
+    return yaml.dump(config, default_flow_style=False)
+
+
+def _build_authbridge_runtime_yaml_fallback() -> str:
+    """Legacy fallback: construct authbridge runtime config in-memory.
+
+    Used when the mounted ConfigMap is unavailable (local dev, tests).
+    The canonical source of truth is values.yaml authBridge.pipeline,
+    rendered by the Helm chart and mounted at the path specified by
+    settings.authbridge_runtime_config_path.
+    """
+    keycloak_url = settings.keycloak_url or DEFAULT_KEYCLOAK_INTERNAL_URL
+    realm = settings.effective_keycloak_realm or DEFAULT_KEYCLOAK_REALM
+    issuer = f"{settings.effective_keycloak_url}/realms/{realm}"
+    spire_enabled = False
+
+    identity_type = "spiffe" if spire_enabled else "client-secret"
+    identity: dict[str, str] = {"type": identity_type}
+    if identity_type == "spiffe":
         identity["jwt_audience"] = issuer
     config: dict[str, object] = {}
     if spire_enabled:
-        # Empty spiffe block signals authbridge to construct the in-process
-        # SPIFFE provider (X.509 source for mTLS + lazy JWT source for
-        # tokenexchange). All fields default: socket points at the standard
-        # SPIRE agent socket, mirror writes /opt/svid*.pem on rotation.
-        # The JWT audience lives per-tokenexchange (under identity above).
         config["spiffe"] = {}
     config["pipeline"] = {
         "inbound": {
@@ -2193,17 +2257,12 @@ def _ensure_authbridge_configmaps(
     # 2. authbridge-runtime-config (YAML config for the unified authbridge binary)
     # The operator reads this at admission time and creates a per-agent ConfigMap
     # with mode and listener addresses merged in.
+    # Source of truth: values.yaml authBridge.pipeline → Helm renders ConfigMap →
+    # mounted into this pod → _get_authbridge_runtime_yaml() reads it.
     kube.ensure_configmap(
         namespace=namespace,
         name="authbridge-runtime-config",
-        data={
-            "config.yaml": _build_authbridge_runtime_yaml(
-                keycloak_url=keycloak_url,
-                realm=realm,
-                issuer=issuer,
-                spire_enabled=spire_enabled,
-            )
-        },
+        data={"config.yaml": _get_authbridge_runtime_yaml()},
     )
 
     # 3. envoy-config


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

This PR comes to fix two issues, both need to be fixed preparing to support Token Broker plugin that was recently added to AuthBridge 

1. There are two multiple places in which AuthBridge config is defined while this PR changes this such that we have a single source of Truth about the expected AuthBridge config
2. The envoy config used lack message_timeout definition needed for token broker plugin

1  - A single source of Truth about the expected AuthBridge config

  The change consolidates the 3 independent definitions into one place — values.yaml authBridge.pipeline. The flow is now:

  values.yaml (authBridge.pipeline)
      → _helpers.tpl named template (tpl() evaluates Helm expressions)
          → authbridge-template-configmaps.yaml (kagenti-system ConfigMap)
          → agent-namespaces.yaml (team1/team2 ConfigMaps)
          → Mounted into backend pod → _get_authbridge_runtime_yaml() reads it
              → Copies to dynamically-created agent namespaces

  Files changed:
  - charts/kagenti/values.yaml — added authBridge.pipeline block
  - charts/kagenti/templates/_helpers.tpl — added kagenti.authbridge-runtime-config-yaml named template
  - charts/kagenti/templates/authbridge-template-configmaps.yaml — replaced inline pipeline with include
  - charts/kagenti/templates/agent-namespaces.yaml — replaced inline pipeline with include
  - charts/kagenti/templates/ui.yaml — added ConfigMap volume mount + checksum annotation
  - kagenti/backend/app/core/config.py — added authbridge_runtime_config_path setting
  - kagenti/backend/app/routers/agents.py — added _get_authbridge_runtime_yaml() that reads from mounted file, renamed old function as fallback

  SRE workflow to switch to token-broker: Edit authBridge.pipeline in values.yaml, run helm upgrade. Done — all consumers get the new config.

2 - missing message_timeout for envoy config

message_timeout: 310s (integrated) — Added to all 6 Envoy ext_proc filter blocks across:
  - charts/kagenti/templates/authbridge-template-configmaps.yaml (2 blocks)
  - charts/kagenti/templates/agent-namespaces.yaml (2 blocks)
  - kagenti/backend/app/core/constants.py DEFAULT_ENVOY_YAML (2 blocks)



Fixes # https://github.com/kagenti/kagenti/issues/1768
