### PR TITLE
Fix: Don't forget about failed and progressing Tool builds

### DIFF
--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -498,9 +498,7 @@ def _get_tool_build_status(kube: KubernetesService, name: str, namespace: str) -
     return "Build Failed" if phase == "Failed" else "Building"
 
 
-def _get_tool_build_detail(
-    kube: KubernetesService, name: str, namespace: str
-) -> Optional[dict]:
+def _get_tool_build_detail(kube: KubernetesService, name: str, namespace: str) -> Optional[dict]:
     """Build a synthetic get_tool response for a source-built tool with no workload.
 
     Returns a response dict (same shape as get_tool's workload response) with a

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -459,6 +459,100 @@ def _get_workload_status(workload: dict) -> str:
     return "Not Ready"
 
 
+def _get_tool_build_status(kube: KubernetesService, name: str, namespace: str) -> Optional[str]:
+    """Derive a build-status indicator for a source-built tool with no workload.
+
+    Looks at the latest Shipwright BuildRun for the given build name and maps its
+    phase to a status string:
+      - "Build Failed"  -> latest BuildRun failed
+      - "Building"      -> BuildRun pending/running, or no BuildRun yet
+      - None            -> build succeeded (a workload exists or is being finalized)
+
+    Returns None (not a status) for Succeeded builds so callers can fall through
+    to the real workload / 404 handling.
+    """
+    try:
+        buildruns = kube.list_custom_resources(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace=namespace,
+            plural=SHIPWRIGHT_BUILDRUNS_PLURAL,
+            label_selector=f"kagenti.io/build-name={name}",
+        )
+    except ApiException:
+        # Constant message only (CodeQL py/log-injection): never
+        # interpolate namespace / build name / API reason.
+        logger.warning("Failed to list BuildRuns for a Shipwright build")
+        buildruns = []
+
+    # No BuildRun yet -> build just started; treat as "Building".
+    phase = "Pending"
+    latest = get_latest_buildrun(buildruns) if buildruns else None
+    if latest:
+        phase = extract_buildrun_info(latest)["phase"]
+
+    # Succeeded builds either already have a workload or are about to be
+    # finalized into one; let the caller handle that case.
+    if phase == "Succeeded":
+        return None
+    return "Build Failed" if phase == "Failed" else "Building"
+
+
+def _get_tool_build_detail(
+    kube: KubernetesService, name: str, namespace: str
+) -> Optional[dict]:
+    """Build a synthetic get_tool response for a source-built tool with no workload.
+
+    Returns a response dict (same shape as get_tool's workload response) with a
+    readyStatus of "Building" or "Build Failed" when a Shipwright Build exists
+    for this tool and its latest BuildRun is in progress or failed. Returns None
+    when there is no build, or when the build has Succeeded (a workload exists or
+    is being finalized), so the caller can fall through to its 404 handling.
+    """
+    try:
+        build = kube.get_custom_resource(
+            group=SHIPWRIGHT_CRD_GROUP,
+            version=SHIPWRIGHT_CRD_VERSION,
+            namespace=namespace,
+            plural=SHIPWRIGHT_BUILDS_PLURAL,
+            name=name,
+        )
+    except ApiException as e:
+        if e.status != 404:
+            logger.warning("Failed to get Shipwright Build for a tool")
+        return None
+
+    status = _get_tool_build_status(kube, name, namespace)
+    if status is None:
+        return None
+
+    metadata = build.get("metadata", {}) or {}
+    labels = metadata.get("labels", {}) or {}
+    return {
+        "metadata": {
+            "name": metadata.get("name", name),
+            "namespace": metadata.get("namespace", namespace),
+            "labels": labels,
+            "annotations": metadata.get("annotations", {}) or {},
+            "creationTimestamp": _format_timestamp(
+                metadata.get("creationTimestamp") or metadata.get("creation_timestamp")
+            ),
+            "uid": metadata.get("uid"),
+        },
+        # No workload spec/status yet; expose the Build spec so callers that
+        # inspect source/git details still have them.
+        "spec": build.get("spec", {}) or {},
+        "status": {},
+        "readyStatus": status,
+        # We may be building a non-deployment.
+        # TODO record and retrieve build type.
+        "workloadType": WORKLOAD_TYPE_DEPLOYMENT,
+        "service": None,
+        # Signals to the frontend that this is a build placeholder, not a workload.
+        "isBuild": True,
+    }
+
+
 def _get_workload_type_from_resource(resource: dict) -> str:
     """Determine workload type from a Kubernetes resource.
 
@@ -697,6 +791,46 @@ async def list_tools(
             if e.status != 404:
                 logger.warning(f"Error listing StatefulSets: {e}")
 
+        # Surface in-progress / failed Shipwright source builds that have no
+        # workload yet. A source-built tool has no Deployment/StatefulSet until
+        # its build Succeeds and is finalized, so without this it would be
+        # invisible here while building or after a failure. Guarded so a
+        # build-listing failure never breaks the core tool list.
+        try:
+            builds = collect_kagenti_shipwright_builds(
+                kube, [namespace], RESOURCE_TYPE_TOOL, logger
+            )
+            for build in builds:
+                # Workload already exists (build Succeeded + finalized, or a
+                # name collision) -> already listed above; skip to avoid dupes.
+                if build.name in existing_names:
+                    continue
+
+                # Succeeded builds either already have a workload (listed above)
+                # or are about to be finalized into one; don't surface them here.
+                status = _get_tool_build_status(kube, build.name, build.namespace)
+                if status is None:
+                    continue
+
+                tools.append(
+                    ToolSummary(
+                        name=build.name,
+                        namespace=build.namespace,
+                        description="Building from source",
+                        status=status,
+                        labels=_extract_labels({KAGENTI_TYPE_LABEL: build.resourceType}),
+                        # Note that we may be building a non-deployment.
+                        # TODO record and retrieve build type.
+                        workloadType=WORKLOAD_TYPE_DEPLOYMENT,
+                        # Collector already formats this as an ISO string, so do
+                        # not pass it through _format_timestamp (datetime-only).
+                        createdAt=build.creationTimestamp,
+                    )
+                )
+                existing_names.add(build.name)
+        except ApiException:
+            logger.warning("Failed to list Shipwright builds for tools", exc_info=True)
+
         return ToolListResponse(items=tools)
 
     except ApiException as e:
@@ -718,6 +852,12 @@ async def get_tool(
 
     Tries to find the tool as a Deployment first, then as a StatefulSet.
     Returns the workload details along with associated Service information.
+
+    A source-built tool has no Deployment/StatefulSet until its Shipwright
+    build Succeeds and is finalized. When no workload exists but a build does,
+    a synthetic response is returned with a readyStatus of "Building" or
+    "Build Failed" so the detail page can surface in-progress / failed builds
+    instead of a 404.
     """
     workload = None
     workload_type = None
@@ -736,12 +876,18 @@ async def get_tool(
             workload = kube.get_statefulset(namespace, name)
             workload_type = WORKLOAD_TYPE_STATEFULSET
         except ApiException as e:
-            if e.status == 404:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Tool '{name}' not found in namespace '{namespace}'",
-                )
-            raise HTTPException(status_code=e.status, detail=str(e.reason))
+            if e.status != 404:
+                raise HTTPException(status_code=e.status, detail=str(e.reason))
+
+    # No workload yet -> fall back to a source build (in-progress or failed).
+    if workload is None:
+        build_response = _get_tool_build_detail(kube, name, namespace)
+        if build_response is not None:
+            return build_response
+        raise HTTPException(
+            status_code=404,
+            detail=f"Tool '{name}' not found in namespace '{namespace}'",
+        )
 
     # Get associated Service
     service_info = None

--- a/kagenti/backend/tests/test_shipwright_builds_api.py
+++ b/kagenti/backend/tests/test_shipwright_builds_api.py
@@ -319,6 +319,153 @@ class TestListAgentsIncludesBuilds:
         assert items == []
 
 
+class TestListToolsIncludesBuilds:
+    """GET /api/v1/tools surfaces in-progress / failed Shipwright builds that
+    have no workload yet, with a status of "Building" or "Build Failed"."""
+
+    def _run(self, kube, buildrun, *, builds=None):
+        """Drive GET /tools with empty workloads and one tool build (unless
+        overridden), returning the parsed items list."""
+        app = FastAPI()
+        app.include_router(tools.router, prefix="/api/v1")
+
+        # Default workloads to empty unless the caller pre-seeded a return_value.
+        for meth in ("list_deployments", "list_statefulsets"):
+            m = getattr(kube, meth)
+            if not isinstance(m.return_value, list):
+                m.return_value = []
+        # Builds listed by collect_kagenti_shipwright_builds (via custom_api).
+        if builds is None:
+            builds = [_sample_build("buildme", "team1", "tool")]
+        kube.custom_api.list_namespaced_custom_object.return_value = {"items": builds}
+        # BuildRuns listed by the new block via kube.list_custom_resources.
+        kube.list_custom_resources.return_value = [] if buildrun is None else [buildrun]
+
+        app.dependency_overrides[get_kubernetes_service] = lambda: kube
+        with patch("app.core.auth.settings") as mock_auth:
+            mock_auth.enable_auth = False
+            tc = TestClient(app)
+            r = tc.get("/api/v1/tools", params={"namespace": "team1"})
+            assert r.status_code == 200
+            items = r.json()["items"]
+        app.dependency_overrides.clear()
+        return items
+
+    def test_failed_build_marked_build_failed(self):
+        items = self._run(MagicMock(), _buildrun("br1", "False"))
+        assert len(items) == 1
+        assert items[0]["name"] == "buildme"
+        assert items[0]["status"] == "Build Failed"
+
+    def test_running_build_marked_building(self):
+        items = self._run(MagicMock(), _buildrun("br1", "Unknown"))
+        assert len(items) == 1
+        assert items[0]["status"] == "Building"
+
+    def test_no_buildrun_marked_building(self):
+        items = self._run(MagicMock(), None)
+        assert len(items) == 1
+        assert items[0]["status"] == "Building"
+
+    def test_succeeded_build_not_listed(self):
+        items = self._run(MagicMock(), _buildrun("br1", "True"))
+        assert items == []
+
+    def test_build_deduped_against_existing_workload(self):
+        kube = MagicMock()
+        kube.list_deployments.return_value = [
+            {
+                "metadata": {
+                    "name": "buildme",
+                    "namespace": "team1",
+                    "labels": {"kagenti.io/type": "tool"},
+                    "creationTimestamp": "2025-01-01T00:00:00Z",
+                },
+                "status": {"conditions": [{"type": "Available", "status": "True"}]},
+                "spec": {"replicas": 1},
+            }
+        ]
+        # Build with the same name as the deployment -> must not be added twice.
+        items = self._run(kube, _buildrun("br1", "False"))
+        assert len(items) == 1
+        # The single entry is the real workload, not the synthetic build entry.
+        assert items[0]["status"] != "Build Failed"
+
+    def test_build_listing_failure_does_not_break_list(self):
+        from kubernetes.client import ApiException
+
+        kube = MagicMock()
+        kube.custom_api.list_namespaced_custom_object.side_effect = ApiException(
+            status=500, reason="boom"
+        )
+        # collect_kagenti_shipwright_builds re-raises non-403/404; the new block's
+        # outer guard must swallow it so the core (empty) list still returns 200.
+        items = self._run(kube, None, builds=[])
+        assert items == []
+
+
+class TestGetToolBuildFallback:
+    """GET /api/v1/tools/{ns}/{name} falls back to a source build when no
+    workload exists, returning readyStatus "Building" / "Build Failed" instead
+    of a 404 (and a real 404 only when there is no build either)."""
+
+    def _run(self, buildrun, *, build="present"):
+        """Drive GET /tools/team1/buildme with no Deployment/StatefulSet.
+
+        build="present" -> get_custom_resource returns a Build CR
+        build="missing" -> get_custom_resource raises 404
+        buildrun         -> BuildRun dict (or None for no BuildRun)
+        Returns (status_code, json_body).
+        """
+        from kubernetes.client import ApiException
+
+        kube = MagicMock()
+        kube.get_deployment.side_effect = ApiException(status=404, reason="nf")
+        kube.get_statefulset.side_effect = ApiException(status=404, reason="nf")
+        if build == "missing":
+            kube.get_custom_resource.side_effect = ApiException(status=404, reason="nf")
+        else:
+            kube.get_custom_resource.return_value = _sample_build("buildme", "team1", "tool")
+        kube.list_custom_resources.return_value = [] if buildrun is None else [buildrun]
+
+        app = FastAPI()
+        app.include_router(tools.router, prefix="/api/v1")
+        app.dependency_overrides[get_kubernetes_service] = lambda: kube
+        with patch("app.core.auth.settings") as mock_auth:
+            mock_auth.enable_auth = False
+            tc = TestClient(app)
+            r = tc.get("/api/v1/tools/team1/buildme")
+        app.dependency_overrides.clear()
+        return r.status_code, (r.json() if r.status_code == 200 else None)
+
+    def test_failed_build_marked_build_failed(self):
+        code, body = self._run(_buildrun("br1", "False"))
+        assert code == 200
+        assert body["readyStatus"] == "Build Failed"
+        assert body["isBuild"] is True
+        assert body["metadata"]["name"] == "buildme"
+
+    def test_running_build_marked_building(self):
+        code, body = self._run(_buildrun("br1", "Unknown"))
+        assert code == 200
+        assert body["readyStatus"] == "Building"
+
+    def test_no_buildrun_marked_building(self):
+        code, body = self._run(None)
+        assert code == 200
+        assert body["readyStatus"] == "Building"
+
+    def test_succeeded_build_returns_404(self):
+        # Build succeeded but no workload exists -> not a build placeholder;
+        # fall through to the normal 404.
+        code, _ = self._run(_buildrun("br1", "True"))
+        assert code == 404
+
+    def test_no_build_returns_404(self):
+        code, _ = self._run(_buildrun("br1", "False"), build="missing")
+        assert code == 404
+
+
 class TestCollectShipwrightBuildsLogging:
     def test_403_warning_is_constant_only(self):
         from kubernetes.client import ApiException


### PR DESCRIPTION
## Summary

For #1906

See also https://github.com/kagenti/kagenti/pull/2111 , the same changes for agent builds (already merged)

## (Optional) Testing Instructions

Deploy Rossi
Bring in this PR
make build-load-ui-frontend and make build-load-ui-backend plus the usual rollout.
