### PR TITLE
Docs: Chore: Run CI on merge.  Update README to suggest testers use release branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Kagenti provides a set of components and assets that make it easier to manage AI
 git clone https://github.com/kagenti/kagenti.git
 cd kagenti
 
-# Use to latest release
+# Check out the latest release
 git checkout v0.6.0
 
 # Copy and configure secrets (optional)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ Kagenti provides a set of components and assets that make it easier to manage AI
 git clone https://github.com/kagenti/kagenti.git
 cd kagenti
 
-# Copy and configure secrets
+# Use to latest release
+git checkout v0.6.0
+
+# Copy and configure secrets (optional)
 cp charts/kagenti/.secrets_template.yaml charts/kagenti/.secrets.yaml
 # Edit charts/kagenti/.secrets.yaml with your values
 


### PR DESCRIPTION
## Summary

The GitHub CI badge on our README says CI is failing.  CI actually hasn't run on seven months.  This runs our unit tests after merge.

The install instructions are for installing the current main branch.  Add an instructions for users to use the release 0.6.0 for testing.

Fixes #

For #1850