### PR TITLE
Fix: enforce helm >= 3.18.0 < 4 in OCP setup pre-flight

### DIFF
--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -202,6 +202,22 @@ if ! command -v helm &>/dev/null; then
   log_error "helm not found in PATH. Install helm >= 3.18.0"
   exit 1
 fi
+# Enforce the supported helm range: >= 3.18.0 and < 4. Helm 4 changed CRD
+# handling (server-side-applies pre-existing CRDs and alters crds/ install
+# semantics), which breaks the install: the kagenti-deps Gateway API CRDs
+# conflict with cluster-managed Gateway API on OCP 4.20+, and the Kuadrant
+# operator CRDs are not installed. See issue #2072.
+_helm_ver="$(helm version --short 2>/dev/null | sed -E 's/^v?([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+_helm_major="${_helm_ver%%.*}"
+_helm_minor="$(printf '%s' "$_helm_ver" | cut -d. -f2)"
+if ! printf '%s' "$_helm_major" | grep -qE '^[0-9]+$'; then
+  log_warn "Could not parse helm version ('$_helm_ver'); this installer requires helm >= 3.18.0 < 4"
+elif [ "$_helm_major" -ge 4 ] || { [ "$_helm_major" -eq 3 ] && [ "${_helm_minor:-0}" -lt 18 ]; }; then
+  log_error "Unsupported helm ${_helm_ver}: this installer requires helm >= 3.18.0 and < 4."
+  log_error "Helm 4 breaks CRD installation (Gateway API conflict, missing Kuadrant CRDs); see issue #2072."
+  log_error "Install a supported version, e.g.: brew install helm@3"
+  exit 1
+fi
 log_success "helm found: $(helm version --short)"
 
 # Check python3


### PR DESCRIPTION
## Summary

`scripts/ocp/setup-kagenti.sh` documents a Helm requirement of `>= 3.18.0 < 4` (script header; `docs/install.md`) but the pre-flight only checks that `helm` *exists* — it never enforced the bounds. Running with **Helm 4** therefore proceeds and then fails with cryptic CRD errors, because Helm 4 changed how `crds/` are handled (server-side-applies pre-existing CRDs; different install-if-missing semantics).

Observed on OCP 4.20.8 / Helm v4.0.5:
- **kagenti-deps (Step 3):** Helm 4 SSA-applies the bundled `gateway-api-1.3.0` CRDs even though OCP 4.20 ships Gateway API as GA (owned by `ingress-operator`) → `conflict with "ingress-operator" ... .spec.versions`.
- **Kuadrant (Step 5):** `kuadrants.kuadrant.io` and `authorinos.operator.authorino.kuadrant.io` are never installed → `helm install --wait` times out, operator crash-loops (`failed to list *v1beta1.Kuadrant ... could not find the requested resource`).

Both disappear on the supported Helm 3.x (skips pre-existing CRDs; installs missing `crds/`).

## Change

Add a pre-flight guard that hard-fails when helm is **>= 4** or **< 3.18.0**, with a clear, actionable message (e.g. `brew install helm@3`). Falls back to a warning (no crash) if the version string can't be parsed. 16 lines, `setup-kagenti.sh` only.

```
Unsupported helm 4.0.5: this installer requires helm >= 3.18.0 and < 4.
Helm 4 breaks CRD installation (Gateway API conflict, missing Kuadrant CRDs); see issue #2072.
Install a supported version, e.g.: brew install helm@3
```

## Test

- `bash -n` syntax check passes; `make lint` (pre-commit) passes.
- Guard logic verified against sample versions: `4.0.5`→block, `3.21.2`→pass, `3.18.0`→pass, `3.17.9`→block, `3.15.3`→block, unparseable→warn.

Fixes #2072

Assisted-By: Claude Code