### PR TITLE
Fix: drop orphaned Istio validation webhooks before kagenti-deps install on OpenShift

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -669,12 +669,41 @@ for doc in docs:
 " | $KUBECTL apply -f - || true
 }
 
+# Remove orphaned Istio validation webhooks left behind by a previous teardown.
+# Deleting the istio-system namespace does NOT remove the cluster-scoped
+# ValidatingWebhookConfigurations that back "validation.istio.io". With
+# failurePolicy=Fail and no istiod Service to call, they reject every Istio
+# config resource (e.g. the otel-collector AuthorizationPolicy) the kagenti-deps
+# chart creates during `helm install`, aborting the release with:
+#   failed calling webhook "validation.istio.io": service "istiod" not found
+# These webhooks are recreated (with the correct caBundle) once the Sail operand
+# CRs in Step 3 bring istiod back up, so it is safe to drop the stale ones here.
+# Only touch the kagenti-managed webhooks — never the OpenShift ingress gateway's
+# (istio-validator-openshift-gateway-openshift-ingress).
+_clean_stale_istio_webhooks() {
+  if $DRY_RUN; then return; fi
+  # If istiod is present, the webhooks have a live backend — leave them alone.
+  if $KUBECTL get svc istiod -n istio-system &>/dev/null; then
+    return
+  fi
+  for _whc in istiod-default-validator istio-validator-istio-system; do
+    if $KUBECTL get validatingwebhookconfiguration "$_whc" &>/dev/null; then
+      log_warn "Removing stale Istio webhook $_whc (no istiod Service to back it)"
+      $KUBECTL delete validatingwebhookconfiguration "$_whc" --ignore-not-found || true
+    fi
+  done
+}
+
 _helm_kagenti_deps() {
   # Pre-flight: ensure namespaces managed by this chart are not stuck terminating
   # from a previous failed install/uninstall cycle
   for _ns in keycloak istio-cni istio-system istio-ztunnel; do
     _wait_ns_gone "$_ns"
   done
+
+  # Pre-flight: drop orphaned Istio validation webhooks that would otherwise
+  # block the chart's Istio config resources before istiod is provisioned.
+  _clean_stale_istio_webhooks
 
   # Build MLflow OTEL flags: enable the pipeline and point it at the DSC-managed endpoint.
   # When --otel-operator-managed is set, the operator handles ConfigMap assembly


### PR DESCRIPTION
## Problem

On OpenShift, `scripts/ocp/setup-kagenti.sh` (Step 3) aborts during `helm install kagenti-deps` when a stale Istio validation webhook survives a prior `istio-system` teardown:

```
failed calling webhook "validation.istio.io":
  Post "https://istiod.istio-system.svc:443/validate?timeout=10s": service "istiod" not found
```

Deleting the `istio-system` namespace does **not** remove the cluster-scoped `istiod-default-validator` ValidatingWebhookConfiguration. With `failurePolicy=Fail` and no `istiod` Service to call, it rejects the otel-collector `AuthorizationPolicy` (`security.istio.io/v1`) that the chart creates during `helm install` — before the Sail operand CRs (a deferred step) bring istiod up. The release is left at revision 1 / `failed`.

The pre-existing `.Capabilities.APIVersions.Has "security.istio.io/v1"` guard (#1589) only checks **CRD presence**, not **istiod liveness**, so it doesn't cover this.

## Fix

Add a preflight in `_helm_kagenti_deps` that deletes the stale **kagenti-managed** Istio webhooks (`istiod-default-validator`, `istio-validator-istio-system`) **only when no `istio-system/istiod` Service exists**. istiod re-registers them with the correct caBundle once the operand CRs are applied in Step 3. The OpenShift ingress gateway's webhook (`istio-validator-openshift-gateway-openshift-ingress`) is never touched, and a healthy istiod is left alone.

### Why not a chart-only reorder?
Making the AuthorizationPolicy a Helm hook does not help: the installer runs `helm install --no-hooks` and `_apply_operand_crs` applies all operand hooks in a single batch *before* waiting for istiod readiness — so a hooked AuthorizationPolicy would still be applied before istiod is Ready. The orphaned-webhook cleanup fixes the actual trigger and unblocks all Istio config resources.

## Testing
- `bash -n scripts/ocp/setup-kagenti.sh` passes; pre-commit (`make lint`) passes.
- No-op on healthy clusters (early-returns when the `istiod` Service is present) and under `--dry-run`.
- Verified against the cluster that reproduced the failure (RCA in #2014).

Fixes #2014

Assisted-By: Claude Code
