### PR TITLE
Chore: Bump AuthBridge sidecars to v0.6.0-alpha.8 and revert #1905 (validate in-cluster egress fix)

### DIFF
--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -155,13 +155,9 @@ else
             log_warn "openai-secret not found in team1 — LLM calls will fail without API key"
         fi
 
-        # Note: proxy-init is only injected in envoy-sidecar mode. The default
+        # Note: proxy-init is only injected in envoy-proxy mode. The default
         # authbridge proxy-sidecar mode uses HTTPS_PROXY env vars instead.
         # See NO_PROXY override above for external LLM endpoints.
-        # When proxy-init IS active, iptables intercepts ALL outbound TCP —
-        # env vars are bypassed at L4. The pod template annotation
-        # kagenti.io/outbound-ports-exclude: "8000" excludes the MCP tool
-        # port from iptables rules so streaming connections work directly.
     fi
 fi
 
@@ -176,22 +172,15 @@ log_success "Weather-service deployed via Deployment + Service (operator-indepen
 # into the pod at admission time.  The pod stays in ContainerCreating until
 # the operator's ClientRegistrationReconciler registers the workload in
 # Keycloak and creates the Secret.  Wait here to avoid a flaky timeout later.
-# When kagenti.io/inject=disabled, the webhook skips injection entirely so
-# no credentials secret is needed.
 # ============================================================================
-INJECT_LABEL=$(kubectl get deployment weather-service -n team1 -o jsonpath='{.spec.template.metadata.labels.kagenti\.io/inject}' 2>/dev/null || echo "")
-if [ "$INJECT_LABEL" = "disabled" ]; then
-    log_info "Injection disabled (kagenti.io/inject=disabled) — skipping credentials secret wait"
+log_info "Waiting for operator to create client credentials secret..."
+if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
+    log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
+    kubectl get pods -n kagenti-system 2>&1 || true
+    kubectl get secrets -n team1 2>&1 || true
+    kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
 else
-    log_info "Waiting for operator to create client credentials secret..."
-    if ! kubectl -n team1 wait --for=create secret/kagenti-keycloak-client-credentials --timeout=120s 2>/dev/null; then
-        log_warn "Credentials secret not found after 120s — pod may be stuck in ContainerCreating"
-        kubectl get pods -n kagenti-system 2>&1 || true
-        kubectl get secrets -n team1 2>&1 || true
-        kubectl logs -n kagenti-system -l app.kubernetes.io/instance=kagenti --tail=20 2>&1 || true
-    else
-        log_success "Client credentials secret created by operator"
-    fi
+    log_success "Client credentials secret created by operator"
 fi
 
 # WORKAROUND: Fix Service targetPort mismatch
@@ -220,17 +209,6 @@ wait_for_deployment "weather-service" "team1" 180 || {
     exit 1
 }
 log_success "weather-service pod is ready"
-
-# Diagnostic: log injected containers to verify authbridge mode
-WEATHER_POD=$(kubectl get pods -n team1 -l app.kubernetes.io/name=weather-service -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-if [ -n "$WEATHER_POD" ]; then
-    INIT_CONTAINERS=$(kubectl get pod "$WEATHER_POD" -n team1 -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null || echo "(none)")
-    CONTAINERS=$(kubectl get pod "$WEATHER_POD" -n team1 -o jsonpath='{.spec.containers[*].name}' 2>/dev/null || echo "(none)")
-    log_info "Pod $WEATHER_POD — init: [$INIT_CONTAINERS] containers: [$CONTAINERS]"
-    if echo "$INIT_CONTAINERS" | grep -q proxy-init; then
-        log_warn "proxy-init detected despite proxy-sidecar mode annotation — iptables interception may break MCP streaming"
-    fi
-fi
 
 # Create OpenShift Route for the agent (on OpenShift only)
 # The kagenti-operator doesn't create routes automatically - they're created by the UI backend

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.3.0-alpha.4
-digest: sha256:c4886fc6566d6cfad8330c45c27dc3cc4df07712ef10ed3fb54f4356ce10dbef
-generated: "2026-06-06T13:42:11.061697-04:00"
+  version: 0.3.0-alpha.5
+digest: sha256:6f506775e7ba6a2dbf4944023ffdd78a268355beeb82c1b1413d0ffec6a17e33
+generated: "2026-06-12T16:29:30.290616-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,6 +7,6 @@ appVersion: "0.7.0-alpha.3"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.3.0-alpha.4
+  version: 0.3.0-alpha.5
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -267,7 +267,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.3.0-alpha.4
+        tag: 0.3.0-alpha.5
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -303,10 +303,10 @@ kagenti-operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.8
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.8
-      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.8
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.8
+      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.9
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.9
+      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.9
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.9
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -303,10 +303,10 @@ kagenti-operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.7
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.7
-      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.7
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.7
+      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.8
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.8
+      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.8
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.8
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/deployments/envs/ocp_ci_values.yaml
+++ b/deployments/envs/ocp_ci_values.yaml
@@ -89,6 +89,23 @@ charts:
       agentNamespaces:
         - team1
         - team2
+      # OCP/HyperShift: the hosted cluster's Services + DNS resolver live in the
+      # service network (172.31.0.0/16 on this hosted shape; 172.30.0.0/16 on
+      # default OCP), which is OUTSIDE the operator's Kind-shaped 10/8 default.
+      # enforce-redirect leaves in-cluster DNS direct only for CLUSTER_CIDRS, so
+      # with the 10/8 default the agent's UDP/53 to the 172.31.x resolver is
+      # DROPped -> name resolution fails -> agent->MCP egress fails. Override the
+      # operator's proxy.clusterCIDRs with the real pod + service ranges so DNS
+      # stays direct while non-DNS in-cluster TCP is still captured. (Validation
+      # of the CLUSTER_CIDRS theory for PR #1911; the durable fix exempts the
+      # resolv.conf nameservers directly in proxy-init.)
+      kagenti-operator-chart:
+        defaults:
+          proxy:
+            clusterCIDRs:
+              - "10.0.0.0/8"
+              - "172.30.0.0/16"
+              - "172.31.0.0/16"
 
   mcpGateway:
     enabled: true

--- a/deployments/envs/ocp_ci_values.yaml
+++ b/deployments/envs/ocp_ci_values.yaml
@@ -89,23 +89,6 @@ charts:
       agentNamespaces:
         - team1
         - team2
-      # OCP/HyperShift: the hosted cluster's Services + DNS resolver live in the
-      # service network (172.31.0.0/16 on this hosted shape; 172.30.0.0/16 on
-      # default OCP), which is OUTSIDE the operator's Kind-shaped 10/8 default.
-      # enforce-redirect leaves in-cluster DNS direct only for CLUSTER_CIDRS, so
-      # with the 10/8 default the agent's UDP/53 to the 172.31.x resolver is
-      # DROPped -> name resolution fails -> agent->MCP egress fails. Override the
-      # operator's proxy.clusterCIDRs with the real pod + service ranges so DNS
-      # stays direct while non-DNS in-cluster TCP is still captured. (Validation
-      # of the CLUSTER_CIDRS theory for PR #1911; the durable fix exempts the
-      # resolv.conf nameservers directly in proxy-init.)
-      kagenti-operator-chart:
-        defaults:
-          proxy:
-            clusterCIDRs:
-              - "10.0.0.0/8"
-              - "172.30.0.0/16"
-              - "172.31.0.0/16"
 
   mcpGateway:
     enabled: true

--- a/kagenti/examples/agents/weather_service_deployment.yaml
+++ b/kagenti/examples/agents/weather_service_deployment.yaml
@@ -27,7 +27,6 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
-        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service

--- a/kagenti/examples/agents/weather_service_deployment_ocp.yaml
+++ b/kagenti/examples/agents/weather_service_deployment_ocp.yaml
@@ -26,7 +26,6 @@ spec:
     metadata:
       labels:
         kagenti.io/type: agent
-        kagenti.io/inject: disabled
         protocol.kagenti.io/a2a: ""
         kagenti.io/framework: LangGraph
         app.kubernetes.io/name: weather-service

--- a/kagenti/tests/e2e/common/test_agent_conversation.py
+++ b/kagenti/tests/e2e/common/test_agent_conversation.py
@@ -117,6 +117,48 @@ _DIAG_TEXT_LIMIT = 200
 _DIAG_ARTIFACT_LIMIT = 100
 _DIAG_ERROR_LIMIT = 500
 
+# Run the agent->MCP egress diagnostic at most once per session.
+_MCP_DIAG_RAN = False
+
+
+def _run_mcp_diagnostics():
+    """Best-effort dump of the agent->MCP egress path (issue #1904) when the agent
+    returns a FAILED "Cannot connect to MCP" task.
+
+    Shows what breaks vs works on the actual cluster — AuthBridge mode, the
+    proxy-init DNS exemption (``resolvers=`` on the resolv.conf fix vs ``CIDRs=``
+    on the old build), the agent's resolv.conf, a DNS-isolation probe (MCP by
+    FQDN which needs DNS vs by ClusterIP which does not), and authbridge proxy
+    logs. Runs at most once per session and never raises, so it cannot change a
+    test outcome.
+    """
+    global _MCP_DIAG_RAN
+    if _MCP_DIAG_RAN:
+        return
+    _MCP_DIAG_RAN = True
+
+    import subprocess
+
+    script = pathlib.Path(__file__).resolve().parent.parent / "diagnose_agent_mcp.sh"
+    namespace = os.getenv("AGENT_NAMESPACE", "team1")
+    if not script.exists():
+        logger.warning("MCP diagnostic script not found at %s", script)
+        return
+    try:
+        result = subprocess.run(
+            ["bash", str(script), namespace],
+            capture_output=True,
+            text=True,
+            timeout=150,
+        )
+        logger.error(
+            "agent->MCP egress diagnostics (#1904):\n%s\n%s",
+            result.stdout,
+            result.stderr,
+        )
+    except Exception as e:  # diagnostics are best-effort; never fail the test
+        logger.warning("could not run agent->MCP diagnostics: %s", e)
+
 
 def _extract_text_from_parts(parts):
     """Extract concatenated text from a list of A2A Part objects."""
@@ -323,6 +365,7 @@ class TestWeatherAgentConversation:
                     )
                     await asyncio.sleep(_LLM_QUERY_RETRY_DELAY_S)
                     continue
+                _run_mcp_diagnostics()
                 pytest.fail(
                     f"Agent returned a FAILED task\n"
                     f"  Agent URL: {agent_url}\n"
@@ -477,6 +520,7 @@ class TestWeatherAgentConversation:
                         )
                         await asyncio.sleep(_LLM_QUERY_RETRY_DELAY_S)
                         continue
+                    _run_mcp_diagnostics()
                     pytest.fail(
                         f"Turn {turn}: Agent returned FAILED task\n"
                         f"  Error: {error_text}\n"

--- a/kagenti/tests/e2e/diagnose_agent_mcp.sh
+++ b/kagenti/tests/e2e/diagnose_agent_mcp.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Diagnose the agent -> MCP-tool egress path (issue #1904 / the DNS-drop in the
+# enforce-redirect guard). Invoked by the agent-conversation e2e tests when the
+# agent returns a FAILED "Cannot connect to MCP" task, so the run shows exactly
+# what breaks vs what works instead of a bare "Cannot connect".
+#
+# It is read-only and best-effort: every command is guarded so it can never
+# change the test outcome. Usage: diagnose_agent_mcp.sh [namespace]   (default team1)
+#
+# Borrows the DNS-isolation trick from PR #1909: probe the MCP tool by FQDN
+# (needs cluster DNS) AND by ClusterIP (no DNS). If FQDN fails but ClusterIP is
+# reached, DNS is the blocker; if both are reached, the path is healthy; if both
+# fail, the break is at the connection/proxy layer, not DNS.
+set +e
+
+NS="${1:-team1}"
+KUBECTL="${KUBECTL:-kubectl}"
+
+echo "=================================================================="
+echo "AGENT->MCP DIAGNOSTICS (namespace=${NS})"
+echo "=================================================================="
+
+# --- Locate the weather agent pod specifically (Deployment 'weather-service' on
+#     OCP, Sandbox 'weather-agent' on Kind). Match by the weather label/name only
+#     — never the generic kagenti.io/type=agent (other agents share it). ---
+POD=$(${KUBECTL} get pod -n "${NS}" -l "app.kubernetes.io/name=weather-service" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -z "${POD}" ] && POD=$(${KUBECTL} get pods -n "${NS}" --no-headers 2>/dev/null \
+  | awk '/^weather-(service|agent)/{print $1; exit}')
+if [ -z "${POD}" ]; then
+  echo "  no weather agent pod found in ${NS} — nothing to diagnose"
+  exit 0
+fi
+echo "  agent pod: ${POD}"
+
+# --- AuthBridge injection mode ---
+INITS=$(${KUBECTL} get pod "${POD}" -n "${NS}" -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null)
+CONTS=$(${KUBECTL} get pod "${POD}" -n "${NS}" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null)
+echo "  init=[${INITS}] containers=[${CONTS}]"
+if echo "${INITS}" | grep -q proxy-init; then
+  echo "  AuthBridge enforce-redirect ACTIVE (proxy-init present -> egress captured at L4)"
+else
+  echo "  no proxy-init (cooperative HTTP_PROXY mode, or AuthBridge not injected)"
+fi
+
+# --- proxy-init log: the DNS exemption it applied. The key line is either
+#     'resolvers=<ip>' (resolv.conf-based fix) or 'CIDRs=<cidrs>' (old build). ---
+echo "--- proxy-init log (DNS exemption applied) ---"
+${KUBECTL} logs "${POD}" -n "${NS}" -c proxy-init 2>&1 \
+  | grep -iE "enforce-redirect|resolver|CIDRs|WARNING|ERROR" || echo "  (no proxy-init log)"
+
+# --- proxy-init env: CLUSTER_CIDRS should be ABSENT once the resolv.conf fix is
+#     in (operator no longer injects it). Its presence means an old image/operator. ---
+echo "--- proxy-init env ---"
+${KUBECTL} get pod "${POD}" -n "${NS}" \
+  -o jsonpath='{range .spec.initContainers[?(@.name=="proxy-init")].env[*]}    {.name}={.value}{"\n"}{end}' 2>/dev/null \
+  || echo "  (could not read proxy-init env)"
+
+# --- The agent's actual resolver(s) ---
+echo "--- agent /etc/resolv.conf nameservers ---"
+${KUBECTL} exec "${POD}" -n "${NS}" -c agent -- \
+  sh -c 'grep "^nameserver" /etc/resolv.conf 2>/dev/null | sed "s/^/    /"' 2>&1 \
+  || echo "  (exec failed)"
+
+# --- DNS-isolation probe: FQDN (needs DNS) vs ClusterIP (no DNS), at the agent's
+#     real MCP port ---
+MCP_URL=$(${KUBECTL} get pod "${POD}" -n "${NS}" \
+  -o jsonpath='{range .spec.containers[?(@.name=="agent")].env[?(@.name=="MCP_URL")].value}{@}{end}' 2>/dev/null)
+[ -z "${MCP_URL}" ] && MCP_URL="http://weather-tool-mcp.${NS}.svc.cluster.local:8000/mcp"
+MCP_PORT=$(printf '%s' "${MCP_URL}" | sed -E 's#^https?://[^/]*:([0-9]+).*#\1#'); echo "${MCP_PORT}" | grep -qE '^[0-9]+$' || MCP_PORT=80
+MCP_SVC_IP=$(${KUBECTL} get svc weather-tool-mcp -n "${NS}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+echo "--- MCP reachability (MCP_URL=${MCP_URL}, ClusterIP=${MCP_SVC_IP:-<none>}, port=${MCP_PORT}) ---"
+
+PYPROBE='
+import sys, http.client, json
+ns, port, svc_ip = sys.argv[1], int(sys.argv[2]), (sys.argv[3] if len(sys.argv) > 3 else "")
+fqdn = "weather-tool-mcp.%s.svc.cluster.local" % ns
+body = json.dumps({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"diag","version":"0"}}})
+def probe(label, host, host_hdr=None):
+    h = {"Content-Type":"application/json","Accept":"application/json, text/event-stream"}
+    if host_hdr: h["Host"] = host_hdr
+    try:
+        c = http.client.HTTPConnection(host, port, timeout=12)
+        c.request("POST", "/mcp", body, h)
+        r = c.getresponse()
+        print("    %-26s REACHED (status=%s, server responded)" % (label, r.status))
+    except Exception as e:
+        print("    %-26s FAIL: %s: %s" % (label, type(e).__name__, e))
+probe("by FQDN (needs DNS)", fqdn)
+if svc_ip:
+    probe("by ClusterIP (no DNS)", svc_ip, host_hdr=fqdn)
+print("    interpretation: FQDN-fail + ClusterIP-reached => DNS is the blocker;")
+print("                    both reached => path healthy; both fail => proxy/connection layer.")
+'
+${KUBECTL} exec "${POD}" -n "${NS}" -c agent -- \
+  python3 -c "${PYPROBE}" "${NS}" "${MCP_PORT}" "${MCP_SVC_IP}" 2>&1 \
+  || echo "  (MCP probe exec failed)"
+
+# --- AuthBridge proxy logs: did it see/forward the MCP call, or error? ---
+AB=$(echo "${CONTS}" | tr ' ' '\n' | grep -E 'authbridge' | head -1)
+if [ -n "${AB}" ]; then
+  echo "--- authbridge proxy logs (${AB}, weather-tool/mcp/error lines, tail) ---"
+  ${KUBECTL} logs "${POD}" -n "${NS}" -c "${AB}" --tail=80 2>&1 \
+    | grep -iE "weather-tool|/mcp|passthrough|outbound|error|denied|503|502" | tail -25 \
+    || echo "  (no matching authbridge log lines)"
+fi
+
+echo "=================================================================="
+exit 0


### PR DESCRIPTION
## Purpose

Validate the **in-cluster egress capture fix** ([kagenti-extensions#498](https://github.com/kagenti/kagenti-extensions/pull/498), merged) end-to-end in the HyperShift e2e — and stop masking the bug it fixes.

## Changes

1. **Bump AuthBridge sidecar images `v0.6.0-alpha.7 → v0.6.0-alpha.8`** (`charts/kagenti/values.yaml`) — all four pins (`authbridge`, `authbridge-envoy`, `authbridge-lite`, `proxy-init`). `v0.6.0-alpha.8` is the first kagenti-extensions tag containing #498: `proxy-init` now captures **in-cluster TCP** for the egress pipeline (running token-exchange/OBO and policy on agent→tool hops) while leaving cluster DNS direct.
2. **Revert #1905** ("exclude MCP port from authbridge iptables intercept"). #1905 set `kagenti.io/inject: disabled` on the weather-service, which removed AuthBridge from the agent→tool path entirely — masking the bug rather than fixing it. With #498 the in-cluster/MCP intercept is handled correctly, so injection is re-enabled (`kagenti.io/type: agent` retained) to actually exercise the egress pipeline.

## Background

#1905's own alternative (#1909) flagged that #1905 "makes the E2E test green by removing the component under test." The real fix landed in #498 and was validated on a Kind + Istio-ambient cluster:

- proxy-bypassing in-cluster TCP is now **captured** by AuthBridge (was invisible before);
- cluster **DNS still resolves**;
- the re-originated hop still rides **ztunnel HBONE/mTLS** (`dst.addr=…:15008`, agent SPIFFE identity) — AuthBridge does L7, ztunnel does transport, composed not conflicting.

This PR moves the platform to those images and re-enables the path so the **HyperShift e2e** confirms the same end-to-end on OCP.

## Testing

Run the HyperShift e2e via `/run-e2e` (deploys this PR's chart → alpha.8 proxy-init + AuthBridge injected on the weather-service). Depends on kagenti-extensions `v0.6.0-alpha.8` images (published).

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
