### PR TITLE
Fix: make token-exchange Keycloak install Kind-safe (no hard oc dep)

### DIFF
--- a/.github/scripts/token-exchange/35-install-keycloak-ocp.sh
+++ b/.github/scripts/token-exchange/35-install-keycloak-ocp.sh
@@ -105,7 +105,7 @@ EOF
   kubectl rollout status statefulset/postgres-kc -n "$KC_NAMESPACE" --timeout=2m 2>/dev/null || true
 
   # Determine hostname
-  KC_HOST="${KEYCLOAK_HOST:-keycloak-keycloak.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null)}"
+  KC_HOST="$(resolve_kc_host)"
 
   # Deploy Keycloak CR
   log_info "Deploying Keycloak CR (community)"
@@ -168,7 +168,7 @@ EOF
     sleep 10
   done
 
-  KC_HOST="${KEYCLOAK_HOST:-keycloak-keycloak.$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null)}"
+  KC_HOST="$(resolve_kc_host)"
 
   log_info "Deploying Keycloak CR (RHBK)"
   cat <<EOF | kubectl apply -n "$KC_NAMESPACE" -f -

--- a/.github/scripts/token-exchange/lib.sh
+++ b/.github/scripts/token-exchange/lib.sh
@@ -52,6 +52,26 @@ get_keycloak_url() {
   echo "${KEYCLOAK_URL:-http://keycloak-service.${KC_NAMESPACE}.svc:8080}"
 }
 
+# Resolve the Keycloak CR external hostname.
+# On OCP, derive it from the ingress domain via `oc`. On Kind (or any cluster
+# without `oc`), fall back to an in-cluster hostname so the install does not
+# abort under `set -e` when `oc` is absent (the Keycloak CR uses strict: false).
+resolve_kc_host() {
+  if [[ -n "${KEYCLOAK_HOST:-}" ]]; then
+    echo "$KEYCLOAK_HOST"
+    return
+  fi
+  local domain=""
+  if command -v oc &>/dev/null; then
+    domain=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || true)
+  fi
+  if [[ -n "$domain" ]]; then
+    echo "keycloak-keycloak.${domain}"
+  else
+    echo "keycloak-service.${KC_NAMESPACE}.svc.cluster.local"
+  fi
+}
+
 # Get Keycloak admin credentials
 get_kc_admin_creds() {
   local user pass


### PR DESCRIPTION
## Summary

The token-exchange E2E track fails on **Kind** when `35-install-keycloak-ocp.sh` derives the Keycloak CR hostname via `oc get ingresses.config/cluster`. On Kind the runner has only `kubectl` (no `oc`), so under `set -e` the command substitution returns **exit 127** ("oc: command not found") and aborts the step — right after the Postgres rollout. Caught by the `release-validation.yaml` Kind E2E during the v0.6.1 release.

## Fix

Add a `resolve_kc_host()` helper in `lib.sh` (mirrors the existing `get_keycloak_url()` platform handling):
- use `KEYCLOAK_HOST` if set;
- derive the OCP ingress domain via `oc` **only when `oc` is available**;
- otherwise fall back to an in-cluster hostname (`keycloak-service.<ns>.svc.cluster.local`) — the Keycloak CR uses `strict: false`, so a non-routable host is fine for Kind.

Replace both `oc`-dependent call sites (community + rhbk modes).

## Test

Reproduced and verified with `oc` absent under `set -e`:

| | reaches next line | exit code |
|---|---|---|
| OLD (inline `$(oc …)`) | no (abort) | **127** |
| NEW (`resolve_kc_host`) | yes → `keycloak-service.keycloak.svc.cluster.local` | **0** |

Also verified: `KEYCLOAK_HOST` override wins; OCP path (fake `oc` returning a domain) yields `keycloak-keycloak.<domain>`. `bash -n` clean on both files.

Fixes #2092

Assisted-By: Claude Code