### PR TITLE
docs: replace deprecated secret_values.yaml references with new path

### DIFF
--- a/.github/scripts/common/20-create-secrets.sh
+++ b/.github/scripts/common/20-create-secrets.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Create Secrets (Wave 20)
-# Creates .secret_values.yaml for platform installer
+# Creates .secrets.yaml for Helm-based installers
 
 set -euo pipefail
 
@@ -11,7 +11,7 @@ source "$SCRIPT_DIR/../lib/logging.sh"
 log_step "20" "Creating secret values"
 
 # Use MAIN_REPO_ROOT for secrets (worktree-aware - secrets stay in main repo)
-SECRET_FILE="$MAIN_REPO_ROOT/deployments/envs/.secret_values.yaml"
+SECRET_FILE="$MAIN_REPO_ROOT/charts/kagenti/.secrets.yaml"
 
 # Check if secrets already exist (in main repo)
 if [ -f "$SECRET_FILE" ]; then
@@ -19,23 +19,13 @@ if [ -f "$SECRET_FILE" ]; then
     exit 0
 fi
 
-# Create directory in main repo (not worktree)
-mkdir -p "$MAIN_REPO_ROOT/deployments/envs"
+# Ensure chart directory exists in main repo
+mkdir -p "$MAIN_REPO_ROOT/charts/kagenti"
 
 if [ "$IS_CI" = true ]; then
     log_info "Creating CI test secrets"
-    # Use real OPENAI_API_KEY from GitHub secrets if available
     OPENAI_KEY="${OPENAI_API_KEY:-ci-test-openai-key}"
     cat > "$SECRET_FILE" <<EOF
-# CI secret values
-global:
-  jwt_key: "ci-test-jwt-key"
-  db_password: "ci-test-db-password"
-
-kagenti:
-  postgres:
-    password: "ci-test-pg-password"
-
 secrets:
   githubUser: "ci-test-user"
   githubToken: "ci-test-token"
@@ -44,17 +34,19 @@ secrets:
   adminSlackBotToken: "ci-test-admin-slack-token"
 EOF
 else
-    log_info "Creating local test secrets"
-    cat > "$SECRET_FILE" <<EOF
-# Local secret values (for testing)
-global:
-  jwt_key: "local-test-jwt-key"
-  db_password: "local-test-db-password"
-
-kagenti:
-  postgres:
-    password: "local-test-pg-password"
+    log_info "Creating local test secrets from template"
+    if [ -f "$MAIN_REPO_ROOT/charts/kagenti/.secrets_template.yaml" ]; then
+        cp "$MAIN_REPO_ROOT/charts/kagenti/.secrets_template.yaml" "$SECRET_FILE"
+    else
+        cat > "$SECRET_FILE" <<EOF
+secrets:
+  githubUser: ""
+  githubToken: ""
+  openaiApiKey: ""
+  slackBotToken: ""
+  adminSlackBotToken: ""
 EOF
+    fi
 fi
 
 log_success "Secret values created"

--- a/.github/scripts/lib/env-detect.sh
+++ b/.github/scripts/lib/env-detect.sh
@@ -26,7 +26,7 @@ else
     echo "Running locally"
 
     # Detect if running from a git worktree - if so, find the main repo root
-    # This is needed because files like .secret_values.yaml may only exist in main repo
+    # This is needed because files like charts/kagenti/.secrets.yaml may only exist in main repo
     if [[ "$REPO_ROOT" == *"/.worktrees/"* ]]; then
         # Extract path before .worktrees - this is the main repo root
         export MAIN_REPO_ROOT="${REPO_ROOT%%/.worktrees/*}"

--- a/CLAUDE-ORG.md
+++ b/CLAUDE-ORG.md
@@ -56,8 +56,8 @@ kagenti/
 ```bash
 # Deploy to Kind cluster
 # From repository root
-cp deployments/envs/secret_values.yaml.example deployments/envs/.secret_values.yaml
-# Edit deployments/envs/.secret_values.yaml with your values
+cp charts/kagenti/.secrets_template.yaml charts/kagenti/.secrets.yaml
+# Edit charts/kagenti/.secrets.yaml with your values
 scripts/kind/setup-kagenti.sh
 
 # Run UI locally
@@ -327,8 +327,8 @@ git clone https://github.com/kagenti/kagenti.git
 cd kagenti
 
 # Configure secrets
-cp deployments/envs/secret_values.yaml.example deployments/envs/.secret_values.yaml
-# Edit .secret_values.yaml with your values
+cp charts/kagenti/.secrets_template.yaml charts/kagenti/.secrets.yaml
+# Edit .secrets.yaml with your values
 
 # Deploy to Kind cluster
 scripts/kind/setup-kagenti.sh

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ git clone https://github.com/kagenti/kagenti.git
 cd kagenti
 
 # Copy and configure secrets
-cp deployments/envs/secret_values.yaml.example deployments/envs/.secret_values.yaml
-# Edit deployments/envs/.secret_values.yaml with your values
+cp charts/kagenti/.secrets_template.yaml charts/kagenti/.secrets.yaml
+# Edit charts/kagenti/.secrets.yaml with your values
 
 # Deploy to Kind cluster
 scripts/kind/setup-kagenti.sh --with-ui --with-spire --with-agent-sandbox --with-builds

--- a/deployments/envs/secret_values.yaml.example
+++ b/deployments/envs/secret_values.yaml.example
@@ -1,9 +1,16 @@
-# Example secret values file. 
-# This file should be kept out of source control (add to .gitignore) 
-# and provided at runtime via -e "secret_values_file=.secret_values.yaml".
-
-# Top-level keys will be merged into each component's values unless you
-# structure them under component-specific keys.
+# DEPRECATED — This file is no longer used by the Kind or OpenShift installers.
+#
+# The canonical secrets file is now:
+#   charts/kagenti/.secrets.yaml
+#
+# Create it from the template:
+#   cp charts/kagenti/.secrets_template.yaml charts/kagenti/.secrets.yaml
+#
+# See docs/install.md for details.
+#
+# --------------------------------------------------------------------------
+# Legacy format below (kept for reference only — do not use for new installs)
+# --------------------------------------------------------------------------
 
 # global secrets:
 global: {}

--- a/docs/demos/demo-slack-research-agent.md
+++ b/docs/demos/demo-slack-research-agent.md
@@ -32,7 +32,7 @@ You should also open the Agent Platform Demo Dashboard as instructed in the [Acc
 
 In this demo, the Slack MCP Server will access the Slack API using Slack bot tokens. We will be using two bot tokens: a general `SLACK_BOT_TOKEN` that is used by default and an `ADMIN_SLACK_BOT_TOKEN` that is used when the access token has the `slack-full-access` scope.
 
-For this demo, prior to installing Kagenti, you need to add two variables to the `deployments/envs/.secret_values.yaml` file. Visit
+For this demo, prior to installing Kagenti, you need to add two variables to the `charts/kagenti/.secrets.yaml` file. Visit
 [Slack Bot Token](https://docs.slack.dev/quickstart) page and follow instructions to generate the bot token:
 
 1. Create a pre-configured app
@@ -51,7 +51,7 @@ For this demo, prior to installing Kagenti, you need to add two variables to the
 
 Repeat the above for another app with a new name. This time limit the scope to `connections:write` only. This will be your `SLACK_BOT_TOKEN`.
 
-Add both variables (`slackBotToken` and `adminSlackBotToken`) to `deployments/envs/.secret_values.yaml` before executing Kagenti install.
+Add both variables (`slackBotToken` and `adminSlackBotToken`) to `charts/kagenti/.secrets.yaml` before executing Kagenti install.
 
 ---
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -41,30 +41,27 @@ Do you have an OpenShift cluster?
 Before deploying to any environment, create the secrets file:
 
 ```bash
-# Copy the example file
-cp deployments/envs/secret_values.yaml.example deployments/envs/.secret_values.yaml
+# Copy the template
+cp charts/kagenti/.secrets_template.yaml charts/kagenti/.secrets.yaml
 
 # Edit with your values
-vi deployments/envs/.secret_values.yaml
+vi charts/kagenti/.secrets.yaml
 ```
 
-Required values in `.secret_values.yaml`:
+Required values in `.secrets.yaml`:
 
 ```yaml
-charts:
-  kagenti:
-    values:
-      secrets:
-        # Required for agent LLM features (weather-service chat, etc.)
-        openaiApiKey: "sk-..."
+secrets:
+  # Required for agent LLM features (weather-service chat, etc.)
+  openaiApiKey: "sk-..."
 
-        # Required for private repos and Shipwright builds
-        githubUser: "your-username"
-        githubToken: "ghp_..."
+  # Required for private repos and Shipwright builds
+  githubUser: "your-username"
+  githubToken: "ghp_..."
 
-        # Optional: Slack integration
-        slackBotToken: "xoxb-..."
-        adminSlackBotToken: "xoxb-..."
+  # Optional: Slack integration
+  slackBotToken: "xoxb-..."
+  adminSlackBotToken: "xoxb-..."
 ```
 
 ### Alternative: Environment Variables
@@ -77,7 +74,7 @@ export GITHUB_USER="your-username"
 export GITHUB_TOKEN_VALUE="ghp_..."
 
 # Force regeneration from env vars
-rm -f deployments/envs/.secret_values.yaml
+rm -f charts/kagenti/.secrets.yaml
 ```
 
 ## Documentation Structure

--- a/docs/install.md
+++ b/docs/install.md
@@ -382,17 +382,14 @@ The installer automatically creates `keycloak-admin-secret` in every agent names
 
 If your Keycloak admin credentials differ from the defaults, override them using a values file (preferred over `--set` to avoid exposing passwords in shell history and process listings):
 
-**OCP installer** (via `.secret_values.yaml`):
+**Secrets file** (via `.secrets.yaml`):
 
-Add to your `deployments/envs/.secret_values.yaml`:
+Add to your `charts/kagenti/.secrets.yaml`:
 
 ```yaml
-charts:
-  kagenti:
-    values:
-      keycloak:
-        adminUsername: myadmin
-        adminPassword: mypassword
+keycloak:
+  adminUsername: myadmin
+  adminPassword: mypassword
 ```
 
 **Helm install** (via values file):

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -33,7 +33,7 @@ scripts/kind/setup-kagenti.sh --with-skills --with-builds --build-images --skip-
 
 ### Using the Kagenti Installer
 
-When using the installer, enable skills by modifying your values file (e.g., `deployments/envs/.secret_values.yaml` or a custom values file):
+When using the installer, enable skills by modifying your values file (e.g., `charts/kagenti/.secrets.yaml` or a custom values file):
 
 ```bash
 cat <<EOF > /tmp/enable-flag-skills.yaml

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -95,7 +95,7 @@ kubectl rollout restart -n kagenti-system deployment http-istio
 
 ### Need to edit ENV values
 
-If you need to update the values in `deployments/envs/.secret_values.yaml` file, e.g., `githubToken`,
+If you need to update the values in `charts/kagenti/.secrets.yaml` file, e.g., `githubToken`,
 delete the secret in all your auto-created namespaces, then re-run the installer:
 
 ```shell


### PR DESCRIPTION
## Summary

- Updates all documentation, scripts, and comments to reference `charts/kagenti/.secrets.yaml` instead of the deprecated `deployments/envs/.secret_values.yaml`
- Updates `20-create-secrets.sh` (used by CI and `kind-full-test.sh`) to write secrets to the new canonical path
- Adds deprecation notice to old `secret_values.yaml.example` pointing to new location

## Files Changed (11)

| Category | Files |
|----------|-------|
| Script (functional) | `.github/scripts/common/20-create-secrets.sh` |
| Script (comment) | `.github/scripts/lib/env-detect.sh` |
| Docs | `README.md`, `CLAUDE-ORG.md`, `docs/troubleshooting.md`, `docs/skills.md`, `docs/developer/README.md`, `docs/demos/demo-slack-research-agent.md`, `docs/install.md` |
| Chart | `charts/kagenti/values.yaml` |
| Deprecation | `deployments/envs/secret_values.yaml.example` |

## Test plan

- [ ] Verify `kind-full-test.sh` still creates secrets correctly (writes to `charts/kagenti/.secrets.yaml`)
- [ ] Verify CI workflows (`e2e-kind.yaml`) pass with the new path
- [ ] Confirm no remaining references to old path: `grep -r secret_values --include="*.md" --include="*.sh" --include="*.yaml"`

Closes #1801

Assisted-By: Claude Code