### PR TITLE
Bug fix: Streaming A2A agents show be shown as streaming

### DIFF
--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -124,9 +124,7 @@ interface AgentCard {
   url: string;
   protocolVersion?: string;
   preferredTransport?: string;
-  capabilities?: {
-    streaming?: boolean;
-  };
+  streaming?: boolean;
   defaultInputModes?: string[];
   defaultOutputModes?: string[];
   skills?: AgentCardSkill[];
@@ -638,9 +636,9 @@ export const AgentDetailPage: React.FC = () => {
                                       <DescriptionListDescription>
                                         <Label
                                           isCompact
-                                          color={agentCard.capabilities?.streaming ? 'green' : 'gold'}
+                                          color={agentCard.streaming ? 'green' : 'gold'}
                                         >
-                                          {agentCard.capabilities?.streaming ? 'Enabled' : 'Disabled'}
+                                          {agentCard.streaming ? 'Enabled' : 'Disabled'}
                                         </Label>
                                       </DescriptionListDescription>
                                     </DescriptionListGroup>


### PR DESCRIPTION
## Summary

The Kagenti UI shows streaming agents as if they cannot stream.

<img width="306" height="298" alt="incorrect-streaming" src="https://github.com/user-attachments/assets/44f06a27-df98-4001-acab-8327a786ab22" />

Fixes #

No associated Issue.