### PR TITLE
Feat: AgentRuntime parity for sandbox agents (AuthBridge/TLS-bridge) + UI tidy-up

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -4448,10 +4448,7 @@ async def finalize_shipwright_build(
         # Sandbox is included (targetRef -> agents.x-k8s.io Sandbox); only Job is
         # excluded. Agents only — tools don't need sidecar injection.
         resource_type = build_labels.get(KAGENTI_TYPE_LABEL, RESOURCE_TYPE_AGENT)
-        if (
-            final_workload_type not in (WORKLOAD_TYPE_JOB,)
-            and resource_type == RESOURCE_TYPE_AGENT
-        ):
+        if final_workload_type not in (WORKLOAD_TYPE_JOB,) and resource_type == RESOURCE_TYPE_AGENT:
             _ensure_agentruntime(
                 kube=kube,
                 name=name,

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2951,6 +2951,15 @@ def _build_selector_labels(request: "CreateAgentRequest") -> Dict[str, str]:
     }
 
 
+def _agentruntime_supported_workload(workload_type: str) -> bool:
+    """Whether a workload type gets an AgentRuntime CR (per-agent AuthBridge
+    config). Sandbox, deployment, and statefulset are supported; Job is not —
+    a run-to-completion Job doesn't fit the attach / config-rollout model.
+    Single source of truth for the two _ensure_agentruntime call sites
+    (create_agent and finalize_shipwright_build)."""
+    return workload_type not in (WORKLOAD_TYPE_JOB,)
+
+
 def _build_agentruntime_manifest(
     name: str,
     namespace: str,
@@ -3798,7 +3807,7 @@ async def create_agent(
             # authBridgeMode / tlsBridgeMode) is applied. Sandbox is included
             # (targetRef -> agents.x-k8s.io Sandbox); only Job is excluded —
             # a run-to-completion Job doesn't fit the attach/restart model.
-            if request.workloadType not in (WORKLOAD_TYPE_JOB,):
+            if _agentruntime_supported_workload(request.workloadType):
                 _ensure_agentruntime(
                     kube=kube,
                     name=request.name,
@@ -4448,7 +4457,10 @@ async def finalize_shipwright_build(
         # Sandbox is included (targetRef -> agents.x-k8s.io Sandbox); only Job is
         # excluded. Agents only — tools don't need sidecar injection.
         resource_type = build_labels.get(KAGENTI_TYPE_LABEL, RESOURCE_TYPE_AGENT)
-        if final_workload_type not in (WORKLOAD_TYPE_JOB,) and resource_type == RESOURCE_TYPE_AGENT:
+        if (
+            _agentruntime_supported_workload(final_workload_type)
+            and resource_type == RESOURCE_TYPE_AGENT
+        ):
             _ensure_agentruntime(
                 kube=kube,
                 name=name,

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -2964,11 +2964,18 @@ def _build_agentruntime_manifest(
     kind_map = {
         WORKLOAD_TYPE_DEPLOYMENT: "Deployment",
         WORKLOAD_TYPE_STATEFULSET: "StatefulSet",
+        WORKLOAD_TYPE_SANDBOX: "Sandbox",
+    }
+    # Sandbox is an agents.x-k8s.io CR, not apps/v1 — emit the right targetRef
+    # apiVersion per kind so the operator's resolveTargetRef finds the workload
+    # (a wrong apps/v1 ref for a Sandbox would dangle and never reconcile).
+    apiversion_map = {
+        WORKLOAD_TYPE_SANDBOX: f"{AGENT_SANDBOX_CRD_GROUP}/{AGENT_SANDBOX_CRD_VERSION}",
     }
     spec: dict = {
         "type": agent_type,
         "targetRef": {
-            "apiVersion": "apps/v1",
+            "apiVersion": apiversion_map.get(workload_type, "apps/v1"),
             "kind": kind_map.get(workload_type, "Deployment"),
             "name": name,
         },
@@ -3787,8 +3794,11 @@ async def create_agent(
                     request.workloadType,
                 )
 
-            # Create AgentRuntime CR so the webhook injects sidecars on pod rollout
-            if request.workloadType not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX):
+            # Create AgentRuntime CR so the per-agent AuthBridge config (mtls /
+            # authBridgeMode / tlsBridgeMode) is applied. Sandbox is included
+            # (targetRef -> agents.x-k8s.io Sandbox); only Job is excluded —
+            # a run-to-completion Job doesn't fit the attach/restart model.
+            if request.workloadType not in (WORKLOAD_TYPE_JOB,):
                 _ensure_agentruntime(
                     kube=kube,
                     name=request.name,
@@ -4434,11 +4444,12 @@ async def finalize_shipwright_build(
         )
         _create_or_replace_service(kube, namespace, name, service_manifest, final_workload_type)
 
-        # Create AgentRuntime CR so the webhook injects sidecars on pod rollout
-        # Only for agents — tools don't need sidecar injection
+        # Create AgentRuntime CR so the per-agent AuthBridge config is applied.
+        # Sandbox is included (targetRef -> agents.x-k8s.io Sandbox); only Job is
+        # excluded. Agents only — tools don't need sidecar injection.
         resource_type = build_labels.get(KAGENTI_TYPE_LABEL, RESOURCE_TYPE_AGENT)
         if (
-            final_workload_type not in (WORKLOAD_TYPE_JOB, WORKLOAD_TYPE_SANDBOX)
+            final_workload_type not in (WORKLOAD_TYPE_JOB,)
             and resource_type == RESOURCE_TYPE_AGENT
         ):
             _ensure_agentruntime(

--- a/kagenti/backend/tests/test_agentruntime_manifest.py
+++ b/kagenti/backend/tests/test_agentruntime_manifest.py
@@ -234,3 +234,34 @@ def test_finalize_request_allows_tls_bridge_with_proxy_sidecar():
 
     r = FinalizeShipwrightBuildRequest(authBridgeMode="proxy-sidecar", tlsBridgeEnabled=True)
     assert r.tlsBridgeEnabled is True
+
+
+# --- targetRef per workload type ---
+
+
+def test_manifest_targetref_sandbox():
+    """Sandbox is an agents.x-k8s.io CR, not apps/v1 — the targetRef must carry
+    the Sandbox kind + group so the operator's resolveTargetRef binds the real
+    workload (a wrong apps/v1 ref would dangle and never reconcile). Pairs with
+    the backend un-excluding sandbox from _ensure_agentruntime."""
+    from app.routers.agents import _build_agentruntime_manifest
+
+    m = _build_agentruntime_manifest("a", "ns", "sandbox", tls_bridge_enabled=True)
+    ref = m["spec"]["targetRef"]
+    assert ref["kind"] == "Sandbox"
+    assert ref["apiVersion"] == "agents.x-k8s.io/v1alpha1"
+    assert ref["name"] == "a"
+    # The AuthBridge knobs flow into the sandbox CR exactly like deployment.
+    assert m["spec"]["tlsBridgeMode"] == "enabled"
+
+
+def test_manifest_targetref_apps_v1_for_deployment_and_statefulset():
+    """Regression: deployment/statefulset keep the apps/v1 targetRef. Locks the
+    default branch of the per-kind apiVersion/kind maps so adding sandbox can't
+    silently change the existing kinds."""
+    from app.routers.agents import _build_agentruntime_manifest
+
+    for wt, kind in (("deployment", "Deployment"), ("statefulset", "StatefulSet")):
+        ref = _build_agentruntime_manifest("a", "ns", wt)["spec"]["targetRef"]
+        assert ref["apiVersion"] == "apps/v1"
+        assert ref["kind"] == kind

--- a/kagenti/backend/tests/test_agentruntime_manifest.py
+++ b/kagenti/backend/tests/test_agentruntime_manifest.py
@@ -255,6 +255,19 @@ def test_manifest_targetref_sandbox():
     assert m["spec"]["tlsBridgeMode"] == "enabled"
 
 
+def test_agentruntime_supported_workload_includes_sandbox_excludes_job():
+    """Lock the exclusion that both _ensure_agentruntime call sites (create_agent
+    and finalize_shipwright_build) gate on: sandbox/deployment/statefulset get an
+    AgentRuntime, job does not. Guards against a regression that re-adds sandbox
+    to the exclusion tuple (the bug this change fixes) or drops job from it."""
+    from app.routers.agents import _agentruntime_supported_workload
+
+    assert _agentruntime_supported_workload("sandbox") is True
+    assert _agentruntime_supported_workload("deployment") is True
+    assert _agentruntime_supported_workload("statefulset") is True
+    assert _agentruntime_supported_workload("job") is False
+
+
 def test_manifest_targetref_apps_v1_for_deployment_and_statefulset():
     """Regression: deployment/statefulset keep the apps/v1 targetRef. Locks the
     default branch of the per-kind apiVersion/kind maps so adding sandbox can't

--- a/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/AgentDetailPage.tsx
@@ -80,7 +80,7 @@ function pluginsToTreeData(plugins: PluginConfig[]): TreeViewDataItem[] {
     id: `plugin-${idx}`,
     name: plugin.name,
     defaultExpanded: true,
-    children: Object.entries(plugin.config).map(([key, value]) => {
+    children: Object.entries(plugin.config || {}).map(([key, value]) => {
       if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
         return {
           id: `plugin-${idx}-${key}`,

--- a/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportAgentPage.tsx
@@ -1161,7 +1161,7 @@ export const ImportAgentPage: React.FC = () => {
               <FormGroup fieldId="authBridgeEnabled">
                 <Checkbox
                   id="authBridgeEnabled"
-                  label="Secure with Kagenti AuthBridge"
+                  label="Secure with AuthBridge"
                   isChecked={authBridgeEnabled}
                   onChange={(_e, checked) => {
                     setAuthBridgeEnabled(checked);
@@ -1172,35 +1172,6 @@ export const ImportAgentPage: React.FC = () => {
                   description="When enabled, the agent will reject inbound messages without valid JWT and can perform outbound token exchange."
               />
               </FormGroup>
-
-              {authBridgeEnabled && (
-                <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
-                  <Checkbox
-                    id="useEnvoyMode"
-                    label="Use Envoy sidecar interception"
-                    isChecked={useEnvoyMode}
-                    onChange={(_e, checked) => setUseEnvoyMode(checked)}
-                    description="Run the Envoy data plane (ext_proc) instead of the default Go forward/reverse proxy sidecar"
-                  />
-                </FormGroup>
-              )}
-
-              {authBridgeEnabled && (
-                <FormGroup fieldId="tlsBridgeEnabled" style={{ marginLeft: '24px' }}>
-                  <Checkbox
-                    id="tlsBridgeEnabled"
-                    label="Decrypt outbound TLS for inspection (TLS bridge)"
-                    isChecked={tlsBridgeEnabled && !useEnvoyMode}
-                    isDisabled={useEnvoyMode}
-                    onChange={(_e, checked) => setTlsBridgeEnabled(checked)}
-                    description={
-                      useEnvoyMode
-                        ? 'Requires proxy-sidecar mode (uncheck Envoy interception to enable)'
-                        : 'Terminate the agent’s outbound HTTPS at the sidecar so the AuthBridge pipeline can see request payloads. Requires cert-manager.'
-                    }
-                  />
-                </FormGroup>
-              )}
 
               {/* SPIRE Identity */}
               <FormGroup fieldId="spireEnabled">
@@ -1319,6 +1290,29 @@ export const ImportAgentPage: React.FC = () => {
                     <FormSelectOption key="passthrough" value="passthrough" label="passthrough — pass traffic through unchanged (default)" />
                     <FormSelectOption key="exchange" value="exchange" label="exchange — require RFC 8693 / OAuth 2.0 Token Exchange for all outbound traffic" />
                   </FormSelect>
+                </FormGroup>
+                <FormGroup fieldId="useEnvoyMode">
+                  <Checkbox
+                    id="useEnvoyMode"
+                    label="Use Envoy sidecar interception"
+                    isChecked={useEnvoyMode}
+                    onChange={(_e, checked) => setUseEnvoyMode(checked)}
+                    description="Run the Envoy data plane (ext_proc) instead of the default Go forward/reverse proxy sidecar"
+                  />
+                </FormGroup>
+                <FormGroup fieldId="tlsBridgeEnabled">
+                  <Checkbox
+                    id="tlsBridgeEnabled"
+                    label="Decrypt outbound TLS for inspection (TLS bridge)"
+                    isChecked={tlsBridgeEnabled && !useEnvoyMode}
+                    isDisabled={useEnvoyMode}
+                    onChange={(_e, checked) => setTlsBridgeEnabled(checked)}
+                    description={
+                      useEnvoyMode
+                        ? 'Requires proxy-sidecar mode (uncheck Envoy interception to enable)'
+                        : 'Terminate the agent’s outbound HTTPS at the sidecar so the AuthBridge pipeline can see request payloads. Requires cert-manager.'
+                    }
+                  />
                 </FormGroup>
                 <FormGroup label="Mutual TLS (mTLS)" fieldId="mtlsMode">
                   <FormSelect


### PR DESCRIPTION
## Summary

Two related AuthBridge changes.

### 1. Backend — create an AgentRuntime for `sandbox` agents (the functional fix)

An agent's workload can be `deployment`, `statefulset`, `job`, or `sandbox` (the default). The per-agent AuthBridge knobs (`mtlsMode` / `authBridgeMode` / `tlsBridgeMode`, including the TLS bridge) are carried by an `AgentRuntime` CR — but the backend only created one for `deployment`/`statefulset`. Sandbox agents got the sidecar but **could not enable the TLS bridge** (no CR → no per-agent CA → no `tls_bridge` config) or override mtls/authBridge.

- `_build_agentruntime_manifest` now emits the correct `targetRef` per kind — `agents.x-k8s.io/v1alpha1` / `Sandbox` for sandbox, `apps/v1` for deployment/statefulset (default). Without this the CR would point at a non-existent `apps/v1` Deployment and never reconcile.
- Dropped `sandbox` from the two `_ensure_agentruntime` exclusion tuples (kept `job` — run-to-completion doesn't fit the attach/restart model).

Everything else was already at parity (Service, ServiceAccount, AuthBridge ConfigMaps, Keycloak client registration, labels/env, delete cleanup, validators), so this is the only backend change. `mtlsMode`/`authBridgeMode`/`tlsBridgeMode` flow through the shared call site unchanged.

### 2. UI — AuthBridge form tidy-up

- "Secure with **Kagenti** AuthBridge" → "Secure with **AuthBridge**".
- Moved the **Envoy** and **TLS bridge** toggles out of the top-level AuthBridge block into the **AuthBridge Advanced Configuration** section, next to mTLS.

### 3. UI fix — agent detail page crash on config-less plugins

`AgentDetailPage`'s `pluginsToTreeData` called `Object.entries(plugin.config)` with no null-guard. Protocol-parser plugins (`a2a-parser`, `mcp-parser`, `inference-parser`) carry no `config:` block, so `plugin.config` is `undefined` → `Object.entries(undefined)` threw and unmounted the page (flicker → blank screen) for **any** agent whose AuthBridge pipeline includes a parser. Fixed with `Object.entries(plugin.config || {})` (config-less plugins render as a leaf node). Pre-existing bug, surfaced as parsers became common in agent pipelines.

## Test plan

- `uv run pytest tests/test_agentruntime_manifest.py` — incl. new `test_manifest_targetref_sandbox` (Sandbox kind + `agents.x-k8s.io/v1alpha1`) and `test_manifest_targetref_apps_v1_for_deployment_and_statefulset` (regression). Full backend suite green (403).
- `npm run typecheck` clean for the UI reorg.
- Verified end-to-end on Kind: recreating `weather-agent` as a **sandbox** with TLS bridge on auto-created an `AgentRuntime` (`targetRef.kind=Sandbox`, `tlsBridgeMode=enabled`) with no manual step, the operator minted the per-agent CA, the sidecar got the two-volume CA mount + `tls_bridge` config, and the session API showed the agent's **real decrypted outbound HTTPS** (LLM `/v1/chat/completions`, MCP `/mcp` tool calls) — proving forged-leaf interception and payload visibility for sandbox agents.

## Notes

Pairs with kagenti-operator#451 (Sandbox owner-resolution + ConfigMap GC). That operator change is optional hardening — the released operator already handles a Sandbox-targetRef AgentRuntime via the pod-name fallback, so this backend PR works against the current operator on its own.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
