### PR TITLE
Fix: Don't forget about failed and progressing Agent builds

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -848,6 +848,65 @@ async def list_agents(
                 if e.status not in (404, 403):
                     logger.warning(f"Failed to list legacy Agent CRDs: {e.reason}")
 
+        # Surface in-progress / failed Shipwright source builds that have no
+        # workload yet. A source-built agent has no Deployment/StatefulSet/etc.
+        # until its build Succeeds and is finalized, so without this it would be
+        # invisible here while building or after a failure. Guarded so a
+        # build-listing failure never breaks the core agent list.
+        try:
+            builds = collect_kagenti_shipwright_builds(
+                kube, [namespace], RESOURCE_TYPE_AGENT, logger
+            )
+            for build in builds:
+                # Workload already exists (build Succeeded + finalized, or a
+                # name collision) -> already listed above; skip to avoid dupes.
+                if build.name in agent_names:
+                    continue
+
+                try:
+                    buildruns = kube.list_custom_resources(
+                        group=SHIPWRIGHT_CRD_GROUP,
+                        version=SHIPWRIGHT_CRD_VERSION,
+                        namespace=build.namespace,
+                        plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+                        label_selector=f"kagenti.io/build-name={build.name}",
+                    )
+                except ApiException:
+                    # Constant message only (CodeQL py/log-injection): never
+                    # interpolate namespace / build name / API reason.
+                    logger.warning("Failed to list BuildRuns for a Shipwright build")
+                    buildruns = []
+
+                # No BuildRun yet -> build just started; treat as "Building".
+                phase = "Pending"
+                latest = get_latest_buildrun(buildruns) if buildruns else None
+                if latest:
+                    phase = extract_buildrun_info(latest)["phase"]
+
+                # Succeeded builds either already have a workload (listed above)
+                # or are about to be finalized into one; don't surface them here.
+                if phase == "Succeeded":
+                    continue
+                status = "Build Failed" if phase == "Failed" else "Building"
+
+                agents.append(
+                    AgentSummary(
+                        name=build.name,
+                        namespace=build.namespace,
+                        description="Building from source",
+                        status=status,
+                        labels=_extract_labels({KAGENTI_TYPE_LABEL: build.resourceType}),
+                        workloadType=WORKLOAD_TYPE_DEPLOYMENT,
+                        # Collector already formats this as an ISO string, so do
+                        # not pass it through _format_timestamp (datetime-only).
+                        createdAt=build.creationTimestamp,
+                    )
+                )
+                agent_names.add(build.name)
+        except ApiException as e:
+            if e.status not in (404, 403):
+                logger.warning("Failed to list Shipwright builds for agents")
+
         return AgentListResponse(items=agents)
 
     except ApiException as e:

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -896,6 +896,7 @@ async def list_agents(
                         description="Building from source",
                         status=status,
                         labels=_extract_labels({KAGENTI_TYPE_LABEL: build.resourceType}),
+                        # Note that we may be building a non-deployment.  TODO record and retrieve build type.
                         workloadType=WORKLOAD_TYPE_DEPLOYMENT,
                         # Collector already formats this as an ISO string, so do
                         # not pass it through _format_timestamp (datetime-only).
@@ -904,8 +905,7 @@ async def list_agents(
                 )
                 agent_names.add(build.name)
         except ApiException as e:
-            if e.status not in (404, 403):
-                logger.warning("Failed to list Shipwright builds for agents")
+            logger.warning("Failed to list Shipwright builds for agents", exc_info=True)
 
         return AgentListResponse(items=agents)
 

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -904,7 +904,7 @@ async def list_agents(
                     )
                 )
                 agent_names.add(build.name)
-        except ApiException as e:
+        except ApiException:
             logger.warning("Failed to list Shipwright builds for agents", exc_info=True)
 
         return AgentListResponse(items=agents)

--- a/kagenti/backend/tests/test_shipwright_builds_api.py
+++ b/kagenti/backend/tests/test_shipwright_builds_api.py
@@ -217,6 +217,106 @@ class TestListAgentShipwrightBuilds:
         agents_shipwright_app.dependency_overrides.clear()
 
 
+def _buildrun(name: str, succeeded_status: str | None):
+    """A BuildRun dict. succeeded_status is the 'Succeeded' condition status
+    ("True"/"False"/"Unknown"), or None for a BuildRun with no conditions."""
+    conditions = []
+    if succeeded_status is not None:
+        conditions = [{"type": "Succeeded", "status": succeeded_status, "message": "boom"}]
+    return {
+        "metadata": {"name": name, "creationTimestamp": "2025-01-02T00:00:00Z"},
+        "status": {"conditions": conditions},
+    }
+
+
+class TestListAgentsIncludesBuilds:
+    """GET /api/v1/agents surfaces in-progress / failed Shipwright builds that
+    have no workload yet, with a status of "Building" or "Build Failed"."""
+
+    def _run(self, kube, buildrun, *, builds=None, params=None):
+        """Drive GET /agents with empty workloads and one agent build (unless
+        overridden), returning the parsed items list."""
+        app = FastAPI()
+        app.include_router(agents.router, prefix="/api/v1")
+
+        # Default workloads to empty unless the caller pre-seeded a return_value.
+        for meth in ("list_deployments", "list_statefulsets", "list_jobs"):
+            m = getattr(kube, meth)
+            if not isinstance(m.return_value, list):
+                m.return_value = []
+        # Builds listed by collect_kagenti_shipwright_builds (via custom_api).
+        if builds is None:
+            builds = [_sample_build("buildme", "team1", "agent")]
+        kube.custom_api.list_namespaced_custom_object.return_value = {"items": builds}
+        # BuildRuns listed by the new block via kube.list_custom_resources.
+        kube.list_custom_resources.return_value = [] if buildrun is None else [buildrun]
+
+        app.dependency_overrides[get_kubernetes_service] = lambda: kube
+        with patch("app.core.auth.settings") as mock_auth, patch(
+            "app.routers.agents.settings"
+        ) as mock_settings:
+            mock_auth.enable_auth = False
+            mock_settings.kagenti_feature_flag_agent_sandbox = False
+            mock_settings.enable_legacy_agent_crd = False
+            tc = TestClient(app)
+            r = tc.get("/api/v1/agents", params=params or {"namespace": "team1"})
+            assert r.status_code == 200
+            items = r.json()["items"]
+        app.dependency_overrides.clear()
+        return items
+
+    def test_failed_build_marked_build_failed(self):
+        items = self._run(MagicMock(), _buildrun("br1", "False"))
+        assert len(items) == 1
+        assert items[0]["name"] == "buildme"
+        assert items[0]["status"] == "Build Failed"
+
+    def test_running_build_marked_building(self):
+        items = self._run(MagicMock(), _buildrun("br1", "Unknown"))
+        assert len(items) == 1
+        assert items[0]["status"] == "Building"
+
+    def test_no_buildrun_marked_building(self):
+        items = self._run(MagicMock(), None)
+        assert len(items) == 1
+        assert items[0]["status"] == "Building"
+
+    def test_succeeded_build_not_listed(self):
+        items = self._run(MagicMock(), _buildrun("br1", "True"))
+        assert items == []
+
+    def test_build_deduped_against_existing_workload(self):
+        kube = MagicMock()
+        kube.list_deployments.return_value = [
+            {
+                "metadata": {
+                    "name": "buildme",
+                    "namespace": "team1",
+                    "labels": {"kagenti.io/type": "agent"},
+                    "creationTimestamp": "2025-01-01T00:00:00Z",
+                },
+                "status": {"conditions": [{"type": "Available", "status": "True"}]},
+            }
+        ]
+        # Build with the same name as the deployment -> must not be added twice.
+        items = self._run(kube, _buildrun("br1", "False"))
+        assert len(items) == 1
+        # The single entry is the real workload, not the synthetic build entry.
+        assert items[0]["status"] != "Build Failed"
+
+    def test_build_listing_failure_does_not_break_list(self):
+        from kubernetes.client import ApiException
+
+        kube = MagicMock()
+        kube.custom_api.list_namespaced_custom_object.side_effect = ApiException(
+            status=500, reason="boom"
+        )
+        # collect_kagenti_shipwright_builds re-raises non-403/404; the new block's
+        # outer guard must swallow it so the core (empty) list still returns 200.
+        items = self._run(kube, None, builds=[])
+        assert items == []
+
+
 class TestCollectShipwrightBuildsLogging:
     def test_403_warning_is_constant_only(self):
         from kubernetes.client import ApiException

--- a/kagenti/backend/tests/test_shipwright_builds_api.py
+++ b/kagenti/backend/tests/test_shipwright_builds_api.py
@@ -218,12 +218,13 @@ class TestListAgentShipwrightBuilds:
 
 
 def _buildrun(name: str, succeeded_status: str | None):
-    """A BuildRun dict. succeeded_status is the 'Succeeded' condition status
+    """Mock a BuildRun dict. succeeded_status is the 'Succeeded' condition status
     ("True"/"False"/"Unknown"), or None for a BuildRun with no conditions."""
     conditions = []
     if succeeded_status is not None:
         conditions = [{"type": "Succeeded", "status": succeeded_status, "message": "boom"}]
     return {
+        # No tests care about timestamps -- mock a dummy timestamp
         "metadata": {"name": name, "creationTimestamp": "2025-01-02T00:00:00Z"},
         "status": {"conditions": conditions},
     }

--- a/kagenti/backend/tests/test_shipwright_builds_api.py
+++ b/kagenti/backend/tests/test_shipwright_builds_api.py
@@ -252,9 +252,10 @@ class TestListAgentsIncludesBuilds:
         kube.list_custom_resources.return_value = [] if buildrun is None else [buildrun]
 
         app.dependency_overrides[get_kubernetes_service] = lambda: kube
-        with patch("app.core.auth.settings") as mock_auth, patch(
-            "app.routers.agents.settings"
-        ) as mock_settings:
+        with (
+            patch("app.core.auth.settings") as mock_auth,
+            patch("app.routers.agents.settings") as mock_settings,
+        ):
             mock_auth.enable_auth = False
             mock_settings.kagenti_feature_flag_agent_sandbox = False
             mock_settings.enable_legacy_agent_crd = False

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -20,7 +20,7 @@ export interface Agent {
   name: string;
   namespace: string;
   description: string;
-  status: 'Ready' | 'Not Ready' | 'Progressing';
+  status: 'Ready' | 'Not Ready' | 'Progressing' | 'Building' | 'Build Failed';
   labels: AgentLabels;
   workloadType?: WorkloadType;
   createdAt?: string;


### PR DESCRIPTION
## Summary

For #1906

If this PR is approved I will follow up with
- a similar PR for tool builds

I will then close the issue with a final PR to cleanup partial failures on POST /api/v1/agents and POST /api/v1/tools

## (Optional) Testing Instructions

Deploy Rossi
Bring in this PR
`make build-load-ui-frontend` and `make build-load-ui-backend` plus the usual rollout.