### PR TITLE
Feat: Bump OpenShell to v0.0.56-rc.3 for per-user provider ownership

### DIFF
--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -395,11 +395,11 @@ openshell:
   enabled: false
   gateway:
     image: ghcr.io/kagenti/openshell/gateway
-    tag: v0.0.56
+    tag: v0.0.56-rc.3
     pullPolicy: IfNotPresent
   computeDriver:
     image: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: v0.1.0-rc.4
+    tag: v0.1.0-rc.7
     pullPolicy: IfNotPresent
   credentialsDriver:
     image: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -387,21 +387,3 @@ mlflowOAuthSecret:
 # ------------------------------------------------------------------
 spire:
   enabled: true
-
-# ------------------------------------------------------------------
-#  OpenShell Configuration
-# ------------------------------------------------------------------
-openshell:
-  enabled: false
-  gateway:
-    image: ghcr.io/kagenti/openshell/gateway
-    tag: v0.0.56-rc.3
-    pullPolicy: IfNotPresent
-  computeDriver:
-    image: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: v0.1.0-rc.7
-    pullPolicy: IfNotPresent
-  credentialsDriver:
-    image: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver
-    tag: main-d7d8306
-    pullPolicy: IfNotPresent

--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -5,11 +5,11 @@ tenant: ""
 images:
   gateway:
     repository: ghcr.io/kagenti/openshell/gateway
-    tag: v0.0.56-rc.2
+    tag: v0.0.56-rc.3
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
-    tag: v0.1.0-rc.6
+    tag: v0.1.0-rc.7
     pullPolicy: IfNotPresent
   credentialsDriver:
     repository: ghcr.io/kagenti/openshell-credentials-keycloak/credentials-driver
@@ -31,7 +31,7 @@ keycloakClusterIP: ""
 # Built from kagenti/OpenShell@mvp-v2 as a multi-arch image (linux/amd64 + linux/arm64).
 supervisorImage:
   repository: ghcr.io/kagenti/openshell/supervisor
-  tag: v0.0.56-rc.2
+  tag: v0.0.56-rc.3
   binaryPath: /openshell-sandbox
 
 # -- Image pull policy for sandbox pods (init + agent containers).

--- a/docs/sandbox-guide.md
+++ b/docs/sandbox-guide.md
@@ -277,12 +277,79 @@ Keycloak.
 
 ### Requirements
 
-- Gateway image `v0.0.56-rc.2` or later
+- Gateway image `v0.0.56-rc.2` or later (provider ownership requires `v0.0.56-rc.3`+)
 - OIDC enabled on the gateway (`oidc.enabled: true` in Helm values — the default)
 - Keycloak `sub` claim must be a UUID (the default for Keycloak realms)
 
 When OIDC is disabled (local development without authentication), ownership is
 skipped and all users share all sandboxes (backward-compatible behavior).
+
+## Per-User Provider Ownership
+
+When OIDC is enabled, providers are also scoped by ownership — the same pattern
+as sandboxes. Each user can create providers with any name, and those providers
+are isolated from other users. Admin-created providers remain shared and
+accessible to everyone.
+
+### Provider types
+
+| Provider type | Owner label | Visible to | Created by |
+|---------------|-------------|------------|------------|
+| Shared (team) | none | All users | Admin |
+| User-owned | `openshell.ai/owner=<sub>` | Owner + admin | User |
+
+### Resolution order (who wins)
+
+When a sandbox references a provider by name, the gateway resolves it in this
+order:
+
+1. **User's own provider** — if the caller owns a provider with that name, it wins
+2. **Shared provider** — fallback to an admin-created provider with the same name
+
+This means if an admin created a shared `openai` provider and Bob also creates
+his own `openai` provider, Bob's sandbox will always bind to Bob's provider.
+The shared one is only used when the user doesn't have their own with that name.
+
+### Example: per-user credentials on a shared gateway
+
+```bash
+# Bob creates his own GitHub provider with his personal PAT
+export GH_TOKEN="ghp_bob_xxx"
+openshell provider create --name gh --type custom \
+  --credential GH_TOKEN \
+  --config BASE_URL=https://api.github.com
+
+# Alice creates her own — no conflict, scoped by owner
+export GH_TOKEN="ghp_alice_yyy"
+openshell provider create --name gh --type custom \
+  --credential GH_TOKEN \
+  --config BASE_URL=https://api.github.com
+
+# Bob's sandbox uses Bob's key automatically
+openshell sandbox create --provider gh -- bash
+
+# Alice's sandbox uses Alice's key — no cross-contamination
+openshell sandbox create --provider gh -- bash
+
+# Neither user can see or bind to the other's provider
+openshell provider list   # Shows only own + shared providers
+```
+
+### Cross-user isolation guarantees
+
+- Users see only their own providers plus shared (admin-created) providers
+- A sandbox cannot bind to another user's provider — the gateway rejects it
+- Provider name uniqueness is scoped to `(owner, name)` — alice and bob can
+  both have a provider named `gh`
+- Admin users bypass ownership and can list/manage all providers
+
+### Requirements
+
+- Gateway image `v0.0.56-rc.3` or later
+- OIDC enabled on the gateway (`oidc.enabled: true` — the default)
+
+When OIDC is disabled, provider ownership is skipped and all providers are
+shared (backward-compatible behavior).
 
 ## Network Egress Policies
 

--- a/scripts/openshell/deploy-tenant.sh
+++ b/scripts/openshell/deploy-tenant.sh
@@ -190,6 +190,7 @@ if [[ -n "$IMAGE_TAG" ]]; then
   EXTRA_HELM_SETS+=("images.gateway.tag=$IMAGE_TAG")
   EXTRA_HELM_SETS+=("images.computeDriver.tag=$IMAGE_TAG")
   EXTRA_HELM_SETS+=("images.credentialsDriver.tag=$IMAGE_TAG")
+  EXTRA_HELM_SETS+=("supervisorImage.tag=$IMAGE_TAG")
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Bump gateway + supervisor images to `v0.0.56-rc.3` (kagenti/OpenShell#20 — scoped provider name uniqueness)
- Bump compute driver to `v0.1.0-rc.7`
- Fix `deploy-tenant.sh` to also override `supervisorImage.tag` when `--image-tag` is passed

## What's in v0.0.56-rc.3

Per-user provider ownership via scoped name uniqueness (Option B — name prefixing). Two users can independently create providers with the same visible name (`openai`, `gh`, etc.) without conflict. Resolution order: user-owned → shared fallback. Admin bypass preserved. Backward compatible with existing shared providers.

See kagenti/OpenShell#20 for full details.

Closes #1995

## Test plan

- [ ] Deploy to Kind cluster with `deploy-tenant.sh team1`
- [ ] Verify gateway starts with new image
- [ ] Create provider as user A, create same-named provider as user B — verify isolation
- [ ] Verify shared (admin-created) providers still accessible to both users

Assisted-By: Claude Code