### PR TITLE
feat(backend): auto-inject MCP_URL and LLM env on agent import

### DIFF
--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -82,6 +82,8 @@ class Settings(BaseSettings):
     )
     kagenti_feature_flag_acp: bool = False  # ACP WebSocket protocol gateway
     kagenti_feature_flag_external_skills: bool = False  # External skill registry references
+    # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
+    kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (
         30  # seconds between registry sync checks (env: SKILL_AUTOSYNC_INTERVAL)
     )

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -101,6 +101,7 @@ from app.models.responses import (
     ResourceLabels,
     DeleteResponse,
 )
+from app.services.agent_env_defaults import apply_agent_import_defaults
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
 from app.routers.skills import _sanitize_k8s_name
 from app.utils.routes import (
@@ -239,6 +240,11 @@ class CreateAgentRequest(BaseModel):
     framework: str = "LangGraph"
     envVars: Optional[List[EnvVar]] = None
     skills: Optional[List[str]] = None
+    # Optional MCP tool link — when agent import defaults are enabled, MCP_URL is injected
+    mcpToolName: Optional[str] = None
+    # LLM preset: openai, ollama, openrouter (used with agent import defaults)
+    llmPreset: Optional[str] = None
+    llmModel: Optional[str] = None
 
     # Workload type: 'deployment', 'statefulset', or 'job'
     workloadType: str = WORKLOAD_TYPE_DEPLOYMENT
@@ -2581,6 +2587,7 @@ def _build_agent_shipwright_build_manifest(
         "authBridgeEnabled": request.authBridgeEnabled,
         "spireEnabled": request.spireEnabled,
         "authBridgeMode": request.authBridgeMode,
+        "gitPath": request.gitPath,
     }
     if request.outboundRoutes:
         resource_config["outboundRoutes"] = [r.model_dump() for r in request.outboundRoutes]
@@ -2599,6 +2606,12 @@ def _build_agent_shipwright_build_manifest(
     # Add env vars if present
     if request.envVars:
         resource_config["envVars"] = [ev.model_dump(exclude_none=True) for ev in request.envVars]
+    if request.mcpToolName:
+        resource_config["mcpToolName"] = request.mcpToolName
+    if request.llmPreset:
+        resource_config["llmPreset"] = request.llmPreset
+    if request.llmModel:
+        resource_config["llmModel"] = request.llmModel
     if request.skills:
         resource_config["skills"] = request.skills
     # Add service ports if present
@@ -3750,6 +3763,8 @@ async def create_agent(
             s for s in request.skills if s and not _is_skill_external(kube, request.namespace, s)
         ]
 
+    request = apply_agent_import_defaults(request, kube)
+
     try:
         if request.deploymentMethod == "image":
             # Deploy from existing container image
@@ -4035,6 +4050,9 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     inboundPortsExclude: Optional[str] = None
     defaultOutboundPolicy: Optional[Literal["passthrough", "exchange"]] = None
     persistentStorage: Optional[PersistentStorageConfig] = None
+    mcpToolName: Optional[str] = None
+    llmPreset: Optional[str] = None
+    llmModel: Optional[str] = None
 
     @model_validator(mode="after")
     def _check_mtls_compatible_with_mode(self) -> "FinalizeShipwrightBuildRequest":
@@ -4365,6 +4383,18 @@ async def finalize_shipwright_build(
         if final_persistent_storage is None and stored_config.get("persistentStorage"):
             final_persistent_storage = PersistentStorageConfig(**stored_config["persistentStorage"])
 
+        final_mcp_tool_name = (
+            request.mcpToolName
+            if request.mcpToolName is not None
+            else stored_config.get("mcpToolName")
+        )
+        final_llm_preset = (
+            request.llmPreset if request.llmPreset is not None else stored_config.get("llmPreset")
+        )
+        final_llm_model = (
+            request.llmModel if request.llmModel is not None else stored_config.get("llmModel")
+        )
+
         # Step 3: Create workload + Service with the built image
         # Build a CreateAgentRequest-like object for manifest builders
         agent_request = CreateAgentRequest(
@@ -4390,7 +4420,13 @@ async def finalize_shipwright_build(
             inboundPortsExclude=final_inbound_ports_exclude,
             defaultOutboundPolicy=final_default_outbound_policy,
             persistentStorage=final_persistent_storage,
+            gitPath=stored_config.get("gitPath")
+            or build.get("spec", {}).get("source", {}).get("contextDir", ""),
+            mcpToolName=final_mcp_tool_name,
+            llmPreset=final_llm_preset,
+            llmModel=final_llm_model,
         )
+        agent_request = apply_agent_import_defaults(agent_request, kube)
 
         # Ensure a dedicated ServiceAccount exists so the webhook's
         # SPIFFE identity uses the workload name, not the ReplicaSet hash.

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -37,6 +37,9 @@ class FeatureFlagsResponse(BaseModel):
     externalSkills: bool = Field(description="External skill registry references")
     authbridgeAPI: bool = Field(description="AuthBridge statistics (API and UI)")
     admin: bool = Field(description="Platform Status card and /platform-status endpoint")
+    agentImportDefaults: bool = Field(
+        description="Auto-inject MCP_URL and LLM env vars on agent import"
+    )
 
 
 class ComponentStatus(BaseModel):
@@ -87,6 +90,7 @@ async def get_feature_flags(
         externalSkills=settings.kagenti_feature_flag_external_skills,
         authbridgeAPI=settings.kagenti_feature_flag_authbridge_api,
         admin=settings.kagenti_feature_flag_admin,
+        agentImportDefaults=settings.kagenti_feature_flag_agent_import_defaults,
     )
 
 

--- a/kagenti/backend/app/services/agent_env_defaults.py
+++ b/kagenti/backend/app/services/agent_env_defaults.py
@@ -1,0 +1,114 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Default agent environment variables for UI/TUI import parity."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+
+from app.core.config import settings
+from app.core.constants import DEFAULT_IN_CLUSTER_PORT, TOOL_SERVICE_SUFFIX
+from app.utils.routes import lookup_service_port
+
+if TYPE_CHECKING:
+    from app.routers.agents import CreateAgentRequest, EnvVar
+    from app.services.kubernetes import KubernetesService
+
+
+def get_mcp_tool_url(tool_name: str, namespace: str, kube: "KubernetesService") -> str:
+    """Return the in-cluster MCP endpoint URL for a tool (includes /mcp path)."""
+    service_name = f"{tool_name}{TOOL_SERVICE_SUFFIX}"
+    port = lookup_service_port(service_name, namespace, kube, DEFAULT_IN_CLUSTER_PORT)
+    if settings.is_running_in_cluster:
+        base = f"http://{service_name}.{namespace}.svc.cluster.local:{port}"
+    else:
+        base = f"http://{tool_name}.{settings.domain_name}:8080"
+    return f"{base}/mcp"
+
+
+def build_llm_preset_env_vars(
+    preset: str,
+    model_override: Optional[str] = None,
+) -> List["EnvVar"]:
+    """Return LLM env vars for a preset (mirrors kagenti/tui/internal/helpers/helpers.go)."""
+    from app.routers.agents import EnvVar, EnvVarSource, SecretKeyRef
+
+    def secret_ref(secret_name: str, key: str) -> EnvVarSource:
+        return EnvVarSource(secretKeyRef=SecretKeyRef(name=secret_name, key=key))
+
+    if preset == "openai":
+        model = model_override or "gpt-4o-mini-2024-07-18"
+        ref = secret_ref("openai-secret", "apikey")
+        return [
+            EnvVar(name="OPENAI_API_KEY", valueFrom=ref),
+            EnvVar(name="LLM_API_KEY", valueFrom=ref),
+            EnvVar(name="LLM_API_BASE", value="https://api.openai.com/v1"),
+            EnvVar(name="LLM_MODEL", value=model),
+        ]
+    if preset == "ollama":
+        model = model_override or "llama3.2:3b-instruct-fp16"
+        return [
+            EnvVar(name="LLM_API_BASE", value="http://host.docker.internal:11434/v1"),
+            EnvVar(name="LLM_API_KEY", value="dummy"),
+            EnvVar(name="LLM_MODEL", value=model),
+        ]
+    if preset == "openrouter":
+        model = model_override or "openai/gpt-4o-mini"
+        ref = secret_ref("openai-secret", "apikey")
+        return [
+            EnvVar(name="OPENAI_API_KEY", valueFrom=ref),
+            EnvVar(name="LLM_API_KEY", valueFrom=ref),
+            EnvVar(name="LLM_API_BASE", value="https://openrouter.ai/api/v1"),
+            EnvVar(name="LLM_MODEL", value=model),
+        ]
+    return []
+
+
+def _infer_weather_demo_defaults(
+    request: "CreateAgentRequest",
+) -> tuple[Optional[str], Optional[str]]:
+    """Infer MCP tool + LLM preset for the weather_service example agent."""
+    git_path = request.gitPath or ""
+    if "weather_service" not in git_path:
+        return request.mcpToolName, request.llmPreset
+
+    mcp_tool = request.mcpToolName or "weather-tool"
+    llm_preset = request.llmPreset or "openai"
+    return mcp_tool, llm_preset
+
+
+def apply_agent_import_defaults(
+    request: "CreateAgentRequest",
+    kube: "KubernetesService",
+) -> "CreateAgentRequest":
+    """Inject MCP_URL and LLM env vars when agent import defaults are enabled."""
+    if not settings.kagenti_feature_flag_agent_import_defaults:
+        return request
+
+    mcp_tool, llm_preset = _infer_weather_demo_defaults(request)
+    env_vars = list(request.envVars or [])
+    existing = {ev.name for ev in env_vars}
+
+    if mcp_tool and "MCP_URL" not in existing:
+        from app.routers.agents import EnvVar
+
+        env_vars.append(
+            EnvVar(
+                name="MCP_URL",
+                value=get_mcp_tool_url(mcp_tool, request.namespace, kube),
+            )
+        )
+        existing.add("MCP_URL")
+
+    if llm_preset:
+        for ev in build_llm_preset_env_vars(llm_preset, request.llmModel):
+            if ev.name not in existing:
+                env_vars.append(ev)
+                existing.add(ev.name)
+
+    if env_vars == (request.envVars or []):
+        return request
+    return request.model_copy(
+        update={"envVars": env_vars, "mcpToolName": mcp_tool, "llmPreset": llm_preset}
+    )

--- a/kagenti/backend/tests/test_agent_env_defaults.py
+++ b/kagenti/backend/tests/test_agent_env_defaults.py
@@ -1,0 +1,89 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for agent import default env injection."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.core.config import settings
+from app.routers.agents import CreateAgentRequest, EnvVar
+from app.services.agent_env_defaults import (
+    apply_agent_import_defaults,
+    build_llm_preset_env_vars,
+    get_mcp_tool_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def enable_import_defaults(monkeypatch):
+    monkeypatch.setattr(settings, "kagenti_feature_flag_agent_import_defaults", True)
+
+
+def test_get_mcp_tool_url_uses_service_port(monkeypatch):
+    kube = MagicMock()
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setattr(
+        "app.services.agent_env_defaults.lookup_service_port",
+        lambda *_args, **_kwargs: 9090,
+    )
+    url = get_mcp_tool_url("weather-tool", "team1", kube)
+    assert url == "http://weather-tool-mcp.team1.svc.cluster.local:9090/mcp"
+
+
+def test_build_llm_preset_openai():
+    envs = build_llm_preset_env_vars("openai")
+    names = {ev.name for ev in envs}
+    assert names == {"OPENAI_API_KEY", "LLM_API_KEY", "LLM_API_BASE", "LLM_MODEL"}
+    base = next(ev for ev in envs if ev.name == "LLM_API_BASE")
+    assert base.value == "https://api.openai.com/v1"
+
+
+def test_apply_defaults_weather_service_git_path(monkeypatch):
+    kube = MagicMock()
+    monkeypatch.setattr(
+        "app.services.agent_env_defaults.get_mcp_tool_url",
+        lambda *_a, **_k: "http://weather-tool-mcp.team1.svc.cluster.local:9090/mcp",
+    )
+    request = CreateAgentRequest(
+        name="demo-weather",
+        namespace="team1",
+        gitPath="a2a/weather_service",
+    )
+    updated = apply_agent_import_defaults(request, kube)
+    env_names = {ev.name for ev in updated.envVars or []}
+    assert "MCP_URL" in env_names
+    assert "LLM_API_BASE" in env_names
+    assert "LLM_MODEL" in env_names
+    mcp = next(ev for ev in updated.envVars if ev.name == "MCP_URL")
+    assert mcp.value.endswith("/mcp")
+
+
+def test_apply_defaults_respects_existing_env(monkeypatch):
+    kube = MagicMock()
+    monkeypatch.setattr(
+        "app.services.agent_env_defaults.get_mcp_tool_url",
+        lambda *_a, **_k: "http://should-not-be-used/mcp",
+    )
+    request = CreateAgentRequest(
+        name="demo-weather",
+        namespace="team1",
+        mcpToolName="weather-tool",
+        envVars=[EnvVar(name="MCP_URL", value="http://custom/mcp")],
+    )
+    updated = apply_agent_import_defaults(request, kube)
+    mcp = next(ev for ev in updated.envVars if ev.name == "MCP_URL")
+    assert mcp.value == "http://custom/mcp"
+
+
+def test_apply_defaults_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "kagenti_feature_flag_agent_import_defaults", False)
+    kube = MagicMock()
+    request = CreateAgentRequest(
+        name="demo-weather",
+        namespace="team1",
+        gitPath="a2a/weather_service",
+    )
+    updated = apply_agent_import_defaults(request, kube)
+    assert updated.envVars is None


### PR DESCRIPTION
## Summary

Wire TUI-style defaults into the backend create/finalize agent paths so `weather_service` imports get `MCP_URL` (with the correct tool service port) and LLM preset env vars when `KAGENTI_FEATURE_FLAG_AGENT_IMPORT_DEFAULTS` is enabled.

- Adds `kagenti/backend/app/services/agent_env_defaults.py` for MCP URL + LLM preset injection
- Adds `mcpToolName`, `llmPreset`, and `llmModel` on `CreateAgentRequest` / finalize request
- Persists import defaults in Shipwright `agent-config` annotation
- Exposes `agentImportDefaults` via `GET /api/v1/config/features`
- For `gitPath` containing `weather_service`, defaults to `weather-tool` + OpenAI LLM preset when flag is on

Motivation: UI-imported weather agents currently need manual env patches (`MCP_URL`, `LLM_*`) even though the TUI already auto-generates these. Reproduced on Kind with default backend manifest — AgentCard syncs but chat fails without env vars.

## Related issue(s)

- Related: user-reported weather demo import friction (no existing issue filed yet)
- Related: TUI deploy flow (`kagenti/tui/internal/ui/views/deployagent.go`) already injects `MCP_URL`

## (Optional) Testing Instructions

1. Enable flag on backend:
   ```bash
   kubectl set env deployment/kagenti-backend -n kagenti-system \
     KAGENTI_FEATURE_FLAG_AGENT_IMPORT_DEFAULTS=true