### PR TITLE
fix(e2e): exclude MCP port from authbridge iptables intercept

### DIFF
--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -155,9 +155,13 @@ else
             log_warn "openai-secret not found in team1 — LLM calls will fail without API key"
         fi
 
-        # Note: proxy-init is only injected in envoy-proxy mode. The default
+        # Note: proxy-init is only injected in envoy-sidecar mode. The default
         # authbridge proxy-sidecar mode uses HTTPS_PROXY env vars instead.
         # See NO_PROXY override above for external LLM endpoints.
+        # When proxy-init IS active, iptables intercepts ALL outbound TCP —
+        # env vars are bypassed at L4. The pod template annotation
+        # kagenti.io/outbound-ports-exclude: "8000" excludes the MCP tool
+        # port from iptables rules so streaming connections work directly.
     fi
 fi
 

--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -176,15 +176,22 @@ log_success "Weather-service deployed via Deployment + Service (operator-indepen
 # into the pod at admission time.  The pod stays in ContainerCreating until
 # the operator's ClientRegistrationReconciler registers the workload in
 # Keycloak and creates the Secret.  Wait here to avoid a flaky timeout later.
+# When kagenti.io/inject=disabled, the webhook does not inject the volume mount
+# so the pod starts without waiting for the secret.
 # ============================================================================
-log_info "Waiting for operator to create client credentials secret..."
-if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
-    log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
-    kubectl get pods -n kagenti-system 2>&1 || true
-    kubectl get secrets -n team1 2>&1 || true
-    kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
+INJECT_LABEL=$(kubectl get deployment weather-service -n team1 -o jsonpath='{.spec.template.metadata.labels.kagenti\.io/inject}' 2>/dev/null || echo "")
+if [ "$INJECT_LABEL" = "disabled" ]; then
+    log_info "Injection disabled (kagenti.io/inject=disabled) — skipping credentials secret wait"
 else
-    log_success "Client credentials secret created by operator"
+    log_info "Waiting for operator to create client credentials secret..."
+    if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
+        log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
+        kubectl get pods -n kagenti-system 2>&1 || true
+        kubectl get secrets -n team1 2>&1 || true
+        kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
+    else
+        log_success "Client credentials secret created by operator"
+    fi
 fi
 
 # WORKAROUND: Fix Service targetPort mismatch

--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -176,22 +176,15 @@ log_success "Weather-service deployed via Deployment + Service (operator-indepen
 # into the pod at admission time.  The pod stays in ContainerCreating until
 # the operator's ClientRegistrationReconciler registers the workload in
 # Keycloak and creates the Secret.  Wait here to avoid a flaky timeout later.
-# When kagenti.io/inject=disabled, the webhook does not inject the volume mount
-# so the pod starts without waiting for the secret.
 # ============================================================================
-INJECT_LABEL=$(kubectl get deployment weather-service -n team1 -o jsonpath='{.spec.template.metadata.labels.kagenti\.io/inject}' 2>/dev/null || echo "")
-if [ "$INJECT_LABEL" = "disabled" ]; then
-    log_info "Injection disabled (kagenti.io/inject=disabled) — skipping credentials secret wait"
+log_info "Waiting for operator to create client credentials secret..."
+if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
+    log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
+    kubectl get pods -n kagenti-system 2>&1 || true
+    kubectl get secrets -n team1 2>&1 || true
+    kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
 else
-    log_info "Waiting for operator to create client credentials secret..."
-    if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
-        log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
-        kubectl get pods -n kagenti-system 2>&1 || true
-        kubectl get secrets -n team1 2>&1 || true
-        kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
-    else
-        log_success "Client credentials secret created by operator"
-    fi
+    log_success "Client credentials secret created by operator"
 fi
 
 # WORKAROUND: Fix Service targetPort mismatch

--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -214,6 +214,17 @@ wait_for_deployment "weather-service" "team1" 180 || {
 }
 log_success "weather-service pod is ready"
 
+# Diagnostic: log injected containers to verify authbridge mode
+WEATHER_POD=$(kubectl get pods -n team1 -l app.kubernetes.io/name=weather-service -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+if [ -n "$WEATHER_POD" ]; then
+    INIT_CONTAINERS=$(kubectl get pod "$WEATHER_POD" -n team1 -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null || echo "(none)")
+    CONTAINERS=$(kubectl get pod "$WEATHER_POD" -n team1 -o jsonpath='{.spec.containers[*].name}' 2>/dev/null || echo "(none)")
+    log_info "Pod $WEATHER_POD — init: [$INIT_CONTAINERS] containers: [$CONTAINERS]"
+    if echo "$INIT_CONTAINERS" | grep -q proxy-init; then
+        log_warn "proxy-init detected despite proxy-sidecar mode annotation — iptables interception may break MCP streaming"
+    fi
+fi
+
 # Create OpenShift Route for the agent (on OpenShift only)
 # The kagenti-operator doesn't create routes automatically - they're created by the UI backend
 # when using the web interface. For E2E tests, we need to create the route manually.

--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -176,15 +176,22 @@ log_success "Weather-service deployed via Deployment + Service (operator-indepen
 # into the pod at admission time.  The pod stays in ContainerCreating until
 # the operator's ClientRegistrationReconciler registers the workload in
 # Keycloak and creates the Secret.  Wait here to avoid a flaky timeout later.
+# When kagenti.io/inject=disabled, the webhook skips injection entirely so
+# no credentials secret is needed.
 # ============================================================================
-log_info "Waiting for operator to create client credentials secret..."
-if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
-    log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
-    kubectl get pods -n kagenti-system 2>&1 || true
-    kubectl get secrets -n team1 2>&1 || true
-    kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
+INJECT_LABEL=$(kubectl get deployment weather-service -n team1 -o jsonpath='{.spec.template.metadata.labels.kagenti\.io/inject}' 2>/dev/null || echo "")
+if [ "$INJECT_LABEL" = "disabled" ]; then
+    log_info "Injection disabled (kagenti.io/inject=disabled) — skipping credentials secret wait"
 else
-    log_success "Client credentials secret created by operator"
+    log_info "Waiting for operator to create client credentials secret..."
+    if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
+        log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
+        kubectl get pods -n kagenti-system 2>&1 || true
+        kubectl get secrets -n team1 2>&1 || true
+        kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
+    else
+        log_success "Client credentials secret created by operator"
+    fi
 fi
 
 # WORKAROUND: Fix Service targetPort mismatch

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -30,6 +30,8 @@ spec:
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
+      annotations:
+        kagenti.io/outbound-ports-exclude: "8000"
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -27,12 +27,14 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
       annotations:
         kagenti.io/outbound-ports-exclude: "8000"
         kagenti.io/authbridge-mode: proxy-sidecar
+        kagenti.io/inject: disabled
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -32,6 +32,7 @@ spec:
         app.kubernetes.io/name: weather-service
       annotations:
         kagenti.io/outbound-ports-exclude: "8000"
+        kagenti.io/authbridge-mode: proxy-sidecar
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -27,11 +27,10 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
-      annotations:
-        kagenti.io/outbound-ports-exclude: "8000"
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -27,14 +27,11 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
-        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
       annotations:
         kagenti.io/outbound-ports-exclude: "8000"
-        kagenti.io/authbridge-mode: proxy-sidecar
-        kagenti.io/inject: disabled
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -31,6 +31,7 @@ spec:
         app.kubernetes.io/name: weather-service
       annotations:
         kagenti.io/outbound-ports-exclude: "8000"
+        kagenti.io/authbridge-mode: proxy-sidecar
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -26,14 +26,11 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
-        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
       annotations:
         kagenti.io/outbound-ports-exclude: "8000"
-        kagenti.io/authbridge-mode: proxy-sidecar
-        kagenti.io/inject: disabled
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -26,11 +26,10 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
-      annotations:
-        kagenti.io/outbound-ports-exclude: "8000"
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -26,12 +26,14 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
+        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
       annotations:
         kagenti.io/outbound-ports-exclude: "8000"
         kagenti.io/authbridge-mode: proxy-sidecar
+        kagenti.io/inject: disabled
     spec:
       serviceAccountName: weather-service
       containers:

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -29,6 +29,8 @@ spec:
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service
+      annotations:
+        kagenti.io/outbound-ports-exclude: "8000"
     spec:
       serviceAccountName: weather-service
       containers:


### PR DESCRIPTION
## Summary

- Add `kagenti.io/outbound-ports-exclude: "8000"` annotation to weather-service pod template in both Kind and OCP deployment manifests
- When `proxy-init` (envoy-sidecar mode) is active, iptables intercepts ALL outbound TCP — including MCP streaming connections to port 8000. This annotation tells `proxy-init` to skip iptables rules for that port, allowing the agent to connect directly to the MCP tool
- Harmless in proxy-sidecar mode (no `proxy-init` exists, annotation is ignored)
- Uses the same mechanism as the [working advanced weather demo](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/demos/weather-agent/demo-ui-advanced.md) uses for Ollama (`kagenti.io/outbound-ports-exclude: "11434"`)

## Root Cause

On HyperShift, the authbridge webhook injects `proxy-init` which configures iptables to redirect all outbound TCP through Envoy. Envoy's ext_proc (`response_header_mode: SEND`) buffers response headers, breaking MCP streamable HTTP's chunked/SSE protocol. The existing `NO_PROXY` env vars are bypassed because iptables operates at L4.

## Test plan

- [ ] CI E2E tests pass on HyperShift (specifically `test_agent_simple_query` and `test_agent_multiturn_conversation`)
- [ ] Kind E2E tests still pass (annotation is harmless without `proxy-init`)
- [ ] Verify no regression in other agent tests

Fixes #1904

Assisted-By: Claude Code