### PR TITLE
CI: Migrate LLM endpoints from dead MaaS to LiteMaaS Qwen

### DIFF
--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -110,7 +110,7 @@ else
     if [ "$IS_OPENSHIFT" = "true" ]; then
         log_info "Patching LLM config for OpenShift (MaaS LiteLLM)..."
 
-        LLM_HOST="litellm-prod.apps.maas.redhatworkshops.io"
+        LLM_HOST="litellm-litemaas.apps.prod.rhoai.rh-aiservices-bu.com"
 
         # The authbridge webhook injects HTTP(S)_PROXY=http://127.0.0.1:8081
         # at pod admission.  We cannot prevent injection, but we can ensure
@@ -125,7 +125,7 @@ else
         # bypasses NO_PROXY handling entirely.  Empty string = no proxy.
         kubectl set env deployment/weather-service -n team1 \
             LLM_API_BASE="https://${LLM_HOST}/v1" \
-            LLM_MODEL="llama-scout-17b" \
+            LLM_MODEL="Qwen3.6-35B-A3B" \
             HTTP_PROXY="" \
             http_proxy="" \
             NO_PROXY="$NO_PROXY_VAL" \

--- a/.github/scripts/local-setup/openshell-full-test.sh
+++ b/.github/scripts/local-setup/openshell-full-test.sh
@@ -164,8 +164,9 @@ done
 # CI fallback: use OPENAI_API_KEY when .env.maas is not available
 if [ "$MAAS_SOURCED" = "false" ] && [ -n "${OPENAI_API_KEY:-}" ]; then
     export MAAS_LLAMA4_API_KEY="$OPENAI_API_KEY"
-    export MAAS_LLAMA4_API_BASE="${MAAS_LLAMA4_API_BASE:-https://litellm-prod.apps.maas.redhatworkshops.io/v1}"
-    export MAAS_LLAMA4_MODEL="${MAAS_LLAMA4_MODEL:-llama-scout-17b}"
+    export MAAS_LLAMA4_API_BASE="${MAAS_LLAMA4_API_BASE:-https://litellm-litemaas.apps.prod.rhoai.rh-aiservices-bu.com/v1}"
+    export MAAS_LLAMA4_MODEL="${MAAS_LLAMA4_MODEL:-Qwen3.6-35B-A3B}"
+    export MAAS_DEEPSEEK_MODEL="${MAAS_DEEPSEEK_MODEL:-Qwen3.6-35B-A3B}"
     MAAS_SOURCED=true
     log_step "Using OPENAI_API_KEY as LiteMaaS credentials (CI mode)"
 fi
@@ -371,7 +372,7 @@ if [ "$SKIP_TEST" = "false" ]; then
 
     if [ "$MAAS_SOURCED" = "true" ]; then
         export OPENSHELL_LLM_AVAILABLE=true
-        export OPENSHELL_LLM_MODELS="${OPENSHELL_LLM_MODELS:-llama-scout-17b,deepseek-r1}"
+        export OPENSHELL_LLM_MODELS="${OPENSHELL_LLM_MODELS:-Qwen3.6-35B-A3B}"
         log_step "LLM tests enabled (models: $OPENSHELL_LLM_MODELS)"
     fi
 

--- a/.github/workflows/e2e-openshell-hypershift.yaml
+++ b/.github/workflows/e2e-openshell-hypershift.yaml
@@ -175,7 +175,7 @@ jobs:
           HCP_ROLE_NAME: ${{ secrets.HCP_ROLE_NAME }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
-          OPENSHELL_LLM_MODELS: "llama-scout-17b,deepseek-r1"
+          OPENSHELL_LLM_MODELS: "Qwen3.6-35B-A3B"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-openshell-kind.yaml
+++ b/.github/workflows/e2e-openshell-kind.yaml
@@ -165,7 +165,7 @@ jobs:
           PLATFORM: kind
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
-          OPENSHELL_LLM_MODELS: "llama-scout-17b,deepseek-r1"
+          OPENSHELL_LLM_MODELS: "Qwen3.6-35B-A3B"
 
       - name: Collect logs on failure
         if: failure()

--- a/scripts/openshell/deploy-shared.sh
+++ b/scripts/openshell/deploy-shared.sh
@@ -566,13 +566,13 @@ fi
 if $STEP_LITELLM; then
   log_info "Step 5: LiteLLM model proxy"
 
-  LITEMAAS_URL="${MAAS_LLAMA4_API_BASE:-https://litellm-prod.apps.maas.redhatworkshops.io/v1}"
+  LITEMAAS_URL="${MAAS_LLAMA4_API_BASE:-https://litellm-litemaas.apps.prod.rhoai.rh-aiservices-bu.com/v1}"
   LITEMAAS_KEY="${MAAS_LLAMA4_API_KEY:-}"
-  LITEMAAS_MODEL="${MAAS_LLAMA4_MODEL:-llama-scout-17b}"
+  LITEMAAS_MODEL="${MAAS_LLAMA4_MODEL:-Qwen3.6-35B-A3B}"
   LITELLM_NS="${LITELLM_NS:-team1}"
   LITELLM_PROXY_NAME="litellm-model-proxy"
 
-  DEEPSEEK_MODEL="${MAAS_DEEPSEEK_MODEL:-deepseek-r1-distill-qwen-14b}"
+  DEEPSEEK_MODEL="${MAAS_DEEPSEEK_MODEL:-Qwen3.6-35B-A3B}"
 
   if [[ -z "$LITEMAAS_KEY" ]]; then
     log_warn "MAAS_LLAMA4_API_KEY not set — skipping LiteLLM proxy"


### PR DESCRIPTION
## Summary
- Old MaaS endpoints (`litellm-prod.apps.maas.redhatworkshops.io`) are dead — LiteMaaS now only serves `Qwen3.6-35B-A3B`
- Updates all CI-affecting paths: openshell-full-test.sh fallback, deploy-shared.sh defaults, weather agent OCP patch, workflow env vars
- `MAAS_LLAMA4_*/MAAS_DEEPSEEK_*` variable names kept as-is (internal plumbing between .env.maas and deploy scripts)

## Files changed
| File | Change |
|------|--------|
| `openshell-full-test.sh` | CI fallback API base + model defaults, OPENSHELL_LLM_MODELS |
| `deploy-shared.sh` | LiteLLM proxy LITEMAAS_URL, LITEMAAS_MODEL, DEEPSEEK_MODEL defaults |
| `74-deploy-weather-agent.sh` | OCP LLM_HOST + LLM_MODEL |
| `e2e-openshell-kind.yaml` | OPENSHELL_LLM_MODELS env var |
| `e2e-openshell-hypershift.yaml` | OPENSHELL_LLM_MODELS env var |



## Test plan
- [ ] Update `OPENAI_API_KEY` GH secret to the LiteMaaS key
- [ ] Trigger `/run-e2e-openshell` on this PR
- [ ] Verify LiteLLM proxy deploys with Qwen model
- [ ] Verify weather agent responds on HyperShift

Assisted-By: Claude Code