### PR TITLE
Fix: Create cluster-monitoring-config when absent to enable UWM

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -519,7 +519,25 @@ _ensure_user_workload_monitoring() {
   existing=$($KUBECTL get configmap cluster-monitoring-config -n openshift-monitoring \
     -o jsonpath='{.data.config\.yaml}' 2>/dev/null || echo "")
   if [ -z "$existing" ]; then
-    # ConfigMap doesn't exist or is empty — the hook can create it from scratch
+    # ConfigMap is absent (or has no config.yaml). We must NOT rely on the
+    # kiali-operand chart hook to create it: that hook is skipped on upgrades
+    # (--no-hooks) and on the fresh-install failure-recovery path (which also
+    # explicitly skips this ConfigMap as the conflict source). Relying on it
+    # silently leaves UWM disabled, so Kiali shows no mesh traffic. Create it
+    # here so the pre-flight is authoritative.
+    $KUBECTL apply -f - >/dev/null <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    prometheusK8s:
+      retentionSize: 10GB
+EOF
+    log_success "Created cluster-monitoring-config with enableUserWorkload: true"
     return
   fi
   if echo "$existing" | grep -q "enableUserWorkload: true"; then


### PR DESCRIPTION
## What

Make the OpenShift installer's `_ensure_user_workload_monitoring()` pre-flight **create** `cluster-monitoring-config` (with `enableUserWorkload: true`) when it is absent, instead of returning early and relying on the kiali-operand Helm hook.

## Why

Kiali reads mesh metrics from `thanos-querier.openshift-monitoring`. Istio/ztunnel ServiceMonitors live in **user namespaces** and are scraped **only** by OpenShift User Workload Monitoring (UWM). If UWM is off, no `istio_*` metrics reach Thanos and **Kiali shows no traffic** — even when agents are actively serving.

The pre-flight returned early when the ConfigMap was absent (`scripts/ocp/setup-kagenti.sh:521-524`), trusting the chart hook to create it. But that hook is skipped:

- on **upgrades** (`--no-hooks`), and
- on the fresh-install **failure-recovery path**, which explicitly skips this ConfigMap as the "conflict source" on managed clusters.

When the hook doesn't run and the ConfigMap didn't already exist, UWM is silently left disabled. This was observed on a live OpenShift cluster: `cluster-monitoring-config` NotFound, zero `prometheus-user-workload` pods, empty Kiali graph despite a healthy mesh and a completed weather-agent run. Manually creating the ConfigMap brought up the UWM stack and Kiali began receiving telemetry.

## Change

When the ConfigMap is absent, the pre-flight now applies it with content matching the chart hook (`enableUserWorkload: true` + `prometheusK8s.retentionSize: 10GB`). The existing "merge into existing config" path is unchanged.

## Testing

- `bash -n scripts/ocp/setup-kagenti.sh` passes.
- Verified the manual equivalent on a live OpenShift cluster: applying the ConfigMap brought up `prometheus-user-workload` (2/2 replicas, 6/6) and the UWM stack.

## Notes

Secondary finding (out of scope, tracked separately): team namespaces are labeled `istio.io/use-waypoint: waypoint` but no waypoint Gateway is deployed, so only L4/TCP metrics are available; the full L7 HTTP request graph needs a waypoint.

Fixes #2032

Assisted-By: Claude Code
