### PR TITLE
fix(e2e): enable injectTools feature gate in test environments

### DIFF
--- a/deployments/envs/dev_values.yaml
+++ b/deployments/envs/dev_values.yaml
@@ -74,6 +74,10 @@ charts:
       ui:
         auth:
           enabled: true
+      # Enable tool workload sidecar injection for token-exchange E2E tests
+      kagenti-operator-chart:
+        featureGates:
+          injectTools: true
       # MLflow auth disabled for Kind (no Keycloak OAuth needed locally)
       mlflow:
         auth:

--- a/deployments/envs/ocp_ci_values.yaml
+++ b/deployments/envs/ocp_ci_values.yaml
@@ -73,6 +73,10 @@ charts:
           enabled: false
         phoenix:
           enabled: false
+      # Enable tool workload sidecar injection for token-exchange E2E tests
+      kagenti-operator-chart:
+        featureGates:
+          injectTools: true
       mlflow:
         auth:
           enabled: false

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1273,6 +1273,7 @@ KAGENTI_FLAGS=(
   --set "components.mlflow.enabled=${WITH_MLFLOW}"
   --set "ui.auth.enabled=$($WITH_SPIRE && echo true || echo false)"
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"
+  --set "kagenti-operator-chart.featureGates.injectTools=true"
 )
 KAGENTI_FLAGS=( "${KAGENTI_FLAGS[@]}" ${KAGENTI_VALUES_FILES[@]+"${KAGENTI_VALUES_FILES[@]}"} )
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1338,6 +1338,7 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   --set "components.mlflow.enabled=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)" \
   --set "components.mlflow.routeNamespace=${MLFLOW_NAMESPACE}" \
   --set "kagenti-operator-chart.mlflow.enable=$([ "$SKIP_MLFLOW" = true ] && echo false || echo true)" \
+  --set "kagenti-operator-chart.featureGates.injectTools=true" \
   --set "featureFlags.agentSandbox=${WITH_AGENT_SANDBOX}"
 
 log_success "Kagenti installed"


### PR DESCRIPTION
## Summary

- Enable `kagenti-operator-chart.featureGates.injectTools=true` in Kind and OCP/HyperShift test deployments
- Document the feature gate expectation in `dev_values.yaml` and `ocp_ci_values.yaml`

## Root Cause

The `injectTools` feature gate defaults to `false` in the kagenti-operator chart (introduced in operator 0.2.0-alpha.34). No test environment overrides this default, so the admission webhook skips sidecar injection for `kagenti.io/type=tool` workloads. This causes all 13 token-exchange E2E tests to fail since May 7.

Full RCA: https://github.com/kagenti/kagenti/issues/1859#issuecomment-4660595572

## Changes

| File | Purpose |
|------|---------|
| `scripts/kind/setup-kagenti.sh` | Pass `--set` flag during Kind Helm install |
| `scripts/ocp/setup-kagenti.sh` | Pass `--set` flag during OCP/HyperShift Helm install |
| `deployments/envs/dev_values.yaml` | Document Kind test expectation |
| `deployments/envs/ocp_ci_values.yaml` | Document HyperShift test expectation |

## Test plan

- [ ] Kind E2E workflow passes (token-exchange tests green)
- [ ] HyperShift E2E passes once cluster creation issue is separately resolved

Fixes #1859

Assisted-By: Claude Code