### PR TITLE
fix(ocp-installer): skip Kuadrant CR when CRD absent in v1.4+

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1509,14 +1509,19 @@ if $WITH_KUADRANT; then
   if ! $DRY_RUN; then
     _wait_deployment_ready kuadrant-operator-controller-manager "$KUADRANT_NS" "Kuadrant operator"
 
-    log_info "Creating Kuadrant CR..."
-    $KUBECTL apply -f - <<EOF
-apiVersion: kuadrant.io/v1beta1
+    if $KUBECTL get crd kuadrants.kuadrant.io &>/dev/null; then
+      log_info "Creating Kuadrant CR..."
+      _kuadrant_api=$($KUBECTL get crd kuadrants.kuadrant.io -o jsonpath='{.spec.versions[?(@.served==true)].name}' | awk '{print $NF}')
+      $KUBECTL apply -f - <<EOF
+apiVersion: kuadrant.io/${_kuadrant_api}
 kind: Kuadrant
 metadata:
   name: kuadrant
   namespace: ${KUADRANT_NS}
 EOF
+    else
+      log_info "Kuadrant CRD not present (v1.4+) — skipping CR creation"
+    fi
   fi
 
   log_success "Kuadrant installed"


### PR DESCRIPTION
## Summary
- Kuadrant operator v1.4.x removed the `Kuadrant` bootstrapping CRD, causing `setup-kagenti.sh --with-all` to fail at Step 5 with `no matches for kind "Kuadrant" in version "kuadrant.io/v1beta1"`
- Guards the CR creation behind a CRD existence check; dynamically resolves the served API version for older operators that still ship the CRD
- Verified: full cleanup + re-install passes cleanly on OCP cluster with Kuadrant 1.4.2

## Test plan
- [x] `scripts/ocp/cleanup-kagenti.sh --yes` followed by `scripts/ocp/setup-kagenti.sh --kagenti-repo . --with-all` completes with exit 0
- [x] No errors in Step 5 output — logs "Kuadrant CRD not present (v1.4+) — skipping CR creation"
- [ ] Regression: test with an older Kuadrant version that still has the CRD (if available)

Assisted-By: Claude Code