### PR TITLE
fix: Correct dtach repo URL in openshell doc

### DIFF
--- a/docs/research/openshell-mvp.md
+++ b/docs/research/openshell-mvp.md
@@ -477,7 +477,7 @@ When the CLI disconnects (network drop, terminal close), the SSH session ends an
 
 ### Solution
 
-[dtach](https://github.com/cribit/dtach) is a minimal (~20KB) statically-compiled process detacher. It is delivered via the same init container as the supervisor binary. Every sandbox has detach/reattach capability without custom images or network egress.
+[dtach](https://github.com/crigler/dtach) is a minimal (~20KB) statically-compiled process detacher. It is delivered via the same init container as the supervisor binary. Every sandbox has detach/reattach capability without custom images or network egress.
 
 ### Usage
 


### PR DESCRIPTION
The link to `https://github.com/cribit/dtach` in `docs/research/openshell-mvp.md` returned a 404. The correct repository is `https://github.com/crigler/dtach`, confirmed by maintainers @evaline-ju and @pdettori in the issue.

This change updates that single URL; no other content is modified.

Fixes #1616

Assisted-By: Claude Code