### PR TITLE
fix(openshell): bump compute driver to v0.1.0-rc.5

### DIFF
--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: v0.1.0-rc.4
+    tag: v0.1.0-rc.5
     pullPolicy: IfNotPresent
   credentialsDriver:
     repository: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver


### PR DESCRIPTION
## Summary

- Bumps compute driver image from `v0.1.0-rc.4` → `v0.1.0-rc.5` in `charts/openshell/values.yaml`
- RC5 includes `shareProcessNamespace: true` for sandbox pods ([openshell-driver-openshift#10](https://github.com/kagenti/openshell-driver-openshift/pull/10))

## Context

Fixes the HTTP 403 proxy error when using `sandbox exec` with an active egress policy. The proxy needs `/proc` visibility to resolve process identity — `shareProcessNamespace` enables this for processes spawned by the SSH relay.

## Test plan

- [ ] Deploy to Kind/HyperShift with updated chart
- [ ] Run `test_T4_3_sandbox_egress_policy.py` E2E tests
- [ ] Verify `test_openshell_with_policy__curl_github_returns_200` passes (was 403)

Refs: #1830

Assisted-By: Claude Code