### PR TITLE
Chore: bump operator chart to 0.3.0-alpha.6 and authbridge extensions to v0.6.0-alpha.10

### DIFF
--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.3.0-alpha.5
-digest: sha256:6f506775e7ba6a2dbf4944023ffdd78a268355beeb82c1b1413d0ffec6a17e33
-generated: "2026-06-12T16:29:30.290616-04:00"
+  version: 0.3.0-alpha.6
+digest: sha256:63167c2bf316a4045a1199a31fa4fcbb6dc252cfb0ee9f23dd289505e58c51a6
+generated: "2026-06-29T15:44:16.84951-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -7,6 +7,6 @@ appVersion: "0.7.0-alpha.3"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.3.0-alpha.5
+  version: 0.3.0-alpha.6
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -376,10 +376,10 @@ kagenti-operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.9
-      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.9
-      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.9
-      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.9
+      authbridge: ghcr.io/kagenti/kagenti-extensions/authbridge:v0.6.0-alpha.10
+      envoyProxy: ghcr.io/kagenti/kagenti-extensions/authbridge-envoy:v0.6.0-alpha.10
+      authbridgeLite: ghcr.io/kagenti/kagenti-extensions/authbridge-lite:v0.6.0-alpha.10
+      proxyInit: ghcr.io/kagenti/kagenti-extensions/proxy-init:v0.6.0-alpha.10
 
 # ------------------------------------------------------------------
 #  MCP Gateway Configuration

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -340,7 +340,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.3.0-alpha.5
+        tag: 0.3.0-alpha.6
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
## Summary

Dependency bump for the 0.7 line — approved by @huang195 (operator) and @pdettori.

- **`kagenti-operator-chart` `0.3.0-alpha.5 → 0.3.0-alpha.6`** — adds the `namespaces: patch` RBAC the AgentRuntime Istio auto-labeling (`ensureIstioMeshLabels`) needs. This is the operator-side fix for the token-exchange E2E `client_not_found` cascade (#2098): on alpha.5 the controller-manager couldn't patch the agent namespace → `tx-e2e` workloads CrashLoopBackOff → per-workload client-registration never ran. alpha.6 also carries TLS-bridge Phase 2, which is **off by default** (`tlsBridgeMode` gated).
- **operator binary image tag `0.3.0-alpha.5 → 0.3.0-alpha.6`** (`charts/kagenti/values.yaml`) — the chart-version bump alone left the controller-manager *image* pinned to alpha.5, producing a chart/binary skew that crash-looped the operator and timed out the platform install. This aligns the binary with the chart.
- **kagenti-extensions `v0.6.0-alpha.9 → v0.6.0-alpha.10`** (`authbridge`, `authbridge-envoy`, `authbridge-lite`, `proxy-init`) — security-audit remediations, IBAC intent-eviction / MCP rejection-frame fixes, iptables backend detection.
- Regenerate `Chart.lock`.

## Validation

`helm lint` passes. Kind `release-validation.yaml` (run 28447999840): **platform install ✅**, **backend E2E ✅** — the skew fix resolves the install timeout.

**#2098 not yet verified end-to-end.** The token-exchange suite is currently blocked *before* it runs by a separate, pre-existing 0.7 issue: the Keycloak bootstrap operand (`charts/kagenti-deps/`) deploys a `postgres-kc` StatefulSet that collides with the one the token-exchange harness (`.github/scripts/token-exchange/35-install-keycloak-ocp.sh`) applies. That collision is unrelated to this bump (no `charts/kagenti-deps/` changes here) and will be fixed in a follow-up, where the namespaces:patch fix can finally be confirmed.

Refs #2098 (kept open until token-exchange E2E passes)

Assisted-By: Claude Code
