### PR TITLE
Feat: Create Kagenti roles in Keycloak and assign roles to test users

### DIFF
--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -40,6 +40,10 @@ DEFAULT_DEMO_PASSWORD_OVERRIDE_ENV_VARS = (
     "KEYCLOAK_DEMO1_PASSWORD",
     "KEYCLOAK_DEMO2_PASSWORD",
 )
+DEFAULT_DEMO_USER_ROLES = {
+    "bob": "kagenti-viewer",
+    "alice": "kagenti-operator",
+}
 
 
 class ConfigurationError(Exception):
@@ -136,6 +140,28 @@ def create_or_update_secret(
             error_msg = f"Failed to create secret '{secret_name}': {e}"
             logger.error(error_msg)
             raise KubernetesResourceError(error_msg) from e
+
+
+KAGENTI_REALM_ROLES = {
+    "kagenti-viewer": "Read-only access to Kagenti resources",
+    "kagenti-operator": "Operator access (create/update Kagenti resources)",
+    "kagenti-admin": "Full administrative access to Kagenti",
+}
+
+
+def ensure_kagenti_realm_roles(keycloak_admin: KeycloakAdmin, realm: str) -> None:
+    """Idempotently create the kagenti-viewer/operator/admin realm roles."""
+    for role_name, description in KAGENTI_REALM_ROLES.items():
+        try:
+            keycloak_admin.create_realm_role(
+                {"name": role_name, "description": description}
+            )
+            logger.info(f"Created realm role '{role_name}' in '{realm}'")
+        except Exception:
+            logger.info(
+                f"Realm role '{role_name}' already exists in '{realm}', "
+                f"skipping creation"
+            )
 
 
 def main() -> None:
@@ -323,6 +349,10 @@ def main() -> None:
                 )
                 raise
 
+            # Ensure Kagenti realm roles exist before any user is created
+            # so role assignments downstream can refer to them.
+            ensure_kagenti_realm_roles(keycloak_admin, keycloak_realm)
+
             # Create a default user so the UI has someone to log in as.
             # Uses the same credentials as the Keycloak admin.
             # Only creates if absent; never resets an existing user's password.
@@ -416,6 +446,22 @@ def main() -> None:
                     logger.warning(
                         f"Could not assign admin realm role (non-fatal): {role_err}"
                     )
+
+                # Ensure the kagenti-admin realm role (created earlier by
+                # ensure_kagenti_realm_roles) is assigned to this user.
+                try:
+                    kagenti_admin_role = keycloak_admin.get_realm_role("kagenti-admin")
+                    keycloak_admin.assign_realm_roles(user_id, [kagenti_admin_role])
+                    logger.info(
+                        f"Ensured 'kagenti-admin' realm role for "
+                        f"'{keycloak_admin_username}' in realm "
+                        f"'{keycloak_realm}'"
+                    )
+                except Exception as role_err:
+                    logger.warning(
+                        f"Could not assign 'kagenti-admin' realm role "
+                        f"(non-fatal): {role_err}"
+                    )
             except Exception as e:
                 logger.error(
                     f"Failed to provision default user in realm '{keycloak_realm}': {e}"
@@ -472,6 +518,35 @@ def main() -> None:
                             f"Demo user '{demo_username}' already exists "
                             f"in realm '{keycloak_realm}', skipping"
                         )
+
+                    # Assign the per-user Kagenti realm role. Idempotent —
+                    # Keycloak ignores duplicate role assignments.
+                    role_name = DEFAULT_DEMO_USER_ROLES.get(demo_username)
+                    if role_name:
+                        try:
+                            users = keycloak_admin.get_users(
+                                {"username": demo_username, "exact": True}
+                            )
+                            if not users:
+                                logger.warning(
+                                    f"Cannot assign '{role_name}' to "
+                                    f"'{demo_username}': user not found "
+                                    f"in '{keycloak_realm}'"
+                                )
+                            else:
+                                role = keycloak_admin.get_realm_role(role_name)
+                                keycloak_admin.assign_realm_roles(
+                                    users[0]["id"], [role]
+                                )
+                                logger.info(
+                                    f"Assigned realm role '{role_name}' to "
+                                    f"'{demo_username}' in '{keycloak_realm}'"
+                                )
+                        except Exception as role_err:
+                            logger.warning(
+                                f"Could not assign '{role_name}' to "
+                                f"'{demo_username}' (non-fatal): {role_err}"
+                            )
                 except Exception as e:
                     logger.warning(f"Failed to create demo user '{demo_username}': {e}")
 

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -481,7 +481,7 @@ def main() -> None:
                         {"username": demo_username, "exact": True}
                     )
                     if not existing:
-                        keycloak_admin.create_user(
+                        demo_user_id = keycloak_admin.create_user(
                             {
                                 "username": demo_username,
                                 "enabled": True,
@@ -506,6 +506,7 @@ def main() -> None:
                             f"in realm '{keycloak_realm}'"
                         )
                     else:
+                        demo_user_id = existing[0]["id"]
                         logger.info(
                             f"Demo user '{demo_username}' already exists "
                             f"in realm '{keycloak_realm}', skipping"
@@ -516,24 +517,14 @@ def main() -> None:
                     role_name = DEFAULT_DEMO_USER_ROLES.get(demo_username)
                     if role_name:
                         try:
-                            users = keycloak_admin.get_users(
-                                {"username": demo_username, "exact": True}
+                            role = keycloak_admin.get_realm_role(role_name)
+                            keycloak_admin.assign_realm_roles(
+                                demo_user_id, [role]
                             )
-                            if not users:
-                                logger.warning(
-                                    f"Cannot assign '{role_name}' to "
-                                    f"'{demo_username}': user not found "
-                                    f"in '{keycloak_realm}'"
-                                )
-                            else:
-                                role = keycloak_admin.get_realm_role(role_name)
-                                keycloak_admin.assign_realm_roles(
-                                    users[0]["id"], [role]
-                                )
-                                logger.info(
-                                    f"Assigned realm role '{role_name}' to "
-                                    f"'{demo_username}' in '{keycloak_realm}'"
-                                )
+                            logger.info(
+                                f"Assigned realm role '{role_name}' to "
+                                f"'{demo_username}' in '{keycloak_realm}'"
+                            )
                         except Exception as role_err:
                             logger.warning(
                                 f"Could not assign '{role_name}' to "

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -518,9 +518,7 @@ def main() -> None:
                     if role_name:
                         try:
                             role = keycloak_admin.get_realm_role(role_name)
-                            keycloak_admin.assign_realm_roles(
-                                demo_user_id, [role]
-                            )
+                            keycloak_admin.assign_realm_roles(demo_user_id, [role])
                             logger.info(
                                 f"Assigned realm role '{role_name}' to "
                                 f"'{demo_username}' in '{keycloak_realm}'"

--- a/kagenti/auth/ui-oauth-secret/auth_secret.py
+++ b/kagenti/auth/ui-oauth-secret/auth_secret.py
@@ -44,6 +44,11 @@ DEFAULT_DEMO_USER_ROLES = {
     "bob": "kagenti-viewer",
     "alice": "kagenti-operator",
 }
+KAGENTI_REALM_ROLES = {
+    "kagenti-viewer": "Read-only access to Kagenti resources",
+    "kagenti-operator": "Operator access (create/update Kagenti resources)",
+    "kagenti-admin": "Full administrative access to Kagenti",
+}
 
 
 class ConfigurationError(Exception):
@@ -142,26 +147,27 @@ def create_or_update_secret(
             raise KubernetesResourceError(error_msg) from e
 
 
-KAGENTI_REALM_ROLES = {
-    "kagenti-viewer": "Read-only access to Kagenti resources",
-    "kagenti-operator": "Operator access (create/update Kagenti resources)",
-    "kagenti-admin": "Full administrative access to Kagenti",
-}
-
-
 def ensure_kagenti_realm_roles(keycloak_admin: KeycloakAdmin, realm: str) -> None:
-    """Idempotently create the kagenti-viewer/operator/admin realm roles."""
+    """Idempotently create the kagenti-viewer/operator/admin realm roles.
+
+    Mirrors the create-first, catch-409 pattern used for realm creation:
+    only a 409 (already exists) is silently treated as success — any other
+    error is re-raised so misconfiguration (auth/network) surfaces clearly.
+    """
     for role_name, description in KAGENTI_REALM_ROLES.items():
         try:
             keycloak_admin.create_realm_role(
                 {"name": role_name, "description": description}
             )
             logger.info(f"Created realm role '{role_name}' in '{realm}'")
-        except Exception:
-            logger.info(
-                f"Realm role '{role_name}' already exists in '{realm}', "
-                f"skipping creation"
-            )
+        except KeycloakPostError as e:
+            if hasattr(e, "response_code") and e.response_code == 409:
+                logger.info(
+                    f"Realm role '{role_name}' already exists in '{realm}', "
+                    f"skipping creation"
+                )
+            else:
+                raise
 
 
 def main() -> None:
@@ -414,11 +420,10 @@ def main() -> None:
                         f"Could not assign realm-admin role (non-fatal): {role_err}"
                     )
 
-                # Ensure 'admin' realm role. The Kagenti backend maps this
-                # to kagenti-admin (which inherits kagenti-operator and
-                # kagenti-viewer) via a temporary mapping in auth.py until
-                # proper realm roles are provisioned by a dedicated
-                # Keycloak setup job.
+                # Ensure 'admin' realm role exists, then assign both 'admin'
+                # (legacy stopgap mapped to kagenti-admin in auth.py) and
+                # 'kagenti-admin' (created earlier by
+                # ensure_kagenti_realm_roles) in a single API call.
                 try:
                     try:
                         keycloak_admin.create_realm_role(
@@ -436,31 +441,18 @@ def main() -> None:
                         )
 
                     admin_realm_role = keycloak_admin.get_realm_role("admin")
-                    keycloak_admin.assign_realm_roles(user_id, [admin_realm_role])
-                    logger.info(
-                        f"Ensured 'admin' realm role for "
-                        f"'{keycloak_admin_username}' in realm "
-                        f"'{keycloak_realm}'"
-                    )
-                except Exception as role_err:
-                    logger.warning(
-                        f"Could not assign admin realm role (non-fatal): {role_err}"
-                    )
-
-                # Ensure the kagenti-admin realm role (created earlier by
-                # ensure_kagenti_realm_roles) is assigned to this user.
-                try:
                     kagenti_admin_role = keycloak_admin.get_realm_role("kagenti-admin")
-                    keycloak_admin.assign_realm_roles(user_id, [kagenti_admin_role])
+                    keycloak_admin.assign_realm_roles(
+                        user_id, [admin_realm_role, kagenti_admin_role]
+                    )
                     logger.info(
-                        f"Ensured 'kagenti-admin' realm role for "
-                        f"'{keycloak_admin_username}' in realm "
+                        f"Ensured 'admin' and 'kagenti-admin' realm roles "
+                        f"for '{keycloak_admin_username}' in realm "
                         f"'{keycloak_realm}'"
                     )
                 except Exception as role_err:
                     logger.warning(
-                        f"Could not assign 'kagenti-admin' realm role "
-                        f"(non-fatal): {role_err}"
+                        f"Could not assign admin realm roles (non-fatal): {role_err}"
                     )
             except Exception as e:
                 logger.error(
@@ -555,6 +547,11 @@ def main() -> None:
                 f"AUTO_BOOTSTRAP_REALM is disabled; assuming realm "
                 f"'{keycloak_realm}' already exists"
             )
+            # Even with bootstrap disabled, ensure the kagenti-* realm
+            # roles exist so the backend's RBAC can assign and validate
+            # them. Idempotent — a 409 from a pre-provisioned role is
+            # treated as success.
+            ensure_kagenti_realm_roles(keycloak_admin, keycloak_realm)
 
         # Register client
         # Configure as public client with PKCE for SPA best practices


### PR DESCRIPTION
## Summary

This PR creates roles kagenti-viewer, kagenti-operator, kagenti-admin when it creates the Kagenti realm.
This PR assigns roles to the admin user and the alice, and bob test users.

## (Optional) Testing Instructions

Install Kagenti on Kind.

```bash
docker build --load -t ui-oauth-secret:dev -f kagenti/auth/ui-oauth-secret/Dockerfile kagenti
kind load docker-image ui-oauth-secret:dev --name kagenti
kubectl create -f - <<'EOF'
  apiVersion: batch/v1
  kind: Job
  metadata:
    generateName: ui-oauth-secret-dev-
    namespace: kagenti-system
  spec:
    backoffLimit: 0
    ttlSecondsAfterFinished: 600
    template:
      spec:
        restartPolicy: Never
        serviceAccountName: kagenti-ui-oauth-secret-writer
        containers:
        - name: ui-oauth-secret-creator
          image: ui-oauth-secret:dev
          imagePullPolicy: IfNotPresent
          env:
          - name: KEYCLOAK_REALM
            value: "kagenti"
          - name: AUTO_BOOTSTRAP_REALM
            value: "true"
          - name: KEYCLOAK_ADMIN_SECRET_NAME
            value: "keycloak-initial-admin"
          - name: KEYCLOAK_ADMIN_USERNAME_KEY
            value: "username"
          - name: KEYCLOAK_ADMIN_PASSWORD_KEY
            value: "password"
          - name: KEYCLOAK_URL
            value: "http://keycloak-service.keycloak:8080"
          - name: KEYCLOAK_PUBLIC_URL
            value: "http://keycloak.localtest.me:8080"
          - name: ROOT_URL
            value: "http://kagenti-ui.localtest.me:8080"
          - name: NAMESPACE
            value: "kagenti-system"
          - name: CLIENT_ID
            value: "kagenti"
          - name: SECRET_NAME
            value: "kagenti-ui-oauth-secret"
          - name: OPENSHIFT_ENABLED
            value: "false"
          - name: KEYCLOAK_NAMESPACE
            value: "keycloak"
          - name: UI_NAMESPACE
            value: "kagenti-system"
          - name: KEYCLOAK_SSO_SESSION_IDLE
            value: "28800"
          - name: KEYCLOAK_SSO_SESSION_MAX
            value: "36000"
          - name: KEYCLOAK_ACCESS_TOKEN_LIFESPAN
            value: "3600"
EOF
```

Fixes #

Resolves #1798