### PR TITLE
Feat: 💬 chat falls back to message/send for non-streaming agents

### DIFF
--- a/kagenti/tui/internal/cli/chat.go
+++ b/kagenti/tui/internal/cli/chat.go
@@ -28,45 +28,23 @@ func newChatCmd(ctx *CLIContext) *cobra.Command {
 				SessionID: sessionID,
 			}
 
-			// Try streaming first.
-			ch, err := ctx.Client.StreamChat(ns, agent, chatReq)
-			if err == nil {
-				var returnedSession string
-				for evt := range ch {
-					if evt.Error != "" {
-						return fmt.Errorf("stream error: %s", evt.Error)
-					}
-					if evt.SessionID != "" {
-						returnedSession = evt.SessionID
-					}
-					if evt.Content != "" {
-						fmt.Print(evt.Content)
-					}
-					if evt.Done {
-						fmt.Println()
-						if returnedSession != "" {
-							fmt.Fprintf(os.Stderr, "session-id: %s\n", returnedSession)
-						}
-						return nil
-					}
-				}
-				fmt.Println()
-				if returnedSession != "" {
-					fmt.Fprintf(os.Stderr, "session-id: %s\n", returnedSession)
-				}
-				return nil
+			// Consult the agent card to decide which transport to use.
+			// A2A agents that declare streaming=false only implement
+			// message/send and will 400 on message/stream, so we must
+			// pick the right endpoint up front rather than try+fallback.
+			useStreaming := true
+			if card, err := ctx.Client.GetAgentCard(ns, agent); err == nil {
+				useStreaming = card.Streaming
+			} else {
+				// Card fetch failed. Preserve prior behavior (attempt stream)
+				// but let the user know we couldn't confirm.
+				fmt.Fprintf(os.Stderr, "warning: could not determine streaming capability (%v), attempting stream\n", err)
 			}
 
-			// Fall back to non-streaming.
-			resp, err := ctx.Client.SendMessage(ns, agent, chatReq)
-			if err != nil {
-				return fmt.Errorf("sending message: %w", err)
+			if useStreaming {
+				return runChatStream(ctx, ns, agent, chatReq)
 			}
-			fmt.Println(resp.Content)
-			if resp.SessionID != "" {
-				fmt.Fprintf(os.Stderr, "session-id: %s\n", resp.SessionID)
-			}
-			return nil
+			return runChatSend(ctx, ns, agent, chatReq)
 		},
 	}
 
@@ -75,4 +53,50 @@ func newChatCmd(ctx *CLIContext) *cobra.Command {
 	_ = cmd.MarkFlagRequired("message")
 
 	return cmd
+}
+
+// runChatStream streams a chat response over SSE, printing content chunks as
+// they arrive.
+func runChatStream(ctx *CLIContext, ns, agent string, chatReq *api.ChatRequest) error {
+	ch, err := ctx.Client.StreamChat(ns, agent, chatReq)
+	if err != nil {
+		return fmt.Errorf("opening chat stream: %w", err)
+	}
+	var returnedSession string
+	for evt := range ch {
+		if evt.Error != "" {
+			return fmt.Errorf("stream error: %s", evt.Error)
+		}
+		if evt.SessionID != "" {
+			returnedSession = evt.SessionID
+		}
+		if evt.Content != "" {
+			fmt.Print(evt.Content)
+		}
+		if evt.Done {
+			fmt.Println()
+			if returnedSession != "" {
+				fmt.Fprintf(os.Stderr, "session-id: %s\n", returnedSession)
+			}
+			return nil
+		}
+	}
+	fmt.Println()
+	if returnedSession != "" {
+		fmt.Fprintf(os.Stderr, "session-id: %s\n", returnedSession)
+	}
+	return nil
+}
+
+// runChatSend sends a non-streaming chat request and prints the full reply.
+func runChatSend(ctx *CLIContext, ns, agent string, chatReq *api.ChatRequest) error {
+	resp, err := ctx.Client.SendMessage(ns, agent, chatReq)
+	if err != nil {
+		return fmt.Errorf("sending message: %w", err)
+	}
+	fmt.Println(resp.Content)
+	if resp.SessionID != "" {
+		fmt.Fprintf(os.Stderr, "session-id: %s\n", resp.SessionID)
+	}
+	return nil
 }

--- a/kagenti/tui/internal/cli/cli_test.go
+++ b/kagenti/tui/internal/cli/cli_test.go
@@ -103,7 +103,16 @@ func newTestServer(t *testing.T) (*httptest.Server, *CLIContext) {
 
 	mux.HandleFunc("/api/v1/chat/", func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if strings.HasSuffix(path, "/stream") {
+		if strings.HasSuffix(path, "/agent-card") {
+			// Default: claim streaming so existing TestChatStreaming keeps its
+			// current path. Tests that need streaming=false use a bespoke mux.
+			json.NewEncoder(w).Encode(api.AgentCardResponse{
+				Name:      "test-agent",
+				Version:   "1.0.0",
+				URL:       "http://agent",
+				Streaming: true,
+			})
+		} else if strings.HasSuffix(path, "/stream") {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(200)
 			flusher, _ := w.(http.Flusher)
@@ -294,6 +303,128 @@ func TestChatStreaming(t *testing.T) {
 		t.Errorf("expected stdout to contain 'hello world', got: %s", stdout)
 	}
 	if !strings.Contains(stderr, "session-id: sess-123") {
+		t.Errorf("expected stderr to contain session ID, got: %s", stderr)
+	}
+}
+
+// TestChatNonStreamingAgentFallsBackToSend verifies that when the agent card
+// declares streaming=false, the CLI uses the non-streaming /send endpoint
+// instead of /stream (which the agent would reject).
+func TestChatNonStreamingAgentFallsBackToSend(t *testing.T) {
+	var streamCalled, sendCalled bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/chat/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasSuffix(path, "/agent-card"):
+			json.NewEncoder(w).Encode(api.AgentCardResponse{
+				Name:      "no-stream-agent",
+				Version:   "1.0.0",
+				URL:       "http://agent",
+				Streaming: false,
+			})
+		case strings.HasSuffix(path, "/stream"):
+			streamCalled = true
+			http.Error(w, "streaming not supported", http.StatusBadRequest)
+		case strings.HasSuffix(path, "/send"):
+			sendCalled = true
+			json.NewEncoder(w).Encode(api.ChatResponse{
+				Content: "non-stream reply", SessionID: "sess-send-1", IsComplete: true,
+			})
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := api.NewClient(srv.URL, "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+
+	cmd := newChatCmd(ctx)
+	cmd.SetArgs([]string{"no-stream-agent", "-m", "hi"})
+	cmd.Flags().String("namespace", "team1", "")
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("chat command failed: %v", err)
+		}
+	})
+
+	if streamCalled {
+		t.Errorf("expected /stream NOT to be called for non-streaming agent")
+	}
+	if !sendCalled {
+		t.Errorf("expected /send to be called for non-streaming agent")
+	}
+	if !strings.Contains(stdout, "non-stream reply") {
+		t.Errorf("expected stdout to contain 'non-stream reply', got: %s", stdout)
+	}
+	if !strings.Contains(stderr, "session-id: sess-send-1") {
+		t.Errorf("expected stderr to contain session ID, got: %s", stderr)
+	}
+}
+
+// TestChatStreamingAgentUsesStream verifies that when the agent card declares
+// streaming=true, the CLI uses the /stream endpoint (not /send).
+func TestChatStreamingAgentUsesStream(t *testing.T) {
+	var streamCalled, sendCalled bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/chat/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasSuffix(path, "/agent-card"):
+			json.NewEncoder(w).Encode(api.AgentCardResponse{
+				Name:      "stream-agent",
+				Version:   "1.0.0",
+				URL:       "http://agent",
+				Streaming: true,
+			})
+		case strings.HasSuffix(path, "/stream"):
+			streamCalled = true
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(200)
+			flusher, _ := w.(http.Flusher)
+			data, _ := json.Marshal(api.ChatStreamEvent{Content: "stream reply", SessionID: "sess-stream-1"})
+			w.Write([]byte("data: " + string(data) + "\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			w.Write([]byte("data: [DONE]\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		case strings.HasSuffix(path, "/send"):
+			sendCalled = true
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := api.NewClient(srv.URL, "test-token", "team1")
+	ctx := &CLIContext{Client: client, Output: "table"}
+
+	cmd := newChatCmd(ctx)
+	cmd.SetArgs([]string{"stream-agent", "-m", "hi"})
+	cmd.Flags().String("namespace", "team1", "")
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("chat command failed: %v", err)
+		}
+	})
+
+	if !streamCalled {
+		t.Errorf("expected /stream to be called for streaming agent")
+	}
+	if sendCalled {
+		t.Errorf("expected /send NOT to be called for streaming agent")
+	}
+	if !strings.Contains(stdout, "stream reply") {
+		t.Errorf("expected stdout to contain 'stream reply', got: %s", stdout)
+	}
+	if !strings.Contains(stderr, "session-id: sess-stream-1") {
 		t.Errorf("expected stderr to contain session ID, got: %s", stderr)
 	}
 }


### PR DESCRIPTION
## Summary

`kagenti chat` unconditionally called the agent's `message/stream` A2A method. Agents that declare `AgentCapabilities.streaming=false` in their agent card correctly reject this and return "Streaming is not supported by the agent" — the CLI silently swallowed the error and returned no output.

This PR fetches the agent card first and branches on the streaming capability:

- `streaming=true`  → existing SSE-based `runChatStream` path (unchanged behavior)
- `streaming=false` → new `runChatSend` path using `/send`
- card fetch fails → log warning to stderr, default to streaming (preserves prior behavior)

## Changes

- `kagenti/tui/internal/cli/chat.go` — split the chat body into `runChatStream` and `runChatSend`, added the card-driven branch.
- `kagenti/tui/internal/cli/cli_test.go` — added `/agent-card` handler to the shared test mux (defaults to `streaming=true` so `TestChatStreaming` is unchanged). Added two new tests:
  - `TestChatNonStreamingAgentFallsBackToSend` — card says `streaming=false`, asserts `/stream` is NOT called and `/send` IS called.
  - `TestChatStreamingAgentUsesStream` — inverse assertion.

## Testing

- Unit: `cd kagenti/tui && go test ./internal/cli -run 'TestChat' -v` — 3 passed.
- Full CLI suite: `go test ./internal/cli -v` — 20 passed.
- Live cluster: verified against an A2A agent whose card declares `streaming=false`. Baseline CLI (before this PR) silently exits with no output; fixed CLI prints the plain reply.

## Related

Complements a matching fix in the `agent-examples` repo that adds streaming support to `minimal_pvc_agent`. Either fix alone unblocks the CLI for this agent; both together cover the general case for both directions.

Assisted-By: Claude (Anthropic AI)