### PR TITLE
Fix: populate MCP Inspector proxy address on OpenShift (#2085)

### DIFF
--- a/kagenti/ui-v2/src/pages/MCPGatewayPage.tsx
+++ b/kagenti/ui-v2/src/pages/MCPGatewayPage.tsx
@@ -52,7 +52,14 @@ export const MCPGatewayPage: React.FC = () => {
   // Build MCP Inspector URL using config from backend
   const getMcpInspectorUrl = () => {
     if (!dashboardConfig?.mcpInspector) return null;
-    return `${dashboardConfig.mcpInspector}?serverUrl=${encodedServerUrl}&transport=streamable-http`;
+    let url = `${dashboardConfig.mcpInspector}?serverUrl=${encodedServerUrl}&transport=streamable-http`;
+    // Pass the external proxy address so the Inspector's "Proxy Address" field is
+    // pre-populated. Required on OpenShift, where the proxy is behind a Route and
+    // the Inspector's localhost default is unreachable from the browser (#2085).
+    if (dashboardConfig.mcpProxy) {
+      url += `&MCP_PROXY_FULL_ADDRESS=${encodeURIComponent(dashboardConfig.mcpProxy)}`;
+    }
+    return url;
   };
   const mcpInspectorUrl = getMcpInspectorUrl();
 


### PR DESCRIPTION
## Summary

On OpenShift, the MCP Gateway → MCP Inspector "Inspector Proxy Address" field was empty, so Connect did nothing (#2085).

`MCPGatewayPage` launched the Inspector with only `serverUrl` + `transport`, never forwarding the proxy address — even though it's available end-to-end (`mcp-proxy` Route → `ui-routes-job` → `kagenti-ui-config` → backend `config.py` `mcpProxy` → frontend `DashboardConfig.mcpProxy`). Only the final forwarding step was missing.

## Change

`kagenti/ui-v2/src/pages/MCPGatewayPage.tsx` — `getMcpInspectorUrl()` now appends `&MCP_PROXY_FULL_ADDRESS=<mcpProxy>` (URL-encoded) when available. The Inspector pre-fills its Proxy Address field from that param. No backend/chart change needed.

On Kind this was unnoticed (the Inspector's `localhost:6277` default is reachable); on OpenShift the proxy is behind a Route, so the address must be passed explicitly.

## Validation (OpenShift, rosso1)

- "Inspector Proxy Address" field now auto-populates with the `mcp-proxy` Route URL. ✅
- Connect succeeds end-to-end (proxy ↔ Kuadrant MCP Gateway MCP handshake confirmed). ✅

Note: on clusters with **self-signed** router certs, Connect additionally requires trusting the `mcp-proxy` host cert (a cross-origin background fetch can't prompt for it). That is a TLS-trust matter independent of this change — tracked separately in #2100.

Fixes #2085

Assisted-By: Claude Code