### PR TITLE
Fix: guard empty ns_flag array in OpenShift installer for Bash 3.2

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -764,10 +764,12 @@ _adopt_for_helm() {
   local kind="$1" name="$2" ns="${3:-}"
   local ns_flag=()
   if [ -n "$ns" ]; then ns_flag=(-n "$ns"); fi
-  if $KUBECTL get "$kind" "$name" "${ns_flag[@]}" &>/dev/null; then
-    $KUBECTL label "$kind" "$name" "${ns_flag[@]}" \
+  # Use the ${arr[@]+...} guard so expanding an empty array does not trip
+  # `set -u` on Bash < 4.4 (e.g. macOS system Bash 3.2). See issue #1822.
+  if $KUBECTL get "$kind" "$name" "${ns_flag[@]+"${ns_flag[@]}"}" &>/dev/null; then
+    $KUBECTL label "$kind" "$name" "${ns_flag[@]+"${ns_flag[@]}"}" \
       app.kubernetes.io/managed-by=Helm --overwrite || true
-    $KUBECTL annotate "$kind" "$name" "${ns_flag[@]}" \
+    $KUBECTL annotate "$kind" "$name" "${ns_flag[@]+"${ns_flag[@]}"}" \
       meta.helm.sh/release-name=kagenti-deps \
       meta.helm.sh/release-namespace=kagenti-system --overwrite || true
   fi

--- a/scripts/ocp/tests/test_adopt_for_helm.sh
+++ b/scripts/ocp/tests/test_adopt_for_helm.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/kagenti/kagenti/issues/1822
+#
+# `_adopt_for_helm` in setup-kagenti.sh builds an optional `-n <ns>` flag as a
+# bash array. When the helper is called for cluster-scoped resources (no
+# namespace), that array stays empty. Under `set -u` (nounset), Bash < 4.4 —
+# notably macOS's system Bash 3.2 — aborts with
+#
+#     setup-kagenti.sh: line NNN: ns_flag[@]: unbound variable
+#
+# when expanding "${ns_flag[@]}". The OpenShift installer enables `set -u`
+# (`set -euo pipefail`), so the install dies right after creating the
+# istio-mesh-root-ca certificate.
+#
+# This test extracts the *real* function from setup-kagenti.sh and exercises
+# both the cluster-scoped (empty namespace) and namespaced paths under
+# `set -u`. Reproduce the original failure under old Bash:
+#
+#     docker run --rm -v "$PWD:/work" -w /work bash:3.2 \
+#       scripts/ocp/tests/test_adopt_for_helm.sh
+#
+# and guard against regressions under modern Bash:
+#
+#     bash scripts/ocp/tests/test_adopt_for_helm.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/../setup-kagenti.sh"
+
+# Extract just the _adopt_for_helm function definition (no need to run the
+# whole installer, which executes top-level install steps on source).
+fn="$(sed -n '/^_adopt_for_helm() {/,/^}/p' "$TARGET")"
+if [ -z "$fn" ]; then
+  echo "FAIL: could not extract _adopt_for_helm from $TARGET"
+  exit 2
+fi
+eval "$fn"
+
+# Stub kubectl: succeed on every call so all three expansion sites
+# (get / label / annotate) inside the function are exercised.
+_stub_kubectl() { return 0; }
+KUBECTL=_stub_kubectl
+
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+failures=0
+
+run_case() {
+  local desc="$1"; shift
+  if ( set -u; _adopt_for_helm "$@" ) 2>"$err_file"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc errored:"
+    sed 's/^/    /' "$err_file"
+    failures=$((failures + 1))
+  fi
+}
+
+# Case 1: cluster-scoped resource, no namespace — the issue-1822 trigger.
+run_case "cluster-scoped call (empty namespace)" clusterissuer istio-mesh-root-selfsigned
+
+# Case 2: namespaced resource — must keep working too.
+run_case "namespaced call" certificate istio-mesh-root-ca cert-manager
+
+if [ "$failures" -eq 0 ]; then
+  echo "OK: all _adopt_for_helm cases passed"
+  exit 0
+fi
+echo "FAILED: $failures case(s)"
+exit 1


### PR DESCRIPTION
## Problem

Fixes #1822. The OpenShift installer aborts early on macOS:

```
certificate.cert-manager.io/istio-mesh-root-ca created
./scripts/ocp/setup-kagenti.sh: line 766: ns_flag[@]: unbound variable
```

## Root cause

`_adopt_for_helm` builds an optional `-n <ns>` flag as a Bash **array**. For
cluster-scoped resources (e.g. `ClusterIssuer`, called with no namespace), the
array stays empty, and expanding `"${ns_flag[@]}"` under `set -u` (`set -euo
pipefail`) raises **`unbound variable`** on **Bash < 4.4** — notably macOS's
system Bash **3.2**. The install dies right after the `istio-mesh-root-ca`
certificate. Modern Bash (4.4+) tolerates this, which is why it wasn't caught.

## Fix

Guard the three expansions with the portable `${ns_flag[@]+"${ns_flag[@]}"}`
idiom — the **same idiom already used** by the other flag arrays in this script
(`KAGENTI_UI_FLAGS`, `OPERATOR_IMAGE_FLAGS`, `BUILD_FLAGS`). This just makes
`_adopt_for_helm` consistent. The sibling empty-array sites were already safe,
so there is no later failure for the reporter to hit.

## Verification (real RED→GREEN via Docker `bash:3.2`)

| | Bash 3.2 | Bash 5.2 |
|---|---|---|
| Before | ❌ `ns_flag[@]: unbound variable` | ✅ pass |
| After  | ✅ pass | ✅ pass |

- Full installer parses (`bash -n`) on both Bash 3.2 and 5.2.
- New regression test `scripts/ocp/tests/test_adopt_for_helm.sh` extracts the
  real function and exercises the empty-namespace path. Reproduce / guard:

  ```sh
  docker run --rm -v "$PWD:/work" -w /work bash:3.2 scripts/ocp/tests/test_adopt_for_helm.sh  # repro old Bash
  bash scripts/ocp/tests/test_adopt_for_helm.sh                                               # modern Bash
  ```

Assisted-By: Claude Code
