### PR TITLE
feat(simulation): provision simulated-tool workload (StatefulSet + PVC + Service)

### DIFF
--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -86,6 +86,10 @@ class Settings(BaseSettings):
     kagenti_feature_flag_simulated_tools: bool = False
     # Generic simulation-harness image serving all simulated tools (epic #2151)
     simulation_harness_image: str = "ghcr.io/kagenti/simulation-harness:latest"
+    # Pull secret for the harness image while it lives in a private registry (interim,
+    # epic #2151). References the Helm-created per-namespace `ghcr-secret`. Set empty
+    # to disable — once the image is public, anonymous pull works and this is unneeded.
+    simulation_image_pull_secret: str = "ghcr-secret"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -82,6 +82,8 @@ class Settings(BaseSettings):
     )
     kagenti_feature_flag_acp: bool = False  # ACP WebSocket protocol gateway
     kagenti_feature_flag_external_skills: bool = False  # External skill registry references
+    # Simulated MCP tools: LLM-driven, stateful tools generated from an OpenAPI spec
+    kagenti_feature_flag_simulated_tools: bool = False
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -90,6 +90,10 @@ class Settings(BaseSettings):
     # epic #2151). References the Helm-created per-namespace `ghcr-secret`. Set empty
     # to disable — once the image is public, anonymous pull works and this is unneeded.
     simulation_image_pull_secret: str = "ghcr-secret"
+    # Image pull policy for the harness container. Defaults to Always (production
+    # pulls :latest from the registry); set IfNotPresent/Never for local dev when
+    # the image is side-loaded into the cluster (e.g. `kind load`).
+    simulation_image_pull_policy: str = "Always"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -84,6 +84,8 @@ class Settings(BaseSettings):
     kagenti_feature_flag_external_skills: bool = False  # External skill registry references
     # Simulated MCP tools: LLM-driven, stateful tools generated from an OpenAPI spec
     kagenti_feature_flag_simulated_tools: bool = False
+    # Generic simulation-harness image serving all simulated tools (epic #2151)
+    simulation_harness_image: str = "ghcr.io/kagenti/simulation-harness:latest"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -34,6 +34,11 @@ APP_KUBERNETES_IO_COMPONENT = "app.kubernetes.io/component"
 KAGENTI_SPIRE_LABEL = "kagenti.io/spire"
 KAGENTI_SPIRE_ENABLED_VALUE = "enabled"
 
+# Simulated MCP tools (epic #2151)
+KAGENTI_SIMULATED_LABEL = "kagenti.io/simulated"  # safety marker; UI badge; list filter
+KAGENTI_AUTOSCALING_ANNOTATION = "kagenti.io/autoscaling"  # HPA-off marker (declarative opt-out)
+SIMULATION_HARNESS_SKILLS_MOUNT = "/app/skills-store"  # HARNESS_SKILLS_FOLDER mount path
+
 # Per-sidecar opt-out labels (envoy-proxy / spiffe-helper /
 # client-registration) are gone after kagenti-extensions#411 — they
 # referenced separate sidecars that no longer exist. The master enable

--- a/kagenti/backend/app/main.py
+++ b/kagenti/backend/app/main.py
@@ -127,6 +127,17 @@ if settings.kagenti_feature_flag_acp:
         logging.getLogger(__name__).warning(
             "ACP flag enabled but acp modules not installed — skipping"
         )
+
+_simulation_modules_loaded = False
+if settings.kagenti_feature_flag_simulated_tools:
+    try:
+        from app.routers import simulation  # noqa: E402
+
+        _simulation_modules_loaded = True
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "SIMULATED_TOOLS flag enabled but simulation modules not installed — skipping"
+        )
 # pylint: enable=wrong-import-position,no-name-in-module,import-error
 
 # Configure logging
@@ -268,6 +279,10 @@ if _skills_modules_loaded:
 if _acp_modules_loaded:
     app.include_router(acp.router, prefix="/api/v1")
     logger.info("Feature flag ACP enabled — ACP WebSocket routes registered")
+
+if _simulation_modules_loaded:
+    app.include_router(simulation.router, prefix="/api/v1")
+    logger.info("Feature flag SIMULATED_TOOLS enabled — simulation routes registered")
 # pylint: enable=used-before-assignment
 
 

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -41,9 +41,7 @@ class FeatureFlagsResponse(BaseModel):
         description="Auto-inject MCP_URL and LLM env vars on agent import"
     )
     traceAnalysis: bool = Field(description="Trace-analysis Observability card")
-    simulatedTools: bool = Field(
-        description="Simulated MCP tools generated from an OpenAPI spec"
-    )
+    simulatedTools: bool = Field(description="Simulated MCP tools generated from an OpenAPI spec")
 
 
 class ComponentStatus(BaseModel):

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -41,6 +41,9 @@ class FeatureFlagsResponse(BaseModel):
         description="Auto-inject MCP_URL and LLM env vars on agent import"
     )
     traceAnalysis: bool = Field(description="Trace-analysis Observability card")
+    simulatedTools: bool = Field(
+        description="Simulated MCP tools generated from an OpenAPI spec"
+    )
 
 
 class ComponentStatus(BaseModel):
@@ -93,6 +96,7 @@ async def get_feature_flags(
         admin=settings.kagenti_feature_flag_admin,
         agentImportDefaults=settings.kagenti_feature_flag_agent_import_defaults,
         traceAnalysis=settings.kagenti_feature_flag_trace_analysis,
+        simulatedTools=settings.kagenti_feature_flag_simulated_tools,
     )
 
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -1,0 +1,33 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Simulated MCP tools API endpoints.
+
+Scaffold for the simulated-tools feature (epic #2151). This router is only
+mounted when ``kagenti_feature_flag_simulated_tools`` is enabled (see
+``app/main.py``). Real endpoints — workload provisioning, generation
+orchestration, lifecycle, and database re-seed — attach in later issues. For
+now a single health/no-op endpoint proves the flag-gated wiring.
+"""
+
+import logging
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/simulation", tags=["simulation"])
+
+
+class SimulationHealthResponse(BaseModel):
+    """Health response confirming the simulation router is mounted."""
+
+    status: str
+
+
+@router.get("/health", response_model=SimulationHealthResponse)
+async def simulation_health() -> SimulationHealthResponse:
+    """Return OK when the flag-gated simulation router is mounted."""
+    return SimulationHealthResponse(status="ok")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -15,7 +15,7 @@ from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from kubernetes.client import ApiException
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from app.core.auth import ROLE_OPERATOR, require_roles
 from app.core.config import settings
@@ -27,7 +27,10 @@ from app.services.simulation_manifests import (
     build_simulation_service,
     build_simulation_statefulset,
     derive_simulation_name,
+    validate_custom_name,
+    validate_namespace,
     validate_openapi_spec,
+    validate_storage_size,
 )
 from app.utils.routes import sanitize_log
 
@@ -53,6 +56,21 @@ class SimulationCreateRequest(BaseModel):
     spireEnabled: bool = False
     authBridgeEnabled: bool = False
     authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
+
+    @field_validator("namespace")
+    @classmethod
+    def _check_namespace(cls, v: str) -> str:
+        return validate_namespace(v)
+
+    @field_validator("storageSize")
+    @classmethod
+    def _check_storage_size(cls, v: str) -> str:
+        return validate_storage_size(v)
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: Optional[str]) -> Optional[str]:
+        return v if v is None else validate_custom_name(v)
 
 
 class SimulationCreateResponse(BaseModel):

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -30,4 +30,5 @@ class SimulationHealthResponse(BaseModel):
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""
+    logger.debug("simulation router health check")
     return SimulationHealthResponse(status="ok")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -127,6 +127,7 @@ async def create_simulated_tool(
         auth_bridge_enabled=request.authBridgeEnabled,
         auth_bridge_mode=request.authBridgeMode,
         image_pull_secret=settings.simulation_image_pull_secret or None,
+        image_pull_policy=settings.simulation_image_pull_policy,
     )
     service = build_simulation_service(name, request.namespace, port=port)
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -29,6 +29,7 @@ from app.services.simulation_manifests import (
     derive_simulation_name,
     validate_openapi_spec,
 )
+from app.utils.routes import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -119,10 +120,18 @@ async def create_simulated_tool(
                 status_code=409,
                 detail=f"Simulated tool '{name}' already exists in namespace '{request.namespace}'",
             )
-        logger.error("Failed to provision simulated tool '%s': %s", name, e)
+        logger.error(
+            "Failed to provision simulated tool '%s': %s",
+            sanitize_log(name),
+            sanitize_log(str(e)),
+        )
         raise HTTPException(status_code=502, detail="Failed to create simulated-tool resources")
 
-    logger.info("Provisioned simulated tool '%s' in namespace '%s'", name, request.namespace)
+    logger.info(
+        "Provisioned simulated tool '%s' in namespace '%s'",
+        sanitize_log(name),
+        sanitize_log(request.namespace),
+    )
     return SimulationCreateResponse(
         success=True,
         name=name,

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -2,19 +2,33 @@
 # Licensed under the Apache License, Version 2.0
 
 """
-Simulated MCP tools API endpoints.
+Simulated MCP tools API endpoints (epic #2151).
 
-Scaffold for the simulated-tools feature (epic #2151). This router is only
-mounted when ``kagenti_feature_flag_simulated_tools`` is enabled (see
-``app/main.py``). Real endpoints — workload provisioning, generation
-orchestration, lifecycle, and database re-seed — attach in later issues. For
-now a single health/no-op endpoint proves the flag-gated wiring.
+Mounted only when ``kagenti_feature_flag_simulated_tools`` is enabled
+(see ``app/main.py``). This module owns the create path that provisions a
+simulated tool's workload (StatefulSet + per-tool PVC + Service). Generation
+orchestration, lifecycle, and database re-seed attach in later issues.
 """
 
 import logging
+from typing import List, Literal, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from kubernetes.client import ApiException
 from pydantic import BaseModel
+
+from app.core.auth import ROLE_OPERATOR, require_roles
+from app.core.config import settings
+from app.core.constants import DEFAULT_IN_CLUSTER_PORT
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.services.simulation_manifests import (
+    EnvVar,
+    build_simulation_env_vars,
+    build_simulation_service,
+    build_simulation_statefulset,
+    derive_simulation_name,
+    validate_openapi_spec,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +41,92 @@ class SimulationHealthResponse(BaseModel):
     status: str
 
 
+class SimulationCreateRequest(BaseModel):
+    """Request to create a simulated tool from an OpenAPI spec."""
+
+    namespace: str
+    openapiSpec: str
+    name: Optional[str] = None
+    envVars: Optional[List[EnvVar]] = None
+    storageSize: str = "1Gi"
+    spireEnabled: bool = False
+    authBridgeEnabled: bool = False
+    authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
+
+
+class SimulationCreateResponse(BaseModel):
+    """Response after starting a simulated-tool creation."""
+
+    success: bool
+    name: str
+    namespace: str
+    status: str
+    message: str
+
+
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""
     logger.debug("simulation router health check")
     return SimulationHealthResponse(status="ok")
+
+
+@router.post(
+    "/tools",
+    status_code=202,
+    response_model=SimulationCreateResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def create_simulated_tool(
+    request: SimulationCreateRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationCreateResponse:
+    """Provision a simulated tool's workload (StatefulSet + PVC + Service).
+
+    Validates the spec synchronously (422 on invalid, no workload created), then
+    creates the workload and returns 202 with a Generating status. Posting the
+    spec to the harness and polling generation status is handled in issue #2162.
+    """
+    try:
+        spec = validate_openapi_spec(request.openapiSpec)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    name = derive_simulation_name(spec, request.name)
+    port = DEFAULT_IN_CLUSTER_PORT
+
+    kube.ensure_service_account(namespace=request.namespace, name=name)
+    env_vars = build_simulation_env_vars(request.envVars, port=port)
+    statefulset = build_simulation_statefulset(
+        name=name,
+        namespace=request.namespace,
+        image=settings.simulation_harness_image,
+        env_vars=env_vars,
+        port=port,
+        storage_size=request.storageSize,
+        spire_enabled=request.spireEnabled,
+        auth_bridge_enabled=request.authBridgeEnabled,
+        auth_bridge_mode=request.authBridgeMode,
+    )
+    service = build_simulation_service(name, request.namespace, port=port)
+
+    try:
+        kube.create_statefulset(request.namespace, statefulset)
+        kube.create_service(request.namespace, service)
+    except ApiException as e:
+        if e.status == 409:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Simulated tool '{name}' already exists in namespace '{request.namespace}'",
+            )
+        logger.error("Failed to provision simulated tool '%s': %s", name, e)
+        raise HTTPException(status_code=502, detail="Failed to create simulated-tool resources")
+
+    logger.info("Provisioned simulated tool '%s' in namespace '%s'", name, request.namespace)
+    return SimulationCreateResponse(
+        success=True,
+        name=name,
+        namespace=request.namespace,
+        status="Generating",
+        message=f"Simulated tool '{name}' provisioning started.",
+    )

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -126,6 +126,7 @@ async def create_simulated_tool(
         spire_enabled=request.spireEnabled,
         auth_bridge_enabled=request.authBridgeEnabled,
         auth_bridge_mode=request.authBridgeMode,
+        image_pull_secret=settings.simulation_image_pull_secret or None,
     )
     service = build_simulation_service(name, request.namespace, port=port)
 

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -179,6 +179,7 @@ def build_simulation_statefulset(
     spire_enabled: bool = False,
     auth_bridge_enabled: bool = False,
     auth_bridge_mode: Optional[str] = None,
+    image_pull_secret: Optional[str] = None,
 ) -> dict:
     """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
@@ -215,7 +216,7 @@ def build_simulation_statefulset(
     if auth_bridge_mode:
         pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
 
-    return {
+    manifest = {
         "apiVersion": "apps/v1",
         "kind": "StatefulSet",
         "metadata": {
@@ -286,6 +287,9 @@ def build_simulation_statefulset(
             ],
         },
     }
+    if image_pull_secret:
+        manifest["spec"]["template"]["spec"]["imagePullSecrets"] = [{"name": image_pull_secret}]
+    return manifest
 
 
 def build_simulation_service(

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -238,3 +238,32 @@ def build_simulation_statefulset(
             ],
         },
     }
+
+
+def build_simulation_service(
+    name: str,
+    namespace: str,
+    *,
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+) -> dict:
+    """Build a ClusterIP Service manifest for a simulated tool ({name}-mcp)."""
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": f"{name}{TOOL_SERVICE_SUFFIX}",
+            "namespace": namespace,
+            "labels": {
+                _MCP_PROTOCOL_LABEL: "",
+                APP_KUBERNETES_IO_NAME: name,
+                APP_KUBERNETES_IO_MANAGED_BY: KAGENTI_UI_CREATOR_LABEL,
+                KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+                KAGENTI_SIMULATED_LABEL: "true",
+            },
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {APP_KUBERNETES_IO_NAME: name},
+            "ports": [{"name": "http", "port": port, "targetPort": port, "protocol": "TCP"}],
+        },
+    }

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -141,6 +141,10 @@ def build_simulation_env_vars(
     env_vars.append({"name": "HARNESS_SKILLS_FOLDER", "value": skills_folder})
     env_vars.append({"name": "HARNESS_SERVER_PORT", "value": str(port)})
     env_vars.append({"name": "HARNESS_SERVER_HOST", "value": "0.0.0.0"})
+    # Serve MCP over streamable-http to match the KAGENTI_TRANSPORT_LABEL the
+    # StatefulSet/pod advertise (and the MCP gateway/clients expect). Without
+    # this the harness falls back to its bundled SSE config default.
+    env_vars.append({"name": "HARNESS_MCP_TRANSPORT", "value": "streamable_http"})
 
     for ev in env_var_list or []:
         if ev.value is not None:
@@ -180,6 +184,7 @@ def build_simulation_statefulset(
     auth_bridge_enabled: bool = False,
     auth_bridge_mode: Optional[str] = None,
     image_pull_secret: Optional[str] = None,
+    image_pull_policy: str = "Always",
 ) -> dict:
     """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
@@ -236,12 +241,17 @@ def build_simulation_statefulset(
                     "securityContext": {
                         "runAsNonRoot": True,
                         "seccompProfile": {"type": "RuntimeDefault"},
+                        # Make the RWO PVC (mounted at skills_folder) group-writable
+                        # by the harness runtime UID. The image runs as uid 1000 and
+                        # its entrypoint no longer chowns when already non-root, so
+                        # without fsGroup the uid-1000 process cannot write the PVC.
+                        "fsGroup": 1000,
                     },
                     "containers": [
                         {
                             "name": "harness",
                             "image": image,
-                            "imagePullPolicy": "Always",
+                            "imagePullPolicy": image_pull_policy,
                             "securityContext": {
                                 "allowPrivilegeEscalation": False,
                                 "capabilities": {"drop": ["ALL"]},

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -220,11 +220,15 @@ def build_simulation_statefulset(
                             },
                             "volumeMounts": [
                                 {"name": "data", "mountPath": skills_folder},
+                                {"name": "cache", "mountPath": "/app/.cache"},
                                 {"name": "tmp", "mountPath": "/tmp"},
                             ],
                         }
                     ],
-                    "volumes": [{"name": "tmp", "emptyDir": {}}],
+                    "volumes": [
+                        {"name": "cache", "emptyDir": {}},
+                        {"name": "tmp", "emptyDir": {}},
+                    ],
                 },
             },
             "volumeClaimTemplates": [

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -267,3 +267,26 @@ def build_simulation_service(
             "ports": [{"name": "http", "port": port, "targetPort": port, "protocol": "TCP"}],
         },
     }
+
+
+def validate_openapi_spec(text: str) -> dict:
+    """Syntactic validation only: parse the spec as a JSON object.
+
+    The harness validates the OpenAPI schema itself; Kagenti only rejects a
+    syntactically invalid spec (non-JSON or not a JSON object) so no workload
+    is created for garbage input. Raises ValueError on failure.
+    """
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise ValueError(f"OpenAPI spec is not valid JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError("OpenAPI spec must be a JSON object")
+    return parsed
+
+
+def derive_simulation_name(spec: dict, requested: Optional[str]) -> str:
+    """Return a Kubernetes-safe name: requested if given, else slug of info.title."""
+    candidate = requested or (spec.get("info", {}) or {}).get("title", "") or ""
+    slug = re.sub(r"[^a-z0-9]+", "-", candidate.lower()).strip("-")[:63].rstrip("-")
+    return slug or "simulated-tool"

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -145,6 +145,13 @@ def build_simulation_env_vars(
     # StatefulSet/pod advertise (and the MCP gateway/clients expect). Without
     # this the harness falls back to its bundled SSE config default.
     env_vars.append({"name": "HARNESS_MCP_TRANSPORT", "value": "streamable_http"})
+    # The harness defaults startup.autostart_enabled=false (boots idle, ignores
+    # the skill baked on the PVC). Kagenti bakes exactly one skill per StatefulSet
+    # and relies on the harness resuming it on every (re)start — Stop->Start
+    # (scale 0->1) and involuntary pod restarts both depend on boot-time
+    # autostart. Opt back in; autostart_simulation is left unset so the harness's
+    # "1 complete skill -> start it, 0 -> idle" discovery stays graceful.
+    env_vars.append({"name": "HARNESS_AUTOSTART_ENABLED", "value": "true"})
 
     for ev in env_var_list or []:
         if ev.value is not None:

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -43,6 +43,50 @@ from app.core.constants import (
 
 _MCP_PROTOCOL_LABEL = f"{PROTOCOL_LABEL_PREFIX}{VALUE_PROTOCOL_MCP}"
 
+# DNS-1123 label: lowercase alphanumeric and '-', must start and end alphanumeric.
+_DNS1123_LABEL_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+# A simulated tool's Service is named "{name}-mcp" and must itself be a valid
+# DNS-1123 label (<=63), so the tool name is capped to leave room for the suffix.
+MAX_SIMULATION_NAME_LEN = 63 - len(TOOL_SERVICE_SUFFIX)
+# Kubernetes resource quantity, e.g. "1Gi", "500Mi", "2G".
+_QUANTITY_RE = re.compile(r"^[1-9][0-9]*(\.[0-9]+)?(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|k)?$")
+
+
+def _is_dns1123_label(value: str) -> bool:
+    """Return True if value is a valid DNS-1123 label (<=63 chars)."""
+    return bool(value) and len(value) <= 63 and _DNS1123_LABEL_RE.match(value) is not None
+
+
+def validate_namespace(namespace: str) -> str:
+    """Validate a target namespace as a DNS-1123 label. Raises ValueError if invalid."""
+    if not _is_dns1123_label(namespace):
+        raise ValueError(
+            "namespace must be a DNS-1123 label: lowercase alphanumeric or '-', "
+            "start and end alphanumeric, at most 63 characters"
+        )
+    return namespace
+
+
+def validate_storage_size(size: str) -> str:
+    """Validate a PVC storage size as a Kubernetes quantity. Raises ValueError if invalid."""
+    if not _QUANTITY_RE.match(size):
+        raise ValueError("storageSize must be a Kubernetes quantity, e.g. '1Gi', '500Mi', '2G'")
+    return size
+
+
+def validate_custom_name(name: str) -> str:
+    """Validate a user-supplied tool name (reject rather than silently mutate).
+
+    Must be a DNS-1123 label short enough that the derived "{name}-mcp" Service
+    name stays a valid label. Raises ValueError if invalid.
+    """
+    if not _is_dns1123_label(name) or len(name) > MAX_SIMULATION_NAME_LEN:
+        raise ValueError(
+            "name must be a DNS-1123 label (lowercase alphanumeric or '-', start and end "
+            f"alphanumeric) of at most {MAX_SIMULATION_NAME_LEN} characters"
+        )
+    return name
+
 
 class SecretKeyRef(BaseModel):
     """Reference to a key in a Secret."""
@@ -292,5 +336,9 @@ def validate_openapi_spec(text: str) -> dict:
 def derive_simulation_name(spec: dict, requested: Optional[str]) -> str:
     """Return a Kubernetes-safe name: requested if given, else slug of info.title."""
     candidate = requested or (spec.get("info", {}) or {}).get("title", "") or ""
-    slug = re.sub(r"[^a-z0-9]+", "-", candidate.lower()).strip("-")[:63].rstrip("-")
+    slug = (
+        re.sub(r"[^a-z0-9]+", "-", candidate.lower())
+        .strip("-")[:MAX_SIMULATION_NAME_LEN]
+        .rstrip("-")
+    )
     return slug or "simulated-tool"

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -119,3 +119,122 @@ def build_simulation_env_vars(
     for env in env_vars:
         seen[env["name"]] = env
     return list(seen.values())
+
+
+def build_simulation_statefulset(
+    name: str,
+    namespace: str,
+    image: str,
+    *,
+    env_vars: List[dict],
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+    storage_size: str = "1Gi",
+    skills_folder: str = SIMULATION_HARNESS_SKILLS_MOUNT,
+    framework: str = "Python",
+    description: str = "",
+    spire_enabled: bool = False,
+    auth_bridge_enabled: bool = False,
+    auth_bridge_mode: Optional[str] = None,
+) -> dict:
+    """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
+    service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
+    inject = "enabled" if auth_bridge_enabled else "disabled"
+
+    labels = {
+        APP_KUBERNETES_IO_NAME: name,
+        _MCP_PROTOCOL_LABEL: "",
+        KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
+        KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_WORKLOAD_TYPE_LABEL: WORKLOAD_TYPE_STATEFULSET,
+        KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+        KAGENTI_SIMULATED_LABEL: "true",
+        APP_KUBERNETES_IO_MANAGED_BY: KAGENTI_UI_CREATOR_LABEL,
+        KAGENTI_INJECT_LABEL: inject,
+    }
+    pod_labels = {
+        APP_KUBERNETES_IO_NAME: name,
+        _MCP_PROTOCOL_LABEL: "",
+        KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
+        KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+        KAGENTI_SIMULATED_LABEL: "true",
+        KAGENTI_INJECT_LABEL: inject,
+    }
+    if spire_enabled:
+        labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
+        pod_labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
+
+    annotations = {KAGENTI_AUTOSCALING_ANNOTATION: "disabled"}
+    if description:
+        annotations[KAGENTI_DESCRIPTION_ANNOTATION] = description
+    pod_annotations: Dict[str, str] = {}
+    if auth_bridge_mode:
+        pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
+
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": labels,
+            "annotations": annotations,
+        },
+        "spec": {
+            "serviceName": service_name,
+            "replicas": 1,
+            "selector": {"matchLabels": {APP_KUBERNETES_IO_NAME: name}},
+            "template": {
+                "metadata": {"labels": pod_labels, "annotations": pod_annotations},
+                "spec": {
+                    "serviceAccountName": name,
+                    "securityContext": {
+                        "runAsNonRoot": True,
+                        "seccompProfile": {"type": "RuntimeDefault"},
+                    },
+                    "containers": [
+                        {
+                            "name": "harness",
+                            "image": image,
+                            "imagePullPolicy": "Always",
+                            "securityContext": {
+                                "allowPrivilegeEscalation": False,
+                                "capabilities": {"drop": ["ALL"]},
+                                "runAsUser": 1000,
+                            },
+                            "env": env_vars,
+                            "ports": [{"containerPort": port, "name": "http"}],
+                            "resources": {
+                                "limits": DEFAULT_RESOURCE_LIMITS,
+                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                            },
+                            "readinessProbe": {
+                                "httpGet": {"path": "/readyz", "port": port},
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 10,
+                            },
+                            "livenessProbe": {
+                                "httpGet": {"path": "/healthz", "port": port},
+                                "initialDelaySeconds": 10,
+                                "periodSeconds": 20,
+                            },
+                            "volumeMounts": [
+                                {"name": "data", "mountPath": skills_folder},
+                                {"name": "tmp", "mountPath": "/tmp"},
+                            ],
+                        }
+                    ],
+                    "volumes": [{"name": "tmp", "emptyDir": {}}],
+                },
+            },
+            "volumeClaimTemplates": [
+                {
+                    "metadata": {"name": "data"},
+                    "spec": {
+                        "accessModes": ["ReadWriteOnce"],
+                        "resources": {"requests": {"storage": storage_size}},
+                    },
+                }
+            ],
+        },
+    }

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -1,0 +1,121 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Pure builders for simulated-tool Kubernetes manifests (epic #2151, issue #2161).
+
+Standalone by design — no changes to app/routers/tools.py. A parity test
+(tests/test_simulation_manifests.py) guards the identity/mesh/security surface
+against drift from the tool builders.
+"""
+
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, field_validator
+
+from app.core.constants import (
+    APP_KUBERNETES_IO_MANAGED_BY,
+    APP_KUBERNETES_IO_NAME,
+    DEFAULT_ENV_VARS,
+    DEFAULT_IN_CLUSTER_PORT,
+    DEFAULT_RESOURCE_LIMITS,
+    DEFAULT_RESOURCE_REQUESTS,
+    KAGENTI_AUTOSCALING_ANNOTATION,
+    KAGENTI_DESCRIPTION_ANNOTATION,
+    KAGENTI_FRAMEWORK_LABEL,
+    KAGENTI_INJECT_LABEL,
+    KAGENTI_SIMULATED_LABEL,
+    KAGENTI_SPIRE_ENABLED_VALUE,
+    KAGENTI_SPIRE_LABEL,
+    KAGENTI_TRANSPORT_LABEL,
+    KAGENTI_TYPE_LABEL,
+    KAGENTI_UI_CREATOR_LABEL,
+    KAGENTI_WORKLOAD_TYPE_LABEL,
+    PROTOCOL_LABEL_PREFIX,
+    RESOURCE_TYPE_TOOL,
+    SIMULATION_HARNESS_SKILLS_MOUNT,
+    TOOL_SERVICE_SUFFIX,
+    VALUE_PROTOCOL_MCP,
+    VALUE_TRANSPORT_STREAMABLE_HTTP,
+    WORKLOAD_TYPE_STATEFULSET,
+)
+
+_MCP_PROTOCOL_LABEL = f"{PROTOCOL_LABEL_PREFIX}{VALUE_PROTOCOL_MCP}"
+
+
+class SecretKeyRef(BaseModel):
+    """Reference to a key in a Secret."""
+
+    name: str
+    key: str
+
+
+class ConfigMapKeyRef(BaseModel):
+    """Reference to a key in a ConfigMap."""
+
+    name: str
+    key: str
+
+
+class EnvVarSource(BaseModel):
+    """Source for an environment variable value."""
+
+    secretKeyRef: Optional[SecretKeyRef] = None
+    configMapKeyRef: Optional[ConfigMapKeyRef] = None
+
+
+class EnvVar(BaseModel):
+    """Environment variable with support for direct values and references."""
+
+    name: str
+    value: Optional[str] = None
+    valueFrom: Optional[EnvVarSource] = None
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", v or ""):
+            raise ValueError(
+                f"Invalid environment variable name '{v}'. Must start with a letter or "
+                "underscore and contain only letters, digits, and underscores."
+            )
+        return v
+
+
+def build_simulation_env_vars(
+    env_var_list: Optional[List[EnvVar]] = None,
+    *,
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+    skills_folder: str = SIMULATION_HARNESS_SKILLS_MOUNT,
+) -> List[dict]:
+    """Build the harness container env: platform defaults + harness config + user vars.
+
+    User-supplied vars (e.g. LLM_API_KEY via secretKeyRef) win on name collision.
+    """
+    env_vars: List[dict] = list(DEFAULT_ENV_VARS)
+    env_vars.append({"name": "HARNESS_SKILLS_FOLDER", "value": skills_folder})
+    env_vars.append({"name": "HARNESS_SERVER_PORT", "value": str(port)})
+    env_vars.append({"name": "HARNESS_SERVER_HOST", "value": "0.0.0.0"})
+
+    for ev in env_var_list or []:
+        if ev.value is not None:
+            env_vars.append({"name": ev.name, "value": ev.value})
+        elif ev.valueFrom is not None:
+            entry: Dict[str, Any] = {"name": ev.name, "valueFrom": {}}
+            if ev.valueFrom.secretKeyRef:
+                entry["valueFrom"]["secretKeyRef"] = {
+                    "name": ev.valueFrom.secretKeyRef.name,
+                    "key": ev.valueFrom.secretKeyRef.key,
+                }
+            elif ev.valueFrom.configMapKeyRef:
+                entry["valueFrom"]["configMapKeyRef"] = {
+                    "name": ev.valueFrom.configMapKeyRef.name,
+                    "key": ev.valueFrom.configMapKeyRef.key,
+                }
+            env_vars.append(entry)
+
+    seen: Dict[str, dict] = {}
+    for env in env_vars:
+        seen[env["name"]] = env
+    return list(seen.values())

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -1,0 +1,80 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for POST /simulation/tools (issue #2161)."""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim_router
+from app.services.kubernetes import get_kubernetes_service
+
+VALID_SPEC = '{"openapi": "3.0.0", "info": {"title": "Pet Store"}, "paths": {}}'
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(sim_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return TestClient(app)
+
+
+def _kube():
+    k = MagicMock()
+    k.ensure_service_account.return_value = None
+    k.create_statefulset.return_value = {}
+    k.create_service.return_value = {}
+    return k
+
+
+def test_create_returns_202_and_provisions_workload():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "Generating"
+    assert body["name"] == "pet-store"
+    kube.create_statefulset.assert_called_once()
+    kube.create_service.assert_called_once()
+
+
+def test_create_rejects_invalid_spec_with_422_and_no_workload():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": "not json"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_conflict_returns_409():
+    kube = _kube()
+    kube.create_statefulset.side_effect = ApiException(status=409)
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "img"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "name": "dup"},
+        )
+    assert r.status_code == 409
+
+
+def test_route_absent_when_flag_off():
+    """With the flag off, main.py never mounts the router (see #2160)."""
+    import app.main
+
+    r = TestClient(app.main.app).post("/api/v1/simulation/tools", json={})
+    assert r.status_code == 404

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -74,6 +74,21 @@ def test_create_wires_image_pull_secret_into_statefulset():
     assert sts["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "ghcr-secret"}]
 
 
+def test_create_omits_image_pull_secret_when_setting_empty():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        s.simulation_image_pull_secret = ""
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    sts = kube.create_statefulset.call_args.args[1]
+    assert "imagePullSecrets" not in sts["spec"]["template"]["spec"]
+
+
 def test_create_conflict_returns_409():
     kube = _kube()
     kube.create_statefulset.side_effect = ApiException(status=409)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -59,6 +59,21 @@ def test_create_rejects_invalid_spec_with_422_and_no_workload():
     kube.create_statefulset.assert_not_called()
 
 
+def test_create_wires_image_pull_secret_into_statefulset():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        s.simulation_image_pull_secret = "ghcr-secret"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    sts = kube.create_statefulset.call_args.args[1]
+    assert sts["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "ghcr-secret"}]
+
+
 def test_create_conflict_returns_409():
     kube = _kube()
     kube.create_statefulset.side_effect = ApiException(status=409)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -78,3 +78,39 @@ def test_route_absent_when_flag_off():
 
     r = TestClient(app.main.app).post("/api/v1/simulation/tools", json={})
     assert r.status_code == 404
+
+
+def test_create_rejects_invalid_namespace_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "Bad_NS", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_rejects_invalid_storage_size_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "storageSize": "big"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_rejects_invalid_custom_name_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "name": "Bad Name!"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_flag.py
+++ b/kagenti/backend/tests/test_simulation_flag.py
@@ -1,0 +1,76 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the simulated-tools feature flag and flagged simulation router (issue #2160)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import config as config_router
+from app.routers import simulation as simulation_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _make_config_app(simulated_tools: bool) -> FastAPI:
+    """Build an app with only the config router, feature flags mocked."""
+    app = FastAPI()
+    app.include_router(config_router.router)
+
+    # Feature flags are read straight off `settings` in get_feature_flags.
+    mock_settings = MagicMock()
+    mock_settings.kagenti_feature_flag_sandbox = False
+    mock_settings.kagenti_feature_flag_integrations = False
+    mock_settings.kagenti_feature_flag_triggers = False
+    mock_settings.kagenti_feature_flag_agent_sandbox = False
+    mock_settings.kagenti_feature_flag_skills = False
+    mock_settings.kagenti_feature_flag_external_skills = False
+    mock_settings.kagenti_feature_flag_authbridge_api = False
+    mock_settings.kagenti_feature_flag_admin = False
+    mock_settings.kagenti_feature_flag_agent_import_defaults = False
+    mock_settings.kagenti_feature_flag_simulated_tools = simulated_tools
+
+    # get_feature_flags depends on the k8s service only to probe the `builds` flag.
+    mock_kube = MagicMock()
+    mock_kube.api_group_exists.return_value = False
+    app.dependency_overrides[get_kubernetes_service] = lambda: mock_kube
+
+    app.state._mock_settings = mock_settings  # keep a reference alive for the patch
+    return app
+
+
+class TestSimulatedToolsFeatureFlag:
+    def test_features_reports_false_when_flag_off(self):
+        app = _make_config_app(simulated_tools=False)
+        with patch("app.routers.config.settings", app.state._mock_settings):
+            r = TestClient(app).get("/config/features")
+        assert r.status_code == 200
+        assert r.json()["simulatedTools"] is False
+
+    def test_features_reports_true_when_flag_on(self):
+        app = _make_config_app(simulated_tools=True)
+        with patch("app.routers.config.settings", app.state._mock_settings):
+            r = TestClient(app).get("/config/features")
+        assert r.status_code == 200
+        assert r.json()["simulatedTools"] is True
+
+
+class TestSimulationRouterScaffold:
+    def test_health_endpoint_returns_ok_when_mounted(self):
+        app = FastAPI()
+        app.include_router(simulation_router.router)
+        r = TestClient(app).get("/simulation/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
+
+    def test_no_simulation_routes_when_router_not_mounted(self):
+        # Mirrors flag-off: the router is simply never included.
+        app = FastAPI()
+        r = TestClient(app).get("/simulation/health")
+        assert r.status_code == 404
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -117,6 +117,21 @@ def test_statefulset_spire_and_authbridge_flags():
     assert pod_ann["kagenti.io/authbridge-mode"] == "lite"
 
 
+def test_statefulset_adds_image_pull_secret_when_provided():
+    spec = _sts(image_pull_secret="ghcr-secret")["spec"]["template"]["spec"]
+    assert spec["imagePullSecrets"] == [{"name": "ghcr-secret"}]
+
+
+def test_statefulset_omits_image_pull_secret_when_none():
+    spec = _sts()["spec"]["template"]["spec"]
+    assert "imagePullSecrets" not in spec
+
+
+def test_statefulset_omits_image_pull_secret_when_empty_string():
+    spec = _sts(image_pull_secret="")["spec"]["template"]["spec"]
+    assert "imagePullSecrets" not in spec
+
+
 from app.services.simulation_manifests import build_simulation_service
 
 

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -25,6 +25,12 @@ def test_simulation_harness_image_setting_defaults():
     assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")
 
 
+def test_simulation_image_pull_secret_setting_defaults():
+    from app.core.config import Settings
+
+    assert Settings().simulation_image_pull_secret == "ghcr-secret"
+
+
 def test_env_vars_include_harness_and_platform_defaults():
     env = build_simulation_env_vars(None, port=8000)
     by_name = {e["name"]: e for e in env}

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -37,6 +37,9 @@ def test_env_vars_include_harness_and_platform_defaults():
     assert by_name["HARNESS_SKILLS_FOLDER"]["value"] == "/app/skills-store"
     assert by_name["HARNESS_SERVER_PORT"]["value"] == "8000"
     assert by_name["HARNESS_SERVER_HOST"]["value"] == "0.0.0.0"
+    # Opt back into boot-time autostart: the harness defaults it off, but Kagenti
+    # relies on it to resume the baked skill on Stop->Start and pod restarts.
+    assert by_name["HARNESS_AUTOSTART_ENABLED"]["value"] == "true"
     # platform default preserved
     assert by_name["OTEL_EXPORTER_OTLP_ENDPOINT"]["value"].startswith("http://otel-collector")
 

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -53,3 +53,65 @@ def test_env_vars_user_value_wins_on_dedupe():
     ports = [e for e in env if e["name"] == "HARNESS_SERVER_PORT"]
     assert len(ports) == 1
     assert ports[0]["value"] == "9999"
+
+
+from app.services.simulation_manifests import build_simulation_statefulset
+
+
+def _sts(**kw):
+    defaults = {
+        "name": "petstore",
+        "namespace": "team1",
+        "image": "ghcr.io/kagenti/simulation-harness:latest",
+        "env_vars": [{"name": "PORT", "value": "8000"}],
+    }
+    defaults.update(kw)
+    return build_simulation_statefulset(**defaults)
+
+
+def test_statefulset_core_shape():
+    m = _sts()
+    assert m["kind"] == "StatefulSet"
+    assert m["spec"]["replicas"] == 1
+    assert m["metadata"]["name"] == "petstore"
+    assert m["metadata"]["namespace"] == "team1"
+    c = m["spec"]["template"]["spec"]["containers"][0]
+    assert c["image"] == "ghcr.io/kagenti/simulation-harness:latest"
+    assert c["ports"][0]["containerPort"] == 8000
+
+
+def test_statefulset_labels_and_markers():
+    labels = _sts()["metadata"]["labels"]
+    assert labels["protocol.kagenti.io/mcp"] == ""
+    assert labels["kagenti.io/type"] == "tool"
+    assert labels["kagenti.io/simulated"] == "true"
+    assert labels["kagenti.io/workload-type"] == "statefulset"
+    assert labels["kagenti.io/inject"] == "disabled"
+    assert _sts()["metadata"]["annotations"]["kagenti.io/autoscaling"] == "disabled"
+
+
+def test_statefulset_pvc_mounted_at_skills_dir():
+    m = _sts(storage_size="2Gi")
+    vct = m["spec"]["volumeClaimTemplates"][0]
+    assert vct["metadata"]["name"] == "data"
+    assert vct["spec"]["resources"]["requests"]["storage"] == "2Gi"
+    mounts = m["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    data_mount = next(v for v in mounts if v["name"] == "data")
+    assert data_mount["mountPath"] == "/app/skills-store"
+
+
+def test_statefulset_probes_and_security_context():
+    c = _sts()["spec"]["template"]["spec"]["containers"][0]
+    assert c["readinessProbe"]["httpGet"]["path"] == "/readyz"
+    assert c["livenessProbe"]["httpGet"]["path"] == "/healthz"
+    assert c["securityContext"]["runAsUser"] == 1000
+    assert c["securityContext"]["capabilities"]["drop"] == ["ALL"]
+
+
+def test_statefulset_spire_and_authbridge_flags():
+    labels = _sts(spire_enabled=True, auth_bridge_enabled=True)["metadata"]["labels"]
+    assert labels["kagenti.io/spire"] == "enabled"
+    assert labels["kagenti.io/inject"] == "enabled"
+    m = _sts(auth_bridge_mode="lite")
+    pod_ann = m["spec"]["template"]["metadata"]["annotations"]
+    assert pod_ann["kagenti.io/authbridge-mode"] == "lite"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -169,6 +169,19 @@ def test_derive_name_falls_back():
     assert derive_simulation_name({}, None) == "simulated-tool"
 
 
+def test_statefulset_cache_emptydir_volume():
+    m = _sts()
+    mounts = m["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    cache_mount = next((v for v in mounts if v["name"] == "cache"), None)
+    assert cache_mount is not None, "cache volumeMount not found"
+    assert cache_mount["mountPath"] == "/app/.cache"
+
+    volumes = m["spec"]["template"]["spec"]["volumes"]
+    cache_vol = next((v for v in volumes if v["name"] == "cache"), None)
+    assert cache_vol is not None, "cache volume not found"
+    assert cache_vol["emptyDir"] == {}
+
+
 def test_parity_simulation_matches_tool_identity_surface():
     """Guard: simulation StatefulSet must carry the same identity/mesh/security
     surface a tool StatefulSet does, so the standalone builders can't silently drift."""

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -4,6 +4,12 @@
 """Unit tests for simulated-tool manifest building (issue #2161)."""
 
 from app.core import constants
+from app.services.simulation_manifests import (
+    EnvVar,
+    EnvVarSource,
+    SecretKeyRef,
+    build_simulation_env_vars,
+)
 
 
 def test_simulation_constants_exist():
@@ -17,3 +23,33 @@ def test_simulation_harness_image_setting_defaults():
 
     s = Settings()
     assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")
+
+
+def test_env_vars_include_harness_and_platform_defaults():
+    env = build_simulation_env_vars(None, port=8000)
+    by_name = {e["name"]: e for e in env}
+    assert by_name["HARNESS_SKILLS_FOLDER"]["value"] == "/app/skills-store"
+    assert by_name["HARNESS_SERVER_PORT"]["value"] == "8000"
+    assert by_name["HARNESS_SERVER_HOST"]["value"] == "0.0.0.0"
+    # platform default preserved
+    assert by_name["OTEL_EXPORTER_OTLP_ENDPOINT"]["value"].startswith("http://otel-collector")
+
+
+def test_env_vars_expand_secret_key_ref():
+    env = build_simulation_env_vars(
+        [
+            EnvVar(
+                name="LLM_API_KEY",
+                valueFrom=EnvVarSource(secretKeyRef=SecretKeyRef(name="llm-secret", key="api-key")),
+            )
+        ]
+    )
+    entry = next(e for e in env if e["name"] == "LLM_API_KEY")
+    assert entry["valueFrom"]["secretKeyRef"] == {"name": "llm-secret", "key": "api-key"}
+
+
+def test_env_vars_user_value_wins_on_dedupe():
+    env = build_simulation_env_vars([EnvVar(name="HARNESS_SERVER_PORT", value="9999")])
+    ports = [e for e in env if e["name"] == "HARNESS_SERVER_PORT"]
+    assert len(ports) == 1
+    assert ports[0]["value"] == "9999"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -219,3 +219,53 @@ def test_parity_simulation_matches_tool_identity_surface():
     spc = sim["spec"]["template"]["spec"]
     assert spc["securityContext"] == tpc["securityContext"]
     assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]
+
+
+from app.services.simulation_manifests import (
+    MAX_SIMULATION_NAME_LEN,
+    validate_custom_name,
+    validate_namespace,
+    validate_storage_size,
+)
+
+
+class TestInputValidators:
+    def test_valid_namespace_passes(self):
+        assert validate_namespace("team1") == "team1"
+        assert validate_namespace("a-b-9") == "a-b-9"
+
+    @pytest.mark.parametrize(
+        "bad", ["Team1", "team_1", "-team", "team-", "team 1", "team\n1", "", "a" * 64]
+    )
+    def test_invalid_namespace_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_namespace(bad)
+
+    @pytest.mark.parametrize("good", ["1Gi", "500Mi", "2G", "10Ti", "1024Ki"])
+    def test_valid_storage_size_passes(self, good):
+        assert validate_storage_size(good) == good
+
+    @pytest.mark.parametrize("bad", ["big", "1gb", "Gi", "0Gi", "-1Gi", "1.Gi", "1 Gi", ""])
+    def test_invalid_storage_size_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_storage_size(bad)
+
+    def test_valid_custom_name_passes(self):
+        assert validate_custom_name("pet-store") == "pet-store"
+
+    @pytest.mark.parametrize("bad", ["Pet Store", "pet_store", "-x", "x-", "", "UPPER"])
+    def test_invalid_custom_name_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_custom_name(bad)
+
+    def test_custom_name_too_long_for_service_suffix_raises(self):
+        # A name longer than MAX_SIMULATION_NAME_LEN would make "{name}-mcp" exceed 63.
+        with pytest.raises(ValueError):
+            validate_custom_name("a" * (MAX_SIMULATION_NAME_LEN + 1))
+        assert validate_custom_name("a" * MAX_SIMULATION_NAME_LEN)
+
+
+def test_derive_name_truncates_to_service_safe_length():
+    name = derive_simulation_name({"info": {"title": "x" * 100}}, None)
+    assert len(name) <= MAX_SIMULATION_NAME_LEN
+    assert not name.endswith("-")

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -132,3 +132,77 @@ def test_service_shape_and_labels():
     assert labels["protocol.kagenti.io/mcp"] == ""
     assert labels["kagenti.io/simulated"] == "true"
     assert labels["kagenti.io/type"] == "tool"
+
+
+import pytest
+
+from app.services.simulation_manifests import (
+    derive_simulation_name,
+    validate_openapi_spec,
+)
+
+
+def test_validate_spec_accepts_valid_json_object():
+    spec = validate_openapi_spec(
+        '{"openapi": "3.0.0", "info": {"title": "Pet Store"}, "paths": {}}'
+    )
+    assert spec["info"]["title"] == "Pet Store"
+
+
+@pytest.mark.parametrize("bad", ["not json", "[]", '"a string"', "123", ""])
+def test_validate_spec_rejects_non_object_or_invalid(bad):
+    with pytest.raises(ValueError):
+        validate_openapi_spec(bad)
+
+
+def test_derive_name_prefers_requested():
+    assert derive_simulation_name({"info": {"title": "Pet Store"}}, "my-sim") == "my-sim"
+
+
+def test_derive_name_slugifies_title():
+    assert (
+        derive_simulation_name({"info": {"title": "Pet Store API v2!"}}, None) == "pet-store-api-v2"
+    )
+
+
+def test_derive_name_falls_back():
+    assert derive_simulation_name({}, None) == "simulated-tool"
+
+
+def test_parity_simulation_matches_tool_identity_surface():
+    """Guard: simulation StatefulSet must carry the same identity/mesh/security
+    surface a tool StatefulSet does, so the standalone builders can't silently drift."""
+    from app.routers.tools import _build_tool_statefulset_manifest
+    from app.services.simulation_manifests import build_simulation_statefulset
+
+    tool = _build_tool_statefulset_manifest(
+        name="x",
+        namespace="team1",
+        image="img",
+        framework="Python",
+        auth_bridge_enabled=True,
+        spire_enabled=True,
+    )
+    sim = build_simulation_statefulset(
+        name="x",
+        namespace="team1",
+        image="img",
+        env_vars=[],
+        framework="Python",
+        auth_bridge_enabled=True,
+        spire_enabled=True,
+    )
+    mesh_keys = [
+        "protocol.kagenti.io/mcp",
+        "kagenti.io/transport",
+        "kagenti.io/framework",
+        "kagenti.io/inject",
+        "kagenti.io/spire",
+    ]
+    tl, sl = tool["metadata"]["labels"], sim["metadata"]["labels"]
+    for k in mesh_keys:
+        assert sl.get(k) == tl.get(k), f"identity label drift on {k}"
+    tpc = tool["spec"]["template"]["spec"]
+    spc = sim["spec"]["template"]["spec"]
+    assert spc["securityContext"] == tpc["securityContext"]
+    assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -115,3 +115,20 @@ def test_statefulset_spire_and_authbridge_flags():
     m = _sts(auth_bridge_mode="lite")
     pod_ann = m["spec"]["template"]["metadata"]["annotations"]
     assert pod_ann["kagenti.io/authbridge-mode"] == "lite"
+
+
+from app.services.simulation_manifests import build_simulation_service
+
+
+def test_service_shape_and_labels():
+    m = build_simulation_service("petstore", "team1", port=8000)
+    assert m["kind"] == "Service"
+    assert m["metadata"]["name"] == "petstore-mcp"
+    assert m["spec"]["type"] == "ClusterIP"
+    assert m["spec"]["selector"]["app.kubernetes.io/name"] == "petstore"
+    assert m["spec"]["ports"][0]["port"] == 8000
+    assert m["spec"]["ports"][0]["targetPort"] == 8000
+    labels = m["metadata"]["labels"]
+    assert labels["protocol.kagenti.io/mcp"] == ""
+    assert labels["kagenti.io/simulated"] == "true"
+    assert labels["kagenti.io/type"] == "tool"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -1,0 +1,19 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Unit tests for simulated-tool manifest building (issue #2161)."""
+
+from app.core import constants
+
+
+def test_simulation_constants_exist():
+    assert constants.KAGENTI_SIMULATED_LABEL == "kagenti.io/simulated"
+    assert constants.KAGENTI_AUTOSCALING_ANNOTATION == "kagenti.io/autoscaling"
+    assert constants.SIMULATION_HARNESS_SKILLS_MOUNT == "/app/skills-store"
+
+
+def test_simulation_harness_image_setting_defaults():
+    from app.core.config import Settings
+
+    s = Settings()
+    assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -238,7 +238,12 @@ def test_parity_simulation_matches_tool_identity_surface():
         assert sl.get(k) == tl.get(k), f"identity label drift on {k}"
     tpc = tool["spec"]["template"]["spec"]
     spc = sim["spec"]["template"]["spec"]
-    assert spc["securityContext"] == tpc["securityContext"]
+    # Simulated tools add fsGroup so the uid-1000 harness can write its PVC;
+    # apart from that PVC-driven divergence the pod securityContext must match
+    # the regular tool identity surface.
+    sim_sec = {k: v for k, v in spc["securityContext"].items() if k != "fsGroup"}
+    assert sim_sec == tpc["securityContext"]
+    assert spc["securityContext"].get("fsGroup") == 1000
     assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]
 
 

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -21,6 +21,8 @@ export interface FeatureFlags {
   externalSkills: boolean;
   /** Trace-analysis Observability card */
   traceAnalysis: boolean;
+  /** Simulated MCP tools generated from an OpenAPI spec */
+  simulatedTools: boolean;
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -34,6 +36,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   admin: false,
   externalSkills: false,
   traceAnalysis: false,
+  simulatedTools: false,
 };
 
 let cachedFlags: FeatureFlags | null = null;
@@ -58,6 +61,7 @@ export function useFeatureFlags(): FeatureFlags {
           admin: data.admin === true,
           externalSkills: data.externalSkills === true,
           traceAnalysis: data.traceAnalysis === true,
+          simulatedTools: data.simulatedTools === true,
           };
         cachedFlags = validated;
         setFlags(validated);

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -76,6 +76,7 @@ const FLAG_LABELS: Record<DisplayedFlag, string> = {
   authbridgeAPI: 'AuthBridge API',
   externalSkills: 'External Skills',
   traceAnalysis: 'Trace Analysis',
+  simulatedTools: 'Simulated Tools',
 };
 
 const PlatformStatusCard: React.FC = () => {


### PR DESCRIPTION
## Summary

Implements #2161 (part of epic #2151): a flag-gated backend create path that provisions a **simulated tool's workload** from an OpenAPI spec — a StatefulSet (`replicas: 1`, HPA-off marker) with a per-tool PVC mounted at the harness skills dir, plus a Service — discoverable by the MCP Gateway exactly like a real tool. Generation orchestration (posting the spec to the harness + status polling) is the next slice, #2162.

## What's included

- **`POST /api/v1/simulation/tools`** (`ROLE_OPERATOR`, flag-gated): validates the OpenAPI spec syntactically → **422 with no workload created** on invalid input; otherwise provisions the workload and returns **202** with `status: "Generating"`.
- **Pure-standalone manifest builders** in new `app/services/simulation_manifests.py` — **zero changes to `tools.py`** (minimal blast radius). A **parity test** asserts the simulated StatefulSet shares the tool StatefulSet's identity/mesh label subset + `securityContext`, guarding against drift.
- **StatefulSet**: `replicas: 1`, per-tool PVC (`volumeClaimTemplate` `data`) at `/app/skills-store`, `cache`/`tmp` emptyDirs, `/readyz`+`/healthz` probes, tool-parity `securityContext`.
- **Labels** on workload + service: `protocol.kagenti.io/mcp`, `kagenti.io/type=tool` (lists in the Tool Catalog), `kagenti.io/simulated="true"`; SPIRE + AuthBridge-inject honored when requested. HPA-off marker `kagenti.io/autoscaling="disabled"` (declarative).
- **No `AgentRuntime` CR** — the `type=tool` label is set directly (no new CRD, no operator changes).
- **`LLM_API_KEY`/`LLM_API_BASE`** via the generic `envVars` + `secretKeyRef` mechanism (no bespoke wiring).
- Additive `simulation_harness_image` setting and `kagenti.io/simulated` / HPA-off / skills-mount constants.

## Image pull secret (private-registry interim)

The simulation-harness image (`ghcr.io/kagenti/simulation-harness`) currently lives in a **private** GHCR package, so the provisioned pod needs an `imagePullSecrets` entry to start. Added, backend-only:

- `build_simulation_statefulset` gains an optional `image_pull_secret` kwarg that injects `imagePullSecrets: [{name: <value>}]` into the pod spec **only when truthy** (omits the key otherwise — mirrors the `tools.py`/`agents.py` convention).
- New `simulation_image_pull_secret: str = "ghcr-secret"` setting, wired from the create endpoint via `settings.simulation_image_pull_secret or None`. `ghcr-secret` is the per-namespace secret the Helm chart already creates when `secrets.githubUser` + `secrets.githubToken` are set.
- **No Helm/UI/CRD changes**; transitively gated by the existing `kagenti_feature_flag_simulated_tools`. When the package goes public, anonymous pull works — flip the default to `""` (one line); the wiring stays as a harmless no-op.

## Testing

- Manifest builders, spec validation, name derivation, endpoint 202/422/409/flag-off, and tool-parity drift guard — all pass.
- Pull-secret coverage: builder adds/omits the key for provided / `None` / empty-string; the create endpoint wires `ghcr-secret` through and omits it end-to-end when the setting is empty.
- Repo-wide `ruff check .` and `ruff format --check .` clean. Full backend suite green (excluding the pre-existing, unrelated `test_migration.py` local-venv collection quirk).
- Verified: flag on → `/simulation/health` + `/simulation/tools` mounted; flag off → routes absent.

## Notes

- **Stacked on #2160 (PR #2168).** Until #2160 merges, this PR's diff also shows #2160's flag/router-scaffold commits; I'll rebase onto `main` once #2168 lands.
- Follow-ups noted for later slices: partial-provision cleanup on Service-create failure (#2163 lifecycle), and on-cluster validation of the harness `/healthz`/`/readyz` contract (#2167 E2E).

Blocked by #2171

Closes #2161

Assisted-By: Claude Code
