### PR TITLE
Fix: Allow user to supply additional container build flags for Podman and preload curl on kind

### DIFF
--- a/kagenti/examples/app-demo/Makefile
+++ b/kagenti/examples/app-demo/Makefile
@@ -7,6 +7,8 @@ IMAGE_PREFIX ?= localhost/
 
 # --- Full workflow: build, load, setup keycloak, deploy ---
 
+# Set `DOCKER_BUILD_FLAGS=--load` if using Podman
+
 all: build kind-load keycloak-setup deploy
 	@echo ""
 	@echo "=========================================="
@@ -45,13 +47,13 @@ dev-frontend:
 # --- Docker builds ---
 
 build-backend:
-	docker build -t $(IMAGE_PREFIX)app-demo-backend:latest -f backend/Dockerfile backend/
+	docker build -t $(IMAGE_PREFIX)app-demo-backend:latest -f backend/Dockerfile backend/ $(DOCKER_BUILD_FLAGS)
 
 build-frontend:
-	docker build -t $(IMAGE_PREFIX)app-demo-frontend:latest -f frontend/Dockerfile frontend/
+	docker build -t $(IMAGE_PREFIX)app-demo-frontend:latest -f frontend/Dockerfile frontend/ $(DOCKER_BUILD_FLAGS)
 
 build-keycloak:
-	docker build -t $(IMAGE_PREFIX)app-demo-keycloak:latest -f keycloak/Dockerfile keycloak/
+	docker build -t $(IMAGE_PREFIX)app-demo-keycloak:latest -f keycloak/Dockerfile keycloak/ $(DOCKER_BUILD_FLAGS)
 
 build: build-backend build-frontend build-keycloak
 
@@ -61,6 +63,7 @@ kind-load: build
 	kind load docker-image $(IMAGE_PREFIX)app-demo-backend:latest --name $(CLUSTER_NAME)
 	kind load docker-image $(IMAGE_PREFIX)app-demo-frontend:latest --name $(CLUSTER_NAME)
 	kind load docker-image $(IMAGE_PREFIX)app-demo-keycloak:latest --name $(CLUSTER_NAME)
+	kind load docker-image curlimages/curl:latest --name $(CLUSTER_NAME)
 
 keycloak-setup: kind-load
 	kubectl delete job app-demo-keycloak-client -n $(NAMESPACE) --ignore-not-found

--- a/kagenti/examples/app-demo/Makefile
+++ b/kagenti/examples/app-demo/Makefile
@@ -63,7 +63,8 @@ kind-load: build
 	kind load docker-image $(IMAGE_PREFIX)app-demo-backend:latest --name $(CLUSTER_NAME)
 	kind load docker-image $(IMAGE_PREFIX)app-demo-frontend:latest --name $(CLUSTER_NAME)
 	kind load docker-image $(IMAGE_PREFIX)app-demo-keycloak:latest --name $(CLUSTER_NAME)
-	kind load docker-image curlimages/curl:latest --name $(CLUSTER_NAME)
+	# Pre-load the image (which helps with image pull rate limiting in some environments)
+	kind load docker-image curlimages/curl:8.13.0 --name $(CLUSTER_NAME)
 
 keycloak-setup: kind-load
 	kubectl delete job app-demo-keycloak-client -n $(NAMESPACE) --ignore-not-found

--- a/kagenti/examples/app-demo/Makefile
+++ b/kagenti/examples/app-demo/Makefile
@@ -64,7 +64,8 @@ kind-load: build
 	kind load docker-image $(IMAGE_PREFIX)app-demo-frontend:latest --name $(CLUSTER_NAME)
 	kind load docker-image $(IMAGE_PREFIX)app-demo-keycloak:latest --name $(CLUSTER_NAME)
 	# Pre-load the image (which helps with image pull rate limiting in some environments)
-	kind load docker-image curlimages/curl:8.13.0 --name $(CLUSTER_NAME)
+	# Ignores failures; pull with `docker pull curlimages/curl:8.13.0` for this behavior.
+	kind load docker-image curlimages/curl:8.13.0 --name $(CLUSTER_NAME)  2>/dev/null || true
 
 keycloak-setup: kind-load
 	kubectl delete job app-demo-keycloak-client -n $(NAMESPACE) --ignore-not-found

--- a/kagenti/examples/app-demo/k8s/agent-access-job.yaml
+++ b/kagenti/examples/app-demo/k8s/agent-access-job.yaml
@@ -18,7 +18,8 @@ spec:
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-keycloak
-          image: curlimages/curl:latest
+          image: curlimages/curl:8.13.0
+          # Allow Job to run if container registry is not reachable
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/kagenti/examples/app-demo/k8s/agent-access-job.yaml
+++ b/kagenti/examples/app-demo/k8s/agent-access-job.yaml
@@ -19,6 +19,7 @@ spec:
       initContainers:
         - name: wait-for-keycloak
           image: curlimages/curl:latest
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c

--- a/kagenti/examples/app-demo/k8s/keycloak-client-job.yaml
+++ b/kagenti/examples/app-demo/k8s/keycloak-client-job.yaml
@@ -55,7 +55,8 @@ spec:
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-keycloak
-          image: curlimages/curl:latest
+          image: curlimages/curl:8.13.0
+          # Allow Job to run if container registry is not reachable
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/kagenti/examples/app-demo/k8s/keycloak-client-job.yaml
+++ b/kagenti/examples/app-demo/k8s/keycloak-client-job.yaml
@@ -56,6 +56,7 @@ spec:
       initContainers:
         - name: wait-for-keycloak
           image: curlimages/curl:latest
+          imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c


### PR DESCRIPTION
## Summary

- _kagenti/examples/app-demo/Makefile_ didn't work with Podman on Kind because the images were not available for loading.
- Preload `curlimages/curl:latest` and don't check for it to avoid a dependency on the rate-limited Docker hub

## Related issue(s)

For #1468

## (Optional) Testing Instructions

Install Rosso on Kind, then

```bash
cd kagenti/examples/app-demo
DOCKER_BUILD_FLAGS=--load make
```
