### PR TITLE
feat(skills): make in-cluster skillberry-store run the Claude Code CLI

### DIFF
--- a/charts/kagenti/templates/skillberry-store.yaml
+++ b/charts/kagenti/templates/skillberry-store.yaml
@@ -28,6 +28,9 @@ spec:
       - name: skillberry-store
         image: "{{ .Values.skillberryStore.image.repository }}:{{ .Values.skillberryStore.image.tag }}"
         imagePullPolicy: {{ .Values.skillberryStore.image.pullPolicy }}
+        {{- with .Values.skillberryStore.image.command }}
+        command: {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         - name: SBS_BASE_DIR
           value: "{{ .Values.skillberryStore.baseDir }}"
@@ -39,6 +42,19 @@ spec:
           value: "{{ .Values.skillberryStore.uiPort }}"
         - name: ENABLE_UI
           value: "true"
+        # The store's skill-generation feature invokes the Claude Code CLI with
+        # --dangerously-skip-permissions, which the CLI refuses to run under
+        # root/sudo unless it believes it is sandboxed. The container runs as
+        # root, so declare the sandbox to allow the flag. The pod IS the sandbox.
+        - name: IS_SANDBOX
+          value: "1"
+        # The embedding model (all-MiniLM-L6-v2) is NOT bundled in the image and
+        # is downloaded from huggingface.co on first use. Point the HF cache at
+        # the persistent /data volume so the model is downloaded only once and
+        # survives pod restarts/redeploys. (The loosened liveness/startup probes
+        # absorb the transient HEAD-check stalls when DNS to HF is slow.)
+        - name: HF_HOME
+          value: "{{ .Values.skillberryStore.baseDir }}/.huggingface"
         # Allow the gateway hostname through the store's Vite dev server host
         # check. Defaults to the HTTPRoute host derived from .Values.domain.
         - name: VITE_ALLOWED_HOSTS
@@ -53,20 +69,37 @@ spec:
         - name: ui
           containerPort: {{ .Values.skillberryStore.uiPort }}
           protocol: TCP
+        # startupProbe gives the app plenty of time to come up on first start
+        # (e.g. downloading/loading the SentenceTransformer embedding model on CPU)
+        # without liveness/readiness counting against it. Up to 20 * 15s = 300s.
+        startupProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.skillberryStore.apiPort }}
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 20
+        # Liveness is intentionally loose: skill creation triggers synchronous,
+        # CPU-heavy embedding-model work that can block the event loop and stall
+        # /health for a while. Only restart if it's unresponsive for ~5 min
+        # (30s period * 10 failures), with a generous 10s per-probe timeout.
         livenessProbe:
           httpGet:
             path: /health
             port: {{ .Values.skillberryStore.apiPort }}
           initialDelaySeconds: 10
           periodSeconds: 30
-          failureThreshold: 3
+          timeoutSeconds: 10
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /health/ready
             port: {{ .Values.skillberryStore.apiPort }}
           initialDelaySeconds: 5
           periodSeconds: 10
-          failureThreshold: 3
+          timeoutSeconds: 5
+          failureThreshold: 6
         resources:
           {{- toYaml .Values.skillberryStore.resources | nindent 10 }}
         volumeMounts:

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -76,6 +76,22 @@ skillberryStore:
     repository: ghcr.io/skillberry-ai/skillberry-store
     tag: "0.2.0"             # override via --set or values overlay
     pullPolicy: IfNotPresent
+    # Override the container entrypoint. The default image command (`make run`)
+    # re-runs `uv install` at startup and requires network access to github.com.
+    # This bypasses that by running the pre-installed venv directly.
+    #
+    # The store's skill-generation feature shells out to the Claude Code CLI,
+    # which is NOT bundled in the upstream image. Install it at startup (best
+    # effort; `|| true` keeps the store up if the npm fetch fails) so it lands
+    # on PATH (/usr/local/bin) before the app process starts. This is a network
+    # fetch on every pod start (~15s); bake it into a derived image if that
+    # startup cost or the network dependency is unacceptable.
+    command:
+      - sh
+      - -c
+      - |
+        npm install -g @anthropic-ai/claude-code || true
+        exec .venv/bin/python -m skillberry_store.main
   imagePullSecrets: []        # public image; empty default
   apiPort: 8000
   uiPort: 8002


### PR DESCRIPTION
Closes #2156.

## Summary

The in-cluster `skillberry-store`'s skill-generation feature shells out to the **Claude Code CLI**, which is not bundled in the upstream `ghcr.io/skillberry-ai/skillberry-store:0.2.0` image. This wires the deployment so the CLI is present and usable at runtime.

## Changes

- **`values.yaml`** — extend the entrypoint (`command:`) override to `npm install -g @anthropic-ai/claude-code` at startup (best effort, `|| true`) so it lands on PATH (`/usr/local/bin`) before the app process starts, then `exec` the app.
- **`skillberry-store.yaml`** — set `IS_SANDBOX=1` so the CLI accepts `--dangerously-skip-permissions` under root (the pod is the sandbox); add `HF_HOME` on the persistent volume so the embedding model downloads once; loosen liveness/readiness/startup probes to absorb CPU-heavy embedding work during skill creation.

## Design decisions

- **Startup install vs. derived image:** chosen to avoid a new build pipeline and to fit the existing `command:` override pattern. Trade-off is a ~15s network fetch on each pod start; the values.yaml comment documents baking a derived image as the alternative.
- **`IS_SANDBOX=1` vs. running non-root:** keeping the container as root avoids PVC-ownership and `npm install -g` write-permission issues; the pod boundary is the sandbox.
- **`ANTHROPIC_BASE_URL`** is intentionally **not** hardcoded in the chart — it belongs in the env overlay and must use the LiteLLM **hostname** (not IP) to satisfy TLS cert validation.

## Testing

- `helm lint` and `helm template` render cleanly with the new `command`/env.
- `make lint` (pre-commit) passes on both files.
- Verified end-to-end on a live Kind cluster: after a rollout, the pod auto-installs the CLI, `IS_SANDBOX=1` is set, and a headless `claude -p` call using only pod-native env returns successfully.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>