### PR TITLE
Feat: Per-agent TLS bridge toggle (UI/backend)

### DIFF
--- a/docs/authbridge/tls-bridge.md
+++ b/docs/authbridge/tls-bridge.md
@@ -1,0 +1,54 @@
+# AuthBridge TLS Bridge
+
+The **TLS bridge** lets AuthBridge decrypt an agent's *outbound* HTTPS so the
+AuthBridge pipeline (parsers, guardrails, audit) can inspect request and
+response payloads instead of seeing an opaque `CONNECT host:443` tunnel.
+
+It works by terminating the agent's outbound TLS at the proxy-sidecar's Go
+forward proxy using a per-agent CA, running the decrypted request through the
+normal outbound pipeline, then re-originating a verified TLS connection to the
+real upstream.
+
+> **This is L7 interception and is OFF by default.** It is opt-in per agent and
+> must be deliberately enabled by a platform operator.
+
+## Requirements
+
+- `authBridgeMode` **proxy-sidecar** or **lite** (the bridge lives in the Go
+  forward proxy; it is rejected with `envoy-sidecar`).
+- **cert-manager** installed (the operator provisions a per-agent CA
+  `Certificate`/`Issuer`; cert-manager issues the Secret). cert-manager is
+  already installed on standard Kind and OpenShift kagenti installs.
+- A **kagenti-operator** build that supports the TLS bridge (the feature is
+  inert on operator versions that predate it).
+
+It is decoupled from SPIRE/mTLS — the bridge CA comes from cert-manager, not an
+SVID.
+
+## Enabling it
+
+There is **no cluster feature gate and no separate UI flag** — the TLS bridge is
+a plain per-agent option, exactly like `mtlsMode`. The single control is the
+per-agent field, which defaults to disabled:
+
+| Control | Where | Effect |
+|---------|-------|--------|
+| `spec.tlsBridgeMode: enabled` | per-agent — set by the UI toggle, or directly on the AgentRuntime CR | Opts that one agent into the bridge. Default `disabled`. |
+
+When importing an agent in the UI, check **"Decrypt outbound TLS for inspection
+(TLS bridge)"** (shown in proxy-sidecar mode, alongside the mTLS control). It
+maps to `AgentRuntime.spec.tlsBridgeMode=enabled`; the operator then provisions
+the per-agent CA (via cert-manager) and the sidecar starts bridging. Nothing is
+decrypted for agents that don't opt in.
+
+## How to tell it is active
+
+On the agent's detail page, the **AuthBridge** tab shows **TLS bridge: Active**
+when the sidecar reports the bridge is on. The agent's outbound HTTPS requests
+then appear — decrypted — in the AuthBridge session API (`:9094`).
+
+## Security note
+
+When the bridge is on, the agent's outbound TLS is decrypted and its payloads
+(including any `Authorization` headers) flow through the AuthBridge pipeline and
+session store. Enable it only where that inspection is intended.

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3950,6 +3950,22 @@ class FinalizeShipwrightBuildRequest(BaseModel):
         """
         return self
 
+    @model_validator(mode="after")
+    def _check_tlsbridge_compatible_with_mode(self) -> "FinalizeShipwrightBuildRequest":
+        """Mirror of CreateAgentRequest._check_tlsbridge_compatible_with_mode at
+        the Shipwright finalize boundary, so a direct finalize caller (or a combo
+        inherited from the BuildRun's stored config) with tlsBridgeEnabled +
+        envoy-sidecar/waypoint gets the same fast 422 instead of a later webhook
+        denial. Same allowlist as the operator (empty → defaults to proxy-sidecar).
+        """
+        allowed = (None, "", "proxy-sidecar", "lite")
+        if self.tlsBridgeEnabled and self.authBridgeMode not in allowed:
+            raise ValueError(
+                "tlsBridgeEnabled requires authBridgeMode proxy-sidecar or lite "
+                f"(the TLS bridge lives in the Go forward proxy); got {self.authBridgeMode!r}"
+            )
+        return self
+
 
 @router.post(
     "/{namespace}/{name}/finalize-shipwright-build",

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -289,6 +289,16 @@ class CreateAgentRequest(BaseModel):
     # webhook denial after the manifest is built.
     mtlsMode: Optional[Literal["disabled", "permissive", "strict"]] = None
 
+    # Per-workload TLS bridge: decrypt the agent's outbound HTTPS so AuthBridge's
+    # pipeline can inspect it. Maps to AgentRuntime.Spec.TLSBridgeMode (enabled
+    # when True; left unset → operator default "disabled"). Like mtlsMode, it's a
+    # plain per-agent field — no operator feature gate and no UI feature flag; the
+    # import-form checkbox shows whenever AuthBridge is enabled. The bridge lives
+    # in the Go forward proxy, so it requires proxy-sidecar/lite mode — the
+    # validator below mirrors the operator webhook's reject of envoy-sidecar. It
+    # also needs cert-manager and an operator build that supports the bridge.
+    tlsBridgeEnabled: bool = False
+
     # Port exclusion annotations
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
@@ -347,6 +357,24 @@ class CreateAgentRequest(BaseModel):
         API call) submitting that combination is valid and the
         operator turns SPIRE on for them.
         """
+        return self
+
+    @model_validator(mode="after")
+    def _check_tlsbridge_compatible_with_mode(self) -> "CreateAgentRequest":
+        """Reject tlsBridgeEnabled with an authBridgeMode that can't host the
+        bridge, mirroring the operator's checkTLSBridgeCompatibleWithMode
+        (agentruntime_webhook.go). The TLS bridge lives in the Go forward proxy,
+        which only exists in proxy-sidecar / lite. Uses the same ALLOWLIST as the
+        operator (empty → defaults to proxy-sidecar) rather than a denylist, so a
+        future authBridgeMode can't slip past this fast-422 and only get rejected
+        at the webhook.
+        """
+        allowed = (None, "", "proxy-sidecar", "lite")
+        if self.tlsBridgeEnabled and self.authBridgeMode not in allowed:
+            raise ValueError(
+                "tlsBridgeEnabled requires authBridgeMode proxy-sidecar or lite "
+                f"(the TLS bridge lives in the Go forward proxy); got {self.authBridgeMode!r}"
+            )
         return self
 
 
@@ -2505,6 +2533,8 @@ def _build_agent_shipwright_build_manifest(
         resource_config["defaultOutboundPolicy"] = request.defaultOutboundPolicy
     if request.mtlsMode:
         resource_config["mtlsMode"] = request.mtlsMode
+    if request.tlsBridgeEnabled:
+        resource_config["tlsBridgeEnabled"] = True
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
     # Add env vars if present
@@ -2928,6 +2958,7 @@ def _build_agentruntime_manifest(
     agent_type: str = RESOURCE_TYPE_AGENT,
     auth_bridge_mode: Optional[str] = None,
     mtls_mode: Optional[str] = None,
+    tls_bridge_enabled: bool = False,
 ) -> dict:
     """Build an AgentRuntime CR manifest for the given workload."""
     kind_map = {
@@ -2946,6 +2977,10 @@ def _build_agentruntime_manifest(
         spec["authBridgeMode"] = auth_bridge_mode
     if mtls_mode:
         spec["mtlsMode"] = mtls_mode
+    # Only set when enabled; unset → operator default "disabled" (also keeps the
+    # CRD field off envoy-sidecar agents so the validating webhook doesn't reject).
+    if tls_bridge_enabled:
+        spec["tlsBridgeMode"] = "enabled"
     return {
         "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
         "kind": "AgentRuntime",
@@ -2969,10 +3004,17 @@ def _ensure_agentruntime(
     agent_type: str = RESOURCE_TYPE_AGENT,
     auth_bridge_mode: Optional[str] = None,
     mtls_mode: Optional[str] = None,
+    tls_bridge_enabled: bool = False,
 ) -> None:
     """Create an AgentRuntime CR for the workload. Skip if it already exists."""
     manifest = _build_agentruntime_manifest(
-        name, namespace, workload_type, agent_type, auth_bridge_mode, mtls_mode
+        name,
+        namespace,
+        workload_type,
+        agent_type,
+        auth_bridge_mode,
+        mtls_mode,
+        tls_bridge_enabled,
     )
     try:
         kube.create_custom_resource(
@@ -3754,6 +3796,7 @@ async def create_agent(
                     workload_type=request.workloadType,
                     auth_bridge_mode=request.authBridgeMode,
                     mtls_mode=request.mtlsMode,
+                    tls_bridge_enabled=request.tlsBridgeEnabled,
                 )
 
             message = f"Agent '{request.name}' deployed as {request.workloadType} successfully."
@@ -3884,6 +3927,9 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     # the user picked at form-submit time (stashed on the BuildRun via
     # kagenti.io/agent-config annotation).
     mtlsMode: Optional[Literal["disabled", "permissive", "strict"]] = None
+    # Mirrors CreateAgentRequest.tlsBridgeEnabled. None → inherit the value
+    # stashed on the BuildRun annotation at form-submit time.
+    tlsBridgeEnabled: Optional[bool] = None
     outboundRoutes: Optional[List[OutboundRoute]] = None
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
@@ -4190,6 +4236,14 @@ async def finalize_shipwright_build(
             request.mtlsMode if request.mtlsMode is not None else stored_config.get("mtlsMode")
         )
 
+        # Per-workload TLS bridge (bool; None on the finalize request → inherit
+        # the stored value). Same store-then-read-back flow as mtlsMode.
+        final_tls_bridge_enabled = (
+            request.tlsBridgeEnabled
+            if request.tlsBridgeEnabled is not None
+            else bool(stored_config.get("tlsBridgeEnabled"))
+        )
+
         # Persistent storage
         final_persistent_storage = request.persistentStorage
         if final_persistent_storage is None and stored_config.get("persistentStorage"):
@@ -4214,6 +4268,7 @@ async def finalize_shipwright_build(
             spireEnabled=final_spire_enabled,
             authBridgeMode=final_auth_bridge_mode,
             mtlsMode=final_mtls_mode,
+            tlsBridgeEnabled=final_tls_bridge_enabled,
             outboundRoutes=final_outbound_routes,
             outboundPortsExclude=final_outbound_ports_exclude,
             inboundPortsExclude=final_inbound_ports_exclude,
@@ -4377,6 +4432,7 @@ async def finalize_shipwright_build(
                 workload_type=final_workload_type,
                 auth_bridge_mode=final_auth_bridge_mode,
                 mtls_mode=final_mtls_mode,
+                tls_bridge_enabled=final_tls_bridge_enabled,
             )
 
         message = f"Agent '{name}' deployed as {final_workload_type} with image '{output_image}'."

--- a/kagenti/backend/tests/test_agentruntime_manifest.py
+++ b/kagenti/backend/tests/test_agentruntime_manifest.py
@@ -174,3 +174,47 @@ def test_create_agent_request_unknown_mtls_value_rejected():
 
     with pytest.raises(ValidationError):
         CreateAgentRequest(name="a", namespace="ns", mtlsMode="loose")
+
+
+# --- TLS bridge ---
+
+
+def test_manifest_omits_tls_bridge_mode_when_unset():
+    """Default (tls_bridge_enabled=False) → no spec.tlsBridgeMode key, so the
+    operator default 'disabled' applies and envoy agents aren't webhook-rejected."""
+    from app.routers.agents import _build_agentruntime_manifest
+
+    m = _build_agentruntime_manifest("a", "ns", "deployment")
+    assert "tlsBridgeMode" not in m["spec"]
+
+
+def test_manifest_sets_tls_bridge_mode_when_enabled():
+    """tls_bridge_enabled=True → spec.tlsBridgeMode == 'enabled'."""
+    from app.routers.agents import _build_agentruntime_manifest
+
+    m = _build_agentruntime_manifest("a", "ns", "deployment", tls_bridge_enabled=True)
+    assert m["spec"]["tlsBridgeMode"] == "enabled"
+
+
+def test_create_agent_request_rejects_tls_bridge_with_envoy():
+    """The TLS bridge lives in the Go forward proxy, so enabling it with
+    envoy-sidecar is rejected at the API layer (mirrors the operator webhook)."""
+    from app.routers.agents import CreateAgentRequest
+
+    with pytest.raises(ValidationError):
+        CreateAgentRequest(
+            name="a", namespace="ns", authBridgeMode="envoy-sidecar", tlsBridgeEnabled=True
+        )
+
+
+def test_create_agent_request_allows_tls_bridge_with_proxy_sidecar():
+    """proxy-sidecar (and the empty default) accept tlsBridgeEnabled."""
+    from app.routers.agents import CreateAgentRequest
+
+    r = CreateAgentRequest(
+        name="a", namespace="ns", authBridgeMode="proxy-sidecar", tlsBridgeEnabled=True
+    )
+    assert r.tlsBridgeEnabled is True
+    # empty mode defaults to proxy-sidecar and is allowed
+    r2 = CreateAgentRequest(name="a", namespace="ns", tlsBridgeEnabled=True)
+    assert r2.tlsBridgeEnabled is True

--- a/kagenti/backend/tests/test_agentruntime_manifest.py
+++ b/kagenti/backend/tests/test_agentruntime_manifest.py
@@ -218,3 +218,19 @@ def test_create_agent_request_allows_tls_bridge_with_proxy_sidecar():
     # empty mode defaults to proxy-sidecar and is allowed
     r2 = CreateAgentRequest(name="a", namespace="ns", tlsBridgeEnabled=True)
     assert r2.tlsBridgeEnabled is True
+
+
+def test_finalize_request_rejects_tls_bridge_with_envoy():
+    """The same fast-422 must hold on the Shipwright finalize boundary, so a
+    direct finalize call (or a stored-config combo) can't bypass it."""
+    from app.routers.agents import FinalizeShipwrightBuildRequest
+
+    with pytest.raises(ValidationError):
+        FinalizeShipwrightBuildRequest(authBridgeMode="envoy-sidecar", tlsBridgeEnabled=True)
+
+
+def test_finalize_request_allows_tls_bridge_with_proxy_sidecar():
+    from app.routers.agents import FinalizeShipwrightBuildRequest
+
+    r = FinalizeShipwrightBuildRequest(authBridgeMode="proxy-sidecar", tlsBridgeEnabled=True)
+    assert r.tlsBridgeEnabled is True

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -1084,6 +1084,14 @@ export const AgentDetailPage: React.FC = () => {
                                 <Label isCompact color="blue">{authBridgeConfig.mode}</Label>
                               </DescriptionListDescription>
                             </DescriptionListGroup>
+                            {authBridgeConfig.tls_bridge?.mode === 'enabled' && (
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>TLS bridge</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  <Label isCompact color="green">Active</Label>
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                            )}
                             {(authBridgeConfig.pipeline?.inbound?.plugins?.length ?? 0) > 0 && (
                               <DescriptionListGroup>
                                 <DescriptionListTerm>Inbound Plugins</DescriptionListTerm>

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -241,6 +241,12 @@ export const ImportAgentPage: React.FC = () => {
   useEffect(() => {
     if (!spireEnabled) setMtlsMode('disabled');
   }, [spireEnabled]);
+  // TLS bridge: decrypt the agent's outbound HTTPS so AuthBridge can inspect it.
+  // Default off. Only valid in proxy-sidecar mode, so force off in Envoy mode.
+  const [tlsBridgeEnabled, setTlsBridgeEnabled] = useState(false);
+  useEffect(() => {
+    if (useEnvoyMode) setTlsBridgeEnabled(false);
+  }, [useEnvoyMode]);
   const [showOutboundRouting, setShowOutboundRouting] = useState(false);
 
   // Validation state
@@ -547,6 +553,8 @@ export const ImportAgentPage: React.FC = () => {
         // and envoy-sidecar support the full disabled/permissive/strict
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
+        // Only when AuthBridge is on and not in Envoy mode (proxy-sidecar only).
+        tlsBridgeEnabled: authBridgeEnabled && !useEnvoyMode && tlsBridgeEnabled,
         outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
           ? outboundRoutes.filter(isCommittedRoute).map(serializeRoute)
           : undefined,
@@ -589,6 +597,8 @@ export const ImportAgentPage: React.FC = () => {
         // and envoy-sidecar support the full disabled/permissive/strict
         // matrix end-to-end (kagenti-operator#381 + extensions#441).
         mtlsMode: authBridgeEnabled ? mtlsMode : undefined,
+        // Only when AuthBridge is on and not in Envoy mode (proxy-sidecar only).
+        tlsBridgeEnabled: authBridgeEnabled && !useEnvoyMode && tlsBridgeEnabled,
         outboundRoutes: authBridgeEnabled && outboundRoutes.some(isCommittedRoute)
           ? outboundRoutes.filter(isCommittedRoute).map(serializeRoute)
           : undefined,
@@ -1167,10 +1177,27 @@ export const ImportAgentPage: React.FC = () => {
                 <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
                   <Checkbox
                     id="useEnvoyMode"
-                    label="Use Envoy + iptables interception"
+                    label="Use Envoy sidecar interception"
                     isChecked={useEnvoyMode}
                     onChange={(_e, checked) => setUseEnvoyMode(checked)}
-                    description="Enforce transparent outbound interception (vs HTTP_PROXY env vars)"
+                    description="Run the Envoy data plane (ext_proc) instead of the default Go forward/reverse proxy sidecar"
+                  />
+                </FormGroup>
+              )}
+
+              {authBridgeEnabled && (
+                <FormGroup fieldId="tlsBridgeEnabled" style={{ marginLeft: '24px' }}>
+                  <Checkbox
+                    id="tlsBridgeEnabled"
+                    label="Decrypt outbound TLS for inspection (TLS bridge)"
+                    isChecked={tlsBridgeEnabled && !useEnvoyMode}
+                    isDisabled={useEnvoyMode}
+                    onChange={(_e, checked) => setTlsBridgeEnabled(checked)}
+                    description={
+                      useEnvoyMode
+                        ? 'Requires proxy-sidecar mode (uncheck Envoy interception to enable)'
+                        : 'Terminate the agent’s outbound HTTPS at the sidecar so the AuthBridge pipeline can see request payloads. Requires cert-manager.'
+                    }
                   />
                 </FormGroup>
               )}

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -245,6 +245,9 @@ export const agentService = {
     // Per-workload mTLS posture (maps to AgentRuntime.Spec.MTLSMode).
     // Backend rejects mtlsMode != 'disabled' when authBridgeMode === 'envoy-sidecar'.
     mtlsMode?: 'disabled' | 'permissive' | 'strict';
+    // Per-workload TLS bridge (maps to AgentRuntime.Spec.TLSBridgeMode=enabled).
+    // Requires proxy-sidecar/lite; backend rejects it with envoy-sidecar.
+    tlsBridgeEnabled?: boolean;
     outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
     outboundPortsExclude?: string;
     inboundPortsExclude?: string;
@@ -459,6 +462,7 @@ export const shipwrightService = {
       authBridgeEnabled?: boolean;
       authBridgeMode?: 'proxy-sidecar' | 'envoy-sidecar' | 'lite' | 'waypoint';
       mtlsMode?: 'disabled' | 'permissive' | 'strict';
+      tlsBridgeEnabled?: boolean;
       outboundRoutes?: Array<{ host: string; target_audience: string; token_scopes: string }>;
       outboundPortsExclude?: string;
       inboundPortsExclude?: string;

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -483,6 +483,8 @@ export interface AuthBridgeConfig {
   AuthBridge: boolean | null;
   mode: AuthBridgeMode | null;
   pipeline: PipelineConfig | null;
+  /** Outbound TLS bridge config from the sidecar; present + mode "enabled" when active. */
+  tls_bridge?: { mode?: string } | null;
 }
 
 export interface PipelineConfig {


### PR DESCRIPTION
## Summary

Surfaces the AuthBridge **TLS bridge** as a per-agent option so an agent's outbound HTTPS can be decrypted and inspected by the AuthBridge pipeline. Modeled exactly on the existing `mtlsMode` / `authBridgeMode` controls: a CRD-backed field plus an always-visible toggle in the import form — **no operator feature gate and no UI feature flag**. Off by default via `spec.tlsBridgeMode=disabled`.

Companion to **kagenti-operator #448** (CRD field + reconciler + sidecar mount) and **kagenti-extensions #522/#523** (the bridge engine).

## What's included

**Backend**
- `tlsBridgeEnabled` on `CreateAgentRequest` and `FinalizeShipwrightBuildRequest`, with a validator that rejects it under `envoy-sidecar`/`waypoint` (mirrors the operator's validating webhook — fast 422 instead of a webhook denial).
- `_build_agentruntime_manifest()` writes `spec.tlsBridgeMode=enabled` only when opted in; threaded through both the direct-deploy and build-from-source (store → finalize) paths.

**UI**
- A **"Decrypt outbound TLS for inspection (TLS bridge)"** checkbox in the agent import form, next to the mTLS control — shown whenever AuthBridge is enabled, disabled + reset under Envoy mode (the bridge lives in the Go forward proxy, so it needs proxy-sidecar/lite).
- **"TLS bridge: Active"** on the agent's AuthBridge detail tab when the sidecar reports the bridge is on.
- Also corrected the Envoy toggle copy — "Use Envoy sidecar interception" (proxy-sidecar uses iptables too, so the old "Envoy + iptables" label was misleading).

**Docs**: `docs/authbridge/tls-bridge.md`.

## Design note (no feature flag — deliberate)

`mtlsMode` and `authBridgeMode` are plain per-agent AuthBridge options with no operator feature gate and no `kagenti_feature_flag_*`. The TLS bridge follows the same pattern for consistency. This is a conscious departure from the "new UI features behind a feature flag" guidance, matching the established AuthBridge-options precedent. The per-agent field defaulting `disabled` keeps the feature off by default.

## Requirements / release ordering

The toggle only functions once the platform ships an operator build that supports the TLS bridge:
- The `spec.tlsBridgeMode` CRD field comes from kagenti-operator #448 — so this should land together with bumping the operator chart/image pins to a release containing #448.
- **cert-manager** must be installed (already true on Kind + OpenShift kagenti installs).

## Test Plan

- [x] Backend: `pytest tests/test_agentruntime_manifest.py` (incl. TLS-bridge manifest + validator cases)
- [x] UI: `tsc --noEmit` clean
- [x] Chart: `helm lint` clean
- [ ] e2e on a cluster running the #448 operator: import an agent with the toggle on, confirm `spec.tlsBridgeMode=enabled`, the per-agent CA is provisioned, and egress is decrypted (verified manually against local #448/#523 builds)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
