### PR TITLE
Feat: Check MLflow status when reporting component status

### DIFF
--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -207,6 +207,9 @@ async def get_platform_status(
         # (openshift-builds), so we check the API group instead of a specific service.
         ComponentStatus(name="Shipwright", status=_check_api_group(kube, "shipwright.io")),
         ComponentStatus(name="Phoenix", status=_check_service(kube, "kagenti-system", "phoenix")),
+        ComponentStatus(
+            name="MLflow", status=_check_deployment_ready(kube, "kagenti-system", "mlflow")
+        ),
     ]
 
     strategy_names: List[str] = []


### PR DESCRIPTION
## Summary

- Adds MLflow status reporting to the /api/v1/config/platform-status endpoint
- The UI renders MLflow status at http://kagenti-ui.localtest.me:8080/admin

## (Optional) Testing Instructions

Install Kagenti with admin feature flag set to true
Build kagenti-ui and kagenti-backand and deploy them in the usual way based on this PR
Visit http://kagenti-ui.localtest.me:8080/admin and see MLflow status rendered

Fixes #

Resolves #1579