### PR TITLE
Chore: Bump OpenShell gateway and supervisor to v0.0.56-rc.5

### DIFF
--- a/charts/openshell/values.yaml
+++ b/charts/openshell/values.yaml
@@ -5,7 +5,7 @@ tenant: ""
 images:
   gateway:
     repository: ghcr.io/kagenti/openshell/gateway
-    tag: v0.0.56-rc.3
+    tag: v0.0.56-rc.5
     pullPolicy: IfNotPresent
   computeDriver:
     repository: ghcr.io/kagenti/openshell-driver-openshift/compute-driver
@@ -31,7 +31,7 @@ keycloakClusterIP: ""
 # Built from kagenti/OpenShell@mvp-v2 as a multi-arch image (linux/amd64 + linux/arm64).
 supervisorImage:
   repository: ghcr.io/kagenti/openshell/supervisor
-  tag: v0.0.56-rc.3
+  tag: v0.0.56-rc.5
   binaryPath: /openshell-sandbox
 
 # -- Image pull policy for sandbox pods (init + agent containers).


### PR DESCRIPTION
## Summary

- Bump `images.gateway.tag` and `supervisorImage.tag` in `charts/openshell/values.yaml` from `v0.0.56-rc.3` to `v0.0.56-rc.5`

## Included upstream changes (kagenti/OpenShell)

- **PR #21**: Per-user inference routes with ownership scoping — users can now set their own inference routing without admin role
- **PR #22**: Fix scoped provider lookup in `inference set` — resolves "provider not found" when referencing per-user providers

## Test plan

- [x] Verified on Kind cluster: `openshell inference set --provider claude --model claude-sonnet-4-6 --no-verify` works for non-admin users

Assisted-By: Claude Code