### PR TITLE
docs: Fix broken OpenClaw and A2A protocol links

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ To learn how to deploy agents and MCP tools, follow the **[Weather Agent Demo](h
 
 ## Supported Protocols
 
-- **[A2A (Agent-to-Agent)](https://google.github.io/A2A)** — Standard protocol for agent communication
+- **[A2A (Agent-to-Agent)](https://a2a-protocol.org/latest/)** — Standard protocol for agent communication
 - **[MCP (Model Context Protocol)](https://modelcontextprotocol.io)** — Protocol for tool/server integration
 
 ## Contributing

--- a/docs/agentic-runtime/agents/nemoclaw-openclaw.md
+++ b/docs/agentic-runtime/agents/nemoclaw-openclaw.md
@@ -11,7 +11,7 @@
 
 ## 1. Overview
 
-OpenClaw is the default agent from the [OpenClaw](https://openclaw.ai) platform,
+OpenClaw is the default agent from the [OpenClaw](https://github.com/openclaw/openclaw) platform,
 integrated via [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw). It provides
 a gateway-based AI assistant with a plugin ecosystem, workspace management, and
 extension support.

--- a/docs/components.md
+++ b/docs/components.md
@@ -623,7 +623,7 @@ Kagenti is framework-neutral and supports agents built with any framework that c
 
 ### A2A (Agent-to-Agent)
 
-[A2A](https://google.github.io/A2A) is Google's standard protocol for agent communication.
+[A2A](https://a2a-protocol.org/latest/) is Google's standard protocol for agent communication.
 
 **Features**:
 

--- a/docs/tech-details.md
+++ b/docs/tech-details.md
@@ -93,7 +93,7 @@ It is deployed in the `kagenti-system` namespace.
  
 ## Agents
 
-- **a2a-contact-extractor-agent**: Marvin agent exposed via [A2A](https://google.github.io/A2A) protocol. 
+- **a2a-contact-extractor-agent**: Marvin agent exposed via [A2A](https://a2a-protocol.org/latest/) protocol. 
 It extracts structured contact information from text using Marvin's extraction capabilities
 - **a2a-currency-agent**: LangGraph agent exposed via A2A protocol. It provides exchange rates for currencies.
 - **slack-researcher**: Autogen agent exposed via A2A protocol. It implements a slack assistant to perform various research tasks on slack.


### PR DESCRIPTION
## Summary

- Fix broken `openclaw.ai` link in nemoclaw-openclaw.md → `github.com/openclaw/openclaw`
- Update A2A protocol URLs from deprecated `google.github.io/A2A` to canonical `a2a-protocol.org/latest/` (README, components.md, tech-details.md)

## Related issue(s)

Fixes #1694

Assisted-By: Claude Code