### PR TITLE
Fix: setup-kagenti.sh fails to upgrade when roleRef changes

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1212,6 +1212,22 @@ kubectl delete job kagenti-ui-oauth-secret-job -n kagenti-system --ignore-not-fo
 kubectl delete job kagenti-agent-oauth-secret-job -n kagenti-system --ignore-not-found 2>/dev/null || true
 kubectl delete job mlflow-oauth-secret-job -n kagenti-system --ignore-not-found 2>/dev/null || true
 
+# Delete ClusterRoleBindings whose roleRef changed between chart versions.
+# Kubernetes forbids mutating roleRef — the binding must be deleted so Helm can
+# recreate it with the new reference. (Fixes #1838)
+_delete_stale_rolebinding() {
+  local binding="$1" expected_role="$2"
+  local current_role
+  current_role=$(kubectl get clusterrolebinding "$binding" -o jsonpath='{.roleRef.name}' 2>/dev/null || echo "")
+  if [ -n "$current_role" ] && [ "$current_role" != "$expected_role" ]; then
+    log_info "Deleting ClusterRoleBinding/$binding (roleRef changed: $current_role → $expected_role)"
+    kubectl delete clusterrolebinding "$binding" --ignore-not-found 2>/dev/null || true
+  fi
+}
+_delete_stale_rolebinding "kagenti-operator-httproute-binding-kagenti" "kagenti-operator-httproute-kagenti"
+_delete_stale_rolebinding "kagenti-manager-rolebinding" "kagenti-manager-role"
+_delete_stale_rolebinding "kagenti-mlflow-integration-kagenti" "mlflow-operator-mlflow-integration"
+
 # ── Wait for preload to finish (if running) ──
 if [ -n "$PRELOAD_LOAD_PID" ]; then
   log_info "Waiting for image preload to complete..."


### PR DESCRIPTION
## Summary

- Adds a pre-upgrade check in `scripts/kind/setup-kagenti.sh` that detects ClusterRoleBindings with stale `roleRef` values and deletes them before `helm upgrade --install`
- Kubernetes forbids mutating `roleRef` on existing bindings, so the binding must be deleted to allow Helm to recreate it with the new ClusterRole reference
- Covers all three operator chart bindings: `httproute-binding`, `manager-rolebinding`, and `mlflow-integration`

## Root Cause

When the operator chart renames a ClusterRole between versions (e.g., adding a release-name suffix), `helm upgrade` attempts to patch the existing ClusterRoleBinding with the new `roleRef`. Kubernetes rejects this with:

```
cannot patch "kagenti-operator-httproute-binding-kagenti" with kind ClusterRoleBinding:
  roleRef: Invalid value: cannot change roleRef
```

## Test plan

- [x] Verified syntax (`bash -n`)
- [x] Verified pre-commit passes
- [x] Tested helper function: matching roleRef → no deletion, missing binding → no-op, mismatched roleRef → deletes
- [x] Simulated the bug (created binding with wrong roleRef), re-ran script → upgrade succeeded
- [x] Full `--skip-cluster` upgrade completed successfully on existing Kind cluster

Fixes #1838

Assisted-By: Claude Code