### PR TITLE
feat(simulation): generation orchestration, status, and failure states (#2162)

### DIFF
--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -86,6 +86,10 @@ class Settings(BaseSettings):
     kagenti_feature_flag_simulated_tools: bool = False
     # Generic simulation-harness image serving all simulated tools (epic #2151)
     simulation_harness_image: str = "ghcr.io/kagenti/simulation-harness:latest"
+    # Pull secret for the harness image while it lives in a private registry (interim,
+    # epic #2151). References the Helm-created per-namespace `ghcr-secret`. Set empty
+    # to disable — once the image is public, anonymous pull works and this is unneeded.
+    simulation_image_pull_secret: str = "ghcr-secret"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -82,6 +82,8 @@ class Settings(BaseSettings):
     )
     kagenti_feature_flag_acp: bool = False  # ACP WebSocket protocol gateway
     kagenti_feature_flag_external_skills: bool = False  # External skill registry references
+    # Simulated MCP tools: LLM-driven, stateful tools generated from an OpenAPI spec
+    kagenti_feature_flag_simulated_tools: bool = False
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -94,6 +94,14 @@ class Settings(BaseSettings):
     # pulls :latest from the registry); set IfNotPresent/Never for local dev when
     # the image is side-loaded into the cluster (e.g. `kind load`).
     simulation_image_pull_policy: str = "Always"
+    # Generation orchestration (#2162): watchdog ceiling from StatefulSet
+    # creationTimestamp — covers image pull + pod start + the harness's own 120s
+    # creation budget. Also bounds the trigger task's post-retry window.
+    simulation_generation_timeout: int = 600
+    # httpx timeout (seconds) for harness control-plane calls.
+    simulation_harness_request_timeout: float = 10.0
+    # Seconds between trigger-task POST attempts while the harness is still starting.
+    simulation_trigger_poll_interval: int = 5
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -90,6 +90,10 @@ class Settings(BaseSettings):
     # epic #2151). References the Helm-created per-namespace `ghcr-secret`. Set empty
     # to disable — once the image is public, anonymous pull works and this is unneeded.
     simulation_image_pull_secret: str = "ghcr-secret"
+    # Image pull policy for the harness container. Defaults to Always (production
+    # pulls :latest from the registry); set IfNotPresent/Never for local dev when
+    # the image is side-loaded into the cluster (e.g. `kind load`).
+    simulation_image_pull_policy: str = "Always"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -84,6 +84,8 @@ class Settings(BaseSettings):
     kagenti_feature_flag_external_skills: bool = False  # External skill registry references
     # Simulated MCP tools: LLM-driven, stateful tools generated from an OpenAPI spec
     kagenti_feature_flag_simulated_tools: bool = False
+    # Generic simulation-harness image serving all simulated tools (epic #2151)
+    simulation_harness_image: str = "ghcr.io/kagenti/simulation-harness:latest"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -34,6 +34,11 @@ APP_KUBERNETES_IO_COMPONENT = "app.kubernetes.io/component"
 KAGENTI_SPIRE_LABEL = "kagenti.io/spire"
 KAGENTI_SPIRE_ENABLED_VALUE = "enabled"
 
+# Simulated MCP tools (epic #2151)
+KAGENTI_SIMULATED_LABEL = "kagenti.io/simulated"  # safety marker; UI badge; list filter
+KAGENTI_AUTOSCALING_ANNOTATION = "kagenti.io/autoscaling"  # HPA-off marker (declarative opt-out)
+SIMULATION_HARNESS_SKILLS_MOUNT = "/app/skills-store"  # HARNESS_SKILLS_FOLDER mount path
+
 # Per-sidecar opt-out labels (envoy-proxy / spiffe-helper /
 # client-registration) are gone after kagenti-extensions#411 — they
 # referenced separate sidecars that no longer exist. The master enable

--- a/kagenti/backend/app/main.py
+++ b/kagenti/backend/app/main.py
@@ -198,6 +198,10 @@ async def lifespan(app: FastAPI):
         except asyncio.CancelledError:
             pass
 
+    # Stop outstanding simulated-tool generation triggers
+    if _simulation_modules_loaded:
+        await simulation.cancel_generation_tasks()
+
     # Close OpenShell gateway gRPC channels
     if _acp_modules_loaded:
         try:

--- a/kagenti/backend/app/main.py
+++ b/kagenti/backend/app/main.py
@@ -127,6 +127,17 @@ if settings.kagenti_feature_flag_acp:
         logging.getLogger(__name__).warning(
             "ACP flag enabled but acp modules not installed — skipping"
         )
+
+_simulation_modules_loaded = False
+if settings.kagenti_feature_flag_simulated_tools:
+    try:
+        from app.routers import simulation  # noqa: E402
+
+        _simulation_modules_loaded = True
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "SIMULATED_TOOLS flag enabled but simulation modules not installed — skipping"
+        )
 # pylint: enable=wrong-import-position,no-name-in-module,import-error
 
 # Configure logging
@@ -268,6 +279,10 @@ if _skills_modules_loaded:
 if _acp_modules_loaded:
     app.include_router(acp.router, prefix="/api/v1")
     logger.info("Feature flag ACP enabled — ACP WebSocket routes registered")
+
+if _simulation_modules_loaded:
+    app.include_router(simulation.router, prefix="/api/v1")
+    logger.info("Feature flag SIMULATED_TOOLS enabled — simulation routes registered")
 # pylint: enable=used-before-assignment
 
 

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -41,9 +41,7 @@ class FeatureFlagsResponse(BaseModel):
         description="Auto-inject MCP_URL and LLM env vars on agent import"
     )
     traceAnalysis: bool = Field(description="Trace-analysis Observability card")
-    simulatedTools: bool = Field(
-        description="Simulated MCP tools generated from an OpenAPI spec"
-    )
+    simulatedTools: bool = Field(description="Simulated MCP tools generated from an OpenAPI spec")
 
 
 class ComponentStatus(BaseModel):

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -41,6 +41,9 @@ class FeatureFlagsResponse(BaseModel):
         description="Auto-inject MCP_URL and LLM env vars on agent import"
     )
     traceAnalysis: bool = Field(description="Trace-analysis Observability card")
+    simulatedTools: bool = Field(
+        description="Simulated MCP tools generated from an OpenAPI spec"
+    )
 
 
 class ComponentStatus(BaseModel):
@@ -93,6 +96,7 @@ async def get_feature_flags(
         admin=settings.kagenti_feature_flag_admin,
         agentImportDefaults=settings.kagenti_feature_flag_agent_import_defaults,
         traceAnalysis=settings.kagenti_feature_flag_trace_analysis,
+        simulatedTools=settings.kagenti_feature_flag_simulated_tools,
     )
 
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -58,8 +58,17 @@ _generation_tasks: set = set()
 
 
 def _harness_base_url(name: str, namespace: str, port: int) -> str:
-    """In-cluster URL of a simulated tool's harness Service ({name}-mcp)."""
-    return f"http://{name}{TOOL_SERVICE_SUFFIX}.{namespace}.svc.cluster.local:{port}"
+    """In-cluster URL of a simulated tool's harness Service ({name}-mcp).
+
+    Both identifiers are re-validated as DNS-1123 labels here so no untrusted
+    value can ever be interpolated into the request URL. This is the single
+    chokepoint that closes SSRF via the status endpoint's path parameters
+    (CWE-918); the create path's names are already valid, so this never rejects
+    a legitimate request.
+    """
+    safe_name = validate_custom_name(name)
+    safe_namespace = validate_namespace(namespace)
+    return f"http://{safe_name}{TOOL_SERVICE_SUFFIX}.{safe_namespace}.svc.cluster.local:{port}"
 
 
 async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
@@ -341,6 +350,16 @@ async def generation_status(
     StatefulSet's creationTimestamp turns a never-started generation into Failed
     rather than hanging (issue #2162).
     """
+    # Reject path parameters that cannot name a real tool before they reach any
+    # backend call (k8s API or the harness URL) — an invalid identifier is
+    # definitionally "not found" and must not be interpolated into a request
+    # target (SSRF guard, CWE-918).
+    try:
+        validate_namespace(namespace)
+        validate_custom_name(name)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Simulated tool not found")
+
     try:
         sts = kube.apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
     except ApiException as e:

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -10,7 +10,9 @@ simulated tool's workload (StatefulSet + per-tool PVC + Service). Generation
 orchestration, lifecycle, and database re-seed attach in later issues.
 """
 
+import asyncio
 import logging
+import time
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
@@ -27,6 +29,7 @@ from app.services.simulation_harness_client import (
     HarnessNotFound,
     HarnessUnreachable,
     get_simulation,
+    post_simulation,
 )
 from app.services.simulation_manifests import (
     EnvVar,
@@ -42,6 +45,59 @@ from app.services.simulation_manifests import (
 from app.utils.routes import sanitize_log
 
 logger = logging.getLogger(__name__)
+
+# Outstanding generation-trigger tasks, tracked so lifespan shutdown can cancel
+# them (mirrors main.py's reconciliation_task handling). Fire-and-forget per tool.
+_generation_tasks: set = set()
+
+
+async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
+    """Wait for the harness pod to accept connections, then POST the spec once.
+
+    The harness generates in the background after a 202; this task's only job is
+    to deliver the spec, retrying while the pod is still starting. Bounded by
+    ``simulation_generation_timeout`` so it never loops forever; a give-up is
+    later surfaced by the status endpoint's watchdog as Failed/generation_stalled.
+    """
+    base_url = f"http://{name}.{namespace}.svc.cluster.local:{port}"
+    deadline = time.monotonic() + settings.simulation_generation_timeout
+    interval = settings.simulation_trigger_poll_interval
+    while True:
+        try:
+            code = await post_simulation(base_url, spec, name)
+        except HarnessUnreachable:
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Gave up posting spec to harness for '%s' (unreachable past timeout)",
+                    sanitize_log(name),
+                )
+                return
+            await asyncio.sleep(interval)
+            continue
+        if code in (202, 409):
+            logger.info(
+                "Generation triggered for simulated tool '%s' (HTTP %d)",
+                sanitize_log(name),
+                code,
+            )
+        else:
+            logger.warning(
+                "Harness rejected spec for simulated tool '%s' (HTTP %d)",
+                sanitize_log(name),
+                code,
+            )
+        return
+
+
+async def cancel_generation_tasks() -> None:
+    """Cancel any outstanding generation-trigger tasks (called on shutdown)."""
+    for task in list(_generation_tasks):
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
 
 router = APIRouter(prefix="/simulation", tags=["simulation"])
 
@@ -218,6 +274,9 @@ async def create_simulated_tool(
         sanitize_log(name),
         sanitize_log(request.namespace),
     )
+    trigger = asyncio.create_task(_run_generation_trigger(request.namespace, name, spec, port))
+    _generation_tasks.add(trigger)
+    trigger.add_done_callback(_generation_tasks.discard)
     return SimulationCreateResponse(
         success=True,
         name=name,

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -14,6 +14,7 @@ Lifecycle and database re-seed attach in later issues.
 
 import asyncio
 import logging
+import re
 import time
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
@@ -38,6 +39,7 @@ from app.services.simulation_harness_client import (
     post_simulation,
 )
 from app.services.simulation_manifests import (
+    MAX_SIMULATION_NAME_LEN,
     EnvVar,
     build_simulation_env_vars,
     build_simulation_service,
@@ -57,6 +59,14 @@ logger = logging.getLogger(__name__)
 _generation_tasks: set = set()
 
 
+# Full-string DNS-1123 label matcher, kept local so the sanitizing guard below
+# lives in the same frame as the URL sink. CodeQL recognizes an re.fullmatch
+# guard as an SSRF barrier only when it directly gates the tainted value at the
+# point of interpolation; the cross-frame boolean helpers in simulation_manifests
+# validate identically but are not seen through by the taint tracker.
+_DNS1123_LABEL_RE = re.compile(r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?")
+
+
 def _harness_base_url(name: str, namespace: str, port: int) -> str:
     """In-cluster URL of a simulated tool's harness Service ({name}-mcp).
 
@@ -66,9 +76,11 @@ def _harness_base_url(name: str, namespace: str, port: int) -> str:
     (CWE-918); the create path's names are already valid, so this never rejects
     a legitimate request.
     """
-    safe_name = validate_custom_name(name)
-    safe_namespace = validate_namespace(namespace)
-    return f"http://{safe_name}{TOOL_SERVICE_SUFFIX}.{safe_namespace}.svc.cluster.local:{port}"
+    if not (_DNS1123_LABEL_RE.fullmatch(name) and len(name) <= MAX_SIMULATION_NAME_LEN):
+        raise ValueError("name must be a DNS-1123 label")
+    if not _DNS1123_LABEL_RE.fullmatch(namespace):
+        raise ValueError("namespace must be a DNS-1123 label")
+    return f"http://{name}{TOOL_SERVICE_SUFFIX}.{namespace}.svc.cluster.local:{port}"
 
 
 async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
@@ -379,7 +391,10 @@ async def generation_status(
     created = sts.metadata.creation_timestamp
     elapsed = (datetime.now(timezone.utc) - created).total_seconds() if created else 0.0
 
-    base_url = _harness_base_url(name, namespace, DEFAULT_IN_CLUSTER_PORT)
+    # Build the harness URL from the StatefulSet's server-returned identity, not
+    # the raw path parameters: these come from the k8s API (not a remote-flow
+    # source) and name a resource we just confirmed exists (extra SSRF defense).
+    base_url = _harness_base_url(sts.metadata.name, sts.metadata.namespace, DEFAULT_IN_CLUSTER_PORT)
     harness = None
     try:
         harness = await get_simulation(base_url)

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -1,0 +1,33 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Simulated MCP tools API endpoints.
+
+Scaffold for the simulated-tools feature (epic #2151). This router is only
+mounted when ``kagenti_feature_flag_simulated_tools`` is enabled (see
+``app/main.py``). Real endpoints — workload provisioning, generation
+orchestration, lifecycle, and database re-seed — attach in later issues. For
+now a single health/no-op endpoint proves the flag-gated wiring.
+"""
+
+import logging
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/simulation", tags=["simulation"])
+
+
+class SimulationHealthResponse(BaseModel):
+    """Health response confirming the simulation router is mounted."""
+
+    status: str
+
+
+@router.get("/health", response_model=SimulationHealthResponse)
+async def simulation_health() -> SimulationHealthResponse:
+    """Return OK when the flag-gated simulation router is mounted."""
+    return SimulationHealthResponse(status="ok")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -15,7 +15,7 @@ from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from kubernetes.client import ApiException
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from app.core.auth import ROLE_OPERATOR, require_roles
 from app.core.config import settings
@@ -27,7 +27,10 @@ from app.services.simulation_manifests import (
     build_simulation_service,
     build_simulation_statefulset,
     derive_simulation_name,
+    validate_custom_name,
+    validate_namespace,
     validate_openapi_spec,
+    validate_storage_size,
 )
 from app.utils.routes import sanitize_log
 
@@ -53,6 +56,21 @@ class SimulationCreateRequest(BaseModel):
     spireEnabled: bool = False
     authBridgeEnabled: bool = False
     authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
+
+    @field_validator("namespace")
+    @classmethod
+    def _check_namespace(cls, v: str) -> str:
+        return validate_namespace(v)
+
+    @field_validator("storageSize")
+    @classmethod
+    def _check_storage_size(cls, v: str) -> str:
+        return validate_storage_size(v)
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: Optional[str]) -> Optional[str]:
+        return v if v is None else validate_custom_name(v)
 
 
 class SimulationCreateResponse(BaseModel):

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -23,7 +23,11 @@ from pydantic import BaseModel, field_validator
 
 from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.core.config import settings
-from app.core.constants import APP_KUBERNETES_IO_NAME, DEFAULT_IN_CLUSTER_PORT
+from app.core.constants import (
+    APP_KUBERNETES_IO_NAME,
+    DEFAULT_IN_CLUSTER_PORT,
+    TOOL_SERVICE_SUFFIX,
+)
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
 from app.services.simulation_harness_client import (
     HarnessNotFound,
@@ -51,6 +55,11 @@ logger = logging.getLogger(__name__)
 _generation_tasks: set = set()
 
 
+def _harness_base_url(name: str, namespace: str, port: int) -> str:
+    """In-cluster URL of a simulated tool's harness Service ({name}-mcp)."""
+    return f"http://{name}{TOOL_SERVICE_SUFFIX}.{namespace}.svc.cluster.local:{port}"
+
+
 async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
     """Wait for the harness pod to accept connections, then POST the spec once.
 
@@ -59,7 +68,7 @@ async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: i
     ``simulation_generation_timeout`` so it never loops forever; a give-up is
     later surfaced by the status endpoint's watchdog as Failed/generation_stalled.
     """
-    base_url = f"http://{name}.{namespace}.svc.cluster.local:{port}"
+    base_url = _harness_base_url(name, namespace, port)
     deadline = time.monotonic() + settings.simulation_generation_timeout
     interval = settings.simulation_trigger_poll_interval
     while True:
@@ -322,7 +331,7 @@ async def generation_status(
     created = sts.metadata.creation_timestamp
     elapsed = (datetime.now(timezone.utc) - created).total_seconds() if created else 0.0
 
-    base_url = f"http://{name}.{namespace}.svc.cluster.local:{DEFAULT_IN_CLUSTER_PORT}"
+    base_url = _harness_base_url(name, namespace, DEFAULT_IN_CLUSTER_PORT)
     harness = None
     try:
         harness = await get_simulation(base_url)

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -11,16 +11,23 @@ orchestration, lifecycle, and database re-seed attach in later issues.
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from kubernetes.client import ApiException
 from pydantic import BaseModel, field_validator
 
-from app.core.auth import ROLE_OPERATOR, require_roles
+from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.core.config import settings
-from app.core.constants import DEFAULT_IN_CLUSTER_PORT
+from app.core.constants import APP_KUBERNETES_IO_NAME, DEFAULT_IN_CLUSTER_PORT
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.services.simulation_harness_client import (
+    HarnessNotFound,
+    HarnessUnreachable,
+    get_simulation,
+)
 from app.services.simulation_manifests import (
     EnvVar,
     build_simulation_env_vars,
@@ -217,4 +224,61 @@ async def create_simulated_tool(
         namespace=request.namespace,
         status="Generating",
         message=f"Simulated tool '{name}' provisioning started.",
+    )
+
+
+@router.get(
+    "/tools/{namespace}/{name}/generation-status",
+    response_model=GenerationStatusResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def generation_status(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> GenerationStatusResponse:
+    """Return the live, UI-pollable generation status of a simulated tool.
+
+    Reads harness `GET /api/v1/simulation` plus pod state on every call and maps
+    to Generating / Ready / Failed / Error. A watchdog derived from the
+    StatefulSet's creationTimestamp turns a never-started generation into Failed
+    rather than hanging (issue #2162).
+    """
+    try:
+        sts = kube.apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
+    except ApiException as e:
+        if e.status == 404:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Simulated tool '{name}' not found in namespace '{namespace}'",
+            )
+        logger.error(
+            "Failed to read simulated tool '%s' in '%s': %s",
+            sanitize_log(name),
+            sanitize_log(namespace),
+            sanitize_log(str(e)),
+        )
+        raise HTTPException(status_code=502, detail="Failed to read simulated-tool workload")
+
+    created = sts.metadata.creation_timestamp
+    elapsed = (datetime.now(timezone.utc) - created).total_seconds() if created else 0.0
+
+    base_url = f"http://{name}.{namespace}.svc.cluster.local:{DEFAULT_IN_CLUSTER_PORT}"
+    harness = None
+    try:
+        harness = await get_simulation(base_url)
+    except HarnessNotFound:
+        harness = None
+    except (HarnessUnreachable, httpx.HTTPError) as e:
+        logger.debug("Harness read failed for '%s': %s", sanitize_log(name), sanitize_log(str(e)))
+        harness = None
+
+    pod = kube.get_workload_pod_status(namespace, f"{APP_KUBERNETES_IO_NAME}={name}")
+    return map_generation_status(
+        harness=harness,
+        pod_ready=pod["ready"],
+        pod_waiting_reason=pod["waiting_reason"],
+        pod_waiting_message=pod["waiting_message"],
+        elapsed_seconds=elapsed,
+        timeout_seconds=settings.simulation_generation_timeout,
     )

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -83,6 +83,65 @@ class SimulationCreateResponse(BaseModel):
     message: str
 
 
+class GenerationStatusResponse(BaseModel):
+    """UI-pollable generation status for a simulated tool (issue #2162)."""
+
+    status: str  # Generating | Ready | Failed | Error
+    reason: Optional[str] = None
+    mcpUrl: Optional[str] = None
+
+
+# Container waiting reasons that indicate a runtime/pod-level Error (not a
+# harness generation failure): missing LLM secret, bad image, crash loop.
+POD_ERROR_REASONS = {
+    "CrashLoopBackOff",
+    "ImagePullBackOff",
+    "ErrImagePull",
+    "CreateContainerConfigError",
+}
+
+
+def map_generation_status(
+    harness: Optional[dict],
+    pod_ready: bool,
+    pod_waiting_reason: Optional[str],
+    pod_waiting_message: Optional[str],
+    elapsed_seconds: float,
+    timeout_seconds: int,
+) -> GenerationStatusResponse:
+    """Map live harness + pod state to a stable UI phase.
+
+    `harness` is the parsed GET /api/v1/simulation body, or None when the harness
+    is unreachable or reports 404 (no simulation active yet). Pure — the caller
+    supplies elapsed time so this is fully unit-testable.
+    """
+    if harness is not None:
+        status = harness.get("status")
+        if status == "ready":
+            return GenerationStatusResponse(
+                status="Ready", reason=None, mcpUrl=harness.get("mcp_url")
+            )
+        if status == "failed":
+            err = harness.get("error") or {}
+            code = err.get("code") or "unknown"
+            message = err.get("message") or ""
+            reason = f"{code}: {message}".rstrip(": ") if message else code
+            return GenerationStatusResponse(status="Failed", reason=reason, mcpUrl=None)
+        # pending / generating_skill / initializing / generated
+        return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)
+
+    # Harness unreachable or no simulation yet — distinguish "still starting"
+    # from "crash-looping" via pod state, and cap the wait with the watchdog.
+    if pod_waiting_reason in POD_ERROR_REASONS:
+        reason = pod_waiting_reason
+        if pod_waiting_message:
+            reason = f"{pod_waiting_reason}: {pod_waiting_message}"
+        return GenerationStatusResponse(status="Error", reason=reason, mcpUrl=None)
+    if elapsed_seconds > timeout_seconds:
+        return GenerationStatusResponse(status="Failed", reason="generation_stalled", mcpUrl=None)
+    return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)
+
+
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -30,4 +30,5 @@ class SimulationHealthResponse(BaseModel):
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""
+    logger.debug("simulation router health check")
     return SimulationHealthResponse(status="ok")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -125,7 +125,7 @@ def map_generation_status(
             err = harness.get("error") or {}
             code = err.get("code") or "unknown"
             message = err.get("message") or ""
-            reason = f"{code}: {message}".rstrip(": ") if message else code
+            reason = f"{code}: {message}" if message else code
             return GenerationStatusResponse(status="Failed", reason=reason, mcpUrl=None)
         # pending / generating_skill / initializing / generated
         return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -6,8 +6,10 @@ Simulated MCP tools API endpoints (epic #2151).
 
 Mounted only when ``kagenti_feature_flag_simulated_tools`` is enabled
 (see ``app/main.py``). This module owns the create path that provisions a
-simulated tool's workload (StatefulSet + per-tool PVC + Service). Generation
-orchestration, lifecycle, and database re-seed attach in later issues.
+simulated tool's workload (StatefulSet + per-tool PVC + Service), the
+generation-trigger task that posts the spec to the harness, and the
+generation-status endpoint that surfaces Generating/Ready/Failed/Error.
+Lifecycle and database re-seed attach in later issues.
 """
 
 import asyncio
@@ -64,38 +66,66 @@ async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: i
     """Wait for the harness pod to accept connections, then POST the spec once.
 
     The harness generates in the background after a 202; this task's only job is
-    to deliver the spec, retrying while the pod is still starting. Bounded by
-    ``simulation_generation_timeout`` so it never loops forever; a give-up is
-    later surfaced by the status endpoint's watchdog as Failed/generation_stalled.
+    to deliver the spec, retrying while the pod is still starting (connection
+    failures) or briefly warming up (5xx). A 202/409 is terminal success; any
+    other 4xx is a terminal rejection. Bounded by ``simulation_generation_timeout``
+    so it never loops forever; a give-up is later surfaced by the status
+    endpoint's watchdog as Failed/generation_stalled.
+
+    Runs fire-and-forget via ``asyncio.create_task``, so it must never let an
+    exception escape (an unretrieved task exception would only surface as log
+    noise); any unexpected error is logged and ends the task.
     """
     base_url = _harness_base_url(name, namespace, port)
     deadline = time.monotonic() + settings.simulation_generation_timeout
     interval = settings.simulation_trigger_poll_interval
-    while True:
-        try:
-            code = await post_simulation(base_url, spec, name)
-        except HarnessUnreachable:
-            if time.monotonic() >= deadline:
-                logger.warning(
-                    "Gave up posting spec to harness for '%s' (unreachable past timeout)",
+    try:
+        while True:
+            try:
+                code = await post_simulation(base_url, spec, name)
+            except HarnessUnreachable:
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Gave up posting spec to harness for '%s' (unreachable past timeout)",
+                        sanitize_log(name),
+                    )
+                    return
+                await asyncio.sleep(interval)
+                continue
+            if code in (202, 409):
+                logger.info(
+                    "Generation triggered for simulated tool '%s' (HTTP %d)",
                     sanitize_log(name),
+                    code,
                 )
                 return
-            await asyncio.sleep(interval)
-            continue
-        if code in (202, 409):
-            logger.info(
-                "Generation triggered for simulated tool '%s' (HTTP %d)",
-                sanitize_log(name),
-                code,
-            )
-        else:
+            if code >= 500:
+                # Transient server error while the harness warms up — retry until
+                # the deadline rather than giving up on the first hiccup.
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Gave up posting spec to harness for '%s' (HTTP %d past timeout)",
+                        sanitize_log(name),
+                        code,
+                    )
+                    return
+                await asyncio.sleep(interval)
+                continue
+            # Terminal 4xx rejection (e.g. 413 too large, 422 invalid spec).
             logger.warning(
                 "Harness rejected spec for simulated tool '%s' (HTTP %d)",
                 sanitize_log(name),
                 code,
             )
-        return
+            return
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning(
+            "Unexpected error in generation trigger for simulated tool '%s'",
+            sanitize_log(name),
+            exc_info=True,
+        )
 
 
 async def cancel_generation_tasks() -> None:
@@ -175,7 +205,6 @@ POD_ERROR_REASONS = {
 
 def map_generation_status(
     harness: Optional[dict],
-    pod_ready: bool,
     pod_waiting_reason: Optional[str],
     pod_waiting_message: Optional[str],
     elapsed_seconds: float,
@@ -336,15 +365,23 @@ async def generation_status(
     try:
         harness = await get_simulation(base_url)
     except HarnessNotFound:
+        # No simulation active yet — routine before the spec is posted.
         harness = None
-    except (HarnessUnreachable, httpx.HTTPError) as e:
-        logger.debug("Harness read failed for '%s': %s", sanitize_log(name), sanitize_log(str(e)))
+    except HarnessUnreachable as e:
+        # Routine while the harness pod is still starting; maps to Generating.
+        logger.debug(
+            "Harness not reachable yet for '%s': %s", sanitize_log(name), sanitize_log(str(e))
+        )
+        harness = None
+    except httpx.HTTPError as e:
+        # An unexpected harness HTTP failure (e.g. 5xx) — degrade to pod state
+        # rather than 500, but surface it: this is not the routine not-started case.
+        logger.warning("Harness read error for '%s': %s", sanitize_log(name), sanitize_log(str(e)))
         harness = None
 
     pod = kube.get_workload_pod_status(namespace, f"{APP_KUBERNETES_IO_NAME}={name}")
     return map_generation_status(
         harness=harness,
-        pod_ready=pod["ready"],
         pod_waiting_reason=pod["waiting_reason"],
         pod_waiting_message=pod["waiting_message"],
         elapsed_seconds=elapsed,

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -127,6 +127,7 @@ async def create_simulated_tool(
         auth_bridge_enabled=request.authBridgeEnabled,
         auth_bridge_mode=request.authBridgeMode,
         image_pull_secret=settings.simulation_image_pull_secret or None,
+        image_pull_policy=settings.simulation_image_pull_policy,
     )
     service = build_simulation_service(name, request.namespace, port=port)
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -29,6 +29,7 @@ from app.services.simulation_manifests import (
     derive_simulation_name,
     validate_openapi_spec,
 )
+from app.utils.routes import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -119,10 +120,18 @@ async def create_simulated_tool(
                 status_code=409,
                 detail=f"Simulated tool '{name}' already exists in namespace '{request.namespace}'",
             )
-        logger.error("Failed to provision simulated tool '%s': %s", name, e)
+        logger.error(
+            "Failed to provision simulated tool '%s': %s",
+            sanitize_log(name),
+            sanitize_log(str(e)),
+        )
         raise HTTPException(status_code=502, detail="Failed to create simulated-tool resources")
 
-    logger.info("Provisioned simulated tool '%s' in namespace '%s'", name, request.namespace)
+    logger.info(
+        "Provisioned simulated tool '%s' in namespace '%s'",
+        sanitize_log(name),
+        sanitize_log(request.namespace),
+    )
     return SimulationCreateResponse(
         success=True,
         name=name,

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -2,19 +2,33 @@
 # Licensed under the Apache License, Version 2.0
 
 """
-Simulated MCP tools API endpoints.
+Simulated MCP tools API endpoints (epic #2151).
 
-Scaffold for the simulated-tools feature (epic #2151). This router is only
-mounted when ``kagenti_feature_flag_simulated_tools`` is enabled (see
-``app/main.py``). Real endpoints — workload provisioning, generation
-orchestration, lifecycle, and database re-seed — attach in later issues. For
-now a single health/no-op endpoint proves the flag-gated wiring.
+Mounted only when ``kagenti_feature_flag_simulated_tools`` is enabled
+(see ``app/main.py``). This module owns the create path that provisions a
+simulated tool's workload (StatefulSet + per-tool PVC + Service). Generation
+orchestration, lifecycle, and database re-seed attach in later issues.
 """
 
 import logging
+from typing import List, Literal, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from kubernetes.client import ApiException
 from pydantic import BaseModel
+
+from app.core.auth import ROLE_OPERATOR, require_roles
+from app.core.config import settings
+from app.core.constants import DEFAULT_IN_CLUSTER_PORT
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.services.simulation_manifests import (
+    EnvVar,
+    build_simulation_env_vars,
+    build_simulation_service,
+    build_simulation_statefulset,
+    derive_simulation_name,
+    validate_openapi_spec,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +41,92 @@ class SimulationHealthResponse(BaseModel):
     status: str
 
 
+class SimulationCreateRequest(BaseModel):
+    """Request to create a simulated tool from an OpenAPI spec."""
+
+    namespace: str
+    openapiSpec: str
+    name: Optional[str] = None
+    envVars: Optional[List[EnvVar]] = None
+    storageSize: str = "1Gi"
+    spireEnabled: bool = False
+    authBridgeEnabled: bool = False
+    authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
+
+
+class SimulationCreateResponse(BaseModel):
+    """Response after starting a simulated-tool creation."""
+
+    success: bool
+    name: str
+    namespace: str
+    status: str
+    message: str
+
+
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""
     logger.debug("simulation router health check")
     return SimulationHealthResponse(status="ok")
+
+
+@router.post(
+    "/tools",
+    status_code=202,
+    response_model=SimulationCreateResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def create_simulated_tool(
+    request: SimulationCreateRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationCreateResponse:
+    """Provision a simulated tool's workload (StatefulSet + PVC + Service).
+
+    Validates the spec synchronously (422 on invalid, no workload created), then
+    creates the workload and returns 202 with a Generating status. Posting the
+    spec to the harness and polling generation status is handled in issue #2162.
+    """
+    try:
+        spec = validate_openapi_spec(request.openapiSpec)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    name = derive_simulation_name(spec, request.name)
+    port = DEFAULT_IN_CLUSTER_PORT
+
+    kube.ensure_service_account(namespace=request.namespace, name=name)
+    env_vars = build_simulation_env_vars(request.envVars, port=port)
+    statefulset = build_simulation_statefulset(
+        name=name,
+        namespace=request.namespace,
+        image=settings.simulation_harness_image,
+        env_vars=env_vars,
+        port=port,
+        storage_size=request.storageSize,
+        spire_enabled=request.spireEnabled,
+        auth_bridge_enabled=request.authBridgeEnabled,
+        auth_bridge_mode=request.authBridgeMode,
+    )
+    service = build_simulation_service(name, request.namespace, port=port)
+
+    try:
+        kube.create_statefulset(request.namespace, statefulset)
+        kube.create_service(request.namespace, service)
+    except ApiException as e:
+        if e.status == 409:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Simulated tool '{name}' already exists in namespace '{request.namespace}'",
+            )
+        logger.error("Failed to provision simulated tool '%s': %s", name, e)
+        raise HTTPException(status_code=502, detail="Failed to create simulated-tool resources")
+
+    logger.info("Provisioned simulated tool '%s' in namespace '%s'", name, request.namespace)
+    return SimulationCreateResponse(
+        success=True,
+        name=name,
+        namespace=request.namespace,
+        status="Generating",
+        message=f"Simulated tool '{name}' provisioning started.",
+    )

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -126,6 +126,7 @@ async def create_simulated_tool(
         spire_enabled=request.spireEnabled,
         auth_bridge_enabled=request.authBridgeEnabled,
         auth_bridge_mode=request.authBridgeMode,
+        image_pull_secret=settings.simulation_image_pull_secret or None,
     )
     service = build_simulation_service(name, request.namespace, port=port)
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -247,7 +247,13 @@ def map_generation_status(
             err = harness.get("error") or {}
             code = err.get("code") or "unknown"
             message = err.get("message") or ""
-            reason = f"{code}: {message}" if message else code
+            # The harness buries the underlying cause (e.g. a timed-out
+            # generation stage rewrapped as a generic RuntimeError) in
+            # error.details.cause_type. Fold it into the reason so the UI shows
+            # *why* it failed instead of just the coarse code.
+            cause_type = (err.get("details") or {}).get("cause_type")
+            label = f"{code} ({cause_type})" if cause_type else code
+            reason = f"{label}: {message}" if message else label
             return GenerationStatusResponse(status="Failed", reason=reason, mcpUrl=None)
         # pending / generating_skill / initializing / generated
         return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -729,6 +729,8 @@ class KubernetesService:
         (e.g. CrashLoopBackOff, ImagePullBackOff, CreateContainerConfigError) — the
         signal used to derive a simulated tool's Error state (#2162).
         """
+        namespace = _sanitize(namespace)
+        label_selector = _sanitize(label_selector)
         try:
             pods = self.core_api.list_namespaced_pod(
                 namespace=namespace, label_selector=label_selector

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -734,7 +734,9 @@ class KubernetesService:
                 namespace=namespace, label_selector=label_selector
             ).items
         except ApiException as e:
-            logger.debug("Error listing pods in %s (%s): %s", namespace, label_selector, e)
+            # A real RBAC/connectivity failure here would otherwise silently
+            # look like "not ready" — surface it at warning level.
+            logger.warning("Error listing pods in %s (%s): %s", namespace, label_selector, e)
             return {"ready": False, "waiting_reason": None, "waiting_message": None}
 
         ready = False

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -720,6 +720,42 @@ class KubernetesService:
             logger.error(f"Error patching StatefulSet {name} in {namespace}: {e}")
             raise
 
+    def get_workload_pod_status(self, namespace: str, label_selector: str) -> dict:
+        """Inspect pods matching a label selector for readiness and waiting state.
+
+        Returns {"ready": bool, "waiting_reason": str|None, "waiting_message": str|None}.
+        `ready` is True if any matching pod reports a Ready condition. The waiting
+        reason/message come from the first container found in a waiting state
+        (e.g. CrashLoopBackOff, ImagePullBackOff, CreateContainerConfigError) — the
+        signal used to derive a simulated tool's Error state (#2162).
+        """
+        try:
+            pods = self.core_api.list_namespaced_pod(
+                namespace=namespace, label_selector=label_selector
+            ).items
+        except ApiException as e:
+            logger.debug("Error listing pods in %s (%s): %s", namespace, label_selector, e)
+            return {"ready": False, "waiting_reason": None, "waiting_message": None}
+
+        ready = False
+        waiting_reason = None
+        waiting_message = None
+        for pod in pods:
+            conditions = (pod.status and pod.status.conditions) or []
+            if any(c.type == "Ready" and c.status == "True" for c in conditions):
+                ready = True
+            container_statuses = (pod.status and pod.status.container_statuses) or []
+            for cs in container_statuses:
+                waiting = cs.state and cs.state.waiting
+                if waiting and waiting.reason and waiting_reason is None:
+                    waiting_reason = waiting.reason
+                    waiting_message = waiting.message
+        return {
+            "ready": ready,
+            "waiting_reason": waiting_reason,
+            "waiting_message": waiting_message,
+        }
+
     # -------------------------------------------------------------------------
     # Job Operations
     # -------------------------------------------------------------------------

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -1,0 +1,63 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Async HTTP client for the simulation harness control plane (issue #2162).
+
+Thin wrappers over the harness REST API at `/api/v1/simulation`. Each call
+creates its own short-lived `httpx.AsyncClient`, matching the in-cluster HTTP
+call pattern used elsewhere in the backend (e.g. skill_autosync, sidecar_manager).
+"""
+
+import logging
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class HarnessUnreachable(Exception):  # noqa: N818
+    """The harness could not be contacted (connect error or timeout)."""
+
+
+class HarnessNotFound(Exception):  # noqa: N818
+    """The harness is up but reports no active simulation (HTTP 404)."""
+
+
+def _timeout() -> float:
+    return settings.simulation_harness_request_timeout
+
+
+async def get_simulation(base_url: str) -> dict:
+    """GET the harness's active-simulation record.
+
+    Returns the parsed SimulationResponse dict. Raises HarnessNotFound on 404
+    (no simulation active yet) and HarnessUnreachable on connect/timeout.
+    """
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        try:
+            resp = await client.get(f"{base_url}/api/v1/simulation")
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise HarnessUnreachable(str(e)) from e
+        if resp.status_code == 404:
+            raise HarnessNotFound()
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def post_simulation(base_url: str, spec: dict, name: str) -> int:
+    """POST the OpenAPI spec to start generation. Returns the HTTP status code.
+
+    202 = accepted (generating in background); 409 = already active. Raises
+    HarnessUnreachable on connect/timeout.
+    """
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        try:
+            resp = await client.post(
+                f"{base_url}/api/v1/simulation",
+                json={"openapi_spec": spec, "name": name},
+            )
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise HarnessUnreachable(str(e)) from e
+        return resp.status_code

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -41,7 +41,7 @@ async def get_simulation(base_url: str) -> dict:
         except (httpx.ConnectError, httpx.TimeoutException) as e:
             raise HarnessUnreachable(str(e)) from e
         if resp.status_code == 404:
-            raise HarnessNotFound()
+            raise HarnessNotFound("harness reports no active simulation")
         resp.raise_for_status()
         return resp.json()
 

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class HarnessUnreachable(Exception):  # noqa: N818
-    """The harness could not be contacted (connect error or timeout)."""
+    """The harness could not be contacted (any transport-level error: connect,
+    read, write, timeout, or protocol — typically while the pod is starting)."""
 
 
 class HarnessNotFound(Exception):  # noqa: N818
@@ -38,7 +39,12 @@ async def get_simulation(base_url: str) -> dict:
     async with httpx.AsyncClient(timeout=_timeout()) as client:
         try:
             resp = await client.get(f"{base_url}/api/v1/simulation")
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except httpx.TransportError as e:
+            # Base class for connect/read/write/timeout/protocol errors. A
+            # starting harness often accepts the TCP connection then resets it
+            # mid-read (ReadError) before uvicorn is serving — treat every
+            # transport-level failure as "unreachable" so callers retry through
+            # the pod's startup window instead of giving up on the first hiccup.
             raise HarnessUnreachable(str(e)) from e
         if resp.status_code == 404:
             raise HarnessNotFound("harness reports no active simulation")
@@ -58,6 +64,11 @@ async def post_simulation(base_url: str, spec: dict, name: str) -> int:
                 f"{base_url}/api/v1/simulation",
                 json={"openapi_spec": spec, "name": name},
             )
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except httpx.TransportError as e:
+            # Base class for connect/read/write/timeout/protocol errors. A
+            # starting harness often accepts the TCP connection then resets it
+            # mid-read (ReadError) before uvicorn is serving — treat every
+            # transport-level failure as "unreachable" so callers retry through
+            # the pod's startup window instead of giving up on the first hiccup.
             raise HarnessUnreachable(str(e)) from e
         return resp.status_code

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -179,6 +179,7 @@ def build_simulation_statefulset(
     spire_enabled: bool = False,
     auth_bridge_enabled: bool = False,
     auth_bridge_mode: Optional[str] = None,
+    image_pull_secret: Optional[str] = None,
 ) -> dict:
     """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
@@ -215,7 +216,7 @@ def build_simulation_statefulset(
     if auth_bridge_mode:
         pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
 
-    return {
+    manifest = {
         "apiVersion": "apps/v1",
         "kind": "StatefulSet",
         "metadata": {
@@ -286,6 +287,9 @@ def build_simulation_statefulset(
             ],
         },
     }
+    if image_pull_secret:
+        manifest["spec"]["template"]["spec"]["imagePullSecrets"] = [{"name": image_pull_secret}]
+    return manifest
 
 
 def build_simulation_service(

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -238,3 +238,32 @@ def build_simulation_statefulset(
             ],
         },
     }
+
+
+def build_simulation_service(
+    name: str,
+    namespace: str,
+    *,
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+) -> dict:
+    """Build a ClusterIP Service manifest for a simulated tool ({name}-mcp)."""
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": f"{name}{TOOL_SERVICE_SUFFIX}",
+            "namespace": namespace,
+            "labels": {
+                _MCP_PROTOCOL_LABEL: "",
+                APP_KUBERNETES_IO_NAME: name,
+                APP_KUBERNETES_IO_MANAGED_BY: KAGENTI_UI_CREATOR_LABEL,
+                KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+                KAGENTI_SIMULATED_LABEL: "true",
+            },
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {APP_KUBERNETES_IO_NAME: name},
+            "ports": [{"name": "http", "port": port, "targetPort": port, "protocol": "TCP"}],
+        },
+    }

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -141,6 +141,10 @@ def build_simulation_env_vars(
     env_vars.append({"name": "HARNESS_SKILLS_FOLDER", "value": skills_folder})
     env_vars.append({"name": "HARNESS_SERVER_PORT", "value": str(port)})
     env_vars.append({"name": "HARNESS_SERVER_HOST", "value": "0.0.0.0"})
+    # Serve MCP over streamable-http to match the KAGENTI_TRANSPORT_LABEL the
+    # StatefulSet/pod advertise (and the MCP gateway/clients expect). Without
+    # this the harness falls back to its bundled SSE config default.
+    env_vars.append({"name": "HARNESS_MCP_TRANSPORT", "value": "streamable_http"})
 
     for ev in env_var_list or []:
         if ev.value is not None:
@@ -180,6 +184,7 @@ def build_simulation_statefulset(
     auth_bridge_enabled: bool = False,
     auth_bridge_mode: Optional[str] = None,
     image_pull_secret: Optional[str] = None,
+    image_pull_policy: str = "Always",
 ) -> dict:
     """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
@@ -236,12 +241,17 @@ def build_simulation_statefulset(
                     "securityContext": {
                         "runAsNonRoot": True,
                         "seccompProfile": {"type": "RuntimeDefault"},
+                        # Make the RWO PVC (mounted at skills_folder) group-writable
+                        # by the harness runtime UID. The image runs as uid 1000 and
+                        # its entrypoint no longer chowns when already non-root, so
+                        # without fsGroup the uid-1000 process cannot write the PVC.
+                        "fsGroup": 1000,
                     },
                     "containers": [
                         {
                             "name": "harness",
                             "image": image,
-                            "imagePullPolicy": "Always",
+                            "imagePullPolicy": image_pull_policy,
                             "securityContext": {
                                 "allowPrivilegeEscalation": False,
                                 "capabilities": {"drop": ["ALL"]},

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -220,11 +220,15 @@ def build_simulation_statefulset(
                             },
                             "volumeMounts": [
                                 {"name": "data", "mountPath": skills_folder},
+                                {"name": "cache", "mountPath": "/app/.cache"},
                                 {"name": "tmp", "mountPath": "/tmp"},
                             ],
                         }
                     ],
-                    "volumes": [{"name": "tmp", "emptyDir": {}}],
+                    "volumes": [
+                        {"name": "cache", "emptyDir": {}},
+                        {"name": "tmp", "emptyDir": {}},
+                    ],
                 },
             },
             "volumeClaimTemplates": [

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -267,3 +267,26 @@ def build_simulation_service(
             "ports": [{"name": "http", "port": port, "targetPort": port, "protocol": "TCP"}],
         },
     }
+
+
+def validate_openapi_spec(text: str) -> dict:
+    """Syntactic validation only: parse the spec as a JSON object.
+
+    The harness validates the OpenAPI schema itself; Kagenti only rejects a
+    syntactically invalid spec (non-JSON or not a JSON object) so no workload
+    is created for garbage input. Raises ValueError on failure.
+    """
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise ValueError(f"OpenAPI spec is not valid JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError("OpenAPI spec must be a JSON object")
+    return parsed
+
+
+def derive_simulation_name(spec: dict, requested: Optional[str]) -> str:
+    """Return a Kubernetes-safe name: requested if given, else slug of info.title."""
+    candidate = requested or (spec.get("info", {}) or {}).get("title", "") or ""
+    slug = re.sub(r"[^a-z0-9]+", "-", candidate.lower()).strip("-")[:63].rstrip("-")
+    return slug or "simulated-tool"

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -145,6 +145,13 @@ def build_simulation_env_vars(
     # StatefulSet/pod advertise (and the MCP gateway/clients expect). Without
     # this the harness falls back to its bundled SSE config default.
     env_vars.append({"name": "HARNESS_MCP_TRANSPORT", "value": "streamable_http"})
+    # The harness defaults startup.autostart_enabled=false (boots idle, ignores
+    # the skill baked on the PVC). Kagenti bakes exactly one skill per StatefulSet
+    # and relies on the harness resuming it on every (re)start — Stop->Start
+    # (scale 0->1) and involuntary pod restarts both depend on boot-time
+    # autostart. Opt back in; autostart_simulation is left unset so the harness's
+    # "1 complete skill -> start it, 0 -> idle" discovery stays graceful.
+    env_vars.append({"name": "HARNESS_AUTOSTART_ENABLED", "value": "true"})
 
     for ev in env_var_list or []:
         if ev.value is not None:

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -43,6 +43,50 @@ from app.core.constants import (
 
 _MCP_PROTOCOL_LABEL = f"{PROTOCOL_LABEL_PREFIX}{VALUE_PROTOCOL_MCP}"
 
+# DNS-1123 label: lowercase alphanumeric and '-', must start and end alphanumeric.
+_DNS1123_LABEL_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+# A simulated tool's Service is named "{name}-mcp" and must itself be a valid
+# DNS-1123 label (<=63), so the tool name is capped to leave room for the suffix.
+MAX_SIMULATION_NAME_LEN = 63 - len(TOOL_SERVICE_SUFFIX)
+# Kubernetes resource quantity, e.g. "1Gi", "500Mi", "2G".
+_QUANTITY_RE = re.compile(r"^[1-9][0-9]*(\.[0-9]+)?(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|k)?$")
+
+
+def _is_dns1123_label(value: str) -> bool:
+    """Return True if value is a valid DNS-1123 label (<=63 chars)."""
+    return bool(value) and len(value) <= 63 and _DNS1123_LABEL_RE.match(value) is not None
+
+
+def validate_namespace(namespace: str) -> str:
+    """Validate a target namespace as a DNS-1123 label. Raises ValueError if invalid."""
+    if not _is_dns1123_label(namespace):
+        raise ValueError(
+            "namespace must be a DNS-1123 label: lowercase alphanumeric or '-', "
+            "start and end alphanumeric, at most 63 characters"
+        )
+    return namespace
+
+
+def validate_storage_size(size: str) -> str:
+    """Validate a PVC storage size as a Kubernetes quantity. Raises ValueError if invalid."""
+    if not _QUANTITY_RE.match(size):
+        raise ValueError("storageSize must be a Kubernetes quantity, e.g. '1Gi', '500Mi', '2G'")
+    return size
+
+
+def validate_custom_name(name: str) -> str:
+    """Validate a user-supplied tool name (reject rather than silently mutate).
+
+    Must be a DNS-1123 label short enough that the derived "{name}-mcp" Service
+    name stays a valid label. Raises ValueError if invalid.
+    """
+    if not _is_dns1123_label(name) or len(name) > MAX_SIMULATION_NAME_LEN:
+        raise ValueError(
+            "name must be a DNS-1123 label (lowercase alphanumeric or '-', start and end "
+            f"alphanumeric) of at most {MAX_SIMULATION_NAME_LEN} characters"
+        )
+    return name
+
 
 class SecretKeyRef(BaseModel):
     """Reference to a key in a Secret."""
@@ -292,5 +336,9 @@ def validate_openapi_spec(text: str) -> dict:
 def derive_simulation_name(spec: dict, requested: Optional[str]) -> str:
     """Return a Kubernetes-safe name: requested if given, else slug of info.title."""
     candidate = requested or (spec.get("info", {}) or {}).get("title", "") or ""
-    slug = re.sub(r"[^a-z0-9]+", "-", candidate.lower()).strip("-")[:63].rstrip("-")
+    slug = (
+        re.sub(r"[^a-z0-9]+", "-", candidate.lower())
+        .strip("-")[:MAX_SIMULATION_NAME_LEN]
+        .rstrip("-")
+    )
     return slug or "simulated-tool"

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -119,3 +119,122 @@ def build_simulation_env_vars(
     for env in env_vars:
         seen[env["name"]] = env
     return list(seen.values())
+
+
+def build_simulation_statefulset(
+    name: str,
+    namespace: str,
+    image: str,
+    *,
+    env_vars: List[dict],
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+    storage_size: str = "1Gi",
+    skills_folder: str = SIMULATION_HARNESS_SKILLS_MOUNT,
+    framework: str = "Python",
+    description: str = "",
+    spire_enabled: bool = False,
+    auth_bridge_enabled: bool = False,
+    auth_bridge_mode: Optional[str] = None,
+) -> dict:
+    """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
+    service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
+    inject = "enabled" if auth_bridge_enabled else "disabled"
+
+    labels = {
+        APP_KUBERNETES_IO_NAME: name,
+        _MCP_PROTOCOL_LABEL: "",
+        KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
+        KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_WORKLOAD_TYPE_LABEL: WORKLOAD_TYPE_STATEFULSET,
+        KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+        KAGENTI_SIMULATED_LABEL: "true",
+        APP_KUBERNETES_IO_MANAGED_BY: KAGENTI_UI_CREATOR_LABEL,
+        KAGENTI_INJECT_LABEL: inject,
+    }
+    pod_labels = {
+        APP_KUBERNETES_IO_NAME: name,
+        _MCP_PROTOCOL_LABEL: "",
+        KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
+        KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+        KAGENTI_SIMULATED_LABEL: "true",
+        KAGENTI_INJECT_LABEL: inject,
+    }
+    if spire_enabled:
+        labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
+        pod_labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
+
+    annotations = {KAGENTI_AUTOSCALING_ANNOTATION: "disabled"}
+    if description:
+        annotations[KAGENTI_DESCRIPTION_ANNOTATION] = description
+    pod_annotations: Dict[str, str] = {}
+    if auth_bridge_mode:
+        pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
+
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": labels,
+            "annotations": annotations,
+        },
+        "spec": {
+            "serviceName": service_name,
+            "replicas": 1,
+            "selector": {"matchLabels": {APP_KUBERNETES_IO_NAME: name}},
+            "template": {
+                "metadata": {"labels": pod_labels, "annotations": pod_annotations},
+                "spec": {
+                    "serviceAccountName": name,
+                    "securityContext": {
+                        "runAsNonRoot": True,
+                        "seccompProfile": {"type": "RuntimeDefault"},
+                    },
+                    "containers": [
+                        {
+                            "name": "harness",
+                            "image": image,
+                            "imagePullPolicy": "Always",
+                            "securityContext": {
+                                "allowPrivilegeEscalation": False,
+                                "capabilities": {"drop": ["ALL"]},
+                                "runAsUser": 1000,
+                            },
+                            "env": env_vars,
+                            "ports": [{"containerPort": port, "name": "http"}],
+                            "resources": {
+                                "limits": DEFAULT_RESOURCE_LIMITS,
+                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                            },
+                            "readinessProbe": {
+                                "httpGet": {"path": "/readyz", "port": port},
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 10,
+                            },
+                            "livenessProbe": {
+                                "httpGet": {"path": "/healthz", "port": port},
+                                "initialDelaySeconds": 10,
+                                "periodSeconds": 20,
+                            },
+                            "volumeMounts": [
+                                {"name": "data", "mountPath": skills_folder},
+                                {"name": "tmp", "mountPath": "/tmp"},
+                            ],
+                        }
+                    ],
+                    "volumes": [{"name": "tmp", "emptyDir": {}}],
+                },
+            },
+            "volumeClaimTemplates": [
+                {
+                    "metadata": {"name": "data"},
+                    "spec": {
+                        "accessModes": ["ReadWriteOnce"],
+                        "resources": {"requests": {"storage": storage_size}},
+                    },
+                }
+            ],
+        },
+    }

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -1,0 +1,121 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Pure builders for simulated-tool Kubernetes manifests (epic #2151, issue #2161).
+
+Standalone by design — no changes to app/routers/tools.py. A parity test
+(tests/test_simulation_manifests.py) guards the identity/mesh/security surface
+against drift from the tool builders.
+"""
+
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, field_validator
+
+from app.core.constants import (
+    APP_KUBERNETES_IO_MANAGED_BY,
+    APP_KUBERNETES_IO_NAME,
+    DEFAULT_ENV_VARS,
+    DEFAULT_IN_CLUSTER_PORT,
+    DEFAULT_RESOURCE_LIMITS,
+    DEFAULT_RESOURCE_REQUESTS,
+    KAGENTI_AUTOSCALING_ANNOTATION,
+    KAGENTI_DESCRIPTION_ANNOTATION,
+    KAGENTI_FRAMEWORK_LABEL,
+    KAGENTI_INJECT_LABEL,
+    KAGENTI_SIMULATED_LABEL,
+    KAGENTI_SPIRE_ENABLED_VALUE,
+    KAGENTI_SPIRE_LABEL,
+    KAGENTI_TRANSPORT_LABEL,
+    KAGENTI_TYPE_LABEL,
+    KAGENTI_UI_CREATOR_LABEL,
+    KAGENTI_WORKLOAD_TYPE_LABEL,
+    PROTOCOL_LABEL_PREFIX,
+    RESOURCE_TYPE_TOOL,
+    SIMULATION_HARNESS_SKILLS_MOUNT,
+    TOOL_SERVICE_SUFFIX,
+    VALUE_PROTOCOL_MCP,
+    VALUE_TRANSPORT_STREAMABLE_HTTP,
+    WORKLOAD_TYPE_STATEFULSET,
+)
+
+_MCP_PROTOCOL_LABEL = f"{PROTOCOL_LABEL_PREFIX}{VALUE_PROTOCOL_MCP}"
+
+
+class SecretKeyRef(BaseModel):
+    """Reference to a key in a Secret."""
+
+    name: str
+    key: str
+
+
+class ConfigMapKeyRef(BaseModel):
+    """Reference to a key in a ConfigMap."""
+
+    name: str
+    key: str
+
+
+class EnvVarSource(BaseModel):
+    """Source for an environment variable value."""
+
+    secretKeyRef: Optional[SecretKeyRef] = None
+    configMapKeyRef: Optional[ConfigMapKeyRef] = None
+
+
+class EnvVar(BaseModel):
+    """Environment variable with support for direct values and references."""
+
+    name: str
+    value: Optional[str] = None
+    valueFrom: Optional[EnvVarSource] = None
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", v or ""):
+            raise ValueError(
+                f"Invalid environment variable name '{v}'. Must start with a letter or "
+                "underscore and contain only letters, digits, and underscores."
+            )
+        return v
+
+
+def build_simulation_env_vars(
+    env_var_list: Optional[List[EnvVar]] = None,
+    *,
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+    skills_folder: str = SIMULATION_HARNESS_SKILLS_MOUNT,
+) -> List[dict]:
+    """Build the harness container env: platform defaults + harness config + user vars.
+
+    User-supplied vars (e.g. LLM_API_KEY via secretKeyRef) win on name collision.
+    """
+    env_vars: List[dict] = list(DEFAULT_ENV_VARS)
+    env_vars.append({"name": "HARNESS_SKILLS_FOLDER", "value": skills_folder})
+    env_vars.append({"name": "HARNESS_SERVER_PORT", "value": str(port)})
+    env_vars.append({"name": "HARNESS_SERVER_HOST", "value": "0.0.0.0"})
+
+    for ev in env_var_list or []:
+        if ev.value is not None:
+            env_vars.append({"name": ev.name, "value": ev.value})
+        elif ev.valueFrom is not None:
+            entry: Dict[str, Any] = {"name": ev.name, "valueFrom": {}}
+            if ev.valueFrom.secretKeyRef:
+                entry["valueFrom"]["secretKeyRef"] = {
+                    "name": ev.valueFrom.secretKeyRef.name,
+                    "key": ev.valueFrom.secretKeyRef.key,
+                }
+            elif ev.valueFrom.configMapKeyRef:
+                entry["valueFrom"]["configMapKeyRef"] = {
+                    "name": ev.valueFrom.configMapKeyRef.name,
+                    "key": ev.valueFrom.configMapKeyRef.key,
+                }
+            env_vars.append(entry)
+
+    seen: Dict[str, dict] = {}
+    for env in env_vars:
+        seen[env["name"]] = env
+    return list(seen.values())

--- a/kagenti/backend/tests/test_kubernetes_pod_status.py
+++ b/kagenti/backend/tests/test_kubernetes_pod_status.py
@@ -59,3 +59,36 @@ def test_api_error_reports_not_ready():
     core.list_namespaced_pod.side_effect = ApiException(status=500)
     result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
     assert result == {"ready": False, "waiting_reason": None, "waiting_message": None}
+
+
+def test_ready_true_if_any_pod_ready():
+    # A later not-ready pod must not overwrite an earlier ready=True.
+    svc, _ = _svc_with_pods([_pod(ready=True), _pod(ready=False)])
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["ready"] is True
+
+
+def test_first_waiting_container_across_pods_wins():
+    # First waiting container found (pod order, then container order) wins.
+    svc, _ = _svc_with_pods(
+        [
+            _pod(ready=False, waiting_reason="ImagePullBackOff", waiting_message="pull failed"),
+            _pod(ready=False, waiting_reason="CrashLoopBackOff", waiting_message="back-off"),
+        ]
+    )
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["waiting_reason"] == "ImagePullBackOff"
+    assert result["waiting_message"] == "pull failed"
+
+
+def test_waiting_reason_picked_up_from_later_pod_when_first_has_none():
+    # A ready pod with no waiting container, plus a crash-looping pod → surface the crash.
+    svc, _ = _svc_with_pods(
+        [
+            _pod(ready=True),
+            _pod(ready=False, waiting_reason="CrashLoopBackOff", waiting_message="back-off"),
+        ]
+    )
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["ready"] is True
+    assert result["waiting_reason"] == "CrashLoopBackOff"

--- a/kagenti/backend/tests/test_kubernetes_pod_status.py
+++ b/kagenti/backend/tests/test_kubernetes_pod_status.py
@@ -1,0 +1,61 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for KubernetesService.get_workload_pod_status (issue #2162)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from kubernetes.client import ApiException
+
+from app.services.kubernetes import KubernetesService
+
+
+def _pod(ready=False, waiting_reason=None, waiting_message=None):
+    conditions = [SimpleNamespace(type="Ready", status="True" if ready else "False")]
+    waiting = (
+        SimpleNamespace(reason=waiting_reason, message=waiting_message)
+        if waiting_reason is not None
+        else None
+    )
+    container = SimpleNamespace(state=SimpleNamespace(waiting=waiting))
+    return SimpleNamespace(
+        status=SimpleNamespace(conditions=conditions, container_statuses=[container])
+    )
+
+
+def _svc_with_pods(pods):
+    svc = KubernetesService.__new__(KubernetesService)  # bypass __init__
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=pods)
+    svc._core_api = core  # see note in Step 3 about the accessor
+    return svc, core
+
+
+def test_ready_pod_reports_ready_no_waiting():
+    svc, _ = _svc_with_pods([_pod(ready=True)])
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result == {"ready": True, "waiting_reason": None, "waiting_message": None}
+
+
+def test_crashloop_pod_reports_waiting_reason():
+    svc, _ = _svc_with_pods(
+        [_pod(ready=False, waiting_reason="CrashLoopBackOff", waiting_message="back-off 5m")]
+    )
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["ready"] is False
+    assert result["waiting_reason"] == "CrashLoopBackOff"
+    assert result["waiting_message"] == "back-off 5m"
+
+
+def test_no_pods_reports_not_ready():
+    svc, _ = _svc_with_pods([])
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result == {"ready": False, "waiting_reason": None, "waiting_message": None}
+
+
+def test_api_error_reports_not_ready():
+    svc, core = _svc_with_pods([])
+    core.list_namespaced_pod.side_effect = ApiException(status=500)
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result == {"ready": False, "waiting_reason": None, "waiting_message": None}

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -1,0 +1,80 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for POST /simulation/tools (issue #2161)."""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim_router
+from app.services.kubernetes import get_kubernetes_service
+
+VALID_SPEC = '{"openapi": "3.0.0", "info": {"title": "Pet Store"}, "paths": {}}'
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(sim_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return TestClient(app)
+
+
+def _kube():
+    k = MagicMock()
+    k.ensure_service_account.return_value = None
+    k.create_statefulset.return_value = {}
+    k.create_service.return_value = {}
+    return k
+
+
+def test_create_returns_202_and_provisions_workload():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "Generating"
+    assert body["name"] == "pet-store"
+    kube.create_statefulset.assert_called_once()
+    kube.create_service.assert_called_once()
+
+
+def test_create_rejects_invalid_spec_with_422_and_no_workload():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": "not json"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_conflict_returns_409():
+    kube = _kube()
+    kube.create_statefulset.side_effect = ApiException(status=409)
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "img"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "name": "dup"},
+        )
+    assert r.status_code == 409
+
+
+def test_route_absent_when_flag_off():
+    """With the flag off, main.py never mounts the router (see #2160)."""
+    import app.main
+
+    r = TestClient(app.main.app).post("/api/v1/simulation/tools", json={})
+    assert r.status_code == 404

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -74,6 +74,21 @@ def test_create_wires_image_pull_secret_into_statefulset():
     assert sts["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "ghcr-secret"}]
 
 
+def test_create_omits_image_pull_secret_when_setting_empty():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        s.simulation_image_pull_secret = ""
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    sts = kube.create_statefulset.call_args.args[1]
+    assert "imagePullSecrets" not in sts["spec"]["template"]["spec"]
+
+
 def test_create_conflict_returns_409():
     kube = _kube()
     kube.create_statefulset.side_effect = ApiException(status=409)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -148,23 +148,28 @@ def test_create_rejects_invalid_custom_name_with_422():
 
 def test_create_spawns_generation_trigger():
     kube = _kube()
-    with (
-        patch("app.core.auth.settings") as auth,
-        patch("app.routers.simulation.settings") as s,
-        patch("app.routers.simulation._run_generation_trigger", new=MagicMock()) as trig,
-    ):
-        auth.enable_auth = False
-        s.simulation_harness_image = "img"
-        # _run_generation_trigger is wrapped in asyncio.create_task; the MagicMock
-        # returns a coroutine-like sentinel, so patch create_task to capture the call.
-        with patch("app.routers.simulation.asyncio.create_task") as create_task:
-            r = _client(kube).post(
-                "/simulation/tools",
-                json={"namespace": "team1", "openapiSpec": VALID_SPEC},
-            )
-    assert r.status_code == 202
-    create_task.assert_called_once()
-    trig.assert_called_once()
-    ns, name, spec, port = trig.call_args.args
-    assert ns == "team1"
-    assert name == "pet-store"
+    saved = set(sim_router._generation_tasks)
+    try:
+        with (
+            patch("app.core.auth.settings") as auth,
+            patch("app.routers.simulation.settings") as s,
+            patch("app.routers.simulation._run_generation_trigger", new=MagicMock()) as trig,
+        ):
+            auth.enable_auth = False
+            s.simulation_harness_image = "img"
+            # _run_generation_trigger is wrapped in asyncio.create_task; the MagicMock
+            # returns a coroutine-like sentinel, so patch create_task to capture the call.
+            with patch("app.routers.simulation.asyncio.create_task") as create_task:
+                r = _client(kube).post(
+                    "/simulation/tools",
+                    json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+                )
+        assert r.status_code == 202
+        create_task.assert_called_once()
+        trig.assert_called_once()
+        ns, name, spec, port = trig.call_args.args
+        assert ns == "team1"
+        assert name == "pet-store"
+    finally:
+        sim_router._generation_tasks.clear()
+        sim_router._generation_tasks.update(saved)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -144,3 +144,27 @@ def test_create_rejects_invalid_custom_name_with_422():
         )
     assert r.status_code == 422
     kube.create_statefulset.assert_not_called()
+
+
+def test_create_spawns_generation_trigger():
+    kube = _kube()
+    with (
+        patch("app.core.auth.settings") as auth,
+        patch("app.routers.simulation.settings") as s,
+        patch("app.routers.simulation._run_generation_trigger", new=MagicMock()) as trig,
+    ):
+        auth.enable_auth = False
+        s.simulation_harness_image = "img"
+        # _run_generation_trigger is wrapped in asyncio.create_task; the MagicMock
+        # returns a coroutine-like sentinel, so patch create_task to capture the call.
+        with patch("app.routers.simulation.asyncio.create_task") as create_task:
+            r = _client(kube).post(
+                "/simulation/tools",
+                json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+            )
+    assert r.status_code == 202
+    create_task.assert_called_once()
+    trig.assert_called_once()
+    ns, name, spec, port = trig.call_args.args
+    assert ns == "team1"
+    assert name == "pet-store"

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -59,6 +59,21 @@ def test_create_rejects_invalid_spec_with_422_and_no_workload():
     kube.create_statefulset.assert_not_called()
 
 
+def test_create_wires_image_pull_secret_into_statefulset():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        s.simulation_image_pull_secret = "ghcr-secret"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    sts = kube.create_statefulset.call_args.args[1]
+    assert sts["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "ghcr-secret"}]
+
+
 def test_create_conflict_returns_409():
     kube = _kube()
     kube.create_statefulset.side_effect = ApiException(status=409)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -78,3 +78,39 @@ def test_route_absent_when_flag_off():
 
     r = TestClient(app.main.app).post("/api/v1/simulation/tools", json={})
     assert r.status_code == 404
+
+
+def test_create_rejects_invalid_namespace_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "Bad_NS", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_rejects_invalid_storage_size_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "storageSize": "big"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_rejects_invalid_custom_name_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "name": "Bad Name!"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_flag.py
+++ b/kagenti/backend/tests/test_simulation_flag.py
@@ -1,0 +1,76 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the simulated-tools feature flag and flagged simulation router (issue #2160)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import config as config_router
+from app.routers import simulation as simulation_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _make_config_app(simulated_tools: bool) -> FastAPI:
+    """Build an app with only the config router, feature flags mocked."""
+    app = FastAPI()
+    app.include_router(config_router.router)
+
+    # Feature flags are read straight off `settings` in get_feature_flags.
+    mock_settings = MagicMock()
+    mock_settings.kagenti_feature_flag_sandbox = False
+    mock_settings.kagenti_feature_flag_integrations = False
+    mock_settings.kagenti_feature_flag_triggers = False
+    mock_settings.kagenti_feature_flag_agent_sandbox = False
+    mock_settings.kagenti_feature_flag_skills = False
+    mock_settings.kagenti_feature_flag_external_skills = False
+    mock_settings.kagenti_feature_flag_authbridge_api = False
+    mock_settings.kagenti_feature_flag_admin = False
+    mock_settings.kagenti_feature_flag_agent_import_defaults = False
+    mock_settings.kagenti_feature_flag_simulated_tools = simulated_tools
+
+    # get_feature_flags depends on the k8s service only to probe the `builds` flag.
+    mock_kube = MagicMock()
+    mock_kube.api_group_exists.return_value = False
+    app.dependency_overrides[get_kubernetes_service] = lambda: mock_kube
+
+    app.state._mock_settings = mock_settings  # keep a reference alive for the patch
+    return app
+
+
+class TestSimulatedToolsFeatureFlag:
+    def test_features_reports_false_when_flag_off(self):
+        app = _make_config_app(simulated_tools=False)
+        with patch("app.routers.config.settings", app.state._mock_settings):
+            r = TestClient(app).get("/config/features")
+        assert r.status_code == 200
+        assert r.json()["simulatedTools"] is False
+
+    def test_features_reports_true_when_flag_on(self):
+        app = _make_config_app(simulated_tools=True)
+        with patch("app.routers.config.settings", app.state._mock_settings):
+            r = TestClient(app).get("/config/features")
+        assert r.status_code == 200
+        assert r.json()["simulatedTools"] is True
+
+
+class TestSimulationRouterScaffold:
+    def test_health_endpoint_returns_ok_when_mounted(self):
+        app = FastAPI()
+        app.include_router(simulation_router.router)
+        r = TestClient(app).get("/simulation/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
+
+    def test_no_simulation_routes_when_router_not_mounted(self):
+        # Mirrors flag-off: the router is simply never included.
+        app = FastAPI()
+        r = TestClient(app).get("/simulation/health")
+        assert r.status_code == 404
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/kagenti/backend/tests/test_simulation_harness_client.py
+++ b/kagenti/backend/tests/test_simulation_harness_client.py
@@ -1,0 +1,89 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the simulation harness HTTP client (issue #2162)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services import simulation_harness_client as hc
+
+
+class _FakeResp:
+    def __init__(self, status_code, json_data=None):
+        self.status_code = status_code
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("err", request=None, response=None)
+
+
+class _FakeClient:
+    def __init__(self, resp=None, exc=None):
+        self._resp = resp
+        self._exc = exc
+        self.posted = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        if self._exc:
+            raise self._exc
+        return self._resp
+
+    async def post(self, url, json=None):
+        if self._exc:
+            raise self._exc
+        self.posted = json
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_returns_parsed_body():
+    fake = _FakeClient(resp=_FakeResp(200, {"status": "ready", "mcp_url": "u"}))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        body = await hc.get_simulation("http://sim")
+    assert body["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_raises_not_found_on_404():
+    fake = _FakeClient(resp=_FakeResp(404))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessNotFound):
+            await hc.get_simulation("http://sim")
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_raises_unreachable_on_connect_error():
+    fake = _FakeClient(exc=httpx.ConnectError("boom"))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessUnreachable):
+            await hc.get_simulation("http://sim")
+
+
+@pytest.mark.asyncio
+async def test_post_simulation_sends_spec_and_name_and_returns_code():
+    fake = _FakeClient(resp=_FakeResp(202))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        code = await hc.post_simulation("http://sim", {"openapi": "3.0.0"}, "petstore")
+    assert code == 202
+    assert fake.posted == {"openapi_spec": {"openapi": "3.0.0"}, "name": "petstore"}
+
+
+@pytest.mark.asyncio
+async def test_post_simulation_raises_unreachable_on_timeout():
+    fake = _FakeClient(exc=httpx.TimeoutException("slow"))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessUnreachable):
+            await hc.post_simulation("http://sim", {}, "x")

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -117,6 +117,21 @@ def test_statefulset_spire_and_authbridge_flags():
     assert pod_ann["kagenti.io/authbridge-mode"] == "lite"
 
 
+def test_statefulset_adds_image_pull_secret_when_provided():
+    spec = _sts(image_pull_secret="ghcr-secret")["spec"]["template"]["spec"]
+    assert spec["imagePullSecrets"] == [{"name": "ghcr-secret"}]
+
+
+def test_statefulset_omits_image_pull_secret_when_none():
+    spec = _sts()["spec"]["template"]["spec"]
+    assert "imagePullSecrets" not in spec
+
+
+def test_statefulset_omits_image_pull_secret_when_empty_string():
+    spec = _sts(image_pull_secret="")["spec"]["template"]["spec"]
+    assert "imagePullSecrets" not in spec
+
+
 from app.services.simulation_manifests import build_simulation_service
 
 

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -25,6 +25,12 @@ def test_simulation_harness_image_setting_defaults():
     assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")
 
 
+def test_simulation_image_pull_secret_setting_defaults():
+    from app.core.config import Settings
+
+    assert Settings().simulation_image_pull_secret == "ghcr-secret"
+
+
 def test_env_vars_include_harness_and_platform_defaults():
     env = build_simulation_env_vars(None, port=8000)
     by_name = {e["name"]: e for e in env}

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -37,6 +37,9 @@ def test_env_vars_include_harness_and_platform_defaults():
     assert by_name["HARNESS_SKILLS_FOLDER"]["value"] == "/app/skills-store"
     assert by_name["HARNESS_SERVER_PORT"]["value"] == "8000"
     assert by_name["HARNESS_SERVER_HOST"]["value"] == "0.0.0.0"
+    # Opt back into boot-time autostart: the harness defaults it off, but Kagenti
+    # relies on it to resume the baked skill on Stop->Start and pod restarts.
+    assert by_name["HARNESS_AUTOSTART_ENABLED"]["value"] == "true"
     # platform default preserved
     assert by_name["OTEL_EXPORTER_OTLP_ENDPOINT"]["value"].startswith("http://otel-collector")
 

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -53,3 +53,65 @@ def test_env_vars_user_value_wins_on_dedupe():
     ports = [e for e in env if e["name"] == "HARNESS_SERVER_PORT"]
     assert len(ports) == 1
     assert ports[0]["value"] == "9999"
+
+
+from app.services.simulation_manifests import build_simulation_statefulset
+
+
+def _sts(**kw):
+    defaults = {
+        "name": "petstore",
+        "namespace": "team1",
+        "image": "ghcr.io/kagenti/simulation-harness:latest",
+        "env_vars": [{"name": "PORT", "value": "8000"}],
+    }
+    defaults.update(kw)
+    return build_simulation_statefulset(**defaults)
+
+
+def test_statefulset_core_shape():
+    m = _sts()
+    assert m["kind"] == "StatefulSet"
+    assert m["spec"]["replicas"] == 1
+    assert m["metadata"]["name"] == "petstore"
+    assert m["metadata"]["namespace"] == "team1"
+    c = m["spec"]["template"]["spec"]["containers"][0]
+    assert c["image"] == "ghcr.io/kagenti/simulation-harness:latest"
+    assert c["ports"][0]["containerPort"] == 8000
+
+
+def test_statefulset_labels_and_markers():
+    labels = _sts()["metadata"]["labels"]
+    assert labels["protocol.kagenti.io/mcp"] == ""
+    assert labels["kagenti.io/type"] == "tool"
+    assert labels["kagenti.io/simulated"] == "true"
+    assert labels["kagenti.io/workload-type"] == "statefulset"
+    assert labels["kagenti.io/inject"] == "disabled"
+    assert _sts()["metadata"]["annotations"]["kagenti.io/autoscaling"] == "disabled"
+
+
+def test_statefulset_pvc_mounted_at_skills_dir():
+    m = _sts(storage_size="2Gi")
+    vct = m["spec"]["volumeClaimTemplates"][0]
+    assert vct["metadata"]["name"] == "data"
+    assert vct["spec"]["resources"]["requests"]["storage"] == "2Gi"
+    mounts = m["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    data_mount = next(v for v in mounts if v["name"] == "data")
+    assert data_mount["mountPath"] == "/app/skills-store"
+
+
+def test_statefulset_probes_and_security_context():
+    c = _sts()["spec"]["template"]["spec"]["containers"][0]
+    assert c["readinessProbe"]["httpGet"]["path"] == "/readyz"
+    assert c["livenessProbe"]["httpGet"]["path"] == "/healthz"
+    assert c["securityContext"]["runAsUser"] == 1000
+    assert c["securityContext"]["capabilities"]["drop"] == ["ALL"]
+
+
+def test_statefulset_spire_and_authbridge_flags():
+    labels = _sts(spire_enabled=True, auth_bridge_enabled=True)["metadata"]["labels"]
+    assert labels["kagenti.io/spire"] == "enabled"
+    assert labels["kagenti.io/inject"] == "enabled"
+    m = _sts(auth_bridge_mode="lite")
+    pod_ann = m["spec"]["template"]["metadata"]["annotations"]
+    assert pod_ann["kagenti.io/authbridge-mode"] == "lite"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -169,6 +169,19 @@ def test_derive_name_falls_back():
     assert derive_simulation_name({}, None) == "simulated-tool"
 
 
+def test_statefulset_cache_emptydir_volume():
+    m = _sts()
+    mounts = m["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    cache_mount = next((v for v in mounts if v["name"] == "cache"), None)
+    assert cache_mount is not None, "cache volumeMount not found"
+    assert cache_mount["mountPath"] == "/app/.cache"
+
+    volumes = m["spec"]["template"]["spec"]["volumes"]
+    cache_vol = next((v for v in volumes if v["name"] == "cache"), None)
+    assert cache_vol is not None, "cache volume not found"
+    assert cache_vol["emptyDir"] == {}
+
+
 def test_parity_simulation_matches_tool_identity_surface():
     """Guard: simulation StatefulSet must carry the same identity/mesh/security
     surface a tool StatefulSet does, so the standalone builders can't silently drift."""

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -4,6 +4,12 @@
 """Unit tests for simulated-tool manifest building (issue #2161)."""
 
 from app.core import constants
+from app.services.simulation_manifests import (
+    EnvVar,
+    EnvVarSource,
+    SecretKeyRef,
+    build_simulation_env_vars,
+)
 
 
 def test_simulation_constants_exist():
@@ -17,3 +23,33 @@ def test_simulation_harness_image_setting_defaults():
 
     s = Settings()
     assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")
+
+
+def test_env_vars_include_harness_and_platform_defaults():
+    env = build_simulation_env_vars(None, port=8000)
+    by_name = {e["name"]: e for e in env}
+    assert by_name["HARNESS_SKILLS_FOLDER"]["value"] == "/app/skills-store"
+    assert by_name["HARNESS_SERVER_PORT"]["value"] == "8000"
+    assert by_name["HARNESS_SERVER_HOST"]["value"] == "0.0.0.0"
+    # platform default preserved
+    assert by_name["OTEL_EXPORTER_OTLP_ENDPOINT"]["value"].startswith("http://otel-collector")
+
+
+def test_env_vars_expand_secret_key_ref():
+    env = build_simulation_env_vars(
+        [
+            EnvVar(
+                name="LLM_API_KEY",
+                valueFrom=EnvVarSource(secretKeyRef=SecretKeyRef(name="llm-secret", key="api-key")),
+            )
+        ]
+    )
+    entry = next(e for e in env if e["name"] == "LLM_API_KEY")
+    assert entry["valueFrom"]["secretKeyRef"] == {"name": "llm-secret", "key": "api-key"}
+
+
+def test_env_vars_user_value_wins_on_dedupe():
+    env = build_simulation_env_vars([EnvVar(name="HARNESS_SERVER_PORT", value="9999")])
+    ports = [e for e in env if e["name"] == "HARNESS_SERVER_PORT"]
+    assert len(ports) == 1
+    assert ports[0]["value"] == "9999"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -219,3 +219,53 @@ def test_parity_simulation_matches_tool_identity_surface():
     spc = sim["spec"]["template"]["spec"]
     assert spc["securityContext"] == tpc["securityContext"]
     assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]
+
+
+from app.services.simulation_manifests import (
+    MAX_SIMULATION_NAME_LEN,
+    validate_custom_name,
+    validate_namespace,
+    validate_storage_size,
+)
+
+
+class TestInputValidators:
+    def test_valid_namespace_passes(self):
+        assert validate_namespace("team1") == "team1"
+        assert validate_namespace("a-b-9") == "a-b-9"
+
+    @pytest.mark.parametrize(
+        "bad", ["Team1", "team_1", "-team", "team-", "team 1", "team\n1", "", "a" * 64]
+    )
+    def test_invalid_namespace_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_namespace(bad)
+
+    @pytest.mark.parametrize("good", ["1Gi", "500Mi", "2G", "10Ti", "1024Ki"])
+    def test_valid_storage_size_passes(self, good):
+        assert validate_storage_size(good) == good
+
+    @pytest.mark.parametrize("bad", ["big", "1gb", "Gi", "0Gi", "-1Gi", "1.Gi", "1 Gi", ""])
+    def test_invalid_storage_size_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_storage_size(bad)
+
+    def test_valid_custom_name_passes(self):
+        assert validate_custom_name("pet-store") == "pet-store"
+
+    @pytest.mark.parametrize("bad", ["Pet Store", "pet_store", "-x", "x-", "", "UPPER"])
+    def test_invalid_custom_name_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_custom_name(bad)
+
+    def test_custom_name_too_long_for_service_suffix_raises(self):
+        # A name longer than MAX_SIMULATION_NAME_LEN would make "{name}-mcp" exceed 63.
+        with pytest.raises(ValueError):
+            validate_custom_name("a" * (MAX_SIMULATION_NAME_LEN + 1))
+        assert validate_custom_name("a" * MAX_SIMULATION_NAME_LEN)
+
+
+def test_derive_name_truncates_to_service_safe_length():
+    name = derive_simulation_name({"info": {"title": "x" * 100}}, None)
+    assert len(name) <= MAX_SIMULATION_NAME_LEN
+    assert not name.endswith("-")

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -132,3 +132,77 @@ def test_service_shape_and_labels():
     assert labels["protocol.kagenti.io/mcp"] == ""
     assert labels["kagenti.io/simulated"] == "true"
     assert labels["kagenti.io/type"] == "tool"
+
+
+import pytest
+
+from app.services.simulation_manifests import (
+    derive_simulation_name,
+    validate_openapi_spec,
+)
+
+
+def test_validate_spec_accepts_valid_json_object():
+    spec = validate_openapi_spec(
+        '{"openapi": "3.0.0", "info": {"title": "Pet Store"}, "paths": {}}'
+    )
+    assert spec["info"]["title"] == "Pet Store"
+
+
+@pytest.mark.parametrize("bad", ["not json", "[]", '"a string"', "123", ""])
+def test_validate_spec_rejects_non_object_or_invalid(bad):
+    with pytest.raises(ValueError):
+        validate_openapi_spec(bad)
+
+
+def test_derive_name_prefers_requested():
+    assert derive_simulation_name({"info": {"title": "Pet Store"}}, "my-sim") == "my-sim"
+
+
+def test_derive_name_slugifies_title():
+    assert (
+        derive_simulation_name({"info": {"title": "Pet Store API v2!"}}, None) == "pet-store-api-v2"
+    )
+
+
+def test_derive_name_falls_back():
+    assert derive_simulation_name({}, None) == "simulated-tool"
+
+
+def test_parity_simulation_matches_tool_identity_surface():
+    """Guard: simulation StatefulSet must carry the same identity/mesh/security
+    surface a tool StatefulSet does, so the standalone builders can't silently drift."""
+    from app.routers.tools import _build_tool_statefulset_manifest
+    from app.services.simulation_manifests import build_simulation_statefulset
+
+    tool = _build_tool_statefulset_manifest(
+        name="x",
+        namespace="team1",
+        image="img",
+        framework="Python",
+        auth_bridge_enabled=True,
+        spire_enabled=True,
+    )
+    sim = build_simulation_statefulset(
+        name="x",
+        namespace="team1",
+        image="img",
+        env_vars=[],
+        framework="Python",
+        auth_bridge_enabled=True,
+        spire_enabled=True,
+    )
+    mesh_keys = [
+        "protocol.kagenti.io/mcp",
+        "kagenti.io/transport",
+        "kagenti.io/framework",
+        "kagenti.io/inject",
+        "kagenti.io/spire",
+    ]
+    tl, sl = tool["metadata"]["labels"], sim["metadata"]["labels"]
+    for k in mesh_keys:
+        assert sl.get(k) == tl.get(k), f"identity label drift on {k}"
+    tpc = tool["spec"]["template"]["spec"]
+    spc = sim["spec"]["template"]["spec"]
+    assert spc["securityContext"] == tpc["securityContext"]
+    assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -115,3 +115,20 @@ def test_statefulset_spire_and_authbridge_flags():
     m = _sts(auth_bridge_mode="lite")
     pod_ann = m["spec"]["template"]["metadata"]["annotations"]
     assert pod_ann["kagenti.io/authbridge-mode"] == "lite"
+
+
+from app.services.simulation_manifests import build_simulation_service
+
+
+def test_service_shape_and_labels():
+    m = build_simulation_service("petstore", "team1", port=8000)
+    assert m["kind"] == "Service"
+    assert m["metadata"]["name"] == "petstore-mcp"
+    assert m["spec"]["type"] == "ClusterIP"
+    assert m["spec"]["selector"]["app.kubernetes.io/name"] == "petstore"
+    assert m["spec"]["ports"][0]["port"] == 8000
+    assert m["spec"]["ports"][0]["targetPort"] == 8000
+    labels = m["metadata"]["labels"]
+    assert labels["protocol.kagenti.io/mcp"] == ""
+    assert labels["kagenti.io/simulated"] == "true"
+    assert labels["kagenti.io/type"] == "tool"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -1,0 +1,19 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Unit tests for simulated-tool manifest building (issue #2161)."""
+
+from app.core import constants
+
+
+def test_simulation_constants_exist():
+    assert constants.KAGENTI_SIMULATED_LABEL == "kagenti.io/simulated"
+    assert constants.KAGENTI_AUTOSCALING_ANNOTATION == "kagenti.io/autoscaling"
+    assert constants.SIMULATION_HARNESS_SKILLS_MOUNT == "/app/skills-store"
+
+
+def test_simulation_harness_image_setting_defaults():
+    from app.core.config import Settings
+
+    s = Settings()
+    assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -238,7 +238,12 @@ def test_parity_simulation_matches_tool_identity_surface():
         assert sl.get(k) == tl.get(k), f"identity label drift on {k}"
     tpc = tool["spec"]["template"]["spec"]
     spc = sim["spec"]["template"]["spec"]
-    assert spc["securityContext"] == tpc["securityContext"]
+    # Simulated tools add fsGroup so the uid-1000 harness can write its PVC;
+    # apart from that PVC-driven divergence the pod securityContext must match
+    # the regular tool identity surface.
+    sim_sec = {k: v for k, v in spc["securityContext"].items() if k != "fsGroup"}
+    assert sim_sec == tpc["securityContext"]
+    assert spc["securityContext"].get("fsGroup") == 1000
     assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]
 
 

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -130,6 +130,44 @@ def test_statefulset_read_error_returns_502():
     assert r.status_code == 502
 
 
+def test_invalid_namespace_path_param_returns_404_without_backend_calls():
+    # A namespace that is not a DNS-1123 label can never name a real tool; it
+    # must be rejected before it can reach the harness URL (SSRF guard, CWE-918).
+    kube = _kube()
+    harness = AsyncMock()
+    with patch("app.routers.simulation.get_simulation", new=harness):
+        r = _get(_client(kube), ns="Bad_NS", name="petstore")
+    assert r.status_code == 404
+    harness.assert_not_called()
+    kube.apps_api.read_namespaced_stateful_set.assert_not_called()
+
+
+def test_invalid_name_path_param_returns_404_without_backend_calls():
+    kube = _kube()
+    harness = AsyncMock()
+    with patch("app.routers.simulation.get_simulation", new=harness):
+        r = _get(_client(kube), ns="team1", name="Bad_Name")
+    assert r.status_code == 404
+    harness.assert_not_called()
+    kube.apps_api.read_namespaced_stateful_set.assert_not_called()
+
+
+def test_harness_base_url_rejects_invalid_identifiers():
+    import pytest
+
+    with pytest.raises(ValueError):
+        sim_router._harness_base_url("Bad_Name", "team1", 8000)
+    with pytest.raises(ValueError):
+        sim_router._harness_base_url("petstore", "Bad_NS", 8000)
+
+
+def test_harness_base_url_builds_url_for_valid_identifiers():
+    assert (
+        sim_router._harness_base_url("petstore", "team1", 8000)
+        == "http://petstore-mcp.team1.svc.cluster.local:8000"
+    )
+
+
 def test_harness_http_error_degrades_to_pod_state():
     import httpx as _httpx
 

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -123,6 +123,13 @@ def test_unknown_workload_returns_404():
     assert r.status_code == 404
 
 
+def test_statefulset_read_error_returns_502():
+    # A non-404 ApiException reading the StatefulSet surfaces as 502.
+    kube = _kube(sts_exc=ApiException(status=403))
+    r = _get(_client(kube))
+    assert r.status_code == 502
+
+
 def test_harness_http_error_degrades_to_pod_state():
     import httpx as _httpx
 

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -1,0 +1,138 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for GET /simulation/tools/{ns}/{name}/generation-status (issue #2162)."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _sts(created=None, ready_replicas=1):
+    created = created or datetime.now(timezone.utc)
+    return SimpleNamespace(
+        metadata=SimpleNamespace(creation_timestamp=created),
+        spec=SimpleNamespace(replicas=1),
+        status=SimpleNamespace(ready_replicas=ready_replicas),
+    )
+
+
+def _kube(sts=None, sts_exc=None, pod_status=None):
+    k = MagicMock()
+    if sts_exc is not None:
+        k.apps_api.read_namespaced_stateful_set.side_effect = sts_exc
+    else:
+        k.apps_api.read_namespaced_stateful_set.return_value = sts or _sts()
+    k.get_workload_pod_status.return_value = pod_status or {
+        "ready": True,
+        "waiting_reason": None,
+        "waiting_message": None,
+    }
+    return k
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(sim_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return app
+
+
+def _get(app, ns="team1", name="petstore"):
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        return TestClient(app).get(f"/simulation/tools/{ns}/{name}/generation-status")
+
+
+def test_ready_returns_ready_with_mcp_url():
+    kube = _kube()
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(return_value={"status": "ready", "mcp_url": "http://x/mcp/petstore"}),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.status_code == 200
+    assert r.json() == {"status": "Ready", "reason": None, "mcpUrl": "http://x/mcp/petstore"}
+
+
+def test_harness_404_healthy_pod_within_timeout_is_generating():
+    kube = _kube()
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(side_effect=sim_router.HarnessNotFound()),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.json()["status"] == "Generating"
+
+
+def test_crashloop_pod_returns_error():
+    kube = _kube(
+        pod_status={
+            "ready": False,
+            "waiting_reason": "CrashLoopBackOff",
+            "waiting_message": "no LLM_API_KEY",
+        }
+    )
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(side_effect=sim_router.HarnessUnreachable("down")),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    body = r.json()
+    assert body["status"] == "Error"
+    assert "CrashLoopBackOff" in body["reason"]
+
+
+def test_stalled_past_timeout_returns_failed():
+    old = datetime.now(timezone.utc) - timedelta(seconds=900)
+    kube = _kube(sts=_sts(created=old))
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(side_effect=sim_router.HarnessNotFound()),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.json() == {"status": "Failed", "reason": "generation_stalled", "mcpUrl": None}
+
+
+def test_unknown_workload_returns_404():
+    kube = _kube(sts_exc=ApiException(status=404))
+    r = _get(_client(kube))
+    assert r.status_code == 404
+
+
+def test_harness_http_error_degrades_to_pod_state():
+    import httpx as _httpx
+
+    kube = _kube()
+    err = _httpx.HTTPStatusError("500", request=None, response=None)
+    with (
+        patch("app.routers.simulation.get_simulation", new=AsyncMock(side_effect=err)),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.status_code == 200
+    assert r.json()["status"] == "Generating"

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -15,10 +15,10 @@ from app.routers import simulation as sim_router
 from app.services.kubernetes import get_kubernetes_service
 
 
-def _sts(created=None, ready_replicas=1):
+def _sts(created=None, ready_replicas=1, name="petstore", namespace="team1"):
     created = created or datetime.now(timezone.utc)
     return SimpleNamespace(
-        metadata=SimpleNamespace(creation_timestamp=created),
+        metadata=SimpleNamespace(creation_timestamp=created, name=name, namespace=namespace),
         spec=SimpleNamespace(replicas=1),
         status=SimpleNamespace(ready_replicas=ready_replicas),
     )

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -7,9 +7,10 @@ from app.routers.simulation import map_generation_status
 
 
 def _map(harness=None, ready=False, reason=None, message=None, elapsed=1.0, timeout=600):
+    # `ready` is accepted for call-site compatibility; the mapper does not
+    # depend on pod readiness (reachability + waiting reason drive the result).
     return map_generation_status(
         harness=harness,
-        pod_ready=ready,
         pod_waiting_reason=reason,
         pod_waiting_message=message,
         elapsed_seconds=elapsed,

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -84,3 +84,53 @@ def test_failed_message_with_trailing_colon_is_preserved():
     )
     assert out.status == "Failed"
     assert out.reason == "sidecar_start_failed: died: "
+
+
+def test_failed_folds_cause_type_into_reason():
+    # The harness records the underlying cause (e.g. a timed-out generation
+    # stage rewrapped as a generic RuntimeError) in error.details.cause_type.
+    # It must surface in the reason so the UI shows *why* it failed.
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {
+                "code": "skill_generation_failed",
+                "message": "Skill generation failed for 'tasks'",
+                "details": {"cause_type": "TimeoutError", "cause": ""},
+            },
+        }
+    )
+    assert out.status == "Failed"
+    assert (
+        out.reason == "skill_generation_failed (TimeoutError): Skill generation failed for 'tasks'"
+    )
+
+
+def test_failed_cause_type_with_empty_message_uses_code_and_cause():
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {
+                "code": "skill_generation_failed",
+                "message": "",
+                "details": {"cause_type": "TimeoutError"},
+            },
+        }
+    )
+    assert out.status == "Failed"
+    assert out.reason == "skill_generation_failed (TimeoutError)"
+
+
+def test_failed_details_without_cause_type_unchanged():
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {
+                "code": "instance_init_failed",
+                "message": "boom",
+                "details": {"exception": "RuntimeError"},
+            },
+        }
+    )
+    assert out.status == "Failed"
+    assert out.reason == "instance_init_failed: boom"

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -1,0 +1,65 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the generation-status mapping (issue #2162)."""
+
+from app.routers.simulation import map_generation_status
+
+
+def _map(harness=None, ready=False, reason=None, message=None, elapsed=1.0, timeout=600):
+    return map_generation_status(
+        harness=harness,
+        pod_ready=ready,
+        pod_waiting_reason=reason,
+        pod_waiting_message=message,
+        elapsed_seconds=elapsed,
+        timeout_seconds=timeout,
+    )
+
+
+def test_harness_pending_maps_to_generating():
+    assert _map(harness={"status": "pending"}).status == "Generating"
+
+
+def test_harness_initializing_maps_to_generating():
+    assert _map(harness={"status": "initializing"}).status == "Generating"
+
+
+def test_harness_ready_maps_to_ready_with_mcp_url():
+    out = _map(harness={"status": "ready", "mcp_url": "http://x/mcp/petstore"})
+    assert out.status == "Ready"
+    assert out.mcpUrl == "http://x/mcp/petstore"
+
+
+def test_harness_failed_surfaces_error_code_and_message():
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {"code": "skill_generation_failed", "message": "LLM error"},
+        }
+    )
+    assert out.status == "Failed"
+    assert out.reason == "skill_generation_failed: LLM error"
+
+
+def test_crashloop_pod_maps_to_error_when_harness_unreachable():
+    out = _map(harness=None, ready=False, reason="CrashLoopBackOff", message="back-off")
+    assert out.status == "Error"
+    assert out.reason == "CrashLoopBackOff: back-off"
+
+
+def test_missing_secret_config_error_maps_to_error():
+    out = _map(harness=None, reason="CreateContainerConfigError", message="secret not found")
+    assert out.status == "Error"
+    assert out.reason == "CreateContainerConfigError: secret not found"
+
+
+def test_healthy_pod_no_harness_within_timeout_is_generating():
+    out = _map(harness=None, ready=True, elapsed=30.0, timeout=600)
+    assert out.status == "Generating"
+
+
+def test_no_harness_past_timeout_maps_to_failed_stalled():
+    out = _map(harness=None, ready=True, elapsed=700.0, timeout=600)
+    assert out.status == "Failed"
+    assert out.reason == "generation_stalled"

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -63,3 +63,23 @@ def test_no_harness_past_timeout_maps_to_failed_stalled():
     out = _map(harness=None, ready=True, elapsed=700.0, timeout=600)
     assert out.status == "Failed"
     assert out.reason == "generation_stalled"
+
+
+def test_failed_missing_code_defaults_to_unknown():
+    out = _map(harness={"status": "failed", "error": {"message": "boom"}})
+    assert out.status == "Failed"
+    assert out.reason == "unknown: boom"
+
+
+def test_failed_empty_message_uses_code_only():
+    out = _map(harness={"status": "failed", "error": {"code": "creation_timeout", "message": ""}})
+    assert out.status == "Failed"
+    assert out.reason == "creation_timeout"
+
+
+def test_failed_message_with_trailing_colon_is_preserved():
+    out = _map(
+        harness={"status": "failed", "error": {"code": "sidecar_start_failed", "message": "died: "}}
+    )
+    assert out.status == "Failed"
+    assert out.reason == "sidecar_start_failed: died: "

--- a/kagenti/backend/tests/test_simulation_trigger.py
+++ b/kagenti/backend/tests/test_simulation_trigger.py
@@ -22,7 +22,7 @@ async def test_trigger_posts_once_on_202():
         await sim._run_generation_trigger("team1", "petstore", {"openapi": "3.0.0"}, 8000)
     post.assert_awaited_once()
     args = post.await_args.args
-    assert args[0] == "http://petstore.team1.svc.cluster.local:8000"
+    assert args[0] == "http://petstore-mcp.team1.svc.cluster.local:8000"
     assert args[1] == {"openapi": "3.0.0"}
     assert args[2] == "petstore"
 

--- a/kagenti/backend/tests/test_simulation_trigger.py
+++ b/kagenti/backend/tests/test_simulation_trigger.py
@@ -1,0 +1,72 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the generation-trigger background task (issue #2162)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.routers import simulation as sim
+
+
+@pytest.mark.asyncio
+async def test_trigger_posts_once_on_202():
+    post = AsyncMock(return_value=202)
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {"openapi": "3.0.0"}, 8000)
+    post.assert_awaited_once()
+    args = post.await_args.args
+    assert args[0] == "http://petstore.team1.svc.cluster.local:8000"
+    assert args[1] == {"openapi": "3.0.0"}
+    assert args[2] == "petstore"
+
+
+@pytest.mark.asyncio
+async def test_trigger_treats_409_as_done():
+    post = AsyncMock(return_value=409)
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_retries_until_harness_accepts():
+    post = AsyncMock(side_effect=[sim.HarnessUnreachable("down"), 202])
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()) as sleep,
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    assert post.await_count == 2
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_gives_up_after_timeout():
+    post = AsyncMock(side_effect=sim.HarnessUnreachable("down"))
+    # monotonic: first read (start) = 0, subsequent reads jump past the deadline.
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()),
+        patch("app.routers.simulation.time.monotonic", side_effect=[0, 1000, 1000]),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    # It attempted at least once and then gave up rather than looping forever.
+    assert post.await_count >= 1

--- a/kagenti/backend/tests/test_simulation_trigger.py
+++ b/kagenti/backend/tests/test_simulation_trigger.py
@@ -68,5 +68,51 @@ async def test_trigger_gives_up_after_timeout():
         s.simulation_trigger_poll_interval = 5
         s.simulation_generation_timeout = 600
         await sim._run_generation_trigger("team1", "petstore", {}, 8000)
-    # It attempted at least once and then gave up rather than looping forever.
-    assert post.await_count >= 1
+    # Deadline (0 + 600) is already passed on the first check (monotonic -> 1000),
+    # so it posts exactly once, then gives up rather than looping.
+    assert post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_trigger_retries_transient_5xx_then_succeeds():
+    post = AsyncMock(side_effect=[503, 202])
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()) as sleep,
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    assert post.await_count == 2
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_terminal_4xx_does_not_retry():
+    post = AsyncMock(return_value=422)
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()) as sleep,
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    post.assert_awaited_once()
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_trigger_swallows_unexpected_exception():
+    # An unexpected error must not escape the fire-and-forget task.
+    post = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        # Should return normally, not raise.
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    post.assert_awaited_once()

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -21,6 +21,8 @@ export interface FeatureFlags {
   externalSkills: boolean;
   /** Trace-analysis Observability card */
   traceAnalysis: boolean;
+  /** Simulated MCP tools generated from an OpenAPI spec */
+  simulatedTools: boolean;
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -34,6 +36,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   admin: false,
   externalSkills: false,
   traceAnalysis: false,
+  simulatedTools: false,
 };
 
 let cachedFlags: FeatureFlags | null = null;
@@ -58,6 +61,7 @@ export function useFeatureFlags(): FeatureFlags {
           admin: data.admin === true,
           externalSkills: data.externalSkills === true,
           traceAnalysis: data.traceAnalysis === true,
+          simulatedTools: data.simulatedTools === true,
           };
         cachedFlags = validated;
         setFlags(validated);

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -76,6 +76,7 @@ const FLAG_LABELS: Record<DisplayedFlag, string> = {
   authbridgeAPI: 'AuthBridge API',
   externalSkills: 'External Skills',
   traceAnalysis: 'Trace Analysis',
+  simulatedTools: 'Simulated Tools',
 };
 
 const PlatformStatusCard: React.FC = () => {


### PR DESCRIPTION
## Summary

Part of epic #2151. Closes #2162.

Adds **generation orchestration, live status, and failure-state surfacing** for simulated MCP tools, building on the workload provisioning from #2161. Entirely gated behind `kagenti_feature_flag_simulated_tools` (off by default) — the `simulation` router is only imported/mounted when the flag is on.

After a simulated tool's workload is provisioned:

- A per-tool **in-memory `asyncio` trigger task** waits for the harness pod to accept connections, then `POST`s the OpenAPI spec once to `POST /api/v1/simulation` (retrying while the pod is starting or briefly returning 5xx, bounded by a timeout; a terminal 4xx ends it). No durable spec store — the spec stays in memory, consistent with #2161's design decision. The task runs fire-and-forget and never lets an exception escape.
- A new endpoint **`GET /api/v1/simulation/tools/{namespace}/{name}/generation-status`** (ROLE_VIEWER, modeled on `shipwright-build-info`) reads **live** state on every poll — harness `GET /api/v1/simulation` + pod inspection — and maps it to a stable UI contract `{status, reason, mcpUrl}`:
  - harness `pending`/`generating_skill`/`initializing` → **Generating**
  - harness `ready` (with `mcp_url`) → **Ready**
  - harness `failed` → **Failed** with `error.code: error.message`
  - pod `CrashLoopBackOff`/`ImagePullBackOff`/`CreateContainerConfigError` (e.g. missing `LLM_API_KEY`) → **Error** with the pod reason
- A **watchdog** derived from the StatefulSet's `creationTimestamp` turns a never-started generation into **Failed / `generation_stalled`** rather than hanging — satisfying the "no silent hang in any failure mode" acceptance criterion.

## Changes

- `app/services/simulation_harness_client.py` *(new)* — async `get_simulation` / `post_simulation` over the harness control plane.
- `app/services/kubernetes.py` — `get_workload_pod_status()` (first pod-level inspection helper; derives the Error state). *See detailed rationale for this change below.*
- `app/routers/simulation.py` — `GenerationStatusResponse` + pure `map_generation_status()`, the `generation-status` endpoint, the generation-trigger task, and spawn-on-create.
- `app/main.py` — cancel outstanding trigger tasks on lifespan shutdown (flag-guarded).
- `app/core/config.py` — additive settings: `simulation_generation_timeout` (600s), `simulation_harness_request_timeout` (10.0s), `simulation_trigger_poll_interval` (5s).
- 108 simulation unit tests pass; `ruff check` + `ruff format --check` clean.

### Why get_workload_pod_status() lives in services/kubernetes.py

This is the only change in the PR that touches a pre-existing shared file rather than the new simulation_* component code, so it's worth explaining the boundary call.

KubernetesService is the single owner of the Kubernetes API client. It centralizes client initialization
(in-cluster/kubeconfig auth), the ApiException handling convention, and — importantly — the _sanitize() log-injection
guard (CWE-117) applied to every namespace/selector before it hits a logger. If the simulation router called
core_api.list_namespaced_pod(...) directly, we'd be standing up a second, separately-configured API client inside a
feature module, duplicating auth setup and bypassing the sanitization barrier that already exists here. That's exactly the
kind of drift the service wrapper exists to prevent.

The method is deliberately generic, not simulation-specific. It takes a namespace + label_selector and returns {ready,
waiting_reason, waiting_message} for any workload's pods. It sits naturally beside the existing StatefulSet/Job operations
in this file and reuses their patterns. Nothing about kagenti.io/simulated, the harness, or generation state leaks into
it — a future feature could reuse it unchanged.

The simulation-specific logic stays in the component. The interpretation of this raw signal — mapping a waiting_reason
like ImagePullBackOff / CrashLoopBackOff / CreateContainerConfigError into a simulated tool's Error status (#2162) — lives entirely in the new simulation code. KubernetesService reports facts about pods; the component decides what they mean.

Net effect on the shared file: +40 lines, one new public method, zero changes to existing behavior. The alternative (a
private K8s client in the component) would have been more code, split the client ownership, and reintroduced a
sanitization gap. Keeping the generic query here and the domain mapping in the component is the correct split of
responsibilities.

## Stacking

Stacked on #2169 (#2161). Until the parents merge, this PR's diff includes the #2160/#2161 commits — the #2162 changes are commits `46be654a..HEAD`. Rebase onto `main` after #2169 merges.

## Out of scope (later epic issues)

Lifecycle start/stop/reset/delete (#2163), DB seed/edit (#2164), UI (#2165/#2166), worked example + E2E (#2167).

Blocked by #2171.

Assisted-By: Claude Code
