### PR TITLE
chore(openshell): bump gateway/supervisor to v0.0.56, document egress policies

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -390,7 +390,7 @@ openshell:
     pullPolicy: IfNotPresent
   computeDriver:
     image: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: v0.0.56
+    tag: v0.1.0-rc.4
     pullPolicy: IfNotPresent
   credentialsDriver:
     image: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -386,11 +386,11 @@ openshell:
   enabled: false
   gateway:
     image: ghcr.io/kagenti/openshell/gateway
-    tag: mvp-00a418f
+    tag: v0.0.56
     pullPolicy: IfNotPresent
   computeDriver:
     image: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: mvp-8c86191
+    tag: v0.0.56
     pullPolicy: IfNotPresent
   credentialsDriver:
     image: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -5,7 +5,7 @@ tenant: ""
 images:
   gateway:
     repository: ghcr.io/kagenti/openshell/gateway
-    tag: mvp-v2-3a1bbea
+    tag: v0.0.56
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
@@ -31,7 +31,7 @@ keycloakClusterIP: ""
 # Built from kagenti/OpenShell@mvp-v2 as a multi-arch image (linux/amd64 + linux/arm64).
 supervisorImage:
   repository: ghcr.io/kagenti/openshell/supervisor
-  tag: mvp-v2-3a1bbea
+  tag: v0.0.56
   binaryPath: /openshell-sandbox
 
 # -- Image pull policy for sandbox pods (init + agent containers).

--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -248,6 +248,8 @@ filesystem_policy:
   read_write:
     - /tmp
     - /sandbox
+    - /dev/null
+    - /dev/urandom
 network_policies:
   github:
     name: "Allow GitHub"
@@ -258,17 +260,29 @@ network_policies:
         port: 443
 ```
 
-Create the sandbox with `--policy`:
+Create the sandbox with `--policy` and a command (the entrypoint process is
+required for the network proxy to function):
 
 ```bash
-openshell sandbox create --policy github-egress.yaml
+# With an interactive tool
+openshell sandbox create --policy github-egress.yaml -- claude
+
+# Or as a persistent sandbox for exec sessions
+openshell sandbox create --policy github-egress.yaml -- sleep infinity
 ```
+
+No binary restrictions are needed — `git`, `curl`, `python`, and any other
+tool in the sandbox can use the allowed endpoints. The endpoint declaration
+is the access gate.
 
 Verify egress inside the sandbox:
 
 ```bash
 openshell sandbox exec -- curl -sS -o /dev/null -w "%{http_code}" https://github.com
 # 200
+
+# git clone works with just github.com:443 in the policy
+openshell sandbox exec -- git clone https://github.com/kagenti/kagenti.git /tmp/repo
 ```
 
 Unlisted endpoints remain blocked:

--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -222,6 +222,125 @@ openshell sandbox connect
 openshell sandbox exec -n <sandbox-name> -- claude --print "Hello"
 ```
 
+## Network Egress Policies
+
+By default, sandboxes have no outbound network access except to
+`inference.local` (the LLM proxy). To allow a sandbox to reach external
+services (e.g., GitHub for `git clone`, package registries, APIs), declare
+a network policy.
+
+### Create a sandbox with an egress policy
+
+Write a policy YAML that lists allowed endpoints:
+
+```yaml
+# github-egress.yaml
+version: 1
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /etc
+    - /bin
+    - /sbin
+  read_write:
+    - /tmp
+    - /sandbox
+network_policies:
+  github:
+    name: "Allow GitHub"
+    endpoints:
+      - host: "github.com"
+        port: 443
+      - host: "api.github.com"
+        port: 443
+```
+
+Create the sandbox with `--policy`:
+
+```bash
+openshell sandbox create --policy github-egress.yaml
+```
+
+Verify egress inside the sandbox:
+
+```bash
+openshell sandbox exec -- curl -sS -o /dev/null -w "%{http_code}" https://github.com
+# 200
+```
+
+Unlisted endpoints remain blocked:
+
+```bash
+openshell sandbox exec -- curl -sS https://example.com
+# curl: (56) CONNECT tunnel failed, response 403
+```
+
+### Dynamically update the policy on a running sandbox
+
+You don't need to recreate a sandbox to change its network policy.
+Updates take effect within seconds.
+
+**Add an endpoint:**
+
+```bash
+openshell policy update <sandbox-name> --add-endpoint pypi.org:443 --wait
+```
+
+**Add multiple endpoints at once:**
+
+```bash
+openshell policy update <sandbox-name> \
+  --add-endpoint registry.npmjs.org:443 \
+  --add-endpoint api.github.com:443 \
+  --wait
+```
+
+**Remove an endpoint:**
+
+```bash
+openshell policy update <sandbox-name> --remove-endpoint pypi.org:443 --wait
+```
+
+**Replace the entire policy from a file:**
+
+```bash
+openshell policy set <sandbox-name> --policy new-policy.yaml --wait
+```
+
+**View the current effective policy:**
+
+```bash
+openshell policy get <sandbox-name> --full
+```
+
+### Policy format reference
+
+The `network_policies` section maps rule names to endpoint lists:
+
+```yaml
+network_policies:
+  <rule-name>:
+    name: "<human-readable description>"
+    endpoints:
+      - host: "<hostname>"
+        port: <port>
+      - host: "*.example.com"   # glob patterns supported
+        port: 443
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `host` | yes | Exact hostname or glob pattern (`*` = single label, `**` = across labels) |
+| `port` | yes | TCP port (usually 443 for HTTPS) |
+| `binaries` | no | If omitted, any process in the sandbox can use this endpoint. If specified, only listed binary paths are allowed. |
+
+When no `binaries` are specified (the common case for egress policies), any
+process in the sandbox can access the endpoint — the endpoint declaration
+itself is the access gate.
+
 ## OpenShift with Self-Signed Certificates
 
 If your OpenShift cluster uses a self-signed or private CA (common in

--- a/kagenti/tests/e2e/openshell/test_T1_7_sandbox_connectivity.py
+++ b/kagenti/tests/e2e/openshell/test_T1_7_sandbox_connectivity.py
@@ -104,17 +104,22 @@ class TestSandboxExec:
     pod count, and the deployed agents already fill the quota.
     """
 
+    # Gateway images (v0.0.56+) are distroless — no shell or coreutils.
+    # Skip these when looking for a pod to exec into.
+    _DISTROLESS_PREFIXES = ("openshell-server",)
+
     def _find_exec_pod(self) -> tuple[str, str] | None:
         """Find a running pod with a ready container suitable for exec testing.
 
-        Selects the first pod where the target container is actually ready,
-        not just where the pod phase is Running (a pod with a crashlooping
-        container still reports Running if its sidecar is up).
+        Skips distroless pods (gateway) that lack a shell. Selects the first
+        pod where the target container is actually ready.
         """
         pods = kubectl_get_pods_json(SANDBOX_NS)
         running = [p for p in pods if p["status"].get("phase") == "Running"]
         for pod in running:
             name = pod["metadata"]["name"]
+            if any(name.startswith(pfx) for pfx in self._DISTROLESS_PREFIXES):
+                continue
             containers = pod["spec"].get("containers", [])
             if not containers:
                 continue

--- a/kagenti/tests/e2e/openshell/test_T4_3_sandbox_egress_policy.py
+++ b/kagenti/tests/e2e/openshell/test_T4_3_sandbox_egress_policy.py
@@ -67,6 +67,8 @@ filesystem_policy:
   read_write:
     - /tmp
     - /sandbox
+    - /dev/null
+    - /dev/urandom
 network_policies:
   external:
     name: "Allow target APIs"
@@ -92,6 +94,8 @@ filesystem_policy:
   read_write:
     - /tmp
     - /sandbox
+    - /dev/null
+    - /dev/urandom
 """
 
 


### PR DESCRIPTION
## Summary

- Bump OpenShell gateway and supervisor images from `mvp-v2-3a1bbea` to `v0.0.56`
- Document network egress policies in `docs/sandbox-guide.md` (create with `--policy`, dynamic updates, git clone example)

## Motivation

v0.0.56 includes [kagenti/OpenShell#10](https://github.com/kagenti/OpenShell/pull/10) which fixes the sandbox egress 403 bug — the CONNECT proxy now falls through to OPA on identity resolution failure, and policies without `binaries` restrictions allow any binary.

## Changes

| File | Change |
|------|--------|
| `charts/openshell/values.yaml` | gateway + supervisor → `v0.0.56` |
| `charts/kagenti/values.yaml` | gateway → `v0.0.56` (compute-driver stays at `v0.1.0-rc.4`) |
| `docs/sandbox-guide.md` | New "Network Egress Policies" section |

## Test plan

- [x] Deployed to Kind cluster, created sandbox with `--policy github-egress.yaml -- sleep infinity`
- [x] Verified `curl https://github.com` returns 200 inside sandbox
- [x] Verified `git clone https://github.com/kagenti/kagenti.git` works
- [x] Verified `curl https://example.com` (not in policy) still returns 403
- [x] Verified dynamic `policy update --add-endpoint` / `--remove-endpoint` works on live sandbox

Assisted-By: Claude Code