### PR TITLE
Feat: 🖥️ Add options for persistent storage to Kagenti CLI

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -3350,10 +3350,14 @@ def _build_statefulset_manifest(
                     "volumes": [
                         {"name": "cache", "emptyDir": {}},
                         {"name": "marvin", "emptyDir": {}},
-                        {"name": "shared-data", "emptyDir": {}},
                         *skill_volumes,
                         *ext_volumes,
-                    ],
+                    ]
+                    + (
+                        []
+                        if request.persistentStorage and request.persistentStorage.enabled
+                        else [{"name": "shared-data", "emptyDir": {}}]
+                    ),
                 },
             },
         },
@@ -3362,6 +3366,24 @@ def _build_statefulset_manifest(
     # Add init containers for external skills
     if ext_init_containers:
         manifest["spec"]["template"]["spec"]["initContainers"] = ext_init_containers
+
+    # When persistent storage is requested, declare a volumeClaimTemplate so the
+    # StatefulSet provisions a PVC bound to the pod's stable identity; the
+    # shared-data volume above is omitted from `volumes` in that case because
+    # the template name (shared-data) becomes the volume.
+    if request.persistentStorage and request.persistentStorage.enabled:
+        manifest["spec"]["volumeClaimTemplates"] = [
+            {
+                "metadata": {
+                    "name": "shared-data",
+                    "labels": {APP_KUBERNETES_IO_NAME: request.name},
+                },
+                "spec": {
+                    "accessModes": ["ReadWriteOnce"],
+                    "resources": {"requests": {"storage": request.persistentStorage.size}},
+                },
+            }
+        ]
 
     # Add image pull secrets if specified
     if request.imagePullSecret:

--- a/kagenti/backend/tests/test_statefulset_manifest.py
+++ b/kagenti/backend/tests/test_statefulset_manifest.py
@@ -1,0 +1,106 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Unit tests for StatefulSet manifest builder PVC wiring.
+
+Mirrors the sandbox PVC tests so the two workload types stay in sync.
+"""
+
+from unittest.mock import MagicMock
+
+from app.routers.agents import CreateAgentRequest, PersistentStorageConfig
+
+
+def _make_request(**overrides):
+    req = MagicMock(spec=CreateAgentRequest)
+    req.name = overrides.get("name", "test-agent")
+    req.namespace = overrides.get("namespace", "team1")
+    req.containerImage = overrides.get("containerImage", "ghcr.io/example/agent:latest")
+    req.framework = overrides.get("framework", "langgraph")
+    req.protocol = overrides.get("protocol", "a2a")
+    req.workloadType = overrides.get("workloadType", "statefulset")
+    req.servicePorts = overrides.get("servicePorts", None)
+    req.envVars = overrides.get("envVars", None)
+    req.imagePullSecret = overrides.get("imagePullSecret", None)
+    req.authBridgeEnabled = overrides.get("authBridgeEnabled", False)
+    req.spireEnabled = overrides.get("spireEnabled", False)
+    req.envoyProxyInject = overrides.get("envoyProxyInject", None)
+    req.spiffeHelperInject = overrides.get("spiffeHelperInject", None)
+    req.clientRegistrationInject = overrides.get("clientRegistrationInject", None)
+    req.outboundPortsExclude = overrides.get("outboundPortsExclude", None)
+    req.inboundPortsExclude = overrides.get("inboundPortsExclude", None)
+    req.outboundRoutes = overrides.get("outboundRoutes", None)
+    req.defaultOutboundPolicy = overrides.get("defaultOutboundPolicy", None)
+    req.persistentStorage = overrides.get("persistentStorage", None)
+    req.skills = overrides.get("skills", None)
+    return req
+
+
+class TestBuildStatefulsetManifestPVC:
+    def test_no_pvc_by_default(self):
+        from app.routers.agents import _build_statefulset_manifest
+
+        request = _make_request()
+        manifest = _build_statefulset_manifest(request=request, image="test:latest")
+
+        assert "volumeClaimTemplates" not in manifest["spec"]
+        volume_names = [v["name"] for v in manifest["spec"]["template"]["spec"]["volumes"]]
+        assert "shared-data" in volume_names
+
+    def test_pvc_when_enabled(self):
+        from app.routers.agents import _build_statefulset_manifest
+
+        storage = PersistentStorageConfig(enabled=True, size="5Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_statefulset_manifest(request=request, image="test:latest")
+
+        vct = manifest["spec"]["volumeClaimTemplates"]
+        assert len(vct) == 1
+        assert vct[0]["metadata"]["name"] == "shared-data"
+        assert vct[0]["metadata"]["labels"]["app.kubernetes.io/name"] == "test-agent"
+        assert vct[0]["spec"]["accessModes"] == ["ReadWriteOnce"]
+        assert vct[0]["spec"]["resources"]["requests"]["storage"] == "5Gi"
+
+    def test_pvc_replaces_shared_data_emptydir(self):
+        from app.routers.agents import _build_statefulset_manifest
+
+        storage = PersistentStorageConfig(enabled=True, size="1Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_statefulset_manifest(request=request, image="test:latest")
+
+        volume_names = [v["name"] for v in manifest["spec"]["template"]["spec"]["volumes"]]
+        assert "shared-data" not in volume_names
+        assert "cache" in volume_names
+        assert "marvin" in volume_names
+
+    def test_pvc_volume_mount_unchanged(self):
+        from app.routers.agents import _build_statefulset_manifest
+
+        storage = PersistentStorageConfig(enabled=True, size="1Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_statefulset_manifest(request=request, image="test:latest")
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        mount = next(m for m in container["volumeMounts"] if m["name"] == "shared-data")
+        assert mount["mountPath"] == "/shared"
+
+    def test_pvc_disabled_keeps_emptydir(self):
+        from app.routers.agents import _build_statefulset_manifest
+
+        storage = PersistentStorageConfig(enabled=False, size="1Gi")
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_statefulset_manifest(request=request, image="test:latest")
+
+        assert "volumeClaimTemplates" not in manifest["spec"]
+        volume_names = [v["name"] for v in manifest["spec"]["template"]["spec"]["volumes"]]
+        assert "shared-data" in volume_names
+
+    def test_pvc_default_size(self):
+        from app.routers.agents import _build_statefulset_manifest
+
+        storage = PersistentStorageConfig(enabled=True)
+        request = _make_request(persistentStorage=storage)
+        manifest = _build_statefulset_manifest(request=request, image="test:latest")
+
+        vct = manifest["spec"]["volumeClaimTemplates"]
+        assert vct[0]["spec"]["resources"]["requests"]["storage"] == "1Gi"

--- a/kagenti/tui/internal/cli/cli_test.go
+++ b/kagenti/tui/internal/cli/cli_test.go
@@ -315,6 +315,123 @@ func TestDeployAgent(t *testing.T) {
 	}
 }
 
+func TestDeployAgentWorkloadType(t *testing.T) {
+	var got api.CreateAgentRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agents" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(api.CreateAgentResponse{
+			Success: true, Name: got.Name, Namespace: got.Namespace,
+		})
+	}))
+	defer srv.Close()
+
+	client := api.NewClient(srv.URL, "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+	deployCmd := newDeployCmd(ctx)
+	deployCmd.SetArgs([]string{
+		"agent",
+		"--name", "stateful-agent",
+		"--container-image", "img:v1",
+		"--workload-type", "statefulset",
+	})
+	deployCmd.PersistentFlags().String("namespace", "team1", "")
+
+	if err := deployCmd.Execute(); err != nil {
+		t.Fatalf("deploy agent command failed: %v", err)
+	}
+	if got.WorkloadType != "statefulset" {
+		t.Fatalf("expected workloadType=statefulset, got %q", got.WorkloadType)
+	}
+}
+
+func TestDeployAgentPersistentStorage(t *testing.T) {
+	var got api.CreateAgentRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agents" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(api.CreateAgentResponse{
+			Success: true, Name: got.Name, Namespace: got.Namespace,
+		})
+	}))
+	defer srv.Close()
+
+	client := api.NewClient(srv.URL, "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+	deployCmd := newDeployCmd(ctx)
+	deployCmd.SetArgs([]string{
+		"agent",
+		"--name", "stateful-agent",
+		"--container-image", "img:v1",
+		"--workload-type", "statefulset",
+		"--persistent-storage",
+		"--persistent-storage-size", "5Gi",
+	})
+	deployCmd.PersistentFlags().String("namespace", "team1", "")
+
+	if err := deployCmd.Execute(); err != nil {
+		t.Fatalf("deploy agent command failed: %v", err)
+	}
+	if got.PersistentStorage == nil {
+		t.Fatal("expected persistentStorage in request")
+	}
+	if !got.PersistentStorage.Enabled {
+		t.Fatal("expected persistentStorage.enabled=true")
+	}
+	if got.PersistentStorage.Size != "5Gi" {
+		t.Fatalf("expected persistentStorage.size=5Gi, got %q", got.PersistentStorage.Size)
+	}
+}
+
+func TestDeployAgentPersistentStorageRequiresStatefulSet(t *testing.T) {
+	client := api.NewClient("http://example.invalid", "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+	deployCmd := newDeployCmd(ctx)
+	deployCmd.SetArgs([]string{
+		"agent",
+		"--name", "deployment-agent",
+		"--container-image", "img:v1",
+		"--persistent-storage",
+	})
+
+	err := deployCmd.Execute()
+	if err == nil {
+		t.Fatal("expected persistent storage with deployment workload to fail")
+	}
+	if !strings.Contains(err.Error(), "--workload-type statefulset") {
+		t.Fatalf("expected statefulset validation error, got: %v", err)
+	}
+}
+
+func TestDeployAgentPersistentStorageSizeRequiresPersistentStorage(t *testing.T) {
+	client := api.NewClient("http://example.invalid", "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+	deployCmd := newDeployCmd(ctx)
+	deployCmd.SetArgs([]string{
+		"agent",
+		"--name", "stateful-agent",
+		"--container-image", "img:v1",
+		"--workload-type", "statefulset",
+		"--persistent-storage-size", "5Gi",
+	})
+
+	err := deployCmd.Execute()
+	if err == nil {
+		t.Fatal("expected storage size without persistent storage to fail")
+	}
+	if !strings.Contains(err.Error(), "--persistent-storage-size requires --persistent-storage") {
+		t.Fatalf("expected persistent storage size validation error, got: %v", err)
+	}
+}
+
 func TestDeployTool(t *testing.T) {
 	_, ctx := newTestServer(t)
 	deployCmd := newDeployCmd(ctx)

--- a/kagenti/tui/internal/cli/cli_test.go
+++ b/kagenti/tui/internal/cli/cli_test.go
@@ -349,6 +349,45 @@ func TestDeployAgentWorkloadType(t *testing.T) {
 	}
 }
 
+func TestDeployAgentGitPath(t *testing.T) {
+	// --git-path must reach the backend as request.gitPath, otherwise the
+	// resulting Shipwright Build uses contextDir "." (repo root) and fails
+	// for any monorepo where the agent source is a subfolder.
+	var got api.CreateAgentRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agents" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(api.CreateAgentResponse{
+			Success: true, Name: got.Name, Namespace: got.Namespace,
+		})
+	}))
+	defer srv.Close()
+
+	client := api.NewClient(srv.URL, "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+	deployCmd := newDeployCmd(ctx)
+	deployCmd.SetArgs([]string{
+		"agent",
+		"--name", "sub-folder-agent",
+		"--deploy-method", "source",
+		"--git-url", "https://github.com/example/monorepo",
+		"--git-path", "a2a/my_agent",
+		"--git-branch", "main",
+	})
+	deployCmd.PersistentFlags().String("namespace", "team1", "")
+
+	if err := deployCmd.Execute(); err != nil {
+		t.Fatalf("deploy agent command failed: %v", err)
+	}
+	if got.GitPath != "a2a/my_agent" {
+		t.Fatalf("expected gitPath=a2a/my_agent, got %q", got.GitPath)
+	}
+}
+
 func TestDeployAgentPersistentStorage(t *testing.T) {
 	var got api.CreateAgentRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/kagenti/tui/internal/cli/cli_test.go
+++ b/kagenti/tui/internal/cli/cli_test.go
@@ -432,6 +432,71 @@ func TestDeployAgentPersistentStorageSizeRequiresPersistentStorage(t *testing.T)
 	}
 }
 
+func TestValidateStorageSize(t *testing.T) {
+	cases := []struct {
+		name       string
+		size       string
+		wantErr    bool
+		wantSubstr string
+	}{
+		{name: "valid Gi", size: "5Gi", wantErr: false},
+		{name: "valid Mi", size: "500Mi", wantErr: false},
+		{name: "valid decimal G", size: "5G", wantErr: false},
+		{name: "valid fractional", size: "1.5Gi", wantErr: false},
+		{name: "valid bare bytes", size: "1073741824", wantErr: false},
+		{name: "default 1Gi", size: "1Gi", wantErr: false},
+		{name: "bad unit", size: "1XB", wantErr: true, wantSubstr: "not a valid"},
+		{name: "non-numeric", size: "banana", wantErr: true, wantSubstr: "not a valid"},
+		{name: "zero", size: "0Gi", wantErr: true, wantSubstr: "must be a positive"},
+		{name: "below 1Mi", size: "1Ki", wantErr: true, wantSubstr: "too small"},
+		{name: "above 10Ti", size: "100Ti", wantErr: true, wantSubstr: "too large"},
+		{name: "empty", size: "", wantErr: true, wantSubstr: "not a valid"},
+		{name: "leading dash", size: "-1Gi", wantErr: true, wantSubstr: "not a valid"},
+		{name: "trailing junk", size: "5Gi extra", wantErr: true, wantSubstr: "not a valid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStorageSize(tc.size)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for size %q, got nil", tc.size)
+				}
+				if tc.wantSubstr != "" && !strings.Contains(err.Error(), tc.wantSubstr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantSubstr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error for size %q, got: %v", tc.size, err)
+			}
+		})
+	}
+}
+
+func TestDeployAgentRejectsInvalidStorageSize(t *testing.T) {
+	// Sanity check that the validator is wired into the deploy command path,
+	// not just exposed as a standalone function. Use an invalid size — the
+	// command must fail before any HTTP call is attempted.
+	client := api.NewClient("http://example.invalid", "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+	deployCmd := newDeployCmd(ctx)
+	deployCmd.SetArgs([]string{
+		"agent",
+		"--name", "stateful-agent",
+		"--container-image", "img:v1",
+		"--workload-type", "statefulset",
+		"--persistent-storage",
+		"--persistent-storage-size", "banana",
+	})
+	deployCmd.PersistentFlags().String("namespace", "team1", "")
+
+	err := deployCmd.Execute()
+	if err == nil {
+		t.Fatal("expected invalid storage size to fail")
+	}
+	if !strings.Contains(err.Error(), "not a valid Kubernetes size") {
+		t.Fatalf("expected size-format error, got: %v", err)
+	}
+}
+
 func TestDeployTool(t *testing.T) {
 	_, ctx := newTestServer(t)
 	deployCmd := newDeployCmd(ctx)

--- a/kagenti/tui/internal/cli/deploy.go
+++ b/kagenti/tui/internal/cli/deploy.go
@@ -29,6 +29,9 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 		framework      string
 		protocol       string
 		deployMethod   string
+		workloadType   string
+		persistent     bool
+		storageSize    string
 		containerImage string
 		gitURL         string
 		gitBranch      string
@@ -46,6 +49,13 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 		Use:   "agent",
 		Short: "Deploy an agent",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if persistent && workloadType != "statefulset" {
+				return fmt.Errorf("--persistent-storage is only supported with --workload-type statefulset")
+			}
+			if cmd.Flags().Changed("persistent-storage-size") && !persistent {
+				return fmt.Errorf("--persistent-storage-size requires --persistent-storage")
+			}
+
 			ns, _ := cmd.Flags().GetString("namespace")
 			if ns == "" {
 				ns = ctx.Client.Namespace
@@ -86,7 +96,7 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 				Protocol:          protocol,
 				Framework:         framework,
 				DeploymentMethod:  deployMethod,
-				WorkloadType:      "deployment",
+				WorkloadType:      workloadType,
 				ContainerImage:    containerImage,
 				GitURL:            gitURL,
 				GitBranch:         gitBranch,
@@ -94,6 +104,12 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 				AuthBridgeEnabled: true,
 				SpireEnabled:      spire,
 				EnvVars:           allEnv,
+			}
+			if persistent {
+				req.PersistentStorage = &api.PersistentStorageConfig{
+					Enabled: true,
+					Size:    storageSize,
+				}
 			}
 
 			resp, err := ctx.Client.CreateAgent(req)
@@ -112,6 +128,9 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 	cmd.Flags().StringVar(&framework, "framework", "LangGraph", "Framework (LangGraph, CrewAI, AG2, Custom)")
 	cmd.Flags().StringVar(&protocol, "protocol", "a2a", "Protocol (a2a, mcp)")
 	cmd.Flags().StringVar(&deployMethod, "deploy-method", "image", "Deployment method (image, source)")
+	cmd.Flags().StringVar(&workloadType, "workload-type", "deployment", "Workload type (deployment, statefulset, job)")
+	cmd.Flags().BoolVar(&persistent, "persistent-storage", false, "Enable persistent storage (statefulset only)")
+	cmd.Flags().StringVar(&storageSize, "persistent-storage-size", "1Gi", "Persistent volume claim size (e.g., 1Gi, 5Gi, 10Gi)")
 	cmd.Flags().StringVar(&containerImage, "container-image", "", "Container image")
 	cmd.Flags().StringVar(&gitURL, "git-url", "", "Git repository URL")
 	cmd.Flags().StringVar(&gitBranch, "git-branch", "main", "Git branch")

--- a/kagenti/tui/internal/cli/deploy.go
+++ b/kagenti/tui/internal/cli/deploy.go
@@ -2,12 +2,79 @@ package cli
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kagenti/kagenti/kagenti/tui/internal/api"
 	"github.com/kagenti/kagenti/kagenti/tui/internal/helpers"
 )
+
+// storageSizeRE matches a Kubernetes resource.Quantity in the binary
+// (e.g. "5Gi") or decimal (e.g. "500M") form, plus plain byte counts.
+// We intentionally accept the same shapes the K8s API server would, then
+// apply a sanity range so an obvious typo like "1XB" or "0Gi" fails up
+// front instead of after the manifest hits the API server.
+var storageSizeRE = regexp.MustCompile(`^(\d+(?:\.\d+)?)(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$`)
+
+const (
+	minStorageBytes int64 = 1 << 20  // 1Mi — anything smaller is almost certainly a typo
+	maxStorageBytes int64 = 10 << 40 // 10Ti — well past any sensible per-agent volume
+)
+
+func validateStorageSize(size string) error {
+	m := storageSizeRE.FindStringSubmatch(size)
+	if m == nil {
+		return fmt.Errorf(
+			"--persistent-storage-size %q is not a valid Kubernetes size (e.g. 1Gi, 500Mi, 5G)",
+			size,
+		)
+	}
+	n, err := strconv.ParseFloat(m[1], 64)
+	if err != nil || n <= 0 {
+		return fmt.Errorf("--persistent-storage-size %q must be a positive number", size)
+	}
+	var unit int64 = 1
+	switch m[2] {
+	case "Ki":
+		unit = 1 << 10
+	case "Mi":
+		unit = 1 << 20
+	case "Gi":
+		unit = 1 << 30
+	case "Ti":
+		unit = 1 << 40
+	case "Pi":
+		unit = 1 << 50
+	case "Ei":
+		unit = 1 << 60
+	case "K":
+		unit = 1_000
+	case "M":
+		unit = 1_000_000
+	case "G":
+		unit = 1_000_000_000
+	case "T":
+		unit = 1_000_000_000_000
+	case "P":
+		unit = 1_000_000_000_000_000
+	case "E":
+		unit = 1_000_000_000_000_000_000
+	}
+	bytes := int64(n * float64(unit))
+	if bytes < minStorageBytes {
+		return fmt.Errorf(
+			"--persistent-storage-size %q is too small; minimum is 1Mi", size,
+		)
+	}
+	if bytes > maxStorageBytes {
+		return fmt.Errorf(
+			"--persistent-storage-size %q is too large; maximum is 10Ti", size,
+		)
+	}
+	return nil
+}
 
 func newDeployCmd(ctx *CLIContext) *cobra.Command {
 	cmd := &cobra.Command{
@@ -54,6 +121,11 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 			}
 			if cmd.Flags().Changed("persistent-storage-size") && !persistent {
 				return fmt.Errorf("--persistent-storage-size requires --persistent-storage")
+			}
+			if persistent {
+				if err := validateStorageSize(storageSize); err != nil {
+					return err
+				}
 			}
 
 			ns, _ := cmd.Flags().GetString("namespace")

--- a/kagenti/tui/internal/cli/deploy.go
+++ b/kagenti/tui/internal/cli/deploy.go
@@ -101,6 +101,7 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 		storageSize    string
 		containerImage string
 		gitURL         string
+		gitPath        string
 		gitBranch      string
 		createRoute    bool
 		spire          bool
@@ -171,6 +172,7 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 				WorkloadType:      workloadType,
 				ContainerImage:    containerImage,
 				GitURL:            gitURL,
+				GitPath:           gitPath,
 				GitBranch:         gitBranch,
 				CreateHTTPRoute:   createRoute,
 				AuthBridgeEnabled: true,
@@ -205,6 +207,7 @@ func newDeployAgentCmd(ctx *CLIContext) *cobra.Command {
 	cmd.Flags().StringVar(&storageSize, "persistent-storage-size", "1Gi", "Persistent volume claim size (e.g., 1Gi, 5Gi, 10Gi)")
 	cmd.Flags().StringVar(&containerImage, "container-image", "", "Container image")
 	cmd.Flags().StringVar(&gitURL, "git-url", "", "Git repository URL")
+	cmd.Flags().StringVar(&gitPath, "git-path", "", "Path to agent source within the repository (e.g. a2a/my_agent)")
 	cmd.Flags().StringVar(&gitBranch, "git-branch", "main", "Git branch")
 	cmd.Flags().BoolVar(&createRoute, "create-route", false, "Create HTTP route")
 	cmd.Flags().BoolVar(&spire, "spire", false, "Enable SPIRE identity")


### PR DESCRIPTION
## Summary

The Kagenti UI already lets users deploy agents as StatefulSets with a PVC, but the CLI didn't have the matching flags. This PR adds them.

While end-to-end testing the new CLI flags, I found that the backend's StatefulSet manifest builder was silently ignoring `request.persistentStorage` — it always emitted `shared-data` as an `emptyDir`, never as a PVC. That meant the UI's "persistent storage size" field on the StatefulSet create form was also a no-op at runtime: pods looked like they had a PVC, but `/shared` was ephemeral and lost on restart. This PR patches the StatefulSet builder so the request is honored, which fixes both the new CLI path and the existing UI path.

### CLI changes
- Adds `--workload-type` to `kagenti deploy agent` with support for `deployment`, `statefulset`, and `job`.
- Adds StatefulSet persistent storage flags:
  - `--persistent-storage`
  - `--persistent-storage-size`
- Sends `persistentStorage` in the agent create request when persistent storage is enabled.
- Validates that persistent storage flags are only used with `--workload-type statefulset`.
- Validates `--persistent-storage-size` against the K8s quantity format and a 1Mi–10Ti range so typos fail at cobra with a clear message instead of bubbling back as a K8s 5xx.
- Adds CLI tests covering workload type forwarding, persistent storage forwarding, invalid flag combinations, and size-format validation.

### Backend fix
- Mirrors the existing Sandbox PVC pattern in `_build_statefulset_manifest`: when `persistentStorage.enabled` is true, drop the `shared-data` `emptyDir` and add a `volumeClaimTemplates[0]` named `shared-data` (size from request, `ReadWriteOnce`, default StorageClass).
- Adds `tests/test_statefulset_manifest.py` mirroring the sandbox PVC tests (6 tests: no-PVC default, PVC when enabled, emptyDir replaced, mount unchanged, disabled flag, default size).
- Behavior change is gated entirely on `persistentStorage.enabled` — existing StatefulSet agents created without the flag are unaffected.

This work will also be useful for Context Operator development.

## Testing

- CLI: `cd kagenti/tui && go test ./internal/cli`
- Backend: `cd kagenti/backend && uv run pytest tests/test_statefulset_manifest.py tests/test_sandbox_manifest.py`
- End-to-end deploy + restart verification: planned with a minimal A2A agent in `agent-examples`; will update once that lands.

## Related issue(s)

None.

Assisted-By: Codex, Claude (Anthropic AI)