### PR TITLE
Fix: Eliminate SPIRE OIDC provider CrashLoop during Kind setup

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -941,14 +941,35 @@ if $WITH_SPIRE && ! $DRY_RUN; then
   SPIRE_SERVER_NS="zero-trust-workload-identity-manager"
   KAGENTI_NS="kagenti-system"
 
-  # 7a: Wait for OIDC discovery provider to be fully ready before starting IdP setup
-  # Note: set_key_use is already configured via Helm values (--set spiffe-oidc-discovery-provider.config.set_key_use=true)
-  # and --wait on the SPIRE install ensures the CSI driver + agent are ready before the provider starts.
+  # 7a: Patch OIDC ConfigMap to enable set_key_use (required for Keycloak to accept JWKS keys)
+  # The helm value spiffe-oidc-discovery-provider.config.set_key_use=true does not render into
+  # the ConfigMap with the current chart version, so we patch it directly.
   log_info "Waiting for OIDC discovery provider to be ready..."
   kubectl wait --for=condition=Available deployment/spire-spiffe-oidc-discovery-provider \
     -n "$SPIRE_SERVER_NS" --timeout=300s 2>/dev/null \
     && log_success "OIDC discovery provider ready" \
     || log_warn "OIDC discovery provider not ready after 5m — IdP setup may fail"
+
+  OIDC_CONF=$(kubectl get configmap spire-spiffe-oidc-discovery-provider \
+    -n "$SPIRE_SERVER_NS" \
+    -o jsonpath='{.data.oidc-discovery-provider\.conf}' 2>/dev/null || echo "")
+  if [ -n "$OIDC_CONF" ] && ! echo "$OIDC_CONF" | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('set_key_use') else 1)" 2>/dev/null; then
+    log_info "Patching OIDC ConfigMap with set_key_use: true..."
+    PATCHED=$(echo "$OIDC_CONF" | python3 -c "import sys,json; d=json.load(sys.stdin); d['set_key_use']=True; json.dump(d,sys.stdout)")
+    kubectl get configmap spire-spiffe-oidc-discovery-provider -n "$SPIRE_SERVER_NS" -o json | \
+      python3 -c "
+import sys, json
+cm = json.load(sys.stdin)
+cm['data']['oidc-discovery-provider.conf'] = '''$PATCHED'''
+json.dump(cm, sys.stdout)
+" | kubectl apply -f -
+    kubectl rollout restart deployment/spire-spiffe-oidc-discovery-provider -n "$SPIRE_SERVER_NS"
+    kubectl rollout status deployment/spire-spiffe-oidc-discovery-provider \
+      -n "$SPIRE_SERVER_NS" --timeout=120s || true
+    log_success "OIDC ConfigMap patched with set_key_use: true"
+  else
+    log_success "OIDC ConfigMap already has set_key_use"
+  fi
 
   # 7b: Run SPIFFE IdP setup job (configures Keycloak with SPIRE identity provider)
   log_info "Setting up SPIFFE IdP..."

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -601,7 +601,7 @@ if $WITH_SPIRE; then
   log_info "Installing SPIRE ${SPIRE_VERSION}..."
   run_cmd helm upgrade --install spire spire \
     --repo "$SPIRE_REPO" --version "$SPIRE_VERSION" \
-    -n spire-mgmt --create-namespace \
+    -n spire-mgmt --create-namespace --wait --timeout=5m \
     --set global.spire.recommendations.enabled=true \
     --set global.spire.namespaces.create=true \
     --set global.spire.namespaces.server.name=zero-trust-workload-identity-manager \
@@ -941,40 +941,9 @@ if $WITH_SPIRE && ! $DRY_RUN; then
   SPIRE_SERVER_NS="zero-trust-workload-identity-manager"
   KAGENTI_NS="kagenti-system"
 
-  # 7a: Patch SPIRE OIDC ConfigMap to add set_key_use if missing
-  log_info "Checking SPIRE OIDC ConfigMap..."
-  tries=0
-  while ! kubectl get configmap spire-spiffe-oidc-discovery-provider \
-    -n "$SPIRE_SERVER_NS" &>/dev/null; do
-    tries=$((tries + 1))
-    [ $tries -ge 90 ] && { log_warn "SPIRE OIDC ConfigMap not found after 3m"; break; }
-    sleep 2
-  done
-
-  if kubectl get configmap spire-spiffe-oidc-discovery-provider -n "$SPIRE_SERVER_NS" &>/dev/null; then
-    OIDC_CONF=$(kubectl get configmap spire-spiffe-oidc-discovery-provider \
-      -n "$SPIRE_SERVER_NS" \
-      -o jsonpath='{.data.oidc-discovery-provider\.conf}' 2>/dev/null || echo "")
-    if [ -n "$OIDC_CONF" ] && ! echo "$OIDC_CONF" | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('set_key_use') else 1)" 2>/dev/null; then
-      log_info "Patching OIDC ConfigMap with set_key_use: true..."
-      PATCHED=$(echo "$OIDC_CONF" | python3 -c "import sys,json; d=json.load(sys.stdin); d['set_key_use']=True; json.dump(d,sys.stdout)")
-      kubectl get configmap spire-spiffe-oidc-discovery-provider -n "$SPIRE_SERVER_NS" -o json | \
-        python3 -c "
-import sys, json
-cm = json.load(sys.stdin)
-cm['data']['oidc-discovery-provider.conf'] = '''$PATCHED'''
-json.dump(cm, sys.stdout)
-" | kubectl apply -f -
-      kubectl rollout restart deployment/spire-spiffe-oidc-discovery-provider -n "$SPIRE_SERVER_NS"
-      kubectl rollout status deployment/spire-spiffe-oidc-discovery-provider \
-        -n "$SPIRE_SERVER_NS" --timeout=120s || true
-      log_success "OIDC ConfigMap patched"
-    else
-      log_success "OIDC ConfigMap already has set_key_use"
-    fi
-  fi
-
-  # Wait for OIDC discovery provider to be fully ready before starting IdP setup
+  # 7a: Wait for OIDC discovery provider to be fully ready before starting IdP setup
+  # Note: set_key_use is already configured via Helm values (--set spiffe-oidc-discovery-provider.config.set_key_use=true)
+  # and --wait on the SPIRE install ensures the CSI driver + agent are ready before the provider starts.
   log_info "Waiting for OIDC discovery provider to be ready..."
   kubectl wait --for=condition=Available deployment/spire-spiffe-oidc-discovery-provider \
     -n "$SPIRE_SERVER_NS" --timeout=300s 2>/dev/null \

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1087,7 +1087,7 @@ spec:
       serviceAccountName: kagenti-spiffe-idp-setup
       restartPolicy: OnFailure
       initContainers:
-        - name: wait-for-spire
+        - name: wait-for-dependencies
           image: "${KUBECTL_IMAGE}"
           command: ["sh", "-c"]
           args:
@@ -1100,6 +1100,9 @@ spec:
               kubectl wait --for=condition=ready pod \
                 -l app.kubernetes.io/name=spiffe-oidc-discovery-provider \
                 -n ${SPIRE_SERVER_NS} --timeout=300s
+              echo "Waiting for Keycloak to be ready..."
+              kubectl wait --for=condition=ready pod \
+                -l app=keycloak -n ${KC_NS} --timeout=300s
       containers:
         - name: setup-spiffe-idp
           image: "${SPIFFE_IDP_IMAGE}"

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1127,22 +1127,16 @@ spec:
               value: "${SPIFFE_IDP_ALIAS}"
 EOF
 
-  # Wait for job to complete
+  # Wait for job to complete (up to 10m — the job's wait_for_spire() retries
+  # for up to 5m if OIDC keys aren't ready, plus container startup overhead)
   log_info "Waiting for SPIFFE IdP setup job..."
-  tries=0
-  while true; do
-    SUCCEEDED=$(kubectl get job kagenti-spiffe-idp-setup-job -n "$KAGENTI_NS" \
-      -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "")
-    [ "$SUCCEEDED" = "1" ] && break
-    tries=$((tries + 1))
-    if [ $tries -ge 60 ]; then
-      log_warn "SPIFFE IdP setup job did not complete in 5m — check logs:"
-      log_warn "  kubectl logs -n $KAGENTI_NS job/kagenti-spiffe-idp-setup-job"
-      break
-    fi
-    sleep 5
-  done
-  [ "$SUCCEEDED" = "1" ] && log_success "SPIFFE IdP setup complete"
+  if kubectl wait --for=condition=complete job/kagenti-spiffe-idp-setup-job \
+       -n "$KAGENTI_NS" --timeout=600s 2>/dev/null; then
+    log_success "SPIFFE IdP setup complete"
+  else
+    log_warn "SPIFFE IdP setup job did not complete in 10m — check logs:"
+    log_warn "  kubectl logs -n $KAGENTI_NS job/kagenti-spiffe-idp-setup-job"
+  fi
   echo ""
 fi
 

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1092,6 +1092,7 @@ spec:
           command: ["sh", "-c"]
           args:
             - |
+              set -e
               echo "Waiting for SPIRE server..."
               kubectl wait --for=condition=ready pod \
                 -l app.kubernetes.io/name=server \
@@ -1103,6 +1104,18 @@ spec:
               echo "Waiting for Keycloak to be ready..."
               kubectl wait --for=condition=ready pod \
                 -l app=keycloak -n ${KC_NS} --timeout=300s
+              echo "Validating OIDC JWKS endpoint serves keys with 'use' field..."
+              OIDC_URL="http://spire-spiffe-oidc-discovery-provider.${SPIRE_SERVER_NS}.svc.cluster.local/keys"
+              for i in \$(seq 1 60); do
+                if curl -sf "\$OIDC_URL" | grep -q '"use"'; then
+                  echo "OIDC JWKS endpoint validated"
+                  exit 0
+                fi
+                echo "  Attempt \$i/60: OIDC keys not ready, retrying in 5s..."
+                sleep 5
+              done
+              echo "WARNING: OIDC keys validation timed out after 5m"
+              exit 1
       containers:
         - name: setup-spiffe-idp
           image: "${SPIFFE_IDP_IMAGE}"


### PR DESCRIPTION
## Summary

Fix SPIRE OIDC discovery provider CrashLoopBackOff during Kind cluster setup (#2010).

**Root cause**: Without `--wait` on the SPIRE helm install, the OIDC discovery provider starts before the CSI driver and SPIRE agent are ready, causing it to fail to find the workload API socket and enter a CrashLoop (12+ restarts).

**Secondary issue**: The helm value `--set spiffe-oidc-discovery-provider.config.set_key_use=true` does NOT render into the ConfigMap with the current SPIRE chart version. Without `set_key_use: true` in the config, the `/keys` endpoint returns JWK keys without `"use":"sig"`, which causes Keycloak to reject them. The ConfigMap patch + rollout restart is the only working mechanism.

### Changes

1. **Add `--wait --timeout=5m`** to SPIRE helm install — ensures CSI driver + agent are ready before the OIDC provider starts (eliminates CrashLoop)
2. **Restore OIDC ConfigMap patch** — adds `set_key_use: true` and restarts the OIDC discovery provider (since the helm value doesn't work)
3. **Add init container** to the SPIFFE IdP setup job that waits for SPIRE server, OIDC provider, Keycloak, and validates the JWKS endpoint serves keys with `"use"` field
4. **Replace polling loop** with `kubectl wait --for=condition=complete --timeout=600s` for cleaner job completion tracking

### Test plan

- [x] CI Deploy & Test passes (23m9s)
- [x] Local Kind cluster: OIDC provider has 0 restarts
- [x] SPIFFE IdP setup job succeeds on first attempt
- [x] OIDC `/keys` endpoint returns keys with `"use":"sig"`

Closes #2010

Assisted-By: Claude Code