### PR TITLE
Feat: Make AuthBridge statistics tab visible on agent details page

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -28,7 +28,8 @@ featureFlags:
   # External skill registry references (skillberry-store, etc.)
   externalSkills: false
   # Enables AuthBridge tab on Agent details page
-  authbridgeAPI: false
+  # Show this UI by default (we'll remove gate after a version where it can be disabled with a flag)
+  authbridgeAPI: true
   # Enables Platform Status card
   # on http://kagenti-ui.localtest.me:8080/admin
   admin: false


### PR DESCRIPTION
## Summary

This makes the "AuthBridge" tab appear on Agent details, allowing users to see how much traffic an agent is getting.

Instead of removing the gate, we make it default, in case there are problems.

By making this the default we will get some feedback.  Currently no one is giving feedback on this tab, because no one except me is installing Kagenti with this UI.

## Related issue(s)

The UI can be seen on the original implementation issue, #1310

Related PR https://github.com/kagenti/kagenti/pull/1796 , a similar PR to turn on a flag.  Turning on flags this way is against Kagenti's written policy, but if we intend to have feature flags it makes sense to have a short phase where the feature is available but can be turned off.
