### PR TITLE
fix(v0.6.1, ocp): make weather-agent CLI deploy work on OpenShift

### DIFF
--- a/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
+++ b/.github/scripts/kagenti-operator/74-deploy-weather-agent.sh
@@ -223,6 +223,9 @@ metadata:
   namespace: team1
   annotations:
     openshift.io/host.generated: "true"
+    # Agent chat involves a cold MCP session + multiple LLM round-trips that can
+    # exceed HAProxy's 30s default, surfacing as a 504 on the first request.
+    haproxy.router.openshift.io/timeout: "120s"
 spec:
   path: /
   port:

--- a/.github/scripts/kagenti-operator/75-deploy-weather-tool-shipwright.sh
+++ b/.github/scripts/kagenti-operator/75-deploy-weather-tool-shipwright.sh
@@ -67,7 +67,7 @@ spec:
       revision: ${GIT_BRANCH}
     contextDir: ${GIT_PATH}
   strategy:
-    name: buildah-insecure
+    name: buildah
     kind: ClusterBuildStrategy
   output:
     image: ${REGISTRY}/${TOOL_NAME}:${IMAGE_TAG}
@@ -133,6 +133,12 @@ echo ""
 echo "Step 4: Retrieving output image..."
 OUTPUT_IMAGE=$(kubectl get buildrun "${BUILDRUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.output.image}')
 OUTPUT_DIGEST=$(kubectl get buildrun "${BUILDRUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.output.digest}')
+# Some Shipwright versions leave .status.output.image empty (only digest is set).
+# Fall back to the registry path we asked the build to push to.
+if [ -z "${OUTPUT_IMAGE}" ]; then
+    OUTPUT_IMAGE="${REGISTRY}/${TOOL_NAME}:${IMAGE_TAG}"
+    echo "Output image empty in BuildRun status; falling back to ${OUTPUT_IMAGE}"
+fi
 echo "Output Image: ${OUTPUT_IMAGE}"
 echo "Output Digest: ${OUTPUT_DIGEST}"
 
@@ -177,6 +183,14 @@ spec:
         - name: mcp
           image: ${OUTPUT_IMAGE}
           imagePullPolicy: Always
+          env:
+            # OpenShift runs the container with an arbitrary non-root UID, so
+            # uv's default cache (\$HOME/.cache -> /.cache) is not writable.
+            # Point both at the writable /tmp emptyDir mounted below.
+            - name: UV_CACHE_DIR
+              value: /tmp/uv-cache
+            - name: HOME
+              value: /tmp
           ports:
             - containerPort: 8000
               name: http

--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -523,6 +523,10 @@ metadata:
     {{- include "kagenti.commonLabels" . | nindent 4 }}
   annotations:
     openshift.io/host.generated: "true"
+    # Agent chat proxied through the UI involves a cold MCP session + multiple
+    # LLM round-trips that can exceed HAProxy's 30s default, surfacing as a 504
+    # on the first request even though the agent itself completes.
+    haproxy.router.openshift.io/timeout: "120s"
 spec:
   path: /
   port:
@@ -547,6 +551,10 @@ metadata:
     {{- include "kagenti.commonLabels" . | nindent 4 }}
   annotations:
     openshift.io/host.generated: "true"
+    # Agent chat proxied through the backend API involves a cold MCP session +
+    # multiple LLM round-trips that can exceed HAProxy's 30s default, surfacing
+    # as a 504 on the first request even though the agent itself completes.
+    haproxy.router.openshift.io/timeout: "120s"
 spec:
   path: /
   port:


### PR DESCRIPTION
## Summary

Deploying the weather agent demo via the `kagenti-operator` CLI scripts
(`.github/scripts/kagenti-operator/74-…` and `75-…`) on HyperShift OpenShift
clusters (validated on two clusters running kagenti v0.6.1) surfaced several
OpenShift-specific gaps. This PR fixes the ones with a clear, low-risk code
change; all are OpenShift-only paths and do not affect Kind.

### `75-deploy-weather-tool-shipwright.sh`
- **Build strategy:** used `ClusterBuildStrategy: buildah-insecure`, which is
  absent on clusters that only ship `buildah` → BuildRun fails with
  `ClusterBuildStrategyNotFound`. Aligned with the agent build (`buildah`).
- **Empty output image:** some Shipwright versions populate
  `.status.output.digest` but leave `.status.output.image` empty, so the tool
  Deployment was created with an empty image (`image: Required value`). Falls
  back to the registry path the build was told to push to.
- **uv cache CrashLoop:** OpenShift runs the container with an arbitrary
  non-root UID whose `$HOME` is `/`, so uv's default cache (`/.cache/uv`) is not
  writable and the tool pod `CrashLoopBackOff`s. Sets `UV_CACHE_DIR=/tmp/uv-cache`
  and `HOME=/tmp` (the Deployment already mounts a writable `/tmp` emptyDir).

### `74-deploy-weather-agent.sh`
- **Route 504:** the `weather-service` Route had no timeout annotation, so a
  cold first chat (MCP session init + multiple LLM round-trips) exceeded
  HAProxy's 30s default and 504'd. Adds `haproxy.router.openshift.io/timeout: 120s`.

### `charts/kagenti/templates/ui.yaml`
- **UI chat 504:** the `kagenti-ui` and `kagenti-api` OpenShift Routes had the
  same 30s default. UI chat is proxied through these front-door routes, so it
  504'd even after the per-agent route was fixed. Adds the 120s timeout to both.

## Test plan

- [x] Deployed the weather agent end-to-end on two HyperShift OCP clusters
      (v0.6.1): tool + agent build via Shipwright, agentcard `SYNCED=True`,
      UI chat returns answers (no 504) after all fixes.
- [x] `helm template` renders `ui.yaml` cleanly with the new annotations on
      both routes.
- [x] `make lint` / pre-commit pass.
- [ ] CI green.

## Follow-ups (not in this PR)

- The legacy client-registration sidecar (`kagenti.io/client-registration-inject: "true"`)
  expects `keycloak-admin-secret` in the **agent** namespace, but v0.6.1 only
  creates it in `kagenti-system`, so the agent pod hangs in
  `CreateContainerConfigError`. Needs a design decision: copy the secret into
  the agent namespace when the label is present, or drop the legacy label and
  use the operator-managed registration path. Currently a manual workaround.
- Confirm whether any supported cluster genuinely needs the `buildah-insecure`
  strategy; if so, make the strategy name configurable rather than hardcoded.

Assisted-By: Claude Code