### PR TITLE
feat(openshell): add sandbox JWT auth config and certgen hook

### DIFF
--- a/charts/openshell/templates/certgen.yaml
+++ b/charts/openshell/templates/certgen.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.gatewayJwt.enabled }}
+{{- $hookName := "openshell-certgen" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Values.tenant }}
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-30"
+    helm.sh/hook-delete-policy: before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Values.tenant }}
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-30"
+    helm.sh/hook-delete-policy: before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Values.tenant }}
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-30"
+    helm.sh/hook-delete-policy: before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $hookName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $hookName }}
+    namespace: {{ .Values.tenant }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Values.tenant }}
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-20"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 120
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "openshell.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ $hookName }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: certgen
+          image: "{{ .Values.images.gateway.repository }}:{{ .Values.images.gateway.tag }}"
+          imagePullPolicy: {{ .Values.images.gateway.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command: ["/usr/local/bin/openshell-gateway"]
+          args:
+            - generate-certs
+            - --server-secret-name=openshell-server-tls
+            - --client-secret-name=openshell-client-tls
+            - --jwt-secret-name={{ .Values.gatewayJwt.signingSecretName | default "openshell-gateway-jwt-keys" }}
+            - --server-san=openshell-server
+            - --server-san=openshell-server.{{ .Values.tenant }}
+            - --server-san=openshell-server.{{ .Values.tenant }}.svc
+            - --server-san=openshell-server.{{ .Values.tenant }}.svc.cluster.local
+            - --server-san=localhost
+            {{- if .Values.ingress.host }}
+            - --server-san={{ .Values.ingress.host }}
+            {{- end }}
+{{- end }}

--- a/charts/openshell/templates/gateway-config.yaml
+++ b/charts/openshell/templates/gateway-config.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshell-gateway-config
+  namespace: {{ .Values.tenant }}
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+data:
+  gateway.toml: |
+    [openshell]
+    version = 1
+
+    [openshell.gateway]
+    bind_address      = "0.0.0.0:8080"
+    log_level         = "info"
+    sandbox_namespace = {{ include "openshell.driverNamespace" . | quote }}
+    supervisor_image  = "{{ .Values.supervisorImage.repository }}:{{ .Values.supervisorImage.tag }}"
+    client_tls_secret_name = "openshell-client-tls"
+
+    [openshell.gateway.tls]
+    cert_path      = "/etc/openshell-tls/server/tls.crt"
+    key_path       = "/etc/openshell-tls/server/tls.key"
+    client_ca_path = "/etc/openshell-tls/server/ca.crt"
+
+    {{- if .Values.gatewayJwt.enabled }}
+
+    [openshell.gateway.gateway_jwt]
+    signing_key_path = "/etc/openshell-jwt/signing.pem"
+    public_key_path  = "/etc/openshell-jwt/public.pem"
+    kid_path         = "/etc/openshell-jwt/kid"
+    gateway_id       = {{ .Values.gatewayJwt.gatewayId | default (printf "openshell-%s" .Values.tenant) | quote }}
+    ttl_secs         = {{ .Values.gatewayJwt.ttlSecs }}
+    {{- end }}
+
+    {{- if .Values.oidc.enabled }}
+
+    [openshell.gateway.oidc]
+    issuer   = {{ .Values.oidc.issuer | quote }}
+    audience = {{ include "openshell.oidcAudience" . | quote }}
+    {{- end }}
+
+    [openshell.drivers.kubernetes]
+    grpc_endpoint        = "https://openshell-server.{{ .Values.tenant }}.svc:8080"
+    service_account_name = {{ .Values.sandboxServiceAccount.name | quote }}
+    sa_token_ttl_secs    = {{ .Values.sandboxServiceAccount.tokenTtlSecs }}
+    {{- if .Values.sandboxImagePullPolicy }}
+    image_pull_policy    = {{ .Values.sandboxImagePullPolicy | quote }}
+    {{- end }}

--- a/charts/openshell/templates/rbac.yaml
+++ b/charts/openshell/templates/rbac.yaml
@@ -58,3 +58,31 @@ subjects:
   - kind: ServiceAccount
     name: openshell-gateway
     namespace: {{ .Values.tenant }}
+{{- if .Values.gatewayJwt.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshell-gateway-tokenreview-{{ .Values.tenant }}
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshell-gateway-tokenreview-{{ .Values.tenant }}
+  labels:
+    {{- include "openshell.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshell-gateway-tokenreview-{{ .Values.tenant }}
+subjects:
+  - kind: ServiceAccount
+    name: openshell-gateway
+    namespace: {{ .Values.tenant }}
+{{- end }}

--- a/charts/openshell/templates/statefulset.yaml
+++ b/charts/openshell/templates/statefulset.yaml
@@ -15,6 +15,8 @@ spec:
       app.kubernetes.io/component: gateway
   template:
     metadata:
+      annotations:
+        checksum/gateway-config: {{ include (print $.Template.BasePath "/gateway-config.yaml") . | sha256sum }}
       labels:
         {{- include "openshell.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: gateway
@@ -37,6 +39,11 @@ spec:
         - name: gateway
           image: "{{ .Values.images.gateway.repository }}:{{ .Values.images.gateway.tag }}"
           imagePullPolicy: {{ .Values.images.gateway.pullPolicy }}
+          args:
+            - --config
+            - /etc/openshell/gateway.toml
+            - --db-url
+            - "sqlite:///data/openshell.db"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -46,47 +53,39 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            - name: OPENSHELL_BIND_ADDRESS
-              value: "0.0.0.0"
-            - name: OPENSHELL_TLS_CERT
-              value: "/tls/server/tls.crt"
-            - name: OPENSHELL_TLS_KEY
-              value: "/tls/server/tls.key"
-            - name: OPENSHELL_TLS_CLIENT_CA
-              value: "/tls/server/ca.crt"
             - name: OPENSHELL_SSH_HANDSHAKE_SECRET
               valueFrom:
                 secretKeyRef:
                   name: openshell-gateway-secrets
                   key: ssh-handshake-secret
-            - name: OPENSHELL_OIDC_ISSUER
-              value: {{ .Values.oidc.issuer | quote }}
-            - name: OPENSHELL_OIDC_AUDIENCE
-              value: {{ include "openshell.oidcAudience" . | quote }}
-            - name: OPENSHELL_OIDC_ENABLED
-              value: {{ .Values.oidc.enabled | quote }}
-            {{- if .Values.trustedCABundle }}
-            - name: SSL_CERT_FILE
-              value: "/etc/ssl/certs/ca-certificates.crt"
-            - name: SSL_CERT_DIR
-              value: "/etc/ssl/certs"
-            {{- end }}
-            - name: OPENSHELL_DB_URL
-              value: "sqlite:///data/openshell.db"
             - name: OPENSHELL_DRIVERS
               value: "external"
             - name: OPENSHELL_COMPUTE_DRIVER_SOCKET
               value: "/run/drivers/compute.sock"
             - name: OPENSHELL_CREDENTIALS_DRIVER_SOCKET
               value: "/run/drivers/credentials.sock"
+            {{- if .Values.trustedCABundle }}
+            - name: SSL_CERT_FILE
+              value: "/etc/ssl/certs/ca-certificates.crt"
+            - name: SSL_CERT_DIR
+              value: "/etc/ssl/certs"
+            {{- end }}
           volumeMounts:
             - name: driver-sockets
               mountPath: /run/drivers
             - name: data
               mountPath: /data
-            - name: server-tls
-              mountPath: /tls/server
+            - name: gateway-config
+              mountPath: /etc/openshell
               readOnly: true
+            - name: server-tls
+              mountPath: /etc/openshell-tls/server
+              readOnly: true
+            {{- if .Values.gatewayJwt.enabled }}
+            - name: jwt-keys
+              mountPath: /etc/openshell-jwt
+              readOnly: true
+            {{- end }}
             {{- if .Values.trustedCABundle }}
             - name: trusted-ca
               mountPath: /etc/ssl/certs/ca-certificates.crt
@@ -143,9 +142,18 @@ spec:
       volumes:
         - name: driver-sockets
           emptyDir: {}
+        - name: gateway-config
+          configMap:
+            name: openshell-gateway-config
         - name: server-tls
           secret:
             secretName: openshell-server-tls
+        {{- if .Values.gatewayJwt.enabled }}
+        - name: jwt-keys
+          secret:
+            secretName: {{ .Values.gatewayJwt.signingSecretName | default "openshell-gateway-jwt-keys" }}
+            defaultMode: 0400
+        {{- end }}
         - name: credentials-config
           configMap:
             name: openshell-credentials-config

--- a/charts/openshell/templates/statefulset.yaml
+++ b/charts/openshell/templates/statefulset.yaml
@@ -103,16 +103,15 @@ spec:
             capabilities:
               drop: [ALL]
           args:
-            - "--socket=/run/drivers/compute.sock"
-            - "--namespace={{ include "openshell.driverNamespace" . }}"
-            - "--supervisor-image={{ .Values.supervisorImage.repository }}:{{ .Values.supervisorImage.tag }}"
-            - "--gateway-endpoint=https://openshell-server.{{ .Values.tenant }}.svc:8080"
-            - "--supervisor-binary-path={{ .Values.supervisorImage.binaryPath }}"
-            - "--dtach-binary-path={{ .Values.supervisorImage.binaryPath }}"
-            - "--tls-ca-secret=openshell-server-tls"
-            - "--tls-client-secret=openshell-client-tls"
+            - "-socket=/run/drivers/compute.sock"
+            - "-namespace={{ include "openshell.driverNamespace" . }}"
+            - "-supervisor-image={{ .Values.supervisorImage.repository }}:{{ .Values.supervisorImage.tag }}"
+            - "-gateway-endpoint=https://openshell-server.{{ .Values.tenant }}.svc:8080"
+            - "-supervisor-binary-path={{ .Values.supervisorImage.binaryPath }}"
+            - "-tls-ca-secret=openshell-server-tls"
+            - "-tls-client-secret=openshell-client-tls"
             {{- if .Values.sandboxImagePullPolicy }}
-            - "--sandbox-image-pull-policy={{ .Values.sandboxImagePullPolicy }}"
+            - "-sandbox-image-pull-policy={{ .Values.sandboxImagePullPolicy }}"
             {{- end }}
           volumeMounts:
             - name: driver-sockets

--- a/charts/openshell/templates/statefulset.yaml
+++ b/charts/openshell/templates/statefulset.yaml
@@ -37,9 +37,6 @@ spec:
         - name: gateway
           image: "{{ .Values.images.gateway.repository }}:{{ .Values.images.gateway.tag }}"
           imagePullPolicy: {{ .Values.images.gateway.pullPolicy }}
-          args:
-            - "--sandbox-namespace"
-            - {{ include "openshell.driverNamespace" . | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -5,7 +5,7 @@ tenant: ""
 images:
   gateway:
     repository: ghcr.io/kagenti/openshell/gateway
-    tag: v0.0.36-kagenti.8
+    tag: latest
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
@@ -28,10 +28,10 @@ keycloakClusterIP: ""
 
 # -- Supervisor image injected as an init container by the compute driver
 # to copy the openshell-sandbox binary into each sandbox pod.
-# Built from kagenti/OpenShell@mvp as a multi-arch image (linux/amd64 + linux/arm64).
+# Built from kagenti/OpenShell@mvp-v2 as a multi-arch image (linux/amd64 + linux/arm64).
 supervisorImage:
   repository: ghcr.io/kagenti/openshell/supervisor
-  tag: v0.0.36-kagenti.8
+  tag: latest
   binaryPath: /openshell-sandbox
 
 # -- Image pull policy for sandbox pods (init + agent containers).

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -5,7 +5,7 @@ tenant: ""
 images:
   gateway:
     repository: ghcr.io/kagenti/openshell/gateway
-    tag: latest
+    tag: mvp-v2-3a1bbea
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
@@ -31,7 +31,7 @@ keycloakClusterIP: ""
 # Built from kagenti/OpenShell@mvp-v2 as a multi-arch image (linux/amd64 + linux/arm64).
 supervisorImage:
   repository: ghcr.io/kagenti/openshell/supervisor
-  tag: latest
+  tag: mvp-v2-9a6a0ed
   binaryPath: /openshell-sandbox
 
 # -- Image pull policy for sandbox pods (init + agent containers).

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: mvp-a5f33f4
+    tag: v0.1.0-rc.1
     pullPolicy: IfNotPresent
   credentialsDriver:
     repository: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -31,7 +31,7 @@ keycloakClusterIP: ""
 # Built from kagenti/OpenShell@mvp-v2 as a multi-arch image (linux/amd64 + linux/arm64).
 supervisorImage:
   repository: ghcr.io/kagenti/openshell/supervisor
-  tag: mvp-v2-9a6a0ed
+  tag: mvp-v2-3a1bbea
   binaryPath: /openshell-sandbox
 
 # -- Image pull policy for sandbox pods (init + agent containers).

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -39,6 +39,24 @@ supervisorImage:
 # Empty string means use the Kubernetes default (Always for :latest, IfNotPresent otherwise).
 sandboxImagePullPolicy: "IfNotPresent"
 
+# -- Gateway JWT configuration for sandbox token minting (Ed25519 keypair)
+# When enabled, the gateway mints short-lived JWTs for sandbox pods after
+# validating their projected ServiceAccount token via TokenReview.
+gatewayJwt:
+  enabled: true
+  # Token TTL in seconds
+  ttlSecs: 3600
+  # Gateway identity embedded in iss/aud claims (defaults to "openshell-<tenant>")
+  gatewayId: ""
+  # Secret name for the JWT signing keypair (defaults to "openshell-gateway-jwt-keys")
+  signingSecretName: ""
+
+# -- Sandbox service account used by sandbox pods for the IssueSandboxToken bootstrap
+sandboxServiceAccount:
+  name: openshell-sandbox
+  # Lifetime of the projected SA token injected into sandbox pods by the compute driver
+  tokenTtlSecs: 3600
+
 # -- Compute driver settings
 driver:
   # Target namespace for sandbox pods (defaults to .Values.tenant)

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: v0.1.0-rc.1
+    tag: v0.1.0-rc.2
     pullPolicy: IfNotPresent
   credentialsDriver:
     repository: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver

--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -2,10 +2,10 @@
 
 This guide covers installing and using the Kagenti sandboxing feature powered by
 [OpenShell](https://github.com/NVIDIA/OpenShell). Kagenti maintains a
-[distribution fork](https://github.com/kagenti/OpenShell) with pre-built
-binaries and Kagenti-specific patches. Sandboxes provide kernel-level isolation
-for autonomous AI agents with credential protection and network policy
-enforcement.
+[distribution fork](https://github.com/kagenti/OpenShell) (`mvp-v2` branch) with
+Kagenti-specific multitenancy patches. The upstream CLI works as-is — no
+fork-specific build is needed. Sandboxes provide kernel-level isolation for
+autonomous AI agents with credential protection and network policy enforcement.
 
 ## Prerequisites
 
@@ -16,17 +16,17 @@ enforcement.
 
 ## Install the OpenShell CLI
 
-Download the latest release for your platform from
-<https://github.com/kagenti/OpenShell/releases>:
+Install the upstream OpenShell CLI (fully compatible with the Kagenti gateway):
 
 ```bash
-# macOS (Apple Silicon)
-curl -L https://github.com/kagenti/OpenShell/releases/latest/download/openshell-aarch64-apple-darwin.tar.gz | tar xz
-sudo mv openshell /usr/local/bin/
+# Via the official install script
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+```
 
-# Linux (x86_64)
-curl -L https://github.com/kagenti/OpenShell/releases/latest/download/openshell-x86_64-unknown-linux-musl.tar.gz | tar xz
-sudo mv openshell /usr/local/bin/
+Or via PyPI:
+
+```bash
+uv tool install openshell
 ```
 
 Verify the installation:

--- a/scripts/openshell/build-images.sh
+++ b/scripts/openshell/build-images.sh
@@ -108,13 +108,12 @@ build_gateway() {
     local src="$REPOS_DIR/OpenShell"
     if [[ ! -d "$src" ]]; then
         echo "ERROR: Gateway source not found at $src" >&2
-        echo "Clone it: git clone https://github.com/kagenti/OpenShell.git -b mvp $src" >&2
+        echo "Clone it: git clone https://github.com/kagenti/OpenShell.git -b mvp-v2 $src" >&2
         return 1
     fi
     echo "Building gateway image: $GATEWAY_IMAGE:$TAG"
     docker build --load -t "$GATEWAY_IMAGE:$TAG" \
-        --target gateway \
-        -f "$src/deploy/docker/Dockerfile.images" \
+        -f "$src/deploy/docker/Dockerfile.gateway" \
         "$src"
 }
 


### PR DESCRIPTION
## Summary

Adds the gateway-side Helm templates needed for sandbox pods to authenticate via projected ServiceAccount tokens (the `IssueSandboxToken` bootstrap exchange from mvp-v2).

- **`gateway-config.yaml`** — TOML ConfigMap replacing individual CLI flags/env vars with a structured config file (`--config /etc/openshell/gateway.toml`)
- **`certgen.yaml`** — Pre-install/pre-upgrade hook Job that generates an Ed25519 signing keypair secret (detects existing cert-manager TLS secrets and only creates the JWT keypair)
- **`rbac.yaml`** — ClusterRole + ClusterRoleBinding granting `tokenreviews/create` to the gateway SA (required for `K8sServiceAccountAuthenticator`)
- **`statefulset.yaml`** — Gateway container uses `--config` arg; mounts gateway-config CM and jwt-keys Secret
- **`values.yaml`** — New `gatewayJwt` and `sandboxServiceAccount` configuration sections

Closes #1818
Depends on #1814

## Test plan

- [ ] `helm template` renders cleanly with default values (gatewayJwt.enabled=true)
- [ ] `helm template` renders cleanly with gatewayJwt.enabled=false (no JWT resources)
- [ ] `helm lint` passes
- [ ] Deploy to Kind cluster — gateway starts with JWT keys mounted
- [ ] Gateway log shows `K8sServiceAccountAuthenticator` constructed
- [ ] `openshell sandbox create` succeeds (supervisor establishes relay)
- [ ] Existing OIDC auth for CLI still works

Assisted-By: Claude Code