### PR TITLE
Fix: reuse platform Keycloak for token-exchange E2E on Kind

### DIFF
--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -199,7 +199,10 @@ jobs:
       - name: Setup Keycloak for token exchange
         if: success()
         run: |
-          bash .github/scripts/token-exchange/35-install-keycloak-ocp.sh community
+          # On Kind, Keycloak is already installed by the platform installer
+          # (35-install-keycloak-ocp.sh is OpenShift-only and would stand up a
+          # second, colliding Keycloak). Reuse the platform Keycloak — its
+          # KC_FEATURES now include token-exchange + admin-fine-grained-authz.
           bash .github/scripts/token-exchange/40-setup-keycloak-realm.sh
           bash .github/scripts/token-exchange/50-enable-kagenti-ns.sh
           bash .github/scripts/token-exchange/55-setup-spiffe-idp.sh

--- a/charts/kagenti-deps/templates/keycloak-k8s.yaml
+++ b/charts/kagenti-deps/templates/keycloak-k8s.yaml
@@ -227,7 +227,10 @@ extraEnvVars with the same name override these defaults.
 */}}
 {{- define "kagenti.keycloak.defaultEnv" -}}
 - name: KC_FEATURES
-  value: "client-auth-federated:v1,spiffe:v1"
+  # token-exchange + admin-fine-grained-authz are required by the token-exchange
+  # E2E suite (realm/FGAP setup). Enabling them on the platform Keycloak lets the
+  # suite reuse it instead of standing up a second, colliding Keycloak on Kind.
+  value: "client-auth-federated:v1,spiffe:v1,token-exchange,admin-fine-grained-authz:v1"
 - name: KC_BOOTSTRAP_ADMIN_USERNAME
   value: "admin"
 - name: KC_BOOTSTRAP_ADMIN_PASSWORD


### PR DESCRIPTION
## Summary

The release-validation **Kind** leg ran `35-install-keycloak-ocp.sh community`, which the script's own header documents as **OpenShift-only** ("On Kind, Keycloak is installed by setup-kagenti.sh"). On Kind it stood up a *second* Keycloak (community operator + `Keycloak` CR + its own postgres) in the **same `keycloak` namespace** the platform installer already populated, causing a StatefulSet immutable-spec / postgres collision. The `Setup Keycloak for token exchange` step aborted **before the suite ran**, blocking the #2098 token-exchange E2E verification.

## Fix — reuse the platform Keycloak on Kind

- **`charts/kagenti-deps/templates/keycloak-k8s.yaml`** — add `token-exchange` + `admin-fine-grained-authz:v1` to the Kind platform Keycloak `KC_FEATURES` (was `client-auth-federated:v1,spiffe:v1`). The suite's realm/FGAP setup needs them; the platform image (`quay.io/keycloak/keycloak:26.5.2`) supports them.
- **`.github/workflows/release-validation.yaml`** (Kind leg) — drop `35-install-keycloak-ocp.sh community`; run the realm/client setup (`40-setup-keycloak-realm.sh` …) against the platform Keycloak. Those scripts only need a running Keycloak + the `keycloak-initial-admin` admin token, both provided by the platform.

## Scope / follow-up

Kept to the **Kind** leg (the one validated by `release-validation.yaml`). The **OCP/HyperShift** legs also run `35` and the operand Keycloak (`keycloak-operand.yaml`) likewise has no `features:` block, so they share the same latent collision — to be addressed in a follow-up once it can be validated on a HyperShift run.

## Validation

`helm lint` + `helm template` confirm the rendered `KC_FEATURES`. Functional verification via the Kind `release-validation.yaml` run triggered on this branch — expecting the token-exchange suite to now run to completion (and the #2098 `client_not_found` cascade to clear, now that the operator alpha.6 namespaces:patch fix from #2112 is in place).

Refs #2098

Assisted-By: Claude Code
