### PR TITLE
Fix stale keycloak-admin-secret docs and remove orphaned Helm flags

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -405,8 +405,8 @@ KC_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.d
 KC_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' | base64 -d)
 
 kubectl create secret generic keycloak-admin-secret -n kagenti-system \
-  --from-literal=username="$KC_USER" \
-  --from-literal=password="$KC_PASS" \
+  --from-literal=KEYCLOAK_ADMIN_USERNAME="$KC_USER" \
+  --from-literal=KEYCLOAK_ADMIN_PASSWORD="$KC_PASS" \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -372,41 +372,45 @@ kubectl get secret keycloak-initial-admin -n keycloak \
 
 ## Keycloak Admin Credentials for Agent Namespaces
 
-The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) stack needs Keycloak admin credentials for automatic OAuth2 client registration. These credentials are provisioned automatically at install time by the `kagenti-agent-oauth-secret-job` Helm Job — no manual configuration is required.
+The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) stack needs Keycloak admin credentials for automatic OAuth2 client registration. Two distinct secrets are involved:
+
+| Secret | Namespace | Purpose |
+|--------|-----------|---------|
+| `keycloak-admin-secret` | `kagenti-system` | Admin credentials used by the operator's ClientRegistrationReconciler and the AuthBridge client-registration sidecar to register per-agent OAuth clients in Keycloak |
+| per-agent OAuth client secrets | agent namespaces (`team1`, `team2`, …) | Per-workload credentials created *by* client registration; consumed by the agent pods |
+
+See the [Identity Guide](./identity-guide.md) for a full description of the client-registration flow.
 
 ### Automatic Provisioning
 
-During `helm install` / `helm upgrade`, the `kagenti-agent-oauth-secret-job` Job runs and:
+`keycloak-admin-secret` is created in `kagenti-system` by the installer (`36-fix-keycloak-admin.sh`), which reads the actual admin credentials from the `keycloak-initial-admin` Secret managed by the RHBK operator. Because the installer reads credentials at deploy time, the secret stays in sync across upgrades — including after an RHBK operator upgrade that rotates the `keycloak-initial-admin` password.
 
-1. Reads the actual admin credentials from the `keycloak-initial-admin` Secret in the Keycloak namespace (created and managed by the RHBK operator with a randomly-generated password).
-2. Creates the per-agent-namespace OAuth client secrets using those credentials.
+The per-agent OAuth client secrets are then provisioned by the `kagenti-agent-oauth-secret-job` Helm Job, which also reads `keycloak-initial-admin` directly.
 
-Because the Job reads credentials at deploy time rather than rendering them into the Helm release, credentials stay in sync across upgrades — including after an RHBK operator upgrade that rotates the `keycloak-initial-admin` password.
-
-The source secret name and key names are configurable via `values.yaml` if you use a different credential secret:
+The source secret name and key names are configurable via `values.yaml`:
 
 ```yaml
 keycloak:
-  adminSecretName: keycloak-initial-admin  # Secret name in keycloak namespace
-  adminUsernameKey: username               # Key within the secret
+  adminSecretName: keycloak-initial-admin  # Secret in the keycloak namespace
+  adminUsernameKey: username
   adminPasswordKey: password
 ```
 
 ### Manual Sync (break-glass)
 
-If a credential rotation leaves an agent namespace out of sync, re-run a `helm upgrade` to trigger a new Job run. Alternatively, update the secret directly:
+If a credential rotation leaves `keycloak-admin-secret` out of sync, re-run the installer or sync it manually:
 
 ```bash
 KC_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' | base64 -d)
 KC_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' | base64 -d)
 
-for ns in team1 team2; do
-  kubectl create secret generic keycloak-admin-secret -n $ns \
-    --from-literal=KEYCLOAK_ADMIN_USERNAME="$KC_USER" \
-    --from-literal=KEYCLOAK_ADMIN_PASSWORD="$KC_PASS" \
-    --dry-run=client -o yaml | kubectl apply -f -
-done
+kubectl create secret generic keycloak-admin-secret -n kagenti-system \
+  --from-literal=username="$KC_USER" \
+  --from-literal=password="$KC_PASS" \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
+
+Then re-run `helm upgrade` to trigger a new `kagenti-agent-oauth-secret-job` run and re-register OAuth clients.
 
 > **Security note:** For production deployments, use a dedicated Keycloak service account with limited permissions instead of the admin account. See the [Identity Guide](./identity-guide.md) for details.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -370,13 +370,20 @@ kubectl get secret keycloak-initial-admin -n keycloak \
 
 ---
 
-## Keycloak Admin Credentials for Agent Namespaces
+## Keycloak Client Registration
 
-The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) stack needs Keycloak admin credentials for automatic OAuth2 client registration. Two distinct secrets are involved:
+The operator automatically registers an OAuth2 client in Keycloak for each agent and tool workload. There are two ways this authentication can work:
+
+| Mode | How it works | When to use |
+|---|---|---|
+| **Client secrets** (default) | Operator uses admin credentials to register clients; per-agent OAuth2 secrets are provisioned and mounted into pods | Default install; no SPIRE required |
+| **SPIFFE auth** (recommended) | Operator and agents authenticate to Keycloak using their SPIFFE JWT-SVIDs; no credentials provisioned or stored | Requires SPIRE; see [SPIFFE authentication guide](./spiffe-keycloak-auth.md) |
+
+Two secrets are involved in the default (client secrets) mode:
 
 | Secret | Namespace | Purpose |
 |--------|-----------|---------|
-| `keycloak-admin-secret` | `kagenti-system` | Admin credentials used by the operator's ClientRegistrationReconciler and the AuthBridge client-registration sidecar to register per-agent OAuth clients in Keycloak |
+| `keycloak-admin-secret` | `kagenti-system` | Admin credentials used by the operator's `ClientRegistrationReconciler` to register per-agent OAuth clients in Keycloak |
 | per-agent OAuth client secrets | agent namespaces (`team1`, `team2`, …) | Per-workload credentials created *by* client registration; consumed by the agent pods |
 
 See the [Identity Guide](./identity-guide.md) for a full description of the client-registration flow.
@@ -412,7 +419,7 @@ kubectl create secret generic keycloak-admin-secret -n kagenti-system \
 
 Then re-run `helm upgrade` to trigger a new `kagenti-agent-oauth-secret-job` run and re-register OAuth clients.
 
-> **Security note:** For production deployments, use a dedicated Keycloak service account with limited permissions instead of the admin account. See the [Identity Guide](./identity-guide.md) for details.
+> **Production recommendation:** Enable SPIFFE-based authentication with `--enable-spiffe-auth` to eliminate all provisioned credentials. See the [SPIFFE authentication guide](./spiffe-keycloak-auth.md) for setup and the [Identity Guide](./identity-guide.md) for architecture details.
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -372,59 +372,40 @@ kubectl get secret keycloak-initial-admin -n keycloak \
 
 ## Keycloak Admin Credentials for Agent Namespaces
 
-The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) stack (separate sidecars or a single [combined `authbridge` container](authbridge-combined-sidecar.md)) needs Keycloak admin credentials for automatic OAuth2 client registration. These credentials are stored in a Kubernetes Secret called `keycloak-admin-secret` in each agent namespace.
+The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) stack needs Keycloak admin credentials for automatic OAuth2 client registration. These credentials are provisioned automatically at install time by the `kagenti-agent-oauth-secret-job` Helm Job — no manual configuration is required.
 
 ### Automatic Provisioning
 
-The installer automatically creates `keycloak-admin-secret` in every agent namespace (e.g., `team1`, `team2`). By default it uses `admin`/`admin`, matching the default Keycloak admin account.
+During `helm install` / `helm upgrade`, the `kagenti-agent-oauth-secret-job` Job runs and:
 
-### Customizing Credentials
+1. Reads the actual admin credentials from the `keycloak-initial-admin` Secret in the Keycloak namespace (created and managed by the RHBK operator with a randomly-generated password).
+2. Creates the per-agent-namespace OAuth client secrets using those credentials.
 
-If your Keycloak admin credentials differ from the defaults, override them using a values file (preferred over `--set` to avoid exposing passwords in shell history and process listings):
+Because the Job reads credentials at deploy time rather than rendering them into the Helm release, credentials stay in sync across upgrades — including after an RHBK operator upgrade that rotates the `keycloak-initial-admin` password.
 
-**Secrets file** (via `.secrets.yaml`):
-
-Add to your `charts/kagenti/.secrets.yaml`:
+The source secret name and key names are configurable via `values.yaml` if you use a different credential secret:
 
 ```yaml
 keycloak:
-  adminUsername: myadmin
-  adminPassword: mypassword
+  adminSecretName: keycloak-initial-admin  # Secret name in keycloak namespace
+  adminUsernameKey: username               # Key within the secret
+  adminPasswordKey: password
 ```
 
-**Helm install** (via values file):
+### Manual Sync (break-glass)
+
+If a credential rotation leaves an agent namespace out of sync, re-run a `helm upgrade` to trigger a new Job run. Alternatively, update the secret directly:
 
 ```bash
-helm upgrade --install kagenti ./charts/kagenti/ \
-  -n kagenti-system --create-namespace \
-  -f my-secret-values.yaml
-```
+KC_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' | base64 -d)
+KC_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' | base64 -d)
 
-### Using an Existing Secret
-
-If you already manage Keycloak admin credentials in a Secret (e.g., via an external secrets operator), you can skip the automatic secret creation entirely by setting `keycloak.adminExistingSecret` to the name of that secret. The referenced secret must contain `KEYCLOAK_ADMIN_USERNAME` and `KEYCLOAK_ADMIN_PASSWORD` keys:
-
-```bash
-helm upgrade --install kagenti ./charts/kagenti/ \
-  -n kagenti-system --create-namespace \
-  --set keycloak.adminExistingSecret=my-keycloak-admin-secret
-```
-
-### Manual Creation
-
-If you need to create or update the secret manually in an agent namespace:
-
-```bash
-kubectl create secret generic keycloak-admin-secret -n <agent-namespace> \
-  --from-literal=KEYCLOAK_ADMIN_USERNAME=admin \
-  --from-literal=KEYCLOAK_ADMIN_PASSWORD=admin \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
-
-### Verifying
-
-```bash
-kubectl get secret keycloak-admin-secret -n team1
+for ns in team1 team2; do
+  kubectl create secret generic keycloak-admin-secret -n $ns \
+    --from-literal=KEYCLOAK_ADMIN_USERNAME="$KC_USER" \
+    --from-literal=KEYCLOAK_ADMIN_PASSWORD="$KC_PASS" \
+    --dry-run=client -o yaml | kubectl apply -f -
+done
 ```
 
 > **Security note:** For production deployments, use a dedicated Keycloak service account with limited permissions instead of the admin account. See the [Identity Guide](./identity-guide.md) for details.

--- a/docs/install.md
+++ b/docs/install.md
@@ -377,7 +377,7 @@ The operator automatically registers an OAuth2 client in Keycloak for each agent
 | Mode | How it works | When to use |
 |---|---|---|
 | **Client secrets** (default) | Operator uses admin credentials to register clients; per-agent OAuth2 secrets are provisioned and mounted into pods | Default install; no SPIRE required |
-| **SPIFFE auth** (recommended) | Operator and agents authenticate to Keycloak using their SPIFFE JWT-SVIDs; no credentials provisioned or stored | Requires SPIRE; see [SPIFFE authentication guide](./spiffe-keycloak-auth.md) |
+| **SPIFFE auth** (recommended) | Operator and agents authenticate to Keycloak using their SPIFFE JWT-SVIDs; no credentials provisioned or stored | Requires SPIRE; see [SPIFFE authentication guide](./authentication.md) |
 
 Two secrets are involved in the default (client secrets) mode:
 
@@ -419,7 +419,7 @@ kubectl create secret generic keycloak-admin-secret -n kagenti-system \
 
 Then re-run `helm upgrade` to trigger a new `kagenti-agent-oauth-secret-job` run and re-register OAuth clients.
 
-> **Production recommendation:** Enable SPIFFE-based authentication with `--enable-spiffe-auth` to eliminate all provisioned credentials. See the [SPIFFE authentication guide](./spiffe-keycloak-auth.md) for setup and the [Identity Guide](./identity-guide.md) for architecture details.
+> **Production recommendation:** Enable SPIFFE-based authentication with `--enable-spiffe-auth` to eliminate all provisioned credentials. See the [SPIFFE authentication guide](./authentication.md) for setup and the [Identity Guide](./identity-guide.md) for architecture details.
 
 ---
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1313,23 +1313,9 @@ fi
 
 log_info "Keycloak: realm=$KC_REALM namespace=$KC_NAMESPACE"
 
-# Read the actual Keycloak admin credentials from the operator-managed secret.
-# The RHBK operator creates keycloak-initial-admin with a random password.
-# The kagenti chart creates keycloak-admin-secret in agent namespaces for the
-# client-registration sidecar — these must match, otherwise client-registration
-# can't authenticate to the master realm to register per-agent OAuth clients.
-KC_ADMIN_FLAGS=()
-_kc_admin_user=$($KUBECTL get secret keycloak-initial-admin -n "$KC_NAMESPACE" \
-  -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
-_kc_admin_pass=$($KUBECTL get secret keycloak-initial-admin -n "$KC_NAMESPACE" \
-  -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
-if [ -n "$_kc_admin_user" ] && [ -n "$_kc_admin_pass" ]; then
-  KC_ADMIN_FLAGS+=(--set "keycloak.adminUsername=${_kc_admin_user}")
-  KC_ADMIN_FLAGS+=(--set "keycloak.adminPassword=${_kc_admin_pass}")
-  log_success "Keycloak admin credentials read from keycloak-initial-admin"
-else
-  log_warn "Could not read keycloak-initial-admin — agent client-registration may fail"
-fi
+# Keycloak admin credentials are read at deploy time by the kagenti-agent-oauth-secret-job
+# Job, which reads keycloak-initial-admin directly from the keycloak namespace.
+# No Helm value overrides are needed — the Job always uses the live secret.
 
 # Build operator image override flags
 OPERATOR_IMAGE_FLAGS=()
@@ -1358,7 +1344,6 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   -f "$SECRETS_FILE" \
   ${KAGENTI_UI_FLAGS[@]+"${KAGENTI_UI_FLAGS[@]}"} \
   ${OPERATOR_IMAGE_FLAGS[@]+"${OPERATOR_IMAGE_FLAGS[@]}"} \
-  ${KC_ADMIN_FLAGS[@]+"${KC_ADMIN_FLAGS[@]}"} \
   ${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"} \
   --set "agentOAuthSecret.spiffePrefix=spiffe://${DOMAIN}/sa" \
   --set uiOAuthSecret.useServiceAccountCA=false \


### PR DESCRIPTION
## Summary

- Removes the stale \"Keycloak Admin Credentials for Agent Namespaces\" section from `docs/install.md` that described a no-longer-existing mechanism (`keycloak-admin-secret`, `keycloak.adminUsername`, `keycloak.adminPassword`, `keycloak.adminExistingSecret`)
- Replaces it with an accurate description of the actual mechanism: the `kagenti-agent-oauth-secret-job` reads `keycloak-initial-admin` at deploy time
- Removes orphaned `--set keycloak.adminUsername` / `--set keycloak.adminPassword` flags from `scripts/ocp/setup-kagenti.sh` — these values don't exist in any chart template, so they were silently ignored on every upgrade

## Root cause

The chart was already fixed (credentials are provisioned by a Job that reads `keycloak-initial-admin` directly), but the docs and the OCP setup script were never updated to match.

## Test plan

- [ ] Verify `helm template` still renders without error
- [ ] Verify `setup-kagenti.sh` completes without referencing removed flags

Closes #1337

Assisted-By: Claude Code