### PR TITLE
chore: :wrench: Update PR review skill for title case insensitivity

### DIFF
--- a/.claude/skills/github:pr-review/SKILL.md
+++ b/.claude/skills/github:pr-review/SKILL.md
@@ -180,11 +180,11 @@ Apply Kagenti-specific review criteria **only for areas the PR touches**.
 | Check | Criteria |
 |-------|----------|
 | Signed-off | Every commit has `Signed-off-by:` line (DCO — enforced, blocking) |
-| Subject prefix | Capitalized conventional prefix, e.g. `Fix:`, `Feat:`, `Docs:` (advisory) — same set as the PR title list in §3.2 |
+| Subject prefix | Conventional prefix, e.g. `fix:`, `Feat:`, `Docs:` (advisory, case-insensitive) — same set as the PR title list in §3.2 |
 | Imperative mood | "Add feature" not "Added feature" (advisory) |
 | Length | Subject line under 72 characters (advisory) |
 
-> Note: the `git:commit` skill documents an emoji-prefix style, but actual practice across the org (and the `pr-verifier-required` workflow) is the capitalized conventional prefixes above. Prefer the prefix convention; treat any prefix deviation as a **nit**, not a blocker. Only DCO sign-off is blocking.
+> Note: the `git:commit` skill documents an emoji-prefix style, but actual practice across the org (and the `pr-verifier-required` workflow) is the conventional prefixes above. Matching is case-insensitive (`fix:`, `Fix:`, and `FIX:` are all valid). Treat any prefix deviation as a **nit**, not a blocker. Only DCO sign-off is blocking.
 
 ```bash
 # Check sign-off on all PR commits
@@ -197,11 +197,11 @@ Check against `repo:pr` conventions:
 
 | Check | Criteria |
 |-------|----------|
-| Title prefix | Starts with a capitalized conventional prefix, under 72 chars (advisory) |
+| Title prefix | Starts with a conventional prefix, under 72 chars (advisory) |
 | Summary section | Body contains `## Summary` |
 | Issue linking | `Fixes #N` or `Closes #N` if applicable (optional) |
 
-**Title prefix** must be one of (case-sensitive, per `kagenti/.github` `pr-verifier-required.yml`):
+**Title prefix** must be one of (case-insensitive, per `kagenti/.github` `pr-verifier-required.yml`):
 `Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test, Feature, Bug fix, Proposal, Breaking change, Other, Other/Misc`.
 
 This is **advisory only** — the title check is not a required/blocking status check, and only runs in repos that invoke `pr-verifier.yml`. Flag a non-conforming title as a **nit**, not a blocker. Do not flag it at all in repos that do not run the verifier workflow.

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -10,4 +10,4 @@ jobs:
   verify-pr-title:
     permissions:
       pull-requests: read
-    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@4e535f2436d167295d39d488ce5c44b5a2d49792
+    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@5df2608afc813a6ec4a002a9ea05640863549122


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

- Do not require case sensitivity in PR titles, in line with the update in https://github.com/kagenti/.github/pull/86
- Update workflow version to include https://github.com/kagenti/.github/pull/86

## Related issue(s)

Fixes https://github.com/kagenti/.github/issues/87
