### PR TITLE
Docs(authbridge): add sidecar injection reference page

### DIFF
--- a/docs/authbridge/README.md
+++ b/docs/authbridge/README.md
@@ -133,6 +133,7 @@ For a progressive walkthrough: [Demos](demos.md)
 |----------|----------|--------|
 | [Security Model](security-model.md) | End users, architects | Trust model, what's enforced, threat model |
 | [Deployment Guide](deployment-guide.md) | Operators, developers | Modes, configuration, troubleshooting |
+| [Sidecar Injection](sidecar-injection.md) | Operators, developers | Expected containers, label vocabulary, feature gates, how to switch modes |
 | [Demos](demos.md) | Everyone | Progressive hands-on walkthrough |
 | [Roadmap](roadmap.md) | Architects, contributors | Vision, upcoming features, epics |
 

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -13,10 +13,12 @@ deployment shape (kagenti-extensions#411):
 | **Plugins included** | jwt-validation + token-exchange + a2a/mcp/inference parsers | Same as proxy-sidecar | jwt-validation + token-exchange only |
 | **Use when** | Standard deployments | Need transparent interception of non-HTTP protocols | Size-constrained / no protocol-aware events |
 
-`spiffe-helper` is bundled inside every combined image and runs only when the
-operator sets `SPIRE_ENABLED=true` on the workload (driven by the
-`kagenti.io/spire: enabled` label). Client registration is handled by the
-operator's reconciler — there's no in-pod client-registration sidecar.
+SPIRE integration is built into every combined image using the
+[go-spiffe](https://github.com/spiffe/go-spiffe) SDK. It is enabled or disabled
+per workload via the `SPIRE_ENABLED` env var (driven by the
+`kagenti.io/spiffe-helper-inject` label) — there is no separate spiffe-helper
+binary or process. Client registration is handled by the operator's reconciler —
+there's no in-pod client-registration sidecar.
 
 ## Selecting a mode
 
@@ -42,8 +44,9 @@ spec:
     name: weather-service
 ```
 
-The deprecated annotation is retained for tools and other workloads that
-don't have their own AgentRuntime CR yet:
+The deprecated annotation is retained for backward compatibility. Use the
+namespace `authbridge-runtime-config` ConfigMap instead — it is the canonical
+way to set mode and applies to all workloads in the namespace:
 
 ```yaml
 metadata:

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -49,11 +49,14 @@ namespace `authbridge-runtime-config` ConfigMap instead — it is the canonical
 way to set mode and applies to all workloads in the namespace:
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  labels:
-    kagenti.io/type: tool
-  annotations:
-    kagenti.io/authbridge-mode: "envoy-sidecar"
+  name: authbridge-runtime-config
+  namespace: team1
+data:
+  config.yaml: |
+    mode: envoy-sidecar
 ```
 
 ## Proxy-Sidecar Mode (Default)

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -22,31 +22,18 @@ there's no in-pod client-registration sidecar.
 
 ## Selecting a mode
 
-The operator resolves mode per workload from this chain
-(kagenti-operator#361):
+The mutating webhook resolves mode from this chain (first non-empty wins):
 
-1. `AgentRuntime.Spec.AuthBridgeMode` on the workload's CR (canonical).
-2. `mode:` field on the namespace-level `authbridge-runtime-config` ConfigMap.
-3. The deprecated `kagenti.io/authbridge-mode` pod annotation (still honored).
-4. Cluster-wide default (`proxy-sidecar`).
+1. `mode:` field in the namespace-level `authbridge-runtime-config` ConfigMap **(canonical)**.
+2. The deprecated `kagenti.io/authbridge-mode` pod annotation (still honored).
+3. Cluster-wide default (`proxy-sidecar`).
 
-```yaml
-# Canonical: per-workload override on the AgentRuntime CR
-apiVersion: kagenti.io/v1alpha1
-kind: AgentRuntime
-metadata:
-  name: weather-service
-spec:
-  authBridgeMode: envoy-sidecar
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: weather-service
-```
+> **Note:** `AgentRuntime.Spec.AuthBridgeMode` is enum-validated by the CRD webhook but is not
+> read by the mutating webhook when resolving injection mode. Setting it does not change which
+> containers are injected.
 
-The deprecated annotation is retained for backward compatibility. Use the
-namespace `authbridge-runtime-config` ConfigMap instead — it is the canonical
-way to set mode and applies to all workloads in the namespace:
+The canonical way to set mode is the namespace ConfigMap, which applies to all workloads in
+the namespace:
 
 ```yaml
 apiVersion: v1
@@ -246,7 +233,7 @@ kubectl exec deploy/weather-service -n team1 -c envoy-proxy -- \
 
 ### Proxy Not Injected
 
-1. Verify the pod has `kagenti.io/type: agent` label
+1. Verify the pod has `kagenti.io/type: agent` label — the operator sets this automatically when an AgentRuntime CR targets the workload
 2. Check that the Kagenti operator webhook is running:
    ```bash
    kubectl get mutatingwebhookconfigurations | grep kagenti

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -260,5 +260,6 @@ injects defaults that can be overridden via Helm values.
 ## Further Reading
 
 - [Sidecar Injection](sidecar-injection.md) — expected containers per mode, label vocabulary, feature gates, how to switch modes
+- [Authentication Guide](../authentication.md) — how `CLIENT_AUTH_TYPE=federated-jwt` (SPIFFE auth) works, how to enable it, and how it compares to client-secret mode
 - [AuthBridge Binary README](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/README.md) — full YAML config reference, all listener modes
 - [AuthBridge Architecture](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/README.md) — sequence diagrams, protocol details

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -42,10 +42,16 @@ spec:
     name: weather-service
 ```
 
-> **Note:** All workloads should use an AgentRuntime CR to enroll with the
-> platform. The operator applies `kagenti.io/type` labels automatically.
-> The deprecated `kagenti.io/authbridge-mode` annotation is still honored
-> but `AgentRuntime.Spec.AuthBridgeMode` is the canonical method.
+The deprecated annotation is retained for tools and other workloads that
+don't have their own AgentRuntime CR yet:
+
+```yaml
+metadata:
+  labels:
+    kagenti.io/type: tool
+  annotations:
+    kagenti.io/authbridge-mode: "envoy-sidecar"
+```
 
 ## Proxy-Sidecar Mode (Default)
 
@@ -234,7 +240,7 @@ kubectl exec deploy/weather-service -n team1 -c envoy-proxy -- \
 
 ### Proxy Not Injected
 
-1. Verify the workload has an AgentRuntime CR targeting it (the operator applies the `kagenti.io/type` label automatically)
+1. Verify the pod has `kagenti.io/type: agent` label
 2. Check that the Kagenti operator webhook is running:
    ```bash
    kubectl get mutatingwebhookconfigurations | grep kagenti
@@ -253,5 +259,6 @@ injects defaults that can be overridden via Helm values.
 
 ## Further Reading
 
+- [Sidecar Injection](sidecar-injection.md) — expected containers per mode, label vocabulary, feature gates, how to switch modes
 - [AuthBridge Binary README](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/cmd/README.md) — full YAML config reference, all listener modes
 - [AuthBridge Architecture](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/README.md) — sequence diagrams, protocol details

--- a/docs/authbridge/sidecar-injection.md
+++ b/docs/authbridge/sidecar-injection.md
@@ -20,7 +20,7 @@ kubectl get pods -n team1 -l app=weather-service \
 | Mode | Regular containers | Init containers | Notes |
 |---|---|---|---|
 | `proxy-sidecar` (default) | `<agent>` `authbridge-proxy` | — | SPIRE integration is in-process inside `authbridge-proxy` when `SPIRE_ENABLED=true` |
-| `lite` | `<agent>` `authbridge-proxy` | — | Same shape as proxy-sidecar; uses `authbridge-lite` image (auth-only) |
+| `lite` | `<agent>` `authbridge-proxy` | — | Same shape as proxy-sidecar; uses `authbridge-lite` image (auth-only plugins); SPIRE integration in-process when `SPIRE_ENABLED=true` |
 | `envoy-sidecar` | `<agent>` `envoy-proxy` | `proxy-init` | SPIRE integration is in-process inside `envoy-proxy` when `SPIRE_ENABLED=true`; proxy-init runs as root (UID 0) with NET_ADMIN/NET_RAW — not privileged |
 | `waypoint` | — | — | Not injected as a sidecar; waypoint is a standalone deployment |
 

--- a/docs/authbridge/sidecar-injection.md
+++ b/docs/authbridge/sidecar-injection.md
@@ -19,15 +19,20 @@ kubectl get pods -n team1 -l app=weather-service \
 
 | Mode | Regular containers | Init containers | Notes |
 |---|---|---|---|
-| `proxy-sidecar` (default) | `<agent>` `authbridge-proxy` | — | spiffe-helper runs as a process **inside** `authbridge-proxy` when SPIRE is on |
+| `proxy-sidecar` (default) | `<agent>` `authbridge-proxy` | — | SPIRE integration is in-process inside `authbridge-proxy` when `SPIRE_ENABLED=true` |
 | `lite` | `<agent>` `authbridge-proxy` | — | Same shape as proxy-sidecar; uses `authbridge-lite` image (auth-only) |
-| `envoy-sidecar` | `<agent>` `envoy-proxy` | `proxy-init` | spiffe-helper runs as a process **inside** `envoy-proxy` when SPIRE is on; proxy-init is privileged |
+| `envoy-sidecar` | `<agent>` `envoy-proxy` | `proxy-init` | SPIRE integration is in-process inside `envoy-proxy` when `SPIRE_ENABLED=true`; proxy-init is privileged |
 | `waypoint` | — | — | Not injected as a sidecar; waypoint is a standalone deployment |
 
-> **spiffe-helper is not a separate container.** It is bundled inside both
-> `authbridge-proxy` (proxy-sidecar/lite) and `envoy-proxy` (envoy-sidecar) and
-> starts conditionally based on the `SPIRE_ENABLED` env var, which the operator
-> sets per workload based on the `kagenti.io/spiffe-helper-inject` label.
+> **There is no spiffe-helper container or process.** AuthBridge uses the
+> [go-spiffe](https://github.com/spiffe/go-spiffe) SDK directly to open a
+> `workloadapi.JWTSource` against the SPIRE workload API socket
+> (`/spiffe-workload-api/spire-agent.sock`) and fetch JWT-SVIDs in-process.
+> The files in `/opt` (`svid.pem`, `jwt_svid.token`, etc.) are written by a
+> goroutine inside AuthBridge itself for compatibility with external file readers
+> — not by a separate binary. SPIRE integration is enabled or disabled via the
+> `SPIRE_ENABLED` env var, which the operator sets per workload based on the
+> `kagenti.io/spiffe-helper-inject` label.
 
 ## Label vocabulary
 

--- a/docs/authbridge/sidecar-injection.md
+++ b/docs/authbridge/sidecar-injection.md
@@ -21,7 +21,7 @@ kubectl get pods -n team1 -l app=weather-service \
 |---|---|---|---|
 | `proxy-sidecar` (default) | `<agent>` `authbridge-proxy` | — | SPIRE integration is in-process inside `authbridge-proxy` when `SPIRE_ENABLED=true` |
 | `lite` | `<agent>` `authbridge-proxy` | — | Same shape as proxy-sidecar; uses `authbridge-lite` image (auth-only) |
-| `envoy-sidecar` | `<agent>` `envoy-proxy` | `proxy-init` | SPIRE integration is in-process inside `envoy-proxy` when `SPIRE_ENABLED=true`; proxy-init is privileged |
+| `envoy-sidecar` | `<agent>` `envoy-proxy` | `proxy-init` | SPIRE integration is in-process inside `envoy-proxy` when `SPIRE_ENABLED=true`; proxy-init runs as root (UID 0) with NET_ADMIN/NET_RAW — not privileged |
 | `waypoint` | — | — | Not injected as a sidecar; waypoint is a standalone deployment |
 
 > **There is no spiffe-helper container or process.** AuthBridge uses the
@@ -54,7 +54,7 @@ These let you disable a specific sidecar while leaving others active.
 | Label | Default | Set to `false` to… |
 |---|---|---|
 | `kagenti.io/envoy-proxy-inject` | inject (when feature gate is on) | Disable the `envoy-proxy` sidecar (envoy-sidecar mode only) |
-| `kagenti.io/spiffe-helper-inject` | inject (enabled) | Suppress SPIRE — sets `SPIRE_ENABLED=false` on the combined sidecar, preventing the bundled spiffe-helper process from starting |
+| `kagenti.io/spiffe-helper-inject` | inject (enabled) | Suppress SPIRE — sets `SPIRE_ENABLED=false` on the sidecar, preventing the go-spiffe workload API source from being opened |
 
 ### Deprecated label
 
@@ -83,28 +83,16 @@ metadata:
 
 ## How to switch modes
 
-Mode is resolved from this chain (first non-empty wins):
+Mode is resolved by the **mutating webhook** from this chain (first non-empty wins):
 
-1. `AgentRuntime.Spec.AuthBridgeMode` on the workload's CR **(canonical)**
-2. `mode:` field in the namespace-level `authbridge-runtime-config` ConfigMap
-3. `kagenti.io/authbridge-mode` pod annotation *(deprecated — still honored)*
-4. Cluster-wide default: `proxy-sidecar`
+1. `mode:` field in the namespace-level `authbridge-runtime-config` ConfigMap
+2. `kagenti.io/authbridge-mode` pod annotation *(deprecated — still honored)*
+3. Cluster-wide default: `proxy-sidecar`
 
-### Per-workload override (AgentRuntime CR)
-
-```yaml
-apiVersion: kagenti.io/v1alpha1
-kind: AgentRuntime
-metadata:
-  name: weather-service
-  namespace: team1
-spec:
-  authBridgeMode: envoy-sidecar   # proxy-sidecar | envoy-sidecar | lite | waypoint
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: weather-service
-```
+> **Note on `AgentRuntime.Spec.AuthBridgeMode`:** This field exists on the CRD and is
+> enum-validated, but the mutating webhook does not read it during injection. Setting it
+> does not change which containers are injected. Use the namespace ConfigMap to control
+> mode for all workloads in a namespace.
 
 ### Namespace default (ConfigMap)
 
@@ -127,7 +115,7 @@ kubectl logs -n kagenti-system deploy/kagenti-operator \
 
 ## Cluster-admin feature gates
 
-Feature gates are loaded from the `kagenti-webhook-config` ConfigMap in the
+Feature gates are loaded from the `kagenti-feature-gates` ConfigMap in the
 operator's namespace and take effect immediately (no restart needed).
 
 | Gate | Default | Controls |
@@ -147,16 +135,16 @@ Pod admitted by webhook
        └─ globalEnabled=true?  — No → skip
             └─ type=tool and injectTools=false?  — Yes → skip
                  └─ kagenti.io/inject=disabled?  — Yes → skip
-                      └─ Resolve mode (CR → namespace CM → annotation → default)
+                      └─ Resolve mode (namespace CM → annotation → default)
                            ├─ waypoint → skip (standalone deployment)
                            ├─ proxy-sidecar / lite
                            │    └─ inject authbridge-proxy
                            │         + HTTP_PROXY env vars into agent container
-                           │         + SPIRE_ENABLED based on spiffe-helper decision
+                           │         + SPIRE_ENABLED based on spiffe-helper-inject label
                            └─ envoy-sidecar
                                 └─ inject envoy-proxy (if envoyProxy gate=true and label≠false)
                                      + proxy-init (follows envoy-proxy decision)
-                                     + SPIRE_ENABLED based on spiffe-helper decision
+                                     + SPIRE_ENABLED based on spiffe-helper-inject label
 ```
 
 ## Related

--- a/docs/authbridge/sidecar-injection.md
+++ b/docs/authbridge/sidecar-injection.md
@@ -132,7 +132,7 @@ operator's namespace and take effect immediately (no restart needed).
 | `injectTools` | `false` | Whether `kagenti.io/type=tool` workloads receive injection (agents are always injected) |
 | `perWorkloadConfigResolution` | `false` | When `true`, webhook reads namespace ConfigMaps at admission time and injects literal env var values instead of `valueFrom` references |
 
-Source of truth: [`kagenti-operator/internal/webhook/config/feature_gates.go`](https://github.com/kagenti/kagenti-extensions/blob/main/kagenti-operator/internal/webhook/config/feature_gates.go)
+Source of truth: [`internal/webhook/config/feature_gates.go`](https://github.com/kagenti/kagenti-operator/blob/main/kagenti-operator/internal/webhook/config/feature_gates.go)
 
 ## Full injection decision flow
 

--- a/docs/authbridge/sidecar-injection.md
+++ b/docs/authbridge/sidecar-injection.md
@@ -1,0 +1,161 @@
+# AuthBridge Sidecar Injection
+
+This page explains what containers to expect in an agent pod, which labels
+control injection, and how to switch modes.
+
+## Verify which mode you're in
+
+```bash
+# List container names in the running pod
+kubectl get pods -n team1 -l kagenti.io/type=agent \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" → "}{.spec.containers[*].name}{"\n"}{end}'
+
+# Or for a specific deployment
+kubectl get pods -n team1 -l app=weather-service \
+  -o jsonpath='{.items[0].spec.containers[*].name}'
+```
+
+## Expected containers by mode
+
+| Mode | Regular containers | Init containers | Notes |
+|---|---|---|---|
+| `proxy-sidecar` (default) | `<agent>` `authbridge-proxy` | — | spiffe-helper runs as a process **inside** `authbridge-proxy` when SPIRE is on |
+| `lite` | `<agent>` `authbridge-proxy` | — | Same shape as proxy-sidecar; uses `authbridge-lite` image (auth-only) |
+| `envoy-sidecar` | `<agent>` `envoy-proxy` | `proxy-init` | spiffe-helper runs as a process **inside** `envoy-proxy` when SPIRE is on; proxy-init is privileged |
+| `waypoint` | — | — | Not injected as a sidecar; waypoint is a standalone deployment |
+
+> **spiffe-helper is not a separate container.** It is bundled inside both
+> `authbridge-proxy` (proxy-sidecar/lite) and `envoy-proxy` (envoy-sidecar) and
+> starts conditionally based on the `SPIRE_ENABLED` env var, which the operator
+> sets per workload based on the `kagenti.io/spiffe-helper-inject` label.
+
+## Label vocabulary
+
+Labels are set on the **pod template** (e.g. `Deployment.spec.template.metadata.labels`).
+The operator applies `kagenti.io/type` automatically via the AgentRuntime reconciler —
+you normally do not need to set it yourself.
+
+### Pre-filter labels (control whether injection runs at all)
+
+| Label | Values | Behavior |
+|---|---|---|
+| `kagenti.io/type` | `agent` \| `tool` | **Required for injection.** Only `agent` and `tool` workloads are mutated. Set automatically by the operator. |
+| `kagenti.io/inject` | `disabled` | Set to `disabled` to opt this workload out of all sidecar injection. Any other value (or absent) allows injection. |
+
+### Per-sidecar opt-out labels
+
+These let you disable a specific sidecar while leaving others active.
+
+| Label | Default | Set to `false` to… |
+|---|---|---|
+| `kagenti.io/envoy-proxy-inject` | inject (when feature gate is on) | Disable the `envoy-proxy` sidecar (envoy-sidecar mode only) |
+| `kagenti.io/spiffe-helper-inject` | inject (enabled) | Suppress SPIRE — sets `SPIRE_ENABLED=false` on the combined sidecar, preventing the bundled spiffe-helper process from starting |
+
+### Deprecated label
+
+| Annotation | Status | Replacement |
+|---|---|---|
+| `kagenti.io/authbridge-mode` | **Deprecated** — still honored | Use `AgentRuntime.Spec.AuthBridgeMode` |
+
+### Examples
+
+```yaml
+# Opt this workload out of all injection
+metadata:
+  labels:
+    kagenti.io/inject: "disabled"
+
+# Keep injection but disable SPIRE
+metadata:
+  labels:
+    kagenti.io/spiffe-helper-inject: "false"
+
+# Disable the envoy-proxy sidecar in envoy-sidecar mode
+metadata:
+  labels:
+    kagenti.io/envoy-proxy-inject: "false"
+```
+
+## How to switch modes
+
+Mode is resolved from this chain (first non-empty wins):
+
+1. `AgentRuntime.Spec.AuthBridgeMode` on the workload's CR **(canonical)**
+2. `mode:` field in the namespace-level `authbridge-runtime-config` ConfigMap
+3. `kagenti.io/authbridge-mode` pod annotation *(deprecated — still honored)*
+4. Cluster-wide default: `proxy-sidecar`
+
+### Per-workload override (AgentRuntime CR)
+
+```yaml
+apiVersion: kagenti.io/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: weather-service
+  namespace: team1
+spec:
+  authBridgeMode: envoy-sidecar   # proxy-sidecar | envoy-sidecar | lite | waypoint
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: weather-service
+```
+
+### Namespace default (ConfigMap)
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-runtime-config
+  namespace: team1
+data:
+  mode: proxy-sidecar
+```
+
+### Verify the resolved mode
+
+```bash
+kubectl logs -n kagenti-system deploy/kagenti-operator \
+  | grep "resolved authbridge mode"
+```
+
+## Cluster-admin feature gates
+
+Feature gates are loaded from the `kagenti-webhook-config` ConfigMap in the
+operator's namespace and take effect immediately (no restart needed).
+
+| Gate | Default | Controls |
+|---|---|---|
+| `globalEnabled` | `true` | Master kill switch — set to `false` to disable all sidecar injection cluster-wide |
+| `envoyProxy` | `true` | Whether the `envoy-proxy` sidecar is injected (envoy-sidecar mode) |
+| `injectTools` | `false` | Whether `kagenti.io/type=tool` workloads receive injection (agents are always injected) |
+| `perWorkloadConfigResolution` | `false` | When `true`, webhook reads namespace ConfigMaps at admission time and injects literal env var values instead of `valueFrom` references |
+
+Source of truth: [`kagenti-operator/internal/webhook/config/feature_gates.go`](https://github.com/kagenti/kagenti-extensions/blob/main/kagenti-operator/internal/webhook/config/feature_gates.go)
+
+## Full injection decision flow
+
+```
+Pod admitted by webhook
+  └─ kagenti.io/type ∈ {agent, tool}?  — No → skip
+       └─ globalEnabled=true?  — No → skip
+            └─ type=tool and injectTools=false?  — Yes → skip
+                 └─ kagenti.io/inject=disabled?  — Yes → skip
+                      └─ Resolve mode (CR → namespace CM → annotation → default)
+                           ├─ waypoint → skip (standalone deployment)
+                           ├─ proxy-sidecar / lite
+                           │    └─ inject authbridge-proxy
+                           │         + HTTP_PROXY env vars into agent container
+                           │         + SPIRE_ENABLED based on spiffe-helper decision
+                           └─ envoy-sidecar
+                                └─ inject envoy-proxy (if envoyProxy gate=true and label≠false)
+                                     + proxy-init (follows envoy-proxy decision)
+                                     + SPIRE_ENABLED based on spiffe-helper decision
+```
+
+## Related
+
+- [Deployment Guide](deployment-guide.md) — mode details, configuration, troubleshooting
+- [Security Model](security-model.md) — mTLS, SPIFFE identity, token exchange
+- [AuthBridge Architecture](https://github.com/kagenti/kagenti-extensions/blob/main/authbridge/README.md) — sequence diagrams, protocol details

--- a/docs/authbridge/sidecar-injection.md
+++ b/docs/authbridge/sidecar-injection.md
@@ -60,7 +60,7 @@ These let you disable a specific sidecar while leaving others active.
 
 | Annotation | Status | Replacement |
 |---|---|---|
-| `kagenti.io/authbridge-mode` | **Deprecated** — still honored | Use `AgentRuntime.Spec.AuthBridgeMode` |
+| `kagenti.io/authbridge-mode` | **Deprecated** — still honored | Set `mode:` in the namespace `authbridge-runtime-config` ConfigMap |
 
 ### Examples
 
@@ -103,7 +103,8 @@ metadata:
   name: authbridge-runtime-config
   namespace: team1
 data:
-  mode: proxy-sidecar
+  config.yaml: |
+    mode: proxy-sidecar
 ```
 
 ### Verify the resolved mode


### PR DESCRIPTION
## Summary

- Adds `docs/authbridge/sidecar-injection.md` — a new user-facing reference page covering the AuthBridge injection model
- Cross-references added in `docs/authbridge/README.md` and `docs/authbridge/deployment-guide.md`

Closes #1775

## What's in the new page

- **Verify command** — `kubectl get pods -o jsonpath` to list container names in running pods
- **Container table** — maps each mode (`proxy-sidecar`, `lite`, `envoy-sidecar`, `waypoint`) to expected containers, with a callout that spiffe-helper is a bundled process (not a separate container)
- **Label vocabulary** — pre-filter labels, per-sidecar opt-out labels, and the deprecated `kagenti.io/authbridge-mode` annotation, each with YAML examples
- **How to switch modes** — full precedence chain (AgentRuntime CR → namespace ConfigMap → deprecated annotation → cluster default) with YAML for each layer
- **Feature gates table** — `globalEnabled`, `envoyProxy`, `injectTools`, `perWorkloadConfigResolution` with defaults and link to source
- **Decision flow diagram** — complete injection logic as an ASCII tree

## Test plan

- [ ] Verify `docs/authbridge/sidecar-injection.md` renders correctly on GitHub
- [ ] Verify links in `README.md` and `deployment-guide.md` resolve correctly

Assisted-By: Claude Code