### PR TITLE
feat(ui): simulated-tool lifecycle controls + database seed/edit (#2166)

### DIFF
--- a/charts/kagenti/templates/ui.yaml
+++ b/charts/kagenti/templates/ui.yaml
@@ -484,8 +484,9 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "create"]
-  {{- if .Values.featureFlags.sandbox }}
-  # PersistentVolumeClaims for agent workspace storage (sandbox)
+  {{- if or .Values.featureFlags.sandbox .Values.featureFlags.simulatedTools }}
+  # PersistentVolumeClaims — sandbox agent workspace storage, and simulated-tool
+  # StatefulSet volumes that the delete path enumerates and tears down (#2151).
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "create", "patch", "delete"]

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -86,6 +86,10 @@ class Settings(BaseSettings):
     kagenti_feature_flag_simulated_tools: bool = False
     # Generic simulation-harness image serving all simulated tools (epic #2151)
     simulation_harness_image: str = "ghcr.io/kagenti/simulation-harness:latest"
+    # Pull secret for the harness image while it lives in a private registry (interim,
+    # epic #2151). References the Helm-created per-namespace `ghcr-secret`. Set empty
+    # to disable — once the image is public, anonymous pull works and this is unneeded.
+    simulation_image_pull_secret: str = "ghcr-secret"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -82,6 +82,8 @@ class Settings(BaseSettings):
     )
     kagenti_feature_flag_acp: bool = False  # ACP WebSocket protocol gateway
     kagenti_feature_flag_external_skills: bool = False  # External skill registry references
+    # Simulated MCP tools: LLM-driven, stateful tools generated from an OpenAPI spec
+    kagenti_feature_flag_simulated_tools: bool = False
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -94,6 +94,14 @@ class Settings(BaseSettings):
     # pulls :latest from the registry); set IfNotPresent/Never for local dev when
     # the image is side-loaded into the cluster (e.g. `kind load`).
     simulation_image_pull_policy: str = "Always"
+    # Generation orchestration (#2162): watchdog ceiling from StatefulSet
+    # creationTimestamp — covers image pull + pod start + the harness's own 120s
+    # creation budget. Also bounds the trigger task's post-retry window.
+    simulation_generation_timeout: int = 600
+    # httpx timeout (seconds) for harness control-plane calls.
+    simulation_harness_request_timeout: float = 10.0
+    # Seconds between trigger-task POST attempts while the harness is still starting.
+    simulation_trigger_poll_interval: int = 5
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -90,6 +90,10 @@ class Settings(BaseSettings):
     # epic #2151). References the Helm-created per-namespace `ghcr-secret`. Set empty
     # to disable — once the image is public, anonymous pull works and this is unneeded.
     simulation_image_pull_secret: str = "ghcr-secret"
+    # Image pull policy for the harness container. Defaults to Always (production
+    # pulls :latest from the registry); set IfNotPresent/Never for local dev when
+    # the image is side-loaded into the cluster (e.g. `kind load`).
+    simulation_image_pull_policy: str = "Always"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/config.py
+++ b/kagenti/backend/app/core/config.py
@@ -84,6 +84,8 @@ class Settings(BaseSettings):
     kagenti_feature_flag_external_skills: bool = False  # External skill registry references
     # Simulated MCP tools: LLM-driven, stateful tools generated from an OpenAPI spec
     kagenti_feature_flag_simulated_tools: bool = False
+    # Generic simulation-harness image serving all simulated tools (epic #2151)
+    simulation_harness_image: str = "ghcr.io/kagenti/simulation-harness:latest"
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     kagenti_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/kagenti/backend/app/core/constants.py
+++ b/kagenti/backend/app/core/constants.py
@@ -34,6 +34,11 @@ APP_KUBERNETES_IO_COMPONENT = "app.kubernetes.io/component"
 KAGENTI_SPIRE_LABEL = "kagenti.io/spire"
 KAGENTI_SPIRE_ENABLED_VALUE = "enabled"
 
+# Simulated MCP tools (epic #2151)
+KAGENTI_SIMULATED_LABEL = "kagenti.io/simulated"  # safety marker; UI badge; list filter
+KAGENTI_AUTOSCALING_ANNOTATION = "kagenti.io/autoscaling"  # HPA-off marker (declarative opt-out)
+SIMULATION_HARNESS_SKILLS_MOUNT = "/app/skills-store"  # HARNESS_SKILLS_FOLDER mount path
+
 # Per-sidecar opt-out labels (envoy-proxy / spiffe-helper /
 # client-registration) are gone after kagenti-extensions#411 — they
 # referenced separate sidecars that no longer exist. The master enable

--- a/kagenti/backend/app/main.py
+++ b/kagenti/backend/app/main.py
@@ -198,6 +198,10 @@ async def lifespan(app: FastAPI):
         except asyncio.CancelledError:
             pass
 
+    # Stop outstanding simulated-tool generation triggers
+    if _simulation_modules_loaded:
+        await simulation.cancel_generation_tasks()
+
     # Close OpenShell gateway gRPC channels
     if _acp_modules_loaded:
         try:

--- a/kagenti/backend/app/main.py
+++ b/kagenti/backend/app/main.py
@@ -127,6 +127,17 @@ if settings.kagenti_feature_flag_acp:
         logging.getLogger(__name__).warning(
             "ACP flag enabled but acp modules not installed — skipping"
         )
+
+_simulation_modules_loaded = False
+if settings.kagenti_feature_flag_simulated_tools:
+    try:
+        from app.routers import simulation  # noqa: E402
+
+        _simulation_modules_loaded = True
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "SIMULATED_TOOLS flag enabled but simulation modules not installed — skipping"
+        )
 # pylint: enable=wrong-import-position,no-name-in-module,import-error
 
 # Configure logging
@@ -268,6 +279,10 @@ if _skills_modules_loaded:
 if _acp_modules_loaded:
     app.include_router(acp.router, prefix="/api/v1")
     logger.info("Feature flag ACP enabled — ACP WebSocket routes registered")
+
+if _simulation_modules_loaded:
+    app.include_router(simulation.router, prefix="/api/v1")
+    logger.info("Feature flag SIMULATED_TOOLS enabled — simulation routes registered")
 # pylint: enable=used-before-assignment
 
 

--- a/kagenti/backend/app/models/responses.py
+++ b/kagenti/backend/app/models/responses.py
@@ -15,6 +15,7 @@ class ResourceLabels(BaseModel):
     protocol: Optional[List[str]] = None
     framework: Optional[str] = None
     type: Optional[str] = None
+    simulated: Optional[bool] = None  # True when the kagenti.io/simulated marker is set (#2165)
 
 
 class AgentSummary(BaseModel):

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -41,9 +41,7 @@ class FeatureFlagsResponse(BaseModel):
         description="Auto-inject MCP_URL and LLM env vars on agent import"
     )
     traceAnalysis: bool = Field(description="Trace-analysis Observability card")
-    simulatedTools: bool = Field(
-        description="Simulated MCP tools generated from an OpenAPI spec"
-    )
+    simulatedTools: bool = Field(description="Simulated MCP tools generated from an OpenAPI spec")
 
 
 class ComponentStatus(BaseModel):

--- a/kagenti/backend/app/routers/config.py
+++ b/kagenti/backend/app/routers/config.py
@@ -41,6 +41,9 @@ class FeatureFlagsResponse(BaseModel):
         description="Auto-inject MCP_URL and LLM env vars on agent import"
     )
     traceAnalysis: bool = Field(description="Trace-analysis Observability card")
+    simulatedTools: bool = Field(
+        description="Simulated MCP tools generated from an OpenAPI spec"
+    )
 
 
 class ComponentStatus(BaseModel):
@@ -93,6 +96,7 @@ async def get_feature_flags(
         admin=settings.kagenti_feature_flag_admin,
         agentImportDefaults=settings.kagenti_feature_flag_agent_import_defaults,
         traceAnalysis=settings.kagenti_feature_flag_trace_analysis,
+        simulatedTools=settings.kagenti_feature_flag_simulated_tools,
     )
 
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -58,8 +58,17 @@ _generation_tasks: set = set()
 
 
 def _harness_base_url(name: str, namespace: str, port: int) -> str:
-    """In-cluster URL of a simulated tool's harness Service ({name}-mcp)."""
-    return f"http://{name}{TOOL_SERVICE_SUFFIX}.{namespace}.svc.cluster.local:{port}"
+    """In-cluster URL of a simulated tool's harness Service ({name}-mcp).
+
+    Both identifiers are re-validated as DNS-1123 labels here so no untrusted
+    value can ever be interpolated into the request URL. This is the single
+    chokepoint that closes SSRF via the status endpoint's path parameters
+    (CWE-918); the create path's names are already valid, so this never rejects
+    a legitimate request.
+    """
+    safe_name = validate_custom_name(name)
+    safe_namespace = validate_namespace(namespace)
+    return f"http://{safe_name}{TOOL_SERVICE_SUFFIX}.{safe_namespace}.svc.cluster.local:{port}"
 
 
 async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
@@ -341,6 +350,16 @@ async def generation_status(
     StatefulSet's creationTimestamp turns a never-started generation into Failed
     rather than hanging (issue #2162).
     """
+    # Reject path parameters that cannot name a real tool before they reach any
+    # backend call (k8s API or the harness URL) — an invalid identifier is
+    # definitionally "not found" and must not be interpolated into a request
+    # target (SSRF guard, CWE-918).
+    try:
+        validate_namespace(namespace)
+        validate_custom_name(name)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Simulated tool not found")
+
     try:
         sts = kube.apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
     except ApiException as e:

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -628,7 +628,7 @@ async def delete_simulated_tool(
             if e.status != 404:
                 logger.warning(
                     "Failed to delete %s for '%s': %s",
-                    resource_label,
+                    sanitize_log(resource_label),
                     sanitize_log(name),
                     sanitize_log(str(e)),
                 )

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -10,7 +10,9 @@ simulated tool's workload (StatefulSet + per-tool PVC + Service). Generation
 orchestration, lifecycle, and database re-seed attach in later issues.
 """
 
+import asyncio
 import logging
+import time
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
@@ -27,6 +29,7 @@ from app.services.simulation_harness_client import (
     HarnessNotFound,
     HarnessUnreachable,
     get_simulation,
+    post_simulation,
 )
 from app.services.simulation_manifests import (
     EnvVar,
@@ -42,6 +45,59 @@ from app.services.simulation_manifests import (
 from app.utils.routes import sanitize_log
 
 logger = logging.getLogger(__name__)
+
+# Outstanding generation-trigger tasks, tracked so lifespan shutdown can cancel
+# them (mirrors main.py's reconciliation_task handling). Fire-and-forget per tool.
+_generation_tasks: set = set()
+
+
+async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
+    """Wait for the harness pod to accept connections, then POST the spec once.
+
+    The harness generates in the background after a 202; this task's only job is
+    to deliver the spec, retrying while the pod is still starting. Bounded by
+    ``simulation_generation_timeout`` so it never loops forever; a give-up is
+    later surfaced by the status endpoint's watchdog as Failed/generation_stalled.
+    """
+    base_url = f"http://{name}.{namespace}.svc.cluster.local:{port}"
+    deadline = time.monotonic() + settings.simulation_generation_timeout
+    interval = settings.simulation_trigger_poll_interval
+    while True:
+        try:
+            code = await post_simulation(base_url, spec, name)
+        except HarnessUnreachable:
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Gave up posting spec to harness for '%s' (unreachable past timeout)",
+                    sanitize_log(name),
+                )
+                return
+            await asyncio.sleep(interval)
+            continue
+        if code in (202, 409):
+            logger.info(
+                "Generation triggered for simulated tool '%s' (HTTP %d)",
+                sanitize_log(name),
+                code,
+            )
+        else:
+            logger.warning(
+                "Harness rejected spec for simulated tool '%s' (HTTP %d)",
+                sanitize_log(name),
+                code,
+            )
+        return
+
+
+async def cancel_generation_tasks() -> None:
+    """Cancel any outstanding generation-trigger tasks (called on shutdown)."""
+    for task in list(_generation_tasks):
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
 
 router = APIRouter(prefix="/simulation", tags=["simulation"])
 
@@ -218,6 +274,9 @@ async def create_simulated_tool(
         sanitize_log(name),
         sanitize_log(request.namespace),
     )
+    trigger = asyncio.create_task(_run_generation_trigger(request.namespace, name, spec, port))
+    _generation_tasks.add(trigger)
+    trigger.add_done_callback(_generation_tasks.discard)
     return SimulationCreateResponse(
         success=True,
         name=name,

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -14,6 +14,7 @@ Lifecycle and database re-seed attach in later issues.
 
 import asyncio
 import logging
+import re
 import time
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
@@ -38,6 +39,7 @@ from app.services.simulation_harness_client import (
     post_simulation,
 )
 from app.services.simulation_manifests import (
+    MAX_SIMULATION_NAME_LEN,
     EnvVar,
     build_simulation_env_vars,
     build_simulation_service,
@@ -57,6 +59,14 @@ logger = logging.getLogger(__name__)
 _generation_tasks: set = set()
 
 
+# Full-string DNS-1123 label matcher, kept local so the sanitizing guard below
+# lives in the same frame as the URL sink. CodeQL recognizes an re.fullmatch
+# guard as an SSRF barrier only when it directly gates the tainted value at the
+# point of interpolation; the cross-frame boolean helpers in simulation_manifests
+# validate identically but are not seen through by the taint tracker.
+_DNS1123_LABEL_RE = re.compile(r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?")
+
+
 def _harness_base_url(name: str, namespace: str, port: int) -> str:
     """In-cluster URL of a simulated tool's harness Service ({name}-mcp).
 
@@ -66,9 +76,11 @@ def _harness_base_url(name: str, namespace: str, port: int) -> str:
     (CWE-918); the create path's names are already valid, so this never rejects
     a legitimate request.
     """
-    safe_name = validate_custom_name(name)
-    safe_namespace = validate_namespace(namespace)
-    return f"http://{safe_name}{TOOL_SERVICE_SUFFIX}.{safe_namespace}.svc.cluster.local:{port}"
+    if not (_DNS1123_LABEL_RE.fullmatch(name) and len(name) <= MAX_SIMULATION_NAME_LEN):
+        raise ValueError("name must be a DNS-1123 label")
+    if not _DNS1123_LABEL_RE.fullmatch(namespace):
+        raise ValueError("namespace must be a DNS-1123 label")
+    return f"http://{name}{TOOL_SERVICE_SUFFIX}.{namespace}.svc.cluster.local:{port}"
 
 
 async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
@@ -379,7 +391,10 @@ async def generation_status(
     created = sts.metadata.creation_timestamp
     elapsed = (datetime.now(timezone.utc) - created).total_seconds() if created else 0.0
 
-    base_url = _harness_base_url(name, namespace, DEFAULT_IN_CLUSTER_PORT)
+    # Build the harness URL from the StatefulSet's server-returned identity, not
+    # the raw path parameters: these come from the k8s API (not a remote-flow
+    # source) and name a resource we just confirmed exists (extra SSRF defense).
+    base_url = _harness_base_url(sts.metadata.name, sts.metadata.namespace, DEFAULT_IN_CLUSTER_PORT)
     harness = None
     try:
         harness = await get_simulation(base_url)

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -1,0 +1,33 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Simulated MCP tools API endpoints.
+
+Scaffold for the simulated-tools feature (epic #2151). This router is only
+mounted when ``kagenti_feature_flag_simulated_tools`` is enabled (see
+``app/main.py``). Real endpoints — workload provisioning, generation
+orchestration, lifecycle, and database re-seed — attach in later issues. For
+now a single health/no-op endpoint proves the flag-gated wiring.
+"""
+
+import logging
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/simulation", tags=["simulation"])
+
+
+class SimulationHealthResponse(BaseModel):
+    """Health response confirming the simulation router is mounted."""
+
+    status: str
+
+
+@router.get("/health", response_model=SimulationHealthResponse)
+async def simulation_health() -> SimulationHealthResponse:
+    """Return OK when the flag-gated simulation router is mounted."""
+    return SimulationHealthResponse(status="ok")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -15,7 +15,7 @@ from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from kubernetes.client import ApiException
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from app.core.auth import ROLE_OPERATOR, require_roles
 from app.core.config import settings
@@ -27,7 +27,10 @@ from app.services.simulation_manifests import (
     build_simulation_service,
     build_simulation_statefulset,
     derive_simulation_name,
+    validate_custom_name,
+    validate_namespace,
     validate_openapi_spec,
+    validate_storage_size,
 )
 from app.utils.routes import sanitize_log
 
@@ -53,6 +56,21 @@ class SimulationCreateRequest(BaseModel):
     spireEnabled: bool = False
     authBridgeEnabled: bool = False
     authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
+
+    @field_validator("namespace")
+    @classmethod
+    def _check_namespace(cls, v: str) -> str:
+        return validate_namespace(v)
+
+    @field_validator("storageSize")
+    @classmethod
+    def _check_storage_size(cls, v: str) -> str:
+        return validate_storage_size(v)
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: Optional[str]) -> Optional[str]:
+        return v if v is None else validate_custom_name(v)
 
 
 class SimulationCreateResponse(BaseModel):

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -589,3 +589,58 @@ async def reset_simulated_tool(
         )
     logger.warning("Unexpected harness reset status %d for '%s'", code, sanitize_log(name))
     raise HTTPException(status_code=502, detail="Failed to reset simulated-tool session")
+
+
+@router.delete(
+    "/tools/{namespace}/{name}",
+    response_model=SimulationDeleteResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def delete_simulated_tool(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationDeleteResponse:
+    """Delete a simulated tool: StatefulSet + Service + PVC(s), no leaked resources."""
+    _validate_path_params(namespace, name)
+    _read_simulated_statefulset(kube, namespace, name)
+
+    # Capture PVC names before deleting the StatefulSet (needs its templates).
+    pvc_names = kube.list_statefulset_pvcs(namespace, name)
+    deleted: List[str] = []
+
+    def _try(delete_call, resource_label: str) -> None:
+        try:
+            delete_call()
+            deleted.append(resource_label)
+        except ApiException as e:
+            if e.status != 404:
+                logger.warning(
+                    "Failed to delete %s for '%s': %s",
+                    resource_label,
+                    sanitize_log(name),
+                    sanitize_log(str(e)),
+                )
+
+    _try(lambda: kube.delete_statefulset(namespace, name), f"StatefulSet/{name}")
+    service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
+    _try(lambda: kube.delete_service(namespace, service_name), f"Service/{service_name}")
+    for pvc in pvc_names:
+        _try(
+            lambda pvc=pvc: kube.delete_persistent_volume_claim(namespace, pvc),
+            f"PersistentVolumeClaim/{pvc}",
+        )
+
+    logger.info(
+        "Deleted simulated tool '%s' in '%s' (%d resources)",
+        sanitize_log(name),
+        sanitize_log(namespace),
+        len(deleted),
+    )
+    return SimulationDeleteResponse(
+        success=True,
+        name=name,
+        namespace=namespace,
+        deletedResources=deleted,
+        message=f"Simulated tool '{name}' deleted.",
+    )

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -23,7 +23,11 @@ from pydantic import BaseModel, field_validator
 
 from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.core.config import settings
-from app.core.constants import APP_KUBERNETES_IO_NAME, DEFAULT_IN_CLUSTER_PORT
+from app.core.constants import (
+    APP_KUBERNETES_IO_NAME,
+    DEFAULT_IN_CLUSTER_PORT,
+    TOOL_SERVICE_SUFFIX,
+)
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
 from app.services.simulation_harness_client import (
     HarnessNotFound,
@@ -51,6 +55,11 @@ logger = logging.getLogger(__name__)
 _generation_tasks: set = set()
 
 
+def _harness_base_url(name: str, namespace: str, port: int) -> str:
+    """In-cluster URL of a simulated tool's harness Service ({name}-mcp)."""
+    return f"http://{name}{TOOL_SERVICE_SUFFIX}.{namespace}.svc.cluster.local:{port}"
+
+
 async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
     """Wait for the harness pod to accept connections, then POST the spec once.
 
@@ -59,7 +68,7 @@ async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: i
     ``simulation_generation_timeout`` so it never loops forever; a give-up is
     later surfaced by the status endpoint's watchdog as Failed/generation_stalled.
     """
-    base_url = f"http://{name}.{namespace}.svc.cluster.local:{port}"
+    base_url = _harness_base_url(name, namespace, port)
     deadline = time.monotonic() + settings.simulation_generation_timeout
     interval = settings.simulation_trigger_poll_interval
     while True:
@@ -322,7 +331,7 @@ async def generation_status(
     created = sts.metadata.creation_timestamp
     elapsed = (datetime.now(timezone.utc) - created).total_seconds() if created else 0.0
 
-    base_url = f"http://{name}.{namespace}.svc.cluster.local:{DEFAULT_IN_CLUSTER_PORT}"
+    base_url = _harness_base_url(name, namespace, DEFAULT_IN_CLUSTER_PORT)
     harness = None
     try:
         harness = await get_simulation(base_url)

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -11,16 +11,23 @@ orchestration, lifecycle, and database re-seed attach in later issues.
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from kubernetes.client import ApiException
 from pydantic import BaseModel, field_validator
 
-from app.core.auth import ROLE_OPERATOR, require_roles
+from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.core.config import settings
-from app.core.constants import DEFAULT_IN_CLUSTER_PORT
+from app.core.constants import APP_KUBERNETES_IO_NAME, DEFAULT_IN_CLUSTER_PORT
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.services.simulation_harness_client import (
+    HarnessNotFound,
+    HarnessUnreachable,
+    get_simulation,
+)
 from app.services.simulation_manifests import (
     EnvVar,
     build_simulation_env_vars,
@@ -217,4 +224,61 @@ async def create_simulated_tool(
         namespace=request.namespace,
         status="Generating",
         message=f"Simulated tool '{name}' provisioning started.",
+    )
+
+
+@router.get(
+    "/tools/{namespace}/{name}/generation-status",
+    response_model=GenerationStatusResponse,
+    dependencies=[Depends(require_roles(ROLE_VIEWER))],
+)
+async def generation_status(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> GenerationStatusResponse:
+    """Return the live, UI-pollable generation status of a simulated tool.
+
+    Reads harness `GET /api/v1/simulation` plus pod state on every call and maps
+    to Generating / Ready / Failed / Error. A watchdog derived from the
+    StatefulSet's creationTimestamp turns a never-started generation into Failed
+    rather than hanging (issue #2162).
+    """
+    try:
+        sts = kube.apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
+    except ApiException as e:
+        if e.status == 404:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Simulated tool '{name}' not found in namespace '{namespace}'",
+            )
+        logger.error(
+            "Failed to read simulated tool '%s' in '%s': %s",
+            sanitize_log(name),
+            sanitize_log(namespace),
+            sanitize_log(str(e)),
+        )
+        raise HTTPException(status_code=502, detail="Failed to read simulated-tool workload")
+
+    created = sts.metadata.creation_timestamp
+    elapsed = (datetime.now(timezone.utc) - created).total_seconds() if created else 0.0
+
+    base_url = f"http://{name}.{namespace}.svc.cluster.local:{DEFAULT_IN_CLUSTER_PORT}"
+    harness = None
+    try:
+        harness = await get_simulation(base_url)
+    except HarnessNotFound:
+        harness = None
+    except (HarnessUnreachable, httpx.HTTPError) as e:
+        logger.debug("Harness read failed for '%s': %s", sanitize_log(name), sanitize_log(str(e)))
+        harness = None
+
+    pod = kube.get_workload_pod_status(namespace, f"{APP_KUBERNETES_IO_NAME}={name}")
+    return map_generation_status(
+        harness=harness,
+        pod_ready=pod["ready"],
+        pod_waiting_reason=pod["waiting_reason"],
+        pod_waiting_message=pod["waiting_message"],
+        elapsed_seconds=elapsed,
+        timeout_seconds=settings.simulation_generation_timeout,
     )

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -605,8 +605,19 @@ async def delete_simulated_tool(
     _validate_path_params(namespace, name)
     _read_simulated_statefulset(kube, namespace, name)
 
-    # Capture PVC names before deleting the StatefulSet (needs its templates).
-    pvc_names = kube.list_statefulset_pvcs(namespace, name)
+    # Enumerate the tool's PVCs before deleting the StatefulSet (its
+    # volumeClaimTemplates are needed to find them). Fail cleanly if we cannot
+    # enumerate, rather than deleting the workload and leaking the volume.
+    try:
+        pvc_names = kube.list_statefulset_pvcs(namespace, name)
+    except ApiException as e:
+        logger.error(
+            "Failed to list PVCs for simulated tool '%s' in '%s': %s",
+            sanitize_log(name),
+            sanitize_log(namespace),
+            sanitize_log(str(e)),
+        )
+        raise HTTPException(status_code=502, detail="Failed to enumerate simulated-tool volumes")
     deleted: List[str] = []
 
     def _try(delete_call, resource_label: str) -> None:

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -83,6 +83,65 @@ class SimulationCreateResponse(BaseModel):
     message: str
 
 
+class GenerationStatusResponse(BaseModel):
+    """UI-pollable generation status for a simulated tool (issue #2162)."""
+
+    status: str  # Generating | Ready | Failed | Error
+    reason: Optional[str] = None
+    mcpUrl: Optional[str] = None
+
+
+# Container waiting reasons that indicate a runtime/pod-level Error (not a
+# harness generation failure): missing LLM secret, bad image, crash loop.
+POD_ERROR_REASONS = {
+    "CrashLoopBackOff",
+    "ImagePullBackOff",
+    "ErrImagePull",
+    "CreateContainerConfigError",
+}
+
+
+def map_generation_status(
+    harness: Optional[dict],
+    pod_ready: bool,
+    pod_waiting_reason: Optional[str],
+    pod_waiting_message: Optional[str],
+    elapsed_seconds: float,
+    timeout_seconds: int,
+) -> GenerationStatusResponse:
+    """Map live harness + pod state to a stable UI phase.
+
+    `harness` is the parsed GET /api/v1/simulation body, or None when the harness
+    is unreachable or reports 404 (no simulation active yet). Pure — the caller
+    supplies elapsed time so this is fully unit-testable.
+    """
+    if harness is not None:
+        status = harness.get("status")
+        if status == "ready":
+            return GenerationStatusResponse(
+                status="Ready", reason=None, mcpUrl=harness.get("mcp_url")
+            )
+        if status == "failed":
+            err = harness.get("error") or {}
+            code = err.get("code") or "unknown"
+            message = err.get("message") or ""
+            reason = f"{code}: {message}".rstrip(": ") if message else code
+            return GenerationStatusResponse(status="Failed", reason=reason, mcpUrl=None)
+        # pending / generating_skill / initializing / generated
+        return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)
+
+    # Harness unreachable or no simulation yet — distinguish "still starting"
+    # from "crash-looping" via pod state, and cap the wait with the watchdog.
+    if pod_waiting_reason in POD_ERROR_REASONS:
+        reason = pod_waiting_reason
+        if pod_waiting_message:
+            reason = f"{pod_waiting_reason}: {pod_waiting_message}"
+        return GenerationStatusResponse(status="Error", reason=reason, mcpUrl=None)
+    if elapsed_seconds > timeout_seconds:
+        return GenerationStatusResponse(status="Failed", reason="generation_stalled", mcpUrl=None)
+    return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)
+
+
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -30,4 +30,5 @@ class SimulationHealthResponse(BaseModel):
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""
+    logger.debug("simulation router health check")
     return SimulationHealthResponse(status="ok")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -125,7 +125,7 @@ def map_generation_status(
             err = harness.get("error") or {}
             code = err.get("code") or "unknown"
             message = err.get("message") or ""
-            reason = f"{code}: {message}".rstrip(": ") if message else code
+            reason = f"{code}: {message}" if message else code
             return GenerationStatusResponse(status="Failed", reason=reason, mcpUrl=None)
         # pending / generating_skill / initializing / generated
         return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -6,8 +6,10 @@ Simulated MCP tools API endpoints (epic #2151).
 
 Mounted only when ``kagenti_feature_flag_simulated_tools`` is enabled
 (see ``app/main.py``). This module owns the create path that provisions a
-simulated tool's workload (StatefulSet + per-tool PVC + Service). Generation
-orchestration, lifecycle, and database re-seed attach in later issues.
+simulated tool's workload (StatefulSet + per-tool PVC + Service), the
+generation-trigger task that posts the spec to the harness, and the
+generation-status endpoint that surfaces Generating/Ready/Failed/Error.
+Lifecycle and database re-seed attach in later issues.
 """
 
 import asyncio
@@ -64,38 +66,66 @@ async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: i
     """Wait for the harness pod to accept connections, then POST the spec once.
 
     The harness generates in the background after a 202; this task's only job is
-    to deliver the spec, retrying while the pod is still starting. Bounded by
-    ``simulation_generation_timeout`` so it never loops forever; a give-up is
-    later surfaced by the status endpoint's watchdog as Failed/generation_stalled.
+    to deliver the spec, retrying while the pod is still starting (connection
+    failures) or briefly warming up (5xx). A 202/409 is terminal success; any
+    other 4xx is a terminal rejection. Bounded by ``simulation_generation_timeout``
+    so it never loops forever; a give-up is later surfaced by the status
+    endpoint's watchdog as Failed/generation_stalled.
+
+    Runs fire-and-forget via ``asyncio.create_task``, so it must never let an
+    exception escape (an unretrieved task exception would only surface as log
+    noise); any unexpected error is logged and ends the task.
     """
     base_url = _harness_base_url(name, namespace, port)
     deadline = time.monotonic() + settings.simulation_generation_timeout
     interval = settings.simulation_trigger_poll_interval
-    while True:
-        try:
-            code = await post_simulation(base_url, spec, name)
-        except HarnessUnreachable:
-            if time.monotonic() >= deadline:
-                logger.warning(
-                    "Gave up posting spec to harness for '%s' (unreachable past timeout)",
+    try:
+        while True:
+            try:
+                code = await post_simulation(base_url, spec, name)
+            except HarnessUnreachable:
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Gave up posting spec to harness for '%s' (unreachable past timeout)",
+                        sanitize_log(name),
+                    )
+                    return
+                await asyncio.sleep(interval)
+                continue
+            if code in (202, 409):
+                logger.info(
+                    "Generation triggered for simulated tool '%s' (HTTP %d)",
                     sanitize_log(name),
+                    code,
                 )
                 return
-            await asyncio.sleep(interval)
-            continue
-        if code in (202, 409):
-            logger.info(
-                "Generation triggered for simulated tool '%s' (HTTP %d)",
-                sanitize_log(name),
-                code,
-            )
-        else:
+            if code >= 500:
+                # Transient server error while the harness warms up — retry until
+                # the deadline rather than giving up on the first hiccup.
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Gave up posting spec to harness for '%s' (HTTP %d past timeout)",
+                        sanitize_log(name),
+                        code,
+                    )
+                    return
+                await asyncio.sleep(interval)
+                continue
+            # Terminal 4xx rejection (e.g. 413 too large, 422 invalid spec).
             logger.warning(
                 "Harness rejected spec for simulated tool '%s' (HTTP %d)",
                 sanitize_log(name),
                 code,
             )
-        return
+            return
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning(
+            "Unexpected error in generation trigger for simulated tool '%s'",
+            sanitize_log(name),
+            exc_info=True,
+        )
 
 
 async def cancel_generation_tasks() -> None:
@@ -175,7 +205,6 @@ POD_ERROR_REASONS = {
 
 def map_generation_status(
     harness: Optional[dict],
-    pod_ready: bool,
     pod_waiting_reason: Optional[str],
     pod_waiting_message: Optional[str],
     elapsed_seconds: float,
@@ -336,15 +365,23 @@ async def generation_status(
     try:
         harness = await get_simulation(base_url)
     except HarnessNotFound:
+        # No simulation active yet — routine before the spec is posted.
         harness = None
-    except (HarnessUnreachable, httpx.HTTPError) as e:
-        logger.debug("Harness read failed for '%s': %s", sanitize_log(name), sanitize_log(str(e)))
+    except HarnessUnreachable as e:
+        # Routine while the harness pod is still starting; maps to Generating.
+        logger.debug(
+            "Harness not reachable yet for '%s': %s", sanitize_log(name), sanitize_log(str(e))
+        )
+        harness = None
+    except httpx.HTTPError as e:
+        # An unexpected harness HTTP failure (e.g. 5xx) — degrade to pod state
+        # rather than 500, but surface it: this is not the routine not-started case.
+        logger.warning("Harness read error for '%s': %s", sanitize_log(name), sanitize_log(str(e)))
         harness = None
 
     pod = kube.get_workload_pod_status(namespace, f"{APP_KUBERNETES_IO_NAME}={name}")
     return map_generation_status(
         harness=harness,
-        pod_ready=pod["ready"],
         pod_waiting_reason=pod["waiting_reason"],
         pod_waiting_message=pod["waiting_message"],
         elapsed_seconds=elapsed,

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -550,3 +550,42 @@ async def start_simulated_tool(
 ) -> SimulationLifecycleResponse:
     """Scale a simulated tool's StatefulSet back to 1 (harness autostarts from bundle)."""
     return _scale_simulated_tool(kube, namespace, name, replicas=1, status_label="Starting")
+
+
+@router.post(
+    "/tools/{namespace}/{name}/reset",
+    response_model=SimulationResetResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def reset_simulated_tool(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationResetResponse:
+    """Reset a simulated tool's session (fresh session, same bundle; no teardown)."""
+    _validate_path_params(namespace, name)
+    sts = _read_simulated_statefulset(kube, namespace, name)
+    base_url = _harness_base_url(sts.metadata.name, sts.metadata.namespace, DEFAULT_IN_CLUSTER_PORT)
+    try:
+        code = await reset_simulation(base_url)
+    except HarnessUnreachable as e:
+        logger.warning(
+            "Harness unreachable resetting '%s': %s", sanitize_log(name), sanitize_log(str(e))
+        )
+        raise HTTPException(
+            status_code=502, detail="Simulated tool is not reachable (it may be stopped)"
+        )
+    if code == 200:
+        return SimulationResetResponse(
+            success=True,
+            name=name,
+            namespace=namespace,
+            message=f"Simulated tool '{name}' session reset.",
+        )
+    if code in (404, 503):
+        raise HTTPException(
+            status_code=409,
+            detail="Simulated tool has no active, ready simulation to reset",
+        )
+    logger.warning("Unexpected harness reset status %d for '%s'", code, sanitize_log(name))
+    raise HTTPException(status_code=502, detail="Failed to reset simulated-tool session")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -127,6 +127,7 @@ async def create_simulated_tool(
         auth_bridge_enabled=request.authBridgeEnabled,
         auth_bridge_mode=request.authBridgeMode,
         image_pull_secret=settings.simulation_image_pull_secret or None,
+        image_pull_policy=settings.simulation_image_pull_policy,
     )
     service = build_simulation_service(name, request.namespace, port=port)
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -13,6 +13,7 @@ Lifecycle and database re-seed attach in later issues.
 """
 
 import asyncio
+import json
 import logging
 import re
 import time
@@ -38,6 +39,7 @@ from app.services.simulation_harness_client import (
     HarnessUnreachable,
     get_simulation,
     post_simulation,
+    put_database,
     reset_simulation,
 )
 from app.services.simulation_manifests import (
@@ -242,6 +244,21 @@ class SimulationDeleteResponse(BaseModel):
     name: str
     namespace: str
     deletedResources: List[str]
+    message: str
+
+
+class SimulationDatabaseRequest(BaseModel):
+    """Request to re-seed a simulated tool's database with a user dataset."""
+
+    database: str  # raw JSON text of the new db.json
+
+
+class SimulationDatabaseResponse(BaseModel):
+    """Response after a successful database re-seed."""
+
+    success: bool
+    name: str
+    namespace: str
     message: str
 
 
@@ -655,3 +672,70 @@ async def delete_simulated_tool(
         deletedResources=deleted,
         message=f"Simulated tool '{name}' deleted.",
     )
+
+
+@router.put(
+    "/tools/{namespace}/{name}/database",
+    response_model=SimulationDatabaseResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def reseed_simulated_tool_database(
+    namespace: str,
+    name: str,
+    request: SimulationDatabaseRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationDatabaseResponse:
+    """Re-seed a simulated tool's database with a user-provided dataset.
+
+    Parses the dataset (422 on malformed / non-object JSON, before any backend
+    call), guards that the tool is a simulated StatefulSet, then forwards to the
+    harness PUT /api/v1/simulation/database. The harness validates against the
+    skill's schema.json, atomically overwrites db.json on the PVC, and resets the
+    session; the re-seed therefore persists across restart via the same volume.
+    """
+    _validate_path_params(namespace, name)
+    try:
+        db = json.loads(request.database)
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(status_code=422, detail="database is not valid JSON")
+    if not isinstance(db, dict):
+        raise HTTPException(status_code=422, detail="database must be a JSON object")
+
+    sts = _read_simulated_statefulset(kube, namespace, name)
+    base_url = _harness_base_url(sts.metadata.name, sts.metadata.namespace, DEFAULT_IN_CLUSTER_PORT)
+    try:
+        code, body = await put_database(base_url, db)
+    except HarnessUnreachable as e:
+        logger.warning(
+            "Harness unreachable re-seeding '%s': %s", sanitize_log(name), sanitize_log(str(e))
+        )
+        raise HTTPException(
+            status_code=502, detail="Simulated tool is not reachable (it may be stopped)"
+        )
+
+    if code == 200:
+        return SimulationDatabaseResponse(
+            success=True,
+            name=name,
+            namespace=namespace,
+            message=f"Simulated tool '{name}' database re-seeded.",
+        )
+    if code == 422:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": body.get("detail")
+                or "Dataset does not validate against the tool schema",
+                "json_path": body.get("json_path"),
+            },
+        )
+    if code == 409:
+        raise HTTPException(
+            status_code=409, detail="Tool calls are in flight; retry the re-seed shortly"
+        )
+    if code in (404, 503):
+        raise HTTPException(
+            status_code=409, detail="Simulated tool has no active, ready simulation to re-seed"
+        )
+    logger.warning("Unexpected harness database status %d for '%s'", code, sanitize_log(name))
+    raise HTTPException(status_code=502, detail="Failed to re-seed simulated-tool database")

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -29,6 +29,7 @@ from app.services.simulation_manifests import (
     derive_simulation_name,
     validate_openapi_spec,
 )
+from app.utils.routes import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -119,10 +120,18 @@ async def create_simulated_tool(
                 status_code=409,
                 detail=f"Simulated tool '{name}' already exists in namespace '{request.namespace}'",
             )
-        logger.error("Failed to provision simulated tool '%s': %s", name, e)
+        logger.error(
+            "Failed to provision simulated tool '%s': %s",
+            sanitize_log(name),
+            sanitize_log(str(e)),
+        )
         raise HTTPException(status_code=502, detail="Failed to create simulated-tool resources")
 
-    logger.info("Provisioned simulated tool '%s' in namespace '%s'", name, request.namespace)
+    logger.info(
+        "Provisioned simulated tool '%s' in namespace '%s'",
+        sanitize_log(name),
+        sanitize_log(request.namespace),
+    )
     return SimulationCreateResponse(
         success=True,
         name=name,

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -2,19 +2,33 @@
 # Licensed under the Apache License, Version 2.0
 
 """
-Simulated MCP tools API endpoints.
+Simulated MCP tools API endpoints (epic #2151).
 
-Scaffold for the simulated-tools feature (epic #2151). This router is only
-mounted when ``kagenti_feature_flag_simulated_tools`` is enabled (see
-``app/main.py``). Real endpoints — workload provisioning, generation
-orchestration, lifecycle, and database re-seed — attach in later issues. For
-now a single health/no-op endpoint proves the flag-gated wiring.
+Mounted only when ``kagenti_feature_flag_simulated_tools`` is enabled
+(see ``app/main.py``). This module owns the create path that provisions a
+simulated tool's workload (StatefulSet + per-tool PVC + Service). Generation
+orchestration, lifecycle, and database re-seed attach in later issues.
 """
 
 import logging
+from typing import List, Literal, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from kubernetes.client import ApiException
 from pydantic import BaseModel
+
+from app.core.auth import ROLE_OPERATOR, require_roles
+from app.core.config import settings
+from app.core.constants import DEFAULT_IN_CLUSTER_PORT
+from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.services.simulation_manifests import (
+    EnvVar,
+    build_simulation_env_vars,
+    build_simulation_service,
+    build_simulation_statefulset,
+    derive_simulation_name,
+    validate_openapi_spec,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +41,92 @@ class SimulationHealthResponse(BaseModel):
     status: str
 
 
+class SimulationCreateRequest(BaseModel):
+    """Request to create a simulated tool from an OpenAPI spec."""
+
+    namespace: str
+    openapiSpec: str
+    name: Optional[str] = None
+    envVars: Optional[List[EnvVar]] = None
+    storageSize: str = "1Gi"
+    spireEnabled: bool = False
+    authBridgeEnabled: bool = False
+    authBridgeMode: Optional[Literal["proxy-sidecar", "envoy-sidecar", "lite", "waypoint"]] = None
+
+
+class SimulationCreateResponse(BaseModel):
+    """Response after starting a simulated-tool creation."""
+
+    success: bool
+    name: str
+    namespace: str
+    status: str
+    message: str
+
+
 @router.get("/health", response_model=SimulationHealthResponse)
 async def simulation_health() -> SimulationHealthResponse:
     """Return OK when the flag-gated simulation router is mounted."""
     logger.debug("simulation router health check")
     return SimulationHealthResponse(status="ok")
+
+
+@router.post(
+    "/tools",
+    status_code=202,
+    response_model=SimulationCreateResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def create_simulated_tool(
+    request: SimulationCreateRequest,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationCreateResponse:
+    """Provision a simulated tool's workload (StatefulSet + PVC + Service).
+
+    Validates the spec synchronously (422 on invalid, no workload created), then
+    creates the workload and returns 202 with a Generating status. Posting the
+    spec to the harness and polling generation status is handled in issue #2162.
+    """
+    try:
+        spec = validate_openapi_spec(request.openapiSpec)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    name = derive_simulation_name(spec, request.name)
+    port = DEFAULT_IN_CLUSTER_PORT
+
+    kube.ensure_service_account(namespace=request.namespace, name=name)
+    env_vars = build_simulation_env_vars(request.envVars, port=port)
+    statefulset = build_simulation_statefulset(
+        name=name,
+        namespace=request.namespace,
+        image=settings.simulation_harness_image,
+        env_vars=env_vars,
+        port=port,
+        storage_size=request.storageSize,
+        spire_enabled=request.spireEnabled,
+        auth_bridge_enabled=request.authBridgeEnabled,
+        auth_bridge_mode=request.authBridgeMode,
+    )
+    service = build_simulation_service(name, request.namespace, port=port)
+
+    try:
+        kube.create_statefulset(request.namespace, statefulset)
+        kube.create_service(request.namespace, service)
+    except ApiException as e:
+        if e.status == 409:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Simulated tool '{name}' already exists in namespace '{request.namespace}'",
+            )
+        logger.error("Failed to provision simulated tool '%s': %s", name, e)
+        raise HTTPException(status_code=502, detail="Failed to create simulated-tool resources")
+
+    logger.info("Provisioned simulated tool '%s' in namespace '%s'", name, request.namespace)
+    return SimulationCreateResponse(
+        success=True,
+        name=name,
+        namespace=request.namespace,
+        status="Generating",
+        message=f"Simulated tool '{name}' provisioning started.",
+    )

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -126,6 +126,7 @@ async def create_simulated_tool(
         spire_enabled=request.spireEnabled,
         auth_bridge_enabled=request.authBridgeEnabled,
         auth_bridge_mode=request.authBridgeMode,
+        image_pull_secret=settings.simulation_image_pull_secret or None,
     )
     service = build_simulation_service(name, request.namespace, port=port)
 

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -247,7 +247,13 @@ def map_generation_status(
             err = harness.get("error") or {}
             code = err.get("code") or "unknown"
             message = err.get("message") or ""
-            reason = f"{code}: {message}" if message else code
+            # The harness buries the underlying cause (e.g. a timed-out
+            # generation stage rewrapped as a generic RuntimeError) in
+            # error.details.cause_type. Fold it into the reason so the UI shows
+            # *why* it failed instead of just the coarse code.
+            cause_type = (err.get("details") or {}).get("cause_type")
+            label = f"{code} ({cause_type})" if cause_type else code
+            reason = f"{label}: {message}" if message else label
             return GenerationStatusResponse(status="Failed", reason=reason, mcpUrl=None)
         # pending / generating_skill / initializing / generated
         return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)

--- a/kagenti/backend/app/routers/simulation.py
+++ b/kagenti/backend/app/routers/simulation.py
@@ -29,6 +29,7 @@ from app.core.config import settings
 from app.core.constants import (
     APP_KUBERNETES_IO_NAME,
     DEFAULT_IN_CLUSTER_PORT,
+    KAGENTI_SIMULATED_LABEL,
     TOOL_SERVICE_SUFFIX,
 )
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
@@ -37,6 +38,7 @@ from app.services.simulation_harness_client import (
     HarnessUnreachable,
     get_simulation,
     post_simulation,
+    reset_simulation,
 )
 from app.services.simulation_manifests import (
     MAX_SIMULATION_NAME_LEN,
@@ -214,6 +216,35 @@ class GenerationStatusResponse(BaseModel):
     mcpUrl: Optional[str] = None
 
 
+class SimulationLifecycleResponse(BaseModel):
+    """Response after a start/stop action on a simulated tool."""
+
+    success: bool
+    name: str
+    namespace: str
+    status: str
+    message: str
+
+
+class SimulationResetResponse(BaseModel):
+    """Response after resetting a simulated tool's session."""
+
+    success: bool
+    name: str
+    namespace: str
+    message: str
+
+
+class SimulationDeleteResponse(BaseModel):
+    """Response after deleting a simulated tool and its backing resources."""
+
+    success: bool
+    name: str
+    namespace: str
+    deletedResources: List[str]
+    message: str
+
+
 # Container waiting reasons that indicate a runtime/pod-level Error (not a
 # harness generation failure): missing LLM secret, bad image, crash loop.
 POD_ERROR_REASONS = {
@@ -268,6 +299,46 @@ def map_generation_status(
     if elapsed_seconds > timeout_seconds:
         return GenerationStatusResponse(status="Failed", reason="generation_stalled", mcpUrl=None)
     return GenerationStatusResponse(status="Generating", reason=None, mcpUrl=None)
+
+
+def _read_simulated_statefulset(kube: KubernetesService, namespace: str, name: str):
+    """Read a simulated tool's StatefulSet, or raise HTTPException.
+
+    404 if the StatefulSet is absent or does not carry kagenti.io/simulated=true
+    (these lifecycle endpoints act only on simulated tools). 502 on any other
+    read failure.
+    """
+    try:
+        sts = kube.apps_api.read_namespaced_stateful_set(name=name, namespace=namespace)
+    except ApiException as e:
+        if e.status == 404:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Simulated tool '{name}' not found in namespace '{namespace}'",
+            )
+        logger.error(
+            "Failed to read simulated tool '%s' in '%s': %s",
+            sanitize_log(name),
+            sanitize_log(namespace),
+            sanitize_log(str(e)),
+        )
+        raise HTTPException(status_code=502, detail="Failed to read simulated-tool workload")
+    labels = sts.metadata.labels or {}
+    if labels.get(KAGENTI_SIMULATED_LABEL) != "true":
+        raise HTTPException(
+            status_code=404,
+            detail=f"Simulated tool '{name}' not found in namespace '{namespace}'",
+        )
+    return sts
+
+
+def _validate_path_params(namespace: str, name: str) -> None:
+    """Reject path params that cannot name a real tool (SSRF guard, CWE-918)."""
+    try:
+        validate_namespace(namespace)
+        validate_custom_name(name)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Simulated tool not found")
 
 
 @router.get("/health", response_model=SimulationHealthResponse)
@@ -427,3 +498,55 @@ async def generation_status(
         elapsed_seconds=elapsed,
         timeout_seconds=settings.simulation_generation_timeout,
     )
+
+
+def _scale_simulated_tool(
+    kube: KubernetesService, namespace: str, name: str, replicas: int, status_label: str
+) -> SimulationLifecycleResponse:
+    _validate_path_params(namespace, name)
+    _read_simulated_statefulset(kube, namespace, name)
+    try:
+        kube.patch_statefulset(namespace, name, {"spec": {"replicas": replicas}})
+    except ApiException as e:
+        logger.error(
+            "Failed to scale simulated tool '%s' to %d: %s",
+            sanitize_log(name),
+            replicas,
+            sanitize_log(str(e)),
+        )
+        raise HTTPException(status_code=502, detail="Failed to scale simulated-tool workload")
+    return SimulationLifecycleResponse(
+        success=True,
+        name=name,
+        namespace=namespace,
+        status=status_label,
+        message=f"Simulated tool '{name}' {status_label.lower()}.",
+    )
+
+
+@router.post(
+    "/tools/{namespace}/{name}/stop",
+    response_model=SimulationLifecycleResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def stop_simulated_tool(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationLifecycleResponse:
+    """Scale a simulated tool's StatefulSet to 0 (bundle retained on the PVC)."""
+    return _scale_simulated_tool(kube, namespace, name, replicas=0, status_label="Stopped")
+
+
+@router.post(
+    "/tools/{namespace}/{name}/start",
+    response_model=SimulationLifecycleResponse,
+    dependencies=[Depends(require_roles(ROLE_OPERATOR))],
+)
+async def start_simulated_tool(
+    namespace: str,
+    name: str,
+    kube: KubernetesService = Depends(get_kubernetes_service),
+) -> SimulationLifecycleResponse:
+    """Scale a simulated tool's StatefulSet back to 1 (harness autostarts from bundle)."""
+    return _scale_simulated_tool(kube, namespace, name, replicas=1, status_label="Starting")

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -36,6 +36,7 @@ from app.core.constants import (
     APP_KUBERNETES_IO_NAME,
     APP_KUBERNETES_IO_MANAGED_BY,
     KAGENTI_UI_CREATOR_LABEL,
+    KAGENTI_SIMULATED_LABEL,
     RESOURCE_TYPE_TOOL,
     VALUE_PROTOCOL_MCP,
     VALUE_TRANSPORT_STREAMABLE_HTTP,
@@ -590,6 +591,7 @@ def _extract_labels(labels: dict) -> ResourceLabels:
         protocol=protocols or None,
         framework=labels.get("kagenti.io/framework"),
         type=labels.get("kagenti.io/type"),
+        simulated=labels.get(KAGENTI_SIMULATED_LABEL) == "true",
     )
 
 

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -997,6 +997,13 @@ async def delete_tool(
         if e.status != 404:
             logger.warning(f"Failed to delete Deployment '{name}': {e}")
 
+    # Capture StatefulSet-owned PVCs before deleting the workload (generic:
+    # StatefulSet PVCs are never auto-deleted, so they leak without this).
+    try:
+        pvc_names = kube.list_statefulset_pvcs(namespace, name)
+    except ApiException:
+        pvc_names = []
+
     # Delete StatefulSet (if exists)
     try:
         kube.delete_statefulset(namespace, name)
@@ -1004,6 +1011,15 @@ async def delete_tool(
     except ApiException as e:
         if e.status != 404:
             logger.warning(f"Failed to delete StatefulSet '{name}': {e}")
+
+    # Delete PVCs the StatefulSet provisioned (404-tolerant, generic).
+    for pvc in pvc_names:
+        try:
+            kube.delete_persistent_volume_claim(namespace, pvc)
+            deleted_resources.append(f"PersistentVolumeClaim/{pvc}")
+        except ApiException as e:
+            if e.status != 404:
+                logger.warning(f"Failed to delete PVC '{pvc}': {e}")
 
     # Delete Service
     service_name = _get_tool_service_name(name)

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -942,7 +942,7 @@ async def delete_tool(
     Deletes in order:
     1. Shipwright BuildRuns (if any)
     2. Shipwright Build (if any)
-    3. Deployment or StatefulSet
+    3. Deployment or StatefulSet (and, for a StatefulSet, its PersistentVolumeClaims)
     4. Service
     5. HTTPRoute or OpenShift Route (whichever exists)
     6. AgentRuntime CR (if exists)

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -729,6 +729,8 @@ class KubernetesService:
         (e.g. CrashLoopBackOff, ImagePullBackOff, CreateContainerConfigError) — the
         signal used to derive a simulated tool's Error state (#2162).
         """
+        namespace = _sanitize(namespace)
+        label_selector = _sanitize(label_selector)
         try:
             pods = self.core_api.list_namespaced_pod(
                 namespace=namespace, label_selector=label_selector

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -734,7 +734,9 @@ class KubernetesService:
                 namespace=namespace, label_selector=label_selector
             ).items
         except ApiException as e:
-            logger.debug("Error listing pods in %s (%s): %s", namespace, label_selector, e)
+            # A real RBAC/connectivity failure here would otherwise silently
+            # look like "not ready" — surface it at warning level.
+            logger.warning("Error listing pods in %s (%s): %s", namespace, label_selector, e)
             return {"ready": False, "waiting_reason": None, "waiting_message": None}
 
         ready = False

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -887,6 +887,37 @@ class KubernetesService:
         """Delete a PersistentVolumeClaim by name."""
         self.core_api.delete_namespaced_persistent_volume_claim(name=name, namespace=namespace)
 
+    def list_statefulset_pvcs(self, namespace: str, name: str) -> List[str]:
+        """Names of PVCs provisioned by a StatefulSet's volumeClaimTemplates.
+
+        Generic: matches existing PVCs by the Kubernetes naming convention
+        `{template}-{sts}-{ordinal}`. Catches ordinals left behind by a prior
+        scale-down (StatefulSet PVCs are never auto-deleted). Returns [] if the
+        StatefulSet or its templates are absent.
+        """
+        try:
+            sts = self.get_statefulset(namespace, name)
+        except ApiException as e:
+            if e.status == 404:
+                return []
+            raise
+        templates = (sts.get("spec") or {}).get("volume_claim_templates") or []
+        template_names = [
+            (t.get("metadata") or {}).get("name")
+            for t in templates
+            if (t.get("metadata") or {}).get("name")
+        ]
+        if not template_names:
+            return []
+        matched: List[str] = []
+        for pvc in self.list_persistent_volume_claims(namespace):
+            for t in template_names:
+                prefix = f"{t}-{name}-"
+                if pvc.startswith(prefix) and pvc[len(prefix) :].isdigit():
+                    matched.append(pvc)
+                    break
+        return matched
+
 
 @lru_cache
 def get_kubernetes_service() -> KubernetesService:

--- a/kagenti/backend/app/services/kubernetes.py
+++ b/kagenti/backend/app/services/kubernetes.py
@@ -720,6 +720,42 @@ class KubernetesService:
             logger.error(f"Error patching StatefulSet {name} in {namespace}: {e}")
             raise
 
+    def get_workload_pod_status(self, namespace: str, label_selector: str) -> dict:
+        """Inspect pods matching a label selector for readiness and waiting state.
+
+        Returns {"ready": bool, "waiting_reason": str|None, "waiting_message": str|None}.
+        `ready` is True if any matching pod reports a Ready condition. The waiting
+        reason/message come from the first container found in a waiting state
+        (e.g. CrashLoopBackOff, ImagePullBackOff, CreateContainerConfigError) — the
+        signal used to derive a simulated tool's Error state (#2162).
+        """
+        try:
+            pods = self.core_api.list_namespaced_pod(
+                namespace=namespace, label_selector=label_selector
+            ).items
+        except ApiException as e:
+            logger.debug("Error listing pods in %s (%s): %s", namespace, label_selector, e)
+            return {"ready": False, "waiting_reason": None, "waiting_message": None}
+
+        ready = False
+        waiting_reason = None
+        waiting_message = None
+        for pod in pods:
+            conditions = (pod.status and pod.status.conditions) or []
+            if any(c.type == "Ready" and c.status == "True" for c in conditions):
+                ready = True
+            container_statuses = (pod.status and pod.status.container_statuses) or []
+            for cs in container_statuses:
+                waiting = cs.state and cs.state.waiting
+                if waiting and waiting.reason and waiting_reason is None:
+                    waiting_reason = waiting.reason
+                    waiting_message = waiting.message
+        return {
+            "ready": ready,
+            "waiting_reason": waiting_reason,
+            "waiting_message": waiting_message,
+        }
+
     # -------------------------------------------------------------------------
     # Job Operations
     # -------------------------------------------------------------------------

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -72,3 +72,17 @@ async def post_simulation(base_url: str, spec: dict, name: str) -> int:
             # the pod's startup window instead of giving up on the first hiccup.
             raise HarnessUnreachable(str(e)) from e
         return resp.status_code
+
+
+async def reset_simulation(base_url: str) -> int:
+    """POST the harness reset endpoint. Returns the HTTP status code.
+
+    200 = session reset; 404 = no active simulation; 503 = exists but not ready.
+    Raises HarnessUnreachable on connect/timeout.
+    """
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        try:
+            resp = await client.post(f"{base_url}/api/v1/simulation/reset")
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise HarnessUnreachable(str(e)) from e
+        return resp.status_code

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -1,0 +1,63 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Async HTTP client for the simulation harness control plane (issue #2162).
+
+Thin wrappers over the harness REST API at `/api/v1/simulation`. Each call
+creates its own short-lived `httpx.AsyncClient`, matching the in-cluster HTTP
+call pattern used elsewhere in the backend (e.g. skill_autosync, sidecar_manager).
+"""
+
+import logging
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class HarnessUnreachable(Exception):  # noqa: N818
+    """The harness could not be contacted (connect error or timeout)."""
+
+
+class HarnessNotFound(Exception):  # noqa: N818
+    """The harness is up but reports no active simulation (HTTP 404)."""
+
+
+def _timeout() -> float:
+    return settings.simulation_harness_request_timeout
+
+
+async def get_simulation(base_url: str) -> dict:
+    """GET the harness's active-simulation record.
+
+    Returns the parsed SimulationResponse dict. Raises HarnessNotFound on 404
+    (no simulation active yet) and HarnessUnreachable on connect/timeout.
+    """
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        try:
+            resp = await client.get(f"{base_url}/api/v1/simulation")
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise HarnessUnreachable(str(e)) from e
+        if resp.status_code == 404:
+            raise HarnessNotFound()
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def post_simulation(base_url: str, spec: dict, name: str) -> int:
+    """POST the OpenAPI spec to start generation. Returns the HTTP status code.
+
+    202 = accepted (generating in background); 409 = already active. Raises
+    HarnessUnreachable on connect/timeout.
+    """
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        try:
+            resp = await client.post(
+                f"{base_url}/api/v1/simulation",
+                json={"openapi_spec": spec, "name": name},
+            )
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise HarnessUnreachable(str(e)) from e
+        return resp.status_code

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -83,6 +83,6 @@ async def reset_simulation(base_url: str) -> int:
     async with httpx.AsyncClient(timeout=_timeout()) as client:
         try:
             resp = await client.post(f"{base_url}/api/v1/simulation/reset")
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except httpx.TransportError as e:
             raise HarnessUnreachable(str(e)) from e
         return resp.status_code

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -41,7 +41,7 @@ async def get_simulation(base_url: str) -> dict:
         except (httpx.ConnectError, httpx.TimeoutException) as e:
             raise HarnessUnreachable(str(e)) from e
         if resp.status_code == 404:
-            raise HarnessNotFound()
+            raise HarnessNotFound("harness reports no active simulation")
         resp.raise_for_status()
         return resp.json()
 

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class HarnessUnreachable(Exception):  # noqa: N818
-    """The harness could not be contacted (connect error or timeout)."""
+    """The harness could not be contacted (any transport-level error: connect,
+    read, write, timeout, or protocol — typically while the pod is starting)."""
 
 
 class HarnessNotFound(Exception):  # noqa: N818
@@ -38,7 +39,12 @@ async def get_simulation(base_url: str) -> dict:
     async with httpx.AsyncClient(timeout=_timeout()) as client:
         try:
             resp = await client.get(f"{base_url}/api/v1/simulation")
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except httpx.TransportError as e:
+            # Base class for connect/read/write/timeout/protocol errors. A
+            # starting harness often accepts the TCP connection then resets it
+            # mid-read (ReadError) before uvicorn is serving — treat every
+            # transport-level failure as "unreachable" so callers retry through
+            # the pod's startup window instead of giving up on the first hiccup.
             raise HarnessUnreachable(str(e)) from e
         if resp.status_code == 404:
             raise HarnessNotFound("harness reports no active simulation")
@@ -58,6 +64,11 @@ async def post_simulation(base_url: str, spec: dict, name: str) -> int:
                 f"{base_url}/api/v1/simulation",
                 json={"openapi_spec": spec, "name": name},
             )
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except httpx.TransportError as e:
+            # Base class for connect/read/write/timeout/protocol errors. A
+            # starting harness often accepts the TCP connection then resets it
+            # mid-read (ReadError) before uvicorn is serving — treat every
+            # transport-level failure as "unreachable" so callers retry through
+            # the pod's startup window instead of giving up on the first hiccup.
             raise HarnessUnreachable(str(e)) from e
         return resp.status_code

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -99,7 +99,7 @@ async def put_database(base_url: str, db: dict) -> tuple[int, dict]:
     async with httpx.AsyncClient(timeout=_timeout()) as client:
         try:
             resp = await client.put(f"{base_url}/api/v1/simulation/database", json=db)
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except httpx.TransportError as e:
             raise HarnessUnreachable(str(e)) from e
         try:
             body = resp.json()

--- a/kagenti/backend/app/services/simulation_harness_client.py
+++ b/kagenti/backend/app/services/simulation_harness_client.py
@@ -86,3 +86,25 @@ async def reset_simulation(base_url: str) -> int:
         except httpx.TransportError as e:
             raise HarnessUnreachable(str(e)) from e
         return resp.status_code
+
+
+async def put_database(base_url: str, db: dict) -> tuple[int, dict]:
+    """PUT a new db.json to the harness. Returns (status_code, parsed_body).
+
+    200 = replaced + session reset; 404 = no simulation; 409 = tool calls in
+    flight; 422 = body failed schema validation (body carries json_path);
+    503 = simulation exists but not ready. Raises HarnessUnreachable on
+    connect/timeout. Body is {} when the response has no JSON object.
+    """
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        try:
+            resp = await client.put(f"{base_url}/api/v1/simulation/database", json=db)
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise HarnessUnreachable(str(e)) from e
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {}
+        if not isinstance(body, dict):
+            body = {}
+        return resp.status_code, body

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -179,6 +179,7 @@ def build_simulation_statefulset(
     spire_enabled: bool = False,
     auth_bridge_enabled: bool = False,
     auth_bridge_mode: Optional[str] = None,
+    image_pull_secret: Optional[str] = None,
 ) -> dict:
     """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
@@ -215,7 +216,7 @@ def build_simulation_statefulset(
     if auth_bridge_mode:
         pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
 
-    return {
+    manifest = {
         "apiVersion": "apps/v1",
         "kind": "StatefulSet",
         "metadata": {
@@ -286,6 +287,9 @@ def build_simulation_statefulset(
             ],
         },
     }
+    if image_pull_secret:
+        manifest["spec"]["template"]["spec"]["imagePullSecrets"] = [{"name": image_pull_secret}]
+    return manifest
 
 
 def build_simulation_service(

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -238,3 +238,32 @@ def build_simulation_statefulset(
             ],
         },
     }
+
+
+def build_simulation_service(
+    name: str,
+    namespace: str,
+    *,
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+) -> dict:
+    """Build a ClusterIP Service manifest for a simulated tool ({name}-mcp)."""
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": f"{name}{TOOL_SERVICE_SUFFIX}",
+            "namespace": namespace,
+            "labels": {
+                _MCP_PROTOCOL_LABEL: "",
+                APP_KUBERNETES_IO_NAME: name,
+                APP_KUBERNETES_IO_MANAGED_BY: KAGENTI_UI_CREATOR_LABEL,
+                KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+                KAGENTI_SIMULATED_LABEL: "true",
+            },
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {APP_KUBERNETES_IO_NAME: name},
+            "ports": [{"name": "http", "port": port, "targetPort": port, "protocol": "TCP"}],
+        },
+    }

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -141,6 +141,10 @@ def build_simulation_env_vars(
     env_vars.append({"name": "HARNESS_SKILLS_FOLDER", "value": skills_folder})
     env_vars.append({"name": "HARNESS_SERVER_PORT", "value": str(port)})
     env_vars.append({"name": "HARNESS_SERVER_HOST", "value": "0.0.0.0"})
+    # Serve MCP over streamable-http to match the KAGENTI_TRANSPORT_LABEL the
+    # StatefulSet/pod advertise (and the MCP gateway/clients expect). Without
+    # this the harness falls back to its bundled SSE config default.
+    env_vars.append({"name": "HARNESS_MCP_TRANSPORT", "value": "streamable_http"})
 
     for ev in env_var_list or []:
         if ev.value is not None:
@@ -180,6 +184,7 @@ def build_simulation_statefulset(
     auth_bridge_enabled: bool = False,
     auth_bridge_mode: Optional[str] = None,
     image_pull_secret: Optional[str] = None,
+    image_pull_policy: str = "Always",
 ) -> dict:
     """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
@@ -236,12 +241,17 @@ def build_simulation_statefulset(
                     "securityContext": {
                         "runAsNonRoot": True,
                         "seccompProfile": {"type": "RuntimeDefault"},
+                        # Make the RWO PVC (mounted at skills_folder) group-writable
+                        # by the harness runtime UID. The image runs as uid 1000 and
+                        # its entrypoint no longer chowns when already non-root, so
+                        # without fsGroup the uid-1000 process cannot write the PVC.
+                        "fsGroup": 1000,
                     },
                     "containers": [
                         {
                             "name": "harness",
                             "image": image,
-                            "imagePullPolicy": "Always",
+                            "imagePullPolicy": image_pull_policy,
                             "securityContext": {
                                 "allowPrivilegeEscalation": False,
                                 "capabilities": {"drop": ["ALL"]},

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -220,11 +220,15 @@ def build_simulation_statefulset(
                             },
                             "volumeMounts": [
                                 {"name": "data", "mountPath": skills_folder},
+                                {"name": "cache", "mountPath": "/app/.cache"},
                                 {"name": "tmp", "mountPath": "/tmp"},
                             ],
                         }
                     ],
-                    "volumes": [{"name": "tmp", "emptyDir": {}}],
+                    "volumes": [
+                        {"name": "cache", "emptyDir": {}},
+                        {"name": "tmp", "emptyDir": {}},
+                    ],
                 },
             },
             "volumeClaimTemplates": [

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -267,3 +267,26 @@ def build_simulation_service(
             "ports": [{"name": "http", "port": port, "targetPort": port, "protocol": "TCP"}],
         },
     }
+
+
+def validate_openapi_spec(text: str) -> dict:
+    """Syntactic validation only: parse the spec as a JSON object.
+
+    The harness validates the OpenAPI schema itself; Kagenti only rejects a
+    syntactically invalid spec (non-JSON or not a JSON object) so no workload
+    is created for garbage input. Raises ValueError on failure.
+    """
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise ValueError(f"OpenAPI spec is not valid JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError("OpenAPI spec must be a JSON object")
+    return parsed
+
+
+def derive_simulation_name(spec: dict, requested: Optional[str]) -> str:
+    """Return a Kubernetes-safe name: requested if given, else slug of info.title."""
+    candidate = requested or (spec.get("info", {}) or {}).get("title", "") or ""
+    slug = re.sub(r"[^a-z0-9]+", "-", candidate.lower()).strip("-")[:63].rstrip("-")
+    return slug or "simulated-tool"

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -145,6 +145,13 @@ def build_simulation_env_vars(
     # StatefulSet/pod advertise (and the MCP gateway/clients expect). Without
     # this the harness falls back to its bundled SSE config default.
     env_vars.append({"name": "HARNESS_MCP_TRANSPORT", "value": "streamable_http"})
+    # The harness defaults startup.autostart_enabled=false (boots idle, ignores
+    # the skill baked on the PVC). Kagenti bakes exactly one skill per StatefulSet
+    # and relies on the harness resuming it on every (re)start — Stop->Start
+    # (scale 0->1) and involuntary pod restarts both depend on boot-time
+    # autostart. Opt back in; autostart_simulation is left unset so the harness's
+    # "1 complete skill -> start it, 0 -> idle" discovery stays graceful.
+    env_vars.append({"name": "HARNESS_AUTOSTART_ENABLED", "value": "true"})
 
     for ev in env_var_list or []:
         if ev.value is not None:

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -43,6 +43,50 @@ from app.core.constants import (
 
 _MCP_PROTOCOL_LABEL = f"{PROTOCOL_LABEL_PREFIX}{VALUE_PROTOCOL_MCP}"
 
+# DNS-1123 label: lowercase alphanumeric and '-', must start and end alphanumeric.
+_DNS1123_LABEL_RE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+# A simulated tool's Service is named "{name}-mcp" and must itself be a valid
+# DNS-1123 label (<=63), so the tool name is capped to leave room for the suffix.
+MAX_SIMULATION_NAME_LEN = 63 - len(TOOL_SERVICE_SUFFIX)
+# Kubernetes resource quantity, e.g. "1Gi", "500Mi", "2G".
+_QUANTITY_RE = re.compile(r"^[1-9][0-9]*(\.[0-9]+)?(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|k)?$")
+
+
+def _is_dns1123_label(value: str) -> bool:
+    """Return True if value is a valid DNS-1123 label (<=63 chars)."""
+    return bool(value) and len(value) <= 63 and _DNS1123_LABEL_RE.match(value) is not None
+
+
+def validate_namespace(namespace: str) -> str:
+    """Validate a target namespace as a DNS-1123 label. Raises ValueError if invalid."""
+    if not _is_dns1123_label(namespace):
+        raise ValueError(
+            "namespace must be a DNS-1123 label: lowercase alphanumeric or '-', "
+            "start and end alphanumeric, at most 63 characters"
+        )
+    return namespace
+
+
+def validate_storage_size(size: str) -> str:
+    """Validate a PVC storage size as a Kubernetes quantity. Raises ValueError if invalid."""
+    if not _QUANTITY_RE.match(size):
+        raise ValueError("storageSize must be a Kubernetes quantity, e.g. '1Gi', '500Mi', '2G'")
+    return size
+
+
+def validate_custom_name(name: str) -> str:
+    """Validate a user-supplied tool name (reject rather than silently mutate).
+
+    Must be a DNS-1123 label short enough that the derived "{name}-mcp" Service
+    name stays a valid label. Raises ValueError if invalid.
+    """
+    if not _is_dns1123_label(name) or len(name) > MAX_SIMULATION_NAME_LEN:
+        raise ValueError(
+            "name must be a DNS-1123 label (lowercase alphanumeric or '-', start and end "
+            f"alphanumeric) of at most {MAX_SIMULATION_NAME_LEN} characters"
+        )
+    return name
+
 
 class SecretKeyRef(BaseModel):
     """Reference to a key in a Secret."""
@@ -292,5 +336,9 @@ def validate_openapi_spec(text: str) -> dict:
 def derive_simulation_name(spec: dict, requested: Optional[str]) -> str:
     """Return a Kubernetes-safe name: requested if given, else slug of info.title."""
     candidate = requested or (spec.get("info", {}) or {}).get("title", "") or ""
-    slug = re.sub(r"[^a-z0-9]+", "-", candidate.lower()).strip("-")[:63].rstrip("-")
+    slug = (
+        re.sub(r"[^a-z0-9]+", "-", candidate.lower())
+        .strip("-")[:MAX_SIMULATION_NAME_LEN]
+        .rstrip("-")
+    )
     return slug or "simulated-tool"

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -119,3 +119,122 @@ def build_simulation_env_vars(
     for env in env_vars:
         seen[env["name"]] = env
     return list(seen.values())
+
+
+def build_simulation_statefulset(
+    name: str,
+    namespace: str,
+    image: str,
+    *,
+    env_vars: List[dict],
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+    storage_size: str = "1Gi",
+    skills_folder: str = SIMULATION_HARNESS_SKILLS_MOUNT,
+    framework: str = "Python",
+    description: str = "",
+    spire_enabled: bool = False,
+    auth_bridge_enabled: bool = False,
+    auth_bridge_mode: Optional[str] = None,
+) -> dict:
+    """Build a StatefulSet manifest for a simulated tool (replicas 1, HPA off)."""
+    service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
+    inject = "enabled" if auth_bridge_enabled else "disabled"
+
+    labels = {
+        APP_KUBERNETES_IO_NAME: name,
+        _MCP_PROTOCOL_LABEL: "",
+        KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
+        KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_WORKLOAD_TYPE_LABEL: WORKLOAD_TYPE_STATEFULSET,
+        KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+        KAGENTI_SIMULATED_LABEL: "true",
+        APP_KUBERNETES_IO_MANAGED_BY: KAGENTI_UI_CREATOR_LABEL,
+        KAGENTI_INJECT_LABEL: inject,
+    }
+    pod_labels = {
+        APP_KUBERNETES_IO_NAME: name,
+        _MCP_PROTOCOL_LABEL: "",
+        KAGENTI_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
+        KAGENTI_FRAMEWORK_LABEL: framework,
+        KAGENTI_TYPE_LABEL: RESOURCE_TYPE_TOOL,
+        KAGENTI_SIMULATED_LABEL: "true",
+        KAGENTI_INJECT_LABEL: inject,
+    }
+    if spire_enabled:
+        labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
+        pod_labels[KAGENTI_SPIRE_LABEL] = KAGENTI_SPIRE_ENABLED_VALUE
+
+    annotations = {KAGENTI_AUTOSCALING_ANNOTATION: "disabled"}
+    if description:
+        annotations[KAGENTI_DESCRIPTION_ANNOTATION] = description
+    pod_annotations: Dict[str, str] = {}
+    if auth_bridge_mode:
+        pod_annotations["kagenti.io/authbridge-mode"] = auth_bridge_mode
+
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": labels,
+            "annotations": annotations,
+        },
+        "spec": {
+            "serviceName": service_name,
+            "replicas": 1,
+            "selector": {"matchLabels": {APP_KUBERNETES_IO_NAME: name}},
+            "template": {
+                "metadata": {"labels": pod_labels, "annotations": pod_annotations},
+                "spec": {
+                    "serviceAccountName": name,
+                    "securityContext": {
+                        "runAsNonRoot": True,
+                        "seccompProfile": {"type": "RuntimeDefault"},
+                    },
+                    "containers": [
+                        {
+                            "name": "harness",
+                            "image": image,
+                            "imagePullPolicy": "Always",
+                            "securityContext": {
+                                "allowPrivilegeEscalation": False,
+                                "capabilities": {"drop": ["ALL"]},
+                                "runAsUser": 1000,
+                            },
+                            "env": env_vars,
+                            "ports": [{"containerPort": port, "name": "http"}],
+                            "resources": {
+                                "limits": DEFAULT_RESOURCE_LIMITS,
+                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                            },
+                            "readinessProbe": {
+                                "httpGet": {"path": "/readyz", "port": port},
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 10,
+                            },
+                            "livenessProbe": {
+                                "httpGet": {"path": "/healthz", "port": port},
+                                "initialDelaySeconds": 10,
+                                "periodSeconds": 20,
+                            },
+                            "volumeMounts": [
+                                {"name": "data", "mountPath": skills_folder},
+                                {"name": "tmp", "mountPath": "/tmp"},
+                            ],
+                        }
+                    ],
+                    "volumes": [{"name": "tmp", "emptyDir": {}}],
+                },
+            },
+            "volumeClaimTemplates": [
+                {
+                    "metadata": {"name": "data"},
+                    "spec": {
+                        "accessModes": ["ReadWriteOnce"],
+                        "resources": {"requests": {"storage": storage_size}},
+                    },
+                }
+            ],
+        },
+    }

--- a/kagenti/backend/app/services/simulation_manifests.py
+++ b/kagenti/backend/app/services/simulation_manifests.py
@@ -1,0 +1,121 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Pure builders for simulated-tool Kubernetes manifests (epic #2151, issue #2161).
+
+Standalone by design — no changes to app/routers/tools.py. A parity test
+(tests/test_simulation_manifests.py) guards the identity/mesh/security surface
+against drift from the tool builders.
+"""
+
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, field_validator
+
+from app.core.constants import (
+    APP_KUBERNETES_IO_MANAGED_BY,
+    APP_KUBERNETES_IO_NAME,
+    DEFAULT_ENV_VARS,
+    DEFAULT_IN_CLUSTER_PORT,
+    DEFAULT_RESOURCE_LIMITS,
+    DEFAULT_RESOURCE_REQUESTS,
+    KAGENTI_AUTOSCALING_ANNOTATION,
+    KAGENTI_DESCRIPTION_ANNOTATION,
+    KAGENTI_FRAMEWORK_LABEL,
+    KAGENTI_INJECT_LABEL,
+    KAGENTI_SIMULATED_LABEL,
+    KAGENTI_SPIRE_ENABLED_VALUE,
+    KAGENTI_SPIRE_LABEL,
+    KAGENTI_TRANSPORT_LABEL,
+    KAGENTI_TYPE_LABEL,
+    KAGENTI_UI_CREATOR_LABEL,
+    KAGENTI_WORKLOAD_TYPE_LABEL,
+    PROTOCOL_LABEL_PREFIX,
+    RESOURCE_TYPE_TOOL,
+    SIMULATION_HARNESS_SKILLS_MOUNT,
+    TOOL_SERVICE_SUFFIX,
+    VALUE_PROTOCOL_MCP,
+    VALUE_TRANSPORT_STREAMABLE_HTTP,
+    WORKLOAD_TYPE_STATEFULSET,
+)
+
+_MCP_PROTOCOL_LABEL = f"{PROTOCOL_LABEL_PREFIX}{VALUE_PROTOCOL_MCP}"
+
+
+class SecretKeyRef(BaseModel):
+    """Reference to a key in a Secret."""
+
+    name: str
+    key: str
+
+
+class ConfigMapKeyRef(BaseModel):
+    """Reference to a key in a ConfigMap."""
+
+    name: str
+    key: str
+
+
+class EnvVarSource(BaseModel):
+    """Source for an environment variable value."""
+
+    secretKeyRef: Optional[SecretKeyRef] = None
+    configMapKeyRef: Optional[ConfigMapKeyRef] = None
+
+
+class EnvVar(BaseModel):
+    """Environment variable with support for direct values and references."""
+
+    name: str
+    value: Optional[str] = None
+    valueFrom: Optional[EnvVarSource] = None
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", v or ""):
+            raise ValueError(
+                f"Invalid environment variable name '{v}'. Must start with a letter or "
+                "underscore and contain only letters, digits, and underscores."
+            )
+        return v
+
+
+def build_simulation_env_vars(
+    env_var_list: Optional[List[EnvVar]] = None,
+    *,
+    port: int = DEFAULT_IN_CLUSTER_PORT,
+    skills_folder: str = SIMULATION_HARNESS_SKILLS_MOUNT,
+) -> List[dict]:
+    """Build the harness container env: platform defaults + harness config + user vars.
+
+    User-supplied vars (e.g. LLM_API_KEY via secretKeyRef) win on name collision.
+    """
+    env_vars: List[dict] = list(DEFAULT_ENV_VARS)
+    env_vars.append({"name": "HARNESS_SKILLS_FOLDER", "value": skills_folder})
+    env_vars.append({"name": "HARNESS_SERVER_PORT", "value": str(port)})
+    env_vars.append({"name": "HARNESS_SERVER_HOST", "value": "0.0.0.0"})
+
+    for ev in env_var_list or []:
+        if ev.value is not None:
+            env_vars.append({"name": ev.name, "value": ev.value})
+        elif ev.valueFrom is not None:
+            entry: Dict[str, Any] = {"name": ev.name, "valueFrom": {}}
+            if ev.valueFrom.secretKeyRef:
+                entry["valueFrom"]["secretKeyRef"] = {
+                    "name": ev.valueFrom.secretKeyRef.name,
+                    "key": ev.valueFrom.secretKeyRef.key,
+                }
+            elif ev.valueFrom.configMapKeyRef:
+                entry["valueFrom"]["configMapKeyRef"] = {
+                    "name": ev.valueFrom.configMapKeyRef.name,
+                    "key": ev.valueFrom.configMapKeyRef.key,
+                }
+            env_vars.append(entry)
+
+    seen: Dict[str, dict] = {}
+    for env in env_vars:
+        seen[env["name"]] = env
+    return list(seen.values())

--- a/kagenti/backend/tests/test_extract_labels.py
+++ b/kagenti/backend/tests/test_extract_labels.py
@@ -1,0 +1,28 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for _extract_labels simulated-marker surfacing (#2165)."""
+
+from app.routers.tools import _extract_labels
+from app.core.constants import KAGENTI_SIMULATED_LABEL
+
+
+class TestExtractLabelsSimulated:
+    def test_simulated_true_when_marker_present(self):
+        result = _extract_labels({KAGENTI_SIMULATED_LABEL: "true"})
+        assert result.simulated is True
+
+    def test_simulated_false_when_marker_absent(self):
+        result = _extract_labels({"kagenti.io/framework": "python"})
+        assert result.simulated is False
+
+    def test_simulated_false_when_marker_not_true(self):
+        result = _extract_labels({KAGENTI_SIMULATED_LABEL: "false"})
+        assert result.simulated is False
+
+    def test_existing_fields_still_extracted(self):
+        result = _extract_labels(
+            {"protocol.kagenti.io/mcp": "", "kagenti.io/framework": "python"}
+        )
+        assert result.protocol == ["mcp"]
+        assert result.framework == "python"

--- a/kagenti/backend/tests/test_extract_labels.py
+++ b/kagenti/backend/tests/test_extract_labels.py
@@ -21,8 +21,6 @@ class TestExtractLabelsSimulated:
         assert result.simulated is False
 
     def test_existing_fields_still_extracted(self):
-        result = _extract_labels(
-            {"protocol.kagenti.io/mcp": "", "kagenti.io/framework": "python"}
-        )
+        result = _extract_labels({"protocol.kagenti.io/mcp": "", "kagenti.io/framework": "python"})
         assert result.protocol == ["mcp"]
         assert result.framework == "python"

--- a/kagenti/backend/tests/test_kubernetes_pod_status.py
+++ b/kagenti/backend/tests/test_kubernetes_pod_status.py
@@ -59,3 +59,36 @@ def test_api_error_reports_not_ready():
     core.list_namespaced_pod.side_effect = ApiException(status=500)
     result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
     assert result == {"ready": False, "waiting_reason": None, "waiting_message": None}
+
+
+def test_ready_true_if_any_pod_ready():
+    # A later not-ready pod must not overwrite an earlier ready=True.
+    svc, _ = _svc_with_pods([_pod(ready=True), _pod(ready=False)])
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["ready"] is True
+
+
+def test_first_waiting_container_across_pods_wins():
+    # First waiting container found (pod order, then container order) wins.
+    svc, _ = _svc_with_pods(
+        [
+            _pod(ready=False, waiting_reason="ImagePullBackOff", waiting_message="pull failed"),
+            _pod(ready=False, waiting_reason="CrashLoopBackOff", waiting_message="back-off"),
+        ]
+    )
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["waiting_reason"] == "ImagePullBackOff"
+    assert result["waiting_message"] == "pull failed"
+
+
+def test_waiting_reason_picked_up_from_later_pod_when_first_has_none():
+    # A ready pod with no waiting container, plus a crash-looping pod → surface the crash.
+    svc, _ = _svc_with_pods(
+        [
+            _pod(ready=True),
+            _pod(ready=False, waiting_reason="CrashLoopBackOff", waiting_message="back-off"),
+        ]
+    )
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["ready"] is True
+    assert result["waiting_reason"] == "CrashLoopBackOff"

--- a/kagenti/backend/tests/test_kubernetes_pod_status.py
+++ b/kagenti/backend/tests/test_kubernetes_pod_status.py
@@ -1,0 +1,61 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for KubernetesService.get_workload_pod_status (issue #2162)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from kubernetes.client import ApiException
+
+from app.services.kubernetes import KubernetesService
+
+
+def _pod(ready=False, waiting_reason=None, waiting_message=None):
+    conditions = [SimpleNamespace(type="Ready", status="True" if ready else "False")]
+    waiting = (
+        SimpleNamespace(reason=waiting_reason, message=waiting_message)
+        if waiting_reason is not None
+        else None
+    )
+    container = SimpleNamespace(state=SimpleNamespace(waiting=waiting))
+    return SimpleNamespace(
+        status=SimpleNamespace(conditions=conditions, container_statuses=[container])
+    )
+
+
+def _svc_with_pods(pods):
+    svc = KubernetesService.__new__(KubernetesService)  # bypass __init__
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=pods)
+    svc._core_api = core  # see note in Step 3 about the accessor
+    return svc, core
+
+
+def test_ready_pod_reports_ready_no_waiting():
+    svc, _ = _svc_with_pods([_pod(ready=True)])
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result == {"ready": True, "waiting_reason": None, "waiting_message": None}
+
+
+def test_crashloop_pod_reports_waiting_reason():
+    svc, _ = _svc_with_pods(
+        [_pod(ready=False, waiting_reason="CrashLoopBackOff", waiting_message="back-off 5m")]
+    )
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result["ready"] is False
+    assert result["waiting_reason"] == "CrashLoopBackOff"
+    assert result["waiting_message"] == "back-off 5m"
+
+
+def test_no_pods_reports_not_ready():
+    svc, _ = _svc_with_pods([])
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result == {"ready": False, "waiting_reason": None, "waiting_message": None}
+
+
+def test_api_error_reports_not_ready():
+    svc, core = _svc_with_pods([])
+    core.list_namespaced_pod.side_effect = ApiException(status=500)
+    result = svc.get_workload_pod_status("team1", "app.kubernetes.io/name=petstore")
+    assert result == {"ready": False, "waiting_reason": None, "waiting_message": None}

--- a/kagenti/backend/tests/test_kubernetes_statefulset_pvcs.py
+++ b/kagenti/backend/tests/test_kubernetes_statefulset_pvcs.py
@@ -1,0 +1,75 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for KubernetesService.list_statefulset_pvcs (issue #2163, generic PVC discovery)."""
+
+from unittest.mock import MagicMock
+
+from kubernetes.client import ApiException
+
+from app.services.kubernetes import KubernetesService
+
+
+def _svc(sts=None, sts_exc=None, pvcs=None):
+    """A KubernetesService with get_statefulset / list_persistent_volume_claims stubbed."""
+    svc = object.__new__(KubernetesService)  # skip __init__ (no kube config load)
+    if sts_exc is not None:
+        svc.get_statefulset = MagicMock(side_effect=sts_exc)
+    else:
+        svc.get_statefulset = MagicMock(return_value=sts)
+    svc.list_persistent_volume_claims = MagicMock(return_value=pvcs or [])
+    return svc
+
+
+def _sts_dict(template_names=("data",)):
+    return {
+        "spec": {
+            "volume_claim_templates": [{"metadata": {"name": t}} for t in template_names]
+        }
+    }
+
+
+def test_matches_template_ordinal_pvcs():
+    svc = _svc(
+        sts=_sts_dict(("data",)),
+        pvcs=["data-petstore-0", "data-other-0", "unrelated"],
+    )
+    assert svc.list_statefulset_pvcs("team1", "petstore") == ["data-petstore-0"]
+
+
+def test_catches_scaled_down_ordinals():
+    # replicas may now be 1, but ordinal-1 PVC lingers (StatefulSet never auto-deletes).
+    svc = _svc(sts=_sts_dict(("data",)), pvcs=["data-petstore-0", "data-petstore-1"])
+    assert sorted(svc.list_statefulset_pvcs("team1", "petstore")) == [
+        "data-petstore-0",
+        "data-petstore-1",
+    ]
+
+
+def test_multiple_templates():
+    svc = _svc(
+        sts=_sts_dict(("data", "cache")),
+        pvcs=["data-petstore-0", "cache-petstore-0", "data-petstore-x"],
+    )
+    assert sorted(svc.list_statefulset_pvcs("team1", "petstore")) == [
+        "cache-petstore-0",
+        "data-petstore-0",
+    ]
+
+
+def test_no_statefulset_returns_empty():
+    svc = _svc(sts_exc=ApiException(status=404))
+    assert svc.list_statefulset_pvcs("team1", "petstore") == []
+
+
+def test_no_templates_returns_empty():
+    svc = _svc(sts={"spec": {}}, pvcs=["data-petstore-0"])
+    assert svc.list_statefulset_pvcs("team1", "petstore") == []
+
+
+def test_non_404_error_propagates():
+    import pytest
+
+    svc = _svc(sts_exc=ApiException(status=403))
+    with pytest.raises(ApiException):
+        svc.list_statefulset_pvcs("team1", "petstore")

--- a/kagenti/backend/tests/test_kubernetes_statefulset_pvcs.py
+++ b/kagenti/backend/tests/test_kubernetes_statefulset_pvcs.py
@@ -22,11 +22,7 @@ def _svc(sts=None, sts_exc=None, pvcs=None):
 
 
 def _sts_dict(template_names=("data",)):
-    return {
-        "spec": {
-            "volume_claim_templates": [{"metadata": {"name": t}} for t in template_names]
-        }
-    }
+    return {"spec": {"volume_claim_templates": [{"metadata": {"name": t}} for t in template_names]}}
 
 
 def test_matches_template_ordinal_pvcs():

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -1,0 +1,80 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for POST /simulation/tools (issue #2161)."""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim_router
+from app.services.kubernetes import get_kubernetes_service
+
+VALID_SPEC = '{"openapi": "3.0.0", "info": {"title": "Pet Store"}, "paths": {}}'
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(sim_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return TestClient(app)
+
+
+def _kube():
+    k = MagicMock()
+    k.ensure_service_account.return_value = None
+    k.create_statefulset.return_value = {}
+    k.create_service.return_value = {}
+    return k
+
+
+def test_create_returns_202_and_provisions_workload():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "Generating"
+    assert body["name"] == "pet-store"
+    kube.create_statefulset.assert_called_once()
+    kube.create_service.assert_called_once()
+
+
+def test_create_rejects_invalid_spec_with_422_and_no_workload():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": "not json"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_conflict_returns_409():
+    kube = _kube()
+    kube.create_statefulset.side_effect = ApiException(status=409)
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "img"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "name": "dup"},
+        )
+    assert r.status_code == 409
+
+
+def test_route_absent_when_flag_off():
+    """With the flag off, main.py never mounts the router (see #2160)."""
+    import app.main
+
+    r = TestClient(app.main.app).post("/api/v1/simulation/tools", json={})
+    assert r.status_code == 404

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -74,6 +74,21 @@ def test_create_wires_image_pull_secret_into_statefulset():
     assert sts["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "ghcr-secret"}]
 
 
+def test_create_omits_image_pull_secret_when_setting_empty():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        s.simulation_image_pull_secret = ""
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    sts = kube.create_statefulset.call_args.args[1]
+    assert "imagePullSecrets" not in sts["spec"]["template"]["spec"]
+
+
 def test_create_conflict_returns_409():
     kube = _kube()
     kube.create_statefulset.side_effect = ApiException(status=409)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -148,23 +148,28 @@ def test_create_rejects_invalid_custom_name_with_422():
 
 def test_create_spawns_generation_trigger():
     kube = _kube()
-    with (
-        patch("app.core.auth.settings") as auth,
-        patch("app.routers.simulation.settings") as s,
-        patch("app.routers.simulation._run_generation_trigger", new=MagicMock()) as trig,
-    ):
-        auth.enable_auth = False
-        s.simulation_harness_image = "img"
-        # _run_generation_trigger is wrapped in asyncio.create_task; the MagicMock
-        # returns a coroutine-like sentinel, so patch create_task to capture the call.
-        with patch("app.routers.simulation.asyncio.create_task") as create_task:
-            r = _client(kube).post(
-                "/simulation/tools",
-                json={"namespace": "team1", "openapiSpec": VALID_SPEC},
-            )
-    assert r.status_code == 202
-    create_task.assert_called_once()
-    trig.assert_called_once()
-    ns, name, spec, port = trig.call_args.args
-    assert ns == "team1"
-    assert name == "pet-store"
+    saved = set(sim_router._generation_tasks)
+    try:
+        with (
+            patch("app.core.auth.settings") as auth,
+            patch("app.routers.simulation.settings") as s,
+            patch("app.routers.simulation._run_generation_trigger", new=MagicMock()) as trig,
+        ):
+            auth.enable_auth = False
+            s.simulation_harness_image = "img"
+            # _run_generation_trigger is wrapped in asyncio.create_task; the MagicMock
+            # returns a coroutine-like sentinel, so patch create_task to capture the call.
+            with patch("app.routers.simulation.asyncio.create_task") as create_task:
+                r = _client(kube).post(
+                    "/simulation/tools",
+                    json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+                )
+        assert r.status_code == 202
+        create_task.assert_called_once()
+        trig.assert_called_once()
+        ns, name, spec, port = trig.call_args.args
+        assert ns == "team1"
+        assert name == "pet-store"
+    finally:
+        sim_router._generation_tasks.clear()
+        sim_router._generation_tasks.update(saved)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -144,3 +144,27 @@ def test_create_rejects_invalid_custom_name_with_422():
         )
     assert r.status_code == 422
     kube.create_statefulset.assert_not_called()
+
+
+def test_create_spawns_generation_trigger():
+    kube = _kube()
+    with (
+        patch("app.core.auth.settings") as auth,
+        patch("app.routers.simulation.settings") as s,
+        patch("app.routers.simulation._run_generation_trigger", new=MagicMock()) as trig,
+    ):
+        auth.enable_auth = False
+        s.simulation_harness_image = "img"
+        # _run_generation_trigger is wrapped in asyncio.create_task; the MagicMock
+        # returns a coroutine-like sentinel, so patch create_task to capture the call.
+        with patch("app.routers.simulation.asyncio.create_task") as create_task:
+            r = _client(kube).post(
+                "/simulation/tools",
+                json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+            )
+    assert r.status_code == 202
+    create_task.assert_called_once()
+    trig.assert_called_once()
+    ns, name, spec, port = trig.call_args.args
+    assert ns == "team1"
+    assert name == "pet-store"

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -59,6 +59,21 @@ def test_create_rejects_invalid_spec_with_422_and_no_workload():
     kube.create_statefulset.assert_not_called()
 
 
+def test_create_wires_image_pull_secret_into_statefulset():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth, patch("app.routers.simulation.settings") as s:
+        auth.enable_auth = False
+        s.simulation_harness_image = "ghcr.io/kagenti/simulation-harness:latest"
+        s.simulation_image_pull_secret = "ghcr-secret"
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 202
+    sts = kube.create_statefulset.call_args.args[1]
+    assert sts["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "ghcr-secret"}]
+
+
 def test_create_conflict_returns_409():
     kube = _kube()
     kube.create_statefulset.side_effect = ApiException(status=409)

--- a/kagenti/backend/tests/test_simulation_create_api.py
+++ b/kagenti/backend/tests/test_simulation_create_api.py
@@ -78,3 +78,39 @@ def test_route_absent_when_flag_off():
 
     r = TestClient(app.main.app).post("/api/v1/simulation/tools", json={})
     assert r.status_code == 404
+
+
+def test_create_rejects_invalid_namespace_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "Bad_NS", "openapiSpec": VALID_SPEC},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_rejects_invalid_storage_size_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "storageSize": "big"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()
+
+
+def test_create_rejects_invalid_custom_name_with_422():
+    kube = _kube()
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        r = _client(kube).post(
+            "/simulation/tools",
+            json={"namespace": "team1", "openapiSpec": VALID_SPEC, "name": "Bad Name!"},
+        )
+    assert r.status_code == 422
+    kube.create_statefulset.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_flag.py
+++ b/kagenti/backend/tests/test_simulation_flag.py
@@ -1,0 +1,76 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the simulated-tools feature flag and flagged simulation router (issue #2160)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import config as config_router
+from app.routers import simulation as simulation_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _make_config_app(simulated_tools: bool) -> FastAPI:
+    """Build an app with only the config router, feature flags mocked."""
+    app = FastAPI()
+    app.include_router(config_router.router)
+
+    # Feature flags are read straight off `settings` in get_feature_flags.
+    mock_settings = MagicMock()
+    mock_settings.kagenti_feature_flag_sandbox = False
+    mock_settings.kagenti_feature_flag_integrations = False
+    mock_settings.kagenti_feature_flag_triggers = False
+    mock_settings.kagenti_feature_flag_agent_sandbox = False
+    mock_settings.kagenti_feature_flag_skills = False
+    mock_settings.kagenti_feature_flag_external_skills = False
+    mock_settings.kagenti_feature_flag_authbridge_api = False
+    mock_settings.kagenti_feature_flag_admin = False
+    mock_settings.kagenti_feature_flag_agent_import_defaults = False
+    mock_settings.kagenti_feature_flag_simulated_tools = simulated_tools
+
+    # get_feature_flags depends on the k8s service only to probe the `builds` flag.
+    mock_kube = MagicMock()
+    mock_kube.api_group_exists.return_value = False
+    app.dependency_overrides[get_kubernetes_service] = lambda: mock_kube
+
+    app.state._mock_settings = mock_settings  # keep a reference alive for the patch
+    return app
+
+
+class TestSimulatedToolsFeatureFlag:
+    def test_features_reports_false_when_flag_off(self):
+        app = _make_config_app(simulated_tools=False)
+        with patch("app.routers.config.settings", app.state._mock_settings):
+            r = TestClient(app).get("/config/features")
+        assert r.status_code == 200
+        assert r.json()["simulatedTools"] is False
+
+    def test_features_reports_true_when_flag_on(self):
+        app = _make_config_app(simulated_tools=True)
+        with patch("app.routers.config.settings", app.state._mock_settings):
+            r = TestClient(app).get("/config/features")
+        assert r.status_code == 200
+        assert r.json()["simulatedTools"] is True
+
+
+class TestSimulationRouterScaffold:
+    def test_health_endpoint_returns_ok_when_mounted(self):
+        app = FastAPI()
+        app.include_router(simulation_router.router)
+        r = TestClient(app).get("/simulation/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
+
+    def test_no_simulation_routes_when_router_not_mounted(self):
+        # Mirrors flag-off: the router is simply never included.
+        app = FastAPI()
+        r = TestClient(app).get("/simulation/health")
+        assert r.status_code == 404
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/kagenti/backend/tests/test_simulation_harness_client.py
+++ b/kagenti/backend/tests/test_simulation_harness_client.py
@@ -47,6 +47,12 @@ class _FakeClient:
         self.posted = json
         return self._resp
 
+    async def put(self, url, json=None):
+        if self._exc:
+            raise self._exc
+        self.posted = json
+        return self._resp
+
 
 @pytest.mark.asyncio
 async def test_get_simulation_returns_parsed_body():
@@ -111,3 +117,48 @@ async def test_reset_simulation_raises_unreachable_on_connect_error():
     with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
         with pytest.raises(hc.HarnessUnreachable):
             await hc.reset_simulation("http://sim")
+
+
+@pytest.mark.asyncio
+async def test_put_database_sends_body_and_returns_code_and_json():
+    fake = _FakeClient(resp=_FakeResp(200, {"message": "Database replaced; simulation reset"}))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        code, body = await hc.put_database("http://sim", {"pets": []})
+    assert code == 200
+    assert body["message"] == "Database replaced; simulation reset"
+    assert fake.posted == {"pets": []}
+
+
+@pytest.mark.asyncio
+async def test_put_database_returns_json_path_on_422():
+    fake = _FakeClient(resp=_FakeResp(422, {"detail": "bad", "json_path": "$.pets[0].id"}))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        code, body = await hc.put_database("http://sim", {"pets": [{}]})
+    assert code == 422
+    assert body["json_path"] == "$.pets[0].id"
+
+
+@pytest.mark.asyncio
+async def test_put_database_returns_empty_body_when_no_json():
+    fake = _FakeClient(resp=_FakeResp(409, json_data=None))
+    # _FakeResp.json() returns None here; put_database must coerce falsy/non-dict to {}.
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        code, body = await hc.put_database("http://sim", {})
+    assert code == 409
+    assert body == {}
+
+
+@pytest.mark.asyncio
+async def test_put_database_raises_unreachable_on_connect_error():
+    fake = _FakeClient(exc=httpx.ConnectError("refused"))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessUnreachable):
+            await hc.put_database("http://sim", {})
+
+
+@pytest.mark.asyncio
+async def test_put_database_raises_unreachable_on_timeout():
+    fake = _FakeClient(exc=httpx.TimeoutException("slow"))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessUnreachable):
+            await hc.put_database("http://sim", {})

--- a/kagenti/backend/tests/test_simulation_harness_client.py
+++ b/kagenti/backend/tests/test_simulation_harness_client.py
@@ -87,3 +87,27 @@ async def test_post_simulation_raises_unreachable_on_timeout():
     with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
         with pytest.raises(hc.HarnessUnreachable):
             await hc.post_simulation("http://sim", {}, "x")
+
+
+@pytest.mark.asyncio
+async def test_reset_simulation_returns_status_code():
+    fake = _FakeClient(resp=_FakeResp(200, {"message": "Session reset successfully"}))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        code = await hc.reset_simulation("http://sim")
+    assert code == 200
+
+
+@pytest.mark.asyncio
+async def test_reset_simulation_passes_through_404():
+    fake = _FakeClient(resp=_FakeResp(404))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        code = await hc.reset_simulation("http://sim")
+    assert code == 404
+
+
+@pytest.mark.asyncio
+async def test_reset_simulation_raises_unreachable_on_connect_error():
+    fake = _FakeClient(exc=httpx.ConnectError("refused"))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessUnreachable):
+            await hc.reset_simulation("http://sim")

--- a/kagenti/backend/tests/test_simulation_harness_client.py
+++ b/kagenti/backend/tests/test_simulation_harness_client.py
@@ -1,0 +1,89 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the simulation harness HTTP client (issue #2162)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services import simulation_harness_client as hc
+
+
+class _FakeResp:
+    def __init__(self, status_code, json_data=None):
+        self.status_code = status_code
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("err", request=None, response=None)
+
+
+class _FakeClient:
+    def __init__(self, resp=None, exc=None):
+        self._resp = resp
+        self._exc = exc
+        self.posted = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        if self._exc:
+            raise self._exc
+        return self._resp
+
+    async def post(self, url, json=None):
+        if self._exc:
+            raise self._exc
+        self.posted = json
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_returns_parsed_body():
+    fake = _FakeClient(resp=_FakeResp(200, {"status": "ready", "mcp_url": "u"}))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        body = await hc.get_simulation("http://sim")
+    assert body["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_raises_not_found_on_404():
+    fake = _FakeClient(resp=_FakeResp(404))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessNotFound):
+            await hc.get_simulation("http://sim")
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_raises_unreachable_on_connect_error():
+    fake = _FakeClient(exc=httpx.ConnectError("boom"))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessUnreachable):
+            await hc.get_simulation("http://sim")
+
+
+@pytest.mark.asyncio
+async def test_post_simulation_sends_spec_and_name_and_returns_code():
+    fake = _FakeClient(resp=_FakeResp(202))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        code = await hc.post_simulation("http://sim", {"openapi": "3.0.0"}, "petstore")
+    assert code == 202
+    assert fake.posted == {"openapi_spec": {"openapi": "3.0.0"}, "name": "petstore"}
+
+
+@pytest.mark.asyncio
+async def test_post_simulation_raises_unreachable_on_timeout():
+    fake = _FakeClient(exc=httpx.TimeoutException("slow"))
+    with patch.object(hc.httpx, "AsyncClient", lambda **kw: fake):
+        with pytest.raises(hc.HarnessUnreachable):
+            await hc.post_simulation("http://sim", {}, "x")

--- a/kagenti/backend/tests/test_simulation_lifecycle_api.py
+++ b/kagenti/backend/tests/test_simulation_lifecycle_api.py
@@ -96,3 +96,47 @@ def test_stop_invalid_name_returns_404_without_backend_calls():
     r = _post(_client(kube), "stop", name="Bad_Name")
     assert r.status_code == 404
     kube.apps_api.read_namespaced_stateful_set.assert_not_called()
+
+
+# ---- reset ----
+
+
+def test_reset_success_returns_200():
+    kube = _kube()
+    with patch("app.routers.simulation.reset_simulation", new=AsyncMock(return_value=200)):
+        r = _post(_client(kube), "reset")
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+
+
+def test_reset_harness_404_returns_409():
+    kube = _kube()
+    with patch("app.routers.simulation.reset_simulation", new=AsyncMock(return_value=404)):
+        r = _post(_client(kube), "reset")
+    assert r.status_code == 409
+
+
+def test_reset_harness_503_returns_409():
+    kube = _kube()
+    with patch("app.routers.simulation.reset_simulation", new=AsyncMock(return_value=503)):
+        r = _post(_client(kube), "reset")
+    assert r.status_code == 409
+
+
+def test_reset_unreachable_returns_502():
+    kube = _kube()
+    with patch(
+        "app.routers.simulation.reset_simulation",
+        new=AsyncMock(side_effect=sim_router.HarnessUnreachable("down")),
+    ):
+        r = _post(_client(kube), "reset")
+    assert r.status_code == 502
+
+
+def test_reset_non_simulated_returns_404():
+    kube = _kube(sts=_sts(simulated=False))
+    reset = AsyncMock()
+    with patch("app.routers.simulation.reset_simulation", new=reset):
+        r = _post(_client(kube), "reset")
+    assert r.status_code == 404
+    reset.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_lifecycle_api.py
+++ b/kagenti/backend/tests/test_simulation_lifecycle_api.py
@@ -213,3 +213,11 @@ def test_delete_all_404_still_returns_200():
     r = _delete(_client(kube))
     assert r.status_code == 200
     assert r.json()["deletedResources"] == []
+
+
+def test_delete_pvc_list_error_returns_502():
+    kube = _kube(pvcs=["data-petstore-0"])
+    kube.list_statefulset_pvcs.side_effect = ApiException(status=403)
+    r = _delete(_client(kube))
+    assert r.status_code == 502
+    kube.delete_statefulset.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_lifecycle_api.py
+++ b/kagenti/backend/tests/test_simulation_lifecycle_api.py
@@ -186,3 +186,30 @@ def test_delete_non_simulated_returns_404():
     r = _delete(_client(kube))
     assert r.status_code == 404
     kube.delete_statefulset.assert_not_called()
+
+
+def test_delete_removes_multiple_pvcs_in_order():
+    # Two PVCs prove per-iteration closure binding (a late-binding bug would
+    # target the last name twice).
+    from unittest.mock import call
+
+    kube = _kube(pvcs=["data-petstore-0", "data-petstore-1"])
+    r = _delete(_client(kube))
+    assert r.status_code == 200
+    body = r.json()
+    assert "PersistentVolumeClaim/data-petstore-0" in body["deletedResources"]
+    assert "PersistentVolumeClaim/data-petstore-1" in body["deletedResources"]
+    assert kube.delete_persistent_volume_claim.call_args_list == [
+        call("team1", "data-petstore-0"),
+        call("team1", "data-petstore-1"),
+    ]
+
+
+def test_delete_all_404_still_returns_200():
+    kube = _kube(pvcs=["data-petstore-0"])
+    kube.delete_statefulset.side_effect = ApiException(status=404)
+    kube.delete_service.side_effect = ApiException(status=404)
+    kube.delete_persistent_volume_claim.side_effect = ApiException(status=404)
+    r = _delete(_client(kube))
+    assert r.status_code == 200
+    assert r.json()["deletedResources"] == []

--- a/kagenti/backend/tests/test_simulation_lifecycle_api.py
+++ b/kagenti/backend/tests/test_simulation_lifecycle_api.py
@@ -140,3 +140,49 @@ def test_reset_non_simulated_returns_404():
         r = _post(_client(kube), "reset")
     assert r.status_code == 404
     reset.assert_not_called()
+
+
+# ---- delete ----
+
+
+def _delete(app, ns="team1", name="petstore"):
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        return TestClient(app).delete(f"/simulation/tools/{ns}/{name}")
+
+
+def test_delete_removes_statefulset_service_and_pvcs():
+    kube = _kube(pvcs=["data-petstore-0"])
+    r = _delete(_client(kube))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert "StatefulSet/petstore" in body["deletedResources"]
+    assert "Service/petstore-mcp" in body["deletedResources"]
+    assert "PersistentVolumeClaim/data-petstore-0" in body["deletedResources"]
+    kube.delete_statefulset.assert_called_once_with("team1", "petstore")
+    kube.delete_service.assert_called_once_with("team1", "petstore-mcp")
+    kube.delete_persistent_volume_claim.assert_called_once_with("team1", "data-petstore-0")
+
+
+def test_delete_is_idempotent_on_missing_service_and_pvc():
+    kube = _kube(pvcs=["data-petstore-0"])
+    kube.delete_service.side_effect = ApiException(status=404)
+    kube.delete_persistent_volume_claim.side_effect = ApiException(status=404)
+    r = _delete(_client(kube))
+    assert r.status_code == 200
+    assert "StatefulSet/petstore" in r.json()["deletedResources"]
+
+
+def test_delete_missing_statefulset_returns_404():
+    kube = _kube(sts_exc=ApiException(status=404))
+    r = _delete(_client(kube))
+    assert r.status_code == 404
+    kube.delete_statefulset.assert_not_called()
+
+
+def test_delete_non_simulated_returns_404():
+    kube = _kube(sts=_sts(simulated=False))
+    r = _delete(_client(kube))
+    assert r.status_code == 404
+    kube.delete_statefulset.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_lifecycle_api.py
+++ b/kagenti/backend/tests/test_simulation_lifecycle_api.py
@@ -1,0 +1,98 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for simulated-tool lifecycle endpoints — stop/start/reset/delete (issue #2163)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _sts(name="petstore", namespace="team1", simulated=True):
+    labels = {"kagenti.io/simulated": "true"} if simulated else {"app.kubernetes.io/name": name}
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, namespace=namespace, labels=labels),
+        spec=SimpleNamespace(replicas=1),
+    )
+
+
+def _kube(sts=None, sts_exc=None, pvcs=None):
+    k = MagicMock()
+    if sts_exc is not None:
+        k.apps_api.read_namespaced_stateful_set.side_effect = sts_exc
+    else:
+        k.apps_api.read_namespaced_stateful_set.return_value = sts if sts is not None else _sts()
+    k.list_statefulset_pvcs.return_value = pvcs if pvcs is not None else ["data-petstore-0"]
+    return k
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(sim_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return app
+
+
+def _post(app, action, ns="team1", name="petstore"):
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        return TestClient(app).post(f"/simulation/tools/{ns}/{name}/{action}")
+
+
+# ---- stop / start ----
+
+
+def test_stop_scales_to_zero():
+    kube = _kube()
+    r = _post(_client(kube), "stop")
+    assert r.status_code == 200
+    assert r.json()["status"] == "Stopped"
+    kube.patch_statefulset.assert_called_once_with("team1", "petstore", {"spec": {"replicas": 0}})
+
+
+def test_start_scales_to_one():
+    kube = _kube()
+    r = _post(_client(kube), "start")
+    assert r.status_code == 200
+    assert r.json()["status"] == "Starting"
+    kube.patch_statefulset.assert_called_once_with("team1", "petstore", {"spec": {"replicas": 1}})
+
+
+def test_stop_missing_statefulset_returns_404():
+    kube = _kube(sts_exc=ApiException(status=404))
+    r = _post(_client(kube), "stop")
+    assert r.status_code == 404
+    kube.patch_statefulset.assert_not_called()
+
+
+def test_stop_non_simulated_statefulset_returns_404():
+    kube = _kube(sts=_sts(simulated=False))
+    r = _post(_client(kube), "stop")
+    assert r.status_code == 404
+    kube.patch_statefulset.assert_not_called()
+
+
+def test_stop_read_error_returns_502():
+    kube = _kube(sts_exc=ApiException(status=403))
+    r = _post(_client(kube), "stop")
+    assert r.status_code == 502
+
+
+def test_stop_patch_error_returns_502():
+    kube = _kube()
+    kube.patch_statefulset.side_effect = ApiException(status=500)
+    r = _post(_client(kube), "stop")
+    assert r.status_code == 502
+
+
+def test_stop_invalid_name_returns_404_without_backend_calls():
+    kube = _kube()
+    r = _post(_client(kube), "stop", name="Bad_Name")
+    assert r.status_code == 404
+    kube.apps_api.read_namespaced_stateful_set.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -117,6 +117,21 @@ def test_statefulset_spire_and_authbridge_flags():
     assert pod_ann["kagenti.io/authbridge-mode"] == "lite"
 
 
+def test_statefulset_adds_image_pull_secret_when_provided():
+    spec = _sts(image_pull_secret="ghcr-secret")["spec"]["template"]["spec"]
+    assert spec["imagePullSecrets"] == [{"name": "ghcr-secret"}]
+
+
+def test_statefulset_omits_image_pull_secret_when_none():
+    spec = _sts()["spec"]["template"]["spec"]
+    assert "imagePullSecrets" not in spec
+
+
+def test_statefulset_omits_image_pull_secret_when_empty_string():
+    spec = _sts(image_pull_secret="")["spec"]["template"]["spec"]
+    assert "imagePullSecrets" not in spec
+
+
 from app.services.simulation_manifests import build_simulation_service
 
 

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -25,6 +25,12 @@ def test_simulation_harness_image_setting_defaults():
     assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")
 
 
+def test_simulation_image_pull_secret_setting_defaults():
+    from app.core.config import Settings
+
+    assert Settings().simulation_image_pull_secret == "ghcr-secret"
+
+
 def test_env_vars_include_harness_and_platform_defaults():
     env = build_simulation_env_vars(None, port=8000)
     by_name = {e["name"]: e for e in env}

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -37,6 +37,9 @@ def test_env_vars_include_harness_and_platform_defaults():
     assert by_name["HARNESS_SKILLS_FOLDER"]["value"] == "/app/skills-store"
     assert by_name["HARNESS_SERVER_PORT"]["value"] == "8000"
     assert by_name["HARNESS_SERVER_HOST"]["value"] == "0.0.0.0"
+    # Opt back into boot-time autostart: the harness defaults it off, but Kagenti
+    # relies on it to resume the baked skill on Stop->Start and pod restarts.
+    assert by_name["HARNESS_AUTOSTART_ENABLED"]["value"] == "true"
     # platform default preserved
     assert by_name["OTEL_EXPORTER_OTLP_ENDPOINT"]["value"].startswith("http://otel-collector")
 

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -53,3 +53,65 @@ def test_env_vars_user_value_wins_on_dedupe():
     ports = [e for e in env if e["name"] == "HARNESS_SERVER_PORT"]
     assert len(ports) == 1
     assert ports[0]["value"] == "9999"
+
+
+from app.services.simulation_manifests import build_simulation_statefulset
+
+
+def _sts(**kw):
+    defaults = {
+        "name": "petstore",
+        "namespace": "team1",
+        "image": "ghcr.io/kagenti/simulation-harness:latest",
+        "env_vars": [{"name": "PORT", "value": "8000"}],
+    }
+    defaults.update(kw)
+    return build_simulation_statefulset(**defaults)
+
+
+def test_statefulset_core_shape():
+    m = _sts()
+    assert m["kind"] == "StatefulSet"
+    assert m["spec"]["replicas"] == 1
+    assert m["metadata"]["name"] == "petstore"
+    assert m["metadata"]["namespace"] == "team1"
+    c = m["spec"]["template"]["spec"]["containers"][0]
+    assert c["image"] == "ghcr.io/kagenti/simulation-harness:latest"
+    assert c["ports"][0]["containerPort"] == 8000
+
+
+def test_statefulset_labels_and_markers():
+    labels = _sts()["metadata"]["labels"]
+    assert labels["protocol.kagenti.io/mcp"] == ""
+    assert labels["kagenti.io/type"] == "tool"
+    assert labels["kagenti.io/simulated"] == "true"
+    assert labels["kagenti.io/workload-type"] == "statefulset"
+    assert labels["kagenti.io/inject"] == "disabled"
+    assert _sts()["metadata"]["annotations"]["kagenti.io/autoscaling"] == "disabled"
+
+
+def test_statefulset_pvc_mounted_at_skills_dir():
+    m = _sts(storage_size="2Gi")
+    vct = m["spec"]["volumeClaimTemplates"][0]
+    assert vct["metadata"]["name"] == "data"
+    assert vct["spec"]["resources"]["requests"]["storage"] == "2Gi"
+    mounts = m["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    data_mount = next(v for v in mounts if v["name"] == "data")
+    assert data_mount["mountPath"] == "/app/skills-store"
+
+
+def test_statefulset_probes_and_security_context():
+    c = _sts()["spec"]["template"]["spec"]["containers"][0]
+    assert c["readinessProbe"]["httpGet"]["path"] == "/readyz"
+    assert c["livenessProbe"]["httpGet"]["path"] == "/healthz"
+    assert c["securityContext"]["runAsUser"] == 1000
+    assert c["securityContext"]["capabilities"]["drop"] == ["ALL"]
+
+
+def test_statefulset_spire_and_authbridge_flags():
+    labels = _sts(spire_enabled=True, auth_bridge_enabled=True)["metadata"]["labels"]
+    assert labels["kagenti.io/spire"] == "enabled"
+    assert labels["kagenti.io/inject"] == "enabled"
+    m = _sts(auth_bridge_mode="lite")
+    pod_ann = m["spec"]["template"]["metadata"]["annotations"]
+    assert pod_ann["kagenti.io/authbridge-mode"] == "lite"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -169,6 +169,19 @@ def test_derive_name_falls_back():
     assert derive_simulation_name({}, None) == "simulated-tool"
 
 
+def test_statefulset_cache_emptydir_volume():
+    m = _sts()
+    mounts = m["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    cache_mount = next((v for v in mounts if v["name"] == "cache"), None)
+    assert cache_mount is not None, "cache volumeMount not found"
+    assert cache_mount["mountPath"] == "/app/.cache"
+
+    volumes = m["spec"]["template"]["spec"]["volumes"]
+    cache_vol = next((v for v in volumes if v["name"] == "cache"), None)
+    assert cache_vol is not None, "cache volume not found"
+    assert cache_vol["emptyDir"] == {}
+
+
 def test_parity_simulation_matches_tool_identity_surface():
     """Guard: simulation StatefulSet must carry the same identity/mesh/security
     surface a tool StatefulSet does, so the standalone builders can't silently drift."""

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -4,6 +4,12 @@
 """Unit tests for simulated-tool manifest building (issue #2161)."""
 
 from app.core import constants
+from app.services.simulation_manifests import (
+    EnvVar,
+    EnvVarSource,
+    SecretKeyRef,
+    build_simulation_env_vars,
+)
 
 
 def test_simulation_constants_exist():
@@ -17,3 +23,33 @@ def test_simulation_harness_image_setting_defaults():
 
     s = Settings()
     assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")
+
+
+def test_env_vars_include_harness_and_platform_defaults():
+    env = build_simulation_env_vars(None, port=8000)
+    by_name = {e["name"]: e for e in env}
+    assert by_name["HARNESS_SKILLS_FOLDER"]["value"] == "/app/skills-store"
+    assert by_name["HARNESS_SERVER_PORT"]["value"] == "8000"
+    assert by_name["HARNESS_SERVER_HOST"]["value"] == "0.0.0.0"
+    # platform default preserved
+    assert by_name["OTEL_EXPORTER_OTLP_ENDPOINT"]["value"].startswith("http://otel-collector")
+
+
+def test_env_vars_expand_secret_key_ref():
+    env = build_simulation_env_vars(
+        [
+            EnvVar(
+                name="LLM_API_KEY",
+                valueFrom=EnvVarSource(secretKeyRef=SecretKeyRef(name="llm-secret", key="api-key")),
+            )
+        ]
+    )
+    entry = next(e for e in env if e["name"] == "LLM_API_KEY")
+    assert entry["valueFrom"]["secretKeyRef"] == {"name": "llm-secret", "key": "api-key"}
+
+
+def test_env_vars_user_value_wins_on_dedupe():
+    env = build_simulation_env_vars([EnvVar(name="HARNESS_SERVER_PORT", value="9999")])
+    ports = [e for e in env if e["name"] == "HARNESS_SERVER_PORT"]
+    assert len(ports) == 1
+    assert ports[0]["value"] == "9999"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -219,3 +219,53 @@ def test_parity_simulation_matches_tool_identity_surface():
     spc = sim["spec"]["template"]["spec"]
     assert spc["securityContext"] == tpc["securityContext"]
     assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]
+
+
+from app.services.simulation_manifests import (
+    MAX_SIMULATION_NAME_LEN,
+    validate_custom_name,
+    validate_namespace,
+    validate_storage_size,
+)
+
+
+class TestInputValidators:
+    def test_valid_namespace_passes(self):
+        assert validate_namespace("team1") == "team1"
+        assert validate_namespace("a-b-9") == "a-b-9"
+
+    @pytest.mark.parametrize(
+        "bad", ["Team1", "team_1", "-team", "team-", "team 1", "team\n1", "", "a" * 64]
+    )
+    def test_invalid_namespace_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_namespace(bad)
+
+    @pytest.mark.parametrize("good", ["1Gi", "500Mi", "2G", "10Ti", "1024Ki"])
+    def test_valid_storage_size_passes(self, good):
+        assert validate_storage_size(good) == good
+
+    @pytest.mark.parametrize("bad", ["big", "1gb", "Gi", "0Gi", "-1Gi", "1.Gi", "1 Gi", ""])
+    def test_invalid_storage_size_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_storage_size(bad)
+
+    def test_valid_custom_name_passes(self):
+        assert validate_custom_name("pet-store") == "pet-store"
+
+    @pytest.mark.parametrize("bad", ["Pet Store", "pet_store", "-x", "x-", "", "UPPER"])
+    def test_invalid_custom_name_raises(self, bad):
+        with pytest.raises(ValueError):
+            validate_custom_name(bad)
+
+    def test_custom_name_too_long_for_service_suffix_raises(self):
+        # A name longer than MAX_SIMULATION_NAME_LEN would make "{name}-mcp" exceed 63.
+        with pytest.raises(ValueError):
+            validate_custom_name("a" * (MAX_SIMULATION_NAME_LEN + 1))
+        assert validate_custom_name("a" * MAX_SIMULATION_NAME_LEN)
+
+
+def test_derive_name_truncates_to_service_safe_length():
+    name = derive_simulation_name({"info": {"title": "x" * 100}}, None)
+    assert len(name) <= MAX_SIMULATION_NAME_LEN
+    assert not name.endswith("-")

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -132,3 +132,77 @@ def test_service_shape_and_labels():
     assert labels["protocol.kagenti.io/mcp"] == ""
     assert labels["kagenti.io/simulated"] == "true"
     assert labels["kagenti.io/type"] == "tool"
+
+
+import pytest
+
+from app.services.simulation_manifests import (
+    derive_simulation_name,
+    validate_openapi_spec,
+)
+
+
+def test_validate_spec_accepts_valid_json_object():
+    spec = validate_openapi_spec(
+        '{"openapi": "3.0.0", "info": {"title": "Pet Store"}, "paths": {}}'
+    )
+    assert spec["info"]["title"] == "Pet Store"
+
+
+@pytest.mark.parametrize("bad", ["not json", "[]", '"a string"', "123", ""])
+def test_validate_spec_rejects_non_object_or_invalid(bad):
+    with pytest.raises(ValueError):
+        validate_openapi_spec(bad)
+
+
+def test_derive_name_prefers_requested():
+    assert derive_simulation_name({"info": {"title": "Pet Store"}}, "my-sim") == "my-sim"
+
+
+def test_derive_name_slugifies_title():
+    assert (
+        derive_simulation_name({"info": {"title": "Pet Store API v2!"}}, None) == "pet-store-api-v2"
+    )
+
+
+def test_derive_name_falls_back():
+    assert derive_simulation_name({}, None) == "simulated-tool"
+
+
+def test_parity_simulation_matches_tool_identity_surface():
+    """Guard: simulation StatefulSet must carry the same identity/mesh/security
+    surface a tool StatefulSet does, so the standalone builders can't silently drift."""
+    from app.routers.tools import _build_tool_statefulset_manifest
+    from app.services.simulation_manifests import build_simulation_statefulset
+
+    tool = _build_tool_statefulset_manifest(
+        name="x",
+        namespace="team1",
+        image="img",
+        framework="Python",
+        auth_bridge_enabled=True,
+        spire_enabled=True,
+    )
+    sim = build_simulation_statefulset(
+        name="x",
+        namespace="team1",
+        image="img",
+        env_vars=[],
+        framework="Python",
+        auth_bridge_enabled=True,
+        spire_enabled=True,
+    )
+    mesh_keys = [
+        "protocol.kagenti.io/mcp",
+        "kagenti.io/transport",
+        "kagenti.io/framework",
+        "kagenti.io/inject",
+        "kagenti.io/spire",
+    ]
+    tl, sl = tool["metadata"]["labels"], sim["metadata"]["labels"]
+    for k in mesh_keys:
+        assert sl.get(k) == tl.get(k), f"identity label drift on {k}"
+    tpc = tool["spec"]["template"]["spec"]
+    spc = sim["spec"]["template"]["spec"]
+    assert spc["securityContext"] == tpc["securityContext"]
+    assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -115,3 +115,20 @@ def test_statefulset_spire_and_authbridge_flags():
     m = _sts(auth_bridge_mode="lite")
     pod_ann = m["spec"]["template"]["metadata"]["annotations"]
     assert pod_ann["kagenti.io/authbridge-mode"] == "lite"
+
+
+from app.services.simulation_manifests import build_simulation_service
+
+
+def test_service_shape_and_labels():
+    m = build_simulation_service("petstore", "team1", port=8000)
+    assert m["kind"] == "Service"
+    assert m["metadata"]["name"] == "petstore-mcp"
+    assert m["spec"]["type"] == "ClusterIP"
+    assert m["spec"]["selector"]["app.kubernetes.io/name"] == "petstore"
+    assert m["spec"]["ports"][0]["port"] == 8000
+    assert m["spec"]["ports"][0]["targetPort"] == 8000
+    labels = m["metadata"]["labels"]
+    assert labels["protocol.kagenti.io/mcp"] == ""
+    assert labels["kagenti.io/simulated"] == "true"
+    assert labels["kagenti.io/type"] == "tool"

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -1,0 +1,19 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Unit tests for simulated-tool manifest building (issue #2161)."""
+
+from app.core import constants
+
+
+def test_simulation_constants_exist():
+    assert constants.KAGENTI_SIMULATED_LABEL == "kagenti.io/simulated"
+    assert constants.KAGENTI_AUTOSCALING_ANNOTATION == "kagenti.io/autoscaling"
+    assert constants.SIMULATION_HARNESS_SKILLS_MOUNT == "/app/skills-store"
+
+
+def test_simulation_harness_image_setting_defaults():
+    from app.core.config import Settings
+
+    s = Settings()
+    assert s.simulation_harness_image.startswith("ghcr.io/kagenti/simulation-harness")

--- a/kagenti/backend/tests/test_simulation_manifests.py
+++ b/kagenti/backend/tests/test_simulation_manifests.py
@@ -238,7 +238,12 @@ def test_parity_simulation_matches_tool_identity_surface():
         assert sl.get(k) == tl.get(k), f"identity label drift on {k}"
     tpc = tool["spec"]["template"]["spec"]
     spc = sim["spec"]["template"]["spec"]
-    assert spc["securityContext"] == tpc["securityContext"]
+    # Simulated tools add fsGroup so the uid-1000 harness can write its PVC;
+    # apart from that PVC-driven divergence the pod securityContext must match
+    # the regular tool identity surface.
+    sim_sec = {k: v for k, v in spc["securityContext"].items() if k != "fsGroup"}
+    assert sim_sec == tpc["securityContext"]
+    assert spc["securityContext"].get("fsGroup") == 1000
     assert spc["containers"][0]["securityContext"] == tpc["containers"][0]["securityContext"]
 
 

--- a/kagenti/backend/tests/test_simulation_reseed_api.py
+++ b/kagenti/backend/tests/test_simulation_reseed_api.py
@@ -1,0 +1,158 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for simulated-tool database re-seed endpoint (issue #2164)."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _sts(name="petstore", namespace="team1", simulated=True):
+    labels = {"kagenti.io/simulated": "true"} if simulated else {"app.kubernetes.io/name": name}
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, namespace=namespace, labels=labels),
+        spec=SimpleNamespace(replicas=1),
+    )
+
+
+def _kube(sts=None, sts_exc=None):
+    k = MagicMock()
+    if sts_exc is not None:
+        k.apps_api.read_namespaced_stateful_set.side_effect = sts_exc
+    else:
+        k.apps_api.read_namespaced_stateful_set.return_value = sts if sts is not None else _sts()
+    return k
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(sim_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return app
+
+
+def _put(app, body, ns="team1", name="petstore"):
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        return TestClient(app).put(f"/simulation/tools/{ns}/{name}/database", json=body)
+
+
+def _valid_body(db=None):
+    return {"database": json.dumps(db if db is not None else {"pets": []})}
+
+
+def test_reseed_happy_path_forwards_parsed_dict():
+    kube = _kube()
+    put = AsyncMock(return_value=(200, {"message": "Database replaced; simulation reset"}))
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body({"pets": [{"id": 1}]}))
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+    # forwarded the PARSED object, not the raw string
+    args = put.call_args.args
+    assert args[1] == {"pets": [{"id": 1}]}
+
+
+def test_reseed_malformed_json_returns_422_without_harness_call():
+    kube = _kube()
+    put = AsyncMock()
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), {"database": "{not json"})
+    assert r.status_code == 422
+    put.assert_not_called()
+
+
+def test_reseed_non_object_json_returns_422_without_harness_call():
+    kube = _kube()
+    put = AsyncMock()
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), {"database": "[1, 2, 3]"})
+    assert r.status_code == 422
+    put.assert_not_called()
+
+
+def test_reseed_harness_422_returns_422_with_json_path():
+    kube = _kube()
+    put = AsyncMock(return_value=(422, {"detail": "bad type", "json_path": "$.pets[0].id"}))
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert detail["json_path"] == "$.pets[0].id"
+    assert detail["message"] == "bad type"
+
+
+def test_reseed_harness_409_returns_409():
+    kube = _kube()
+    put = AsyncMock(return_value=(409, {}))
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 409
+
+
+def test_reseed_harness_404_returns_409():
+    kube = _kube()
+    put = AsyncMock(return_value=(404, {}))
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 409
+
+
+def test_reseed_harness_503_returns_409():
+    kube = _kube()
+    put = AsyncMock(return_value=(503, {}))
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 409
+
+
+def test_reseed_unreachable_returns_502():
+    kube = _kube()
+    put = AsyncMock(side_effect=sim_router.HarnessUnreachable("down"))
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 502
+
+
+def test_reseed_unexpected_status_returns_502():
+    kube = _kube()
+    put = AsyncMock(return_value=(500, {}))
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 502
+
+
+def test_reseed_missing_statefulset_returns_404():
+    kube = _kube(sts_exc=ApiException(status=404))
+    put = AsyncMock()
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 404
+    put.assert_not_called()
+
+
+def test_reseed_non_simulated_returns_404():
+    kube = _kube(sts=_sts(simulated=False))
+    put = AsyncMock()
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body())
+    assert r.status_code == 404
+    put.assert_not_called()
+
+
+def test_reseed_invalid_name_returns_404_without_backend_calls():
+    kube = _kube()
+    put = AsyncMock()
+    with patch("app.routers.simulation.put_database", new=put):
+        r = _put(_client(kube), _valid_body(), name="Bad_Name")
+    assert r.status_code == 404
+    kube.apps_api.read_namespaced_stateful_set.assert_not_called()
+    put.assert_not_called()

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -130,6 +130,44 @@ def test_statefulset_read_error_returns_502():
     assert r.status_code == 502
 
 
+def test_invalid_namespace_path_param_returns_404_without_backend_calls():
+    # A namespace that is not a DNS-1123 label can never name a real tool; it
+    # must be rejected before it can reach the harness URL (SSRF guard, CWE-918).
+    kube = _kube()
+    harness = AsyncMock()
+    with patch("app.routers.simulation.get_simulation", new=harness):
+        r = _get(_client(kube), ns="Bad_NS", name="petstore")
+    assert r.status_code == 404
+    harness.assert_not_called()
+    kube.apps_api.read_namespaced_stateful_set.assert_not_called()
+
+
+def test_invalid_name_path_param_returns_404_without_backend_calls():
+    kube = _kube()
+    harness = AsyncMock()
+    with patch("app.routers.simulation.get_simulation", new=harness):
+        r = _get(_client(kube), ns="team1", name="Bad_Name")
+    assert r.status_code == 404
+    harness.assert_not_called()
+    kube.apps_api.read_namespaced_stateful_set.assert_not_called()
+
+
+def test_harness_base_url_rejects_invalid_identifiers():
+    import pytest
+
+    with pytest.raises(ValueError):
+        sim_router._harness_base_url("Bad_Name", "team1", 8000)
+    with pytest.raises(ValueError):
+        sim_router._harness_base_url("petstore", "Bad_NS", 8000)
+
+
+def test_harness_base_url_builds_url_for_valid_identifiers():
+    assert (
+        sim_router._harness_base_url("petstore", "team1", 8000)
+        == "http://petstore-mcp.team1.svc.cluster.local:8000"
+    )
+
+
 def test_harness_http_error_degrades_to_pod_state():
     import httpx as _httpx
 

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -123,6 +123,13 @@ def test_unknown_workload_returns_404():
     assert r.status_code == 404
 
 
+def test_statefulset_read_error_returns_502():
+    # A non-404 ApiException reading the StatefulSet surfaces as 502.
+    kube = _kube(sts_exc=ApiException(status=403))
+    r = _get(_client(kube))
+    assert r.status_code == 502
+
+
 def test_harness_http_error_degrades_to_pod_state():
     import httpx as _httpx
 

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -1,0 +1,138 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for GET /simulation/tools/{ns}/{name}/generation-status (issue #2162)."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _sts(created=None, ready_replicas=1):
+    created = created or datetime.now(timezone.utc)
+    return SimpleNamespace(
+        metadata=SimpleNamespace(creation_timestamp=created),
+        spec=SimpleNamespace(replicas=1),
+        status=SimpleNamespace(ready_replicas=ready_replicas),
+    )
+
+
+def _kube(sts=None, sts_exc=None, pod_status=None):
+    k = MagicMock()
+    if sts_exc is not None:
+        k.apps_api.read_namespaced_stateful_set.side_effect = sts_exc
+    else:
+        k.apps_api.read_namespaced_stateful_set.return_value = sts or _sts()
+    k.get_workload_pod_status.return_value = pod_status or {
+        "ready": True,
+        "waiting_reason": None,
+        "waiting_message": None,
+    }
+    return k
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(sim_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return app
+
+
+def _get(app, ns="team1", name="petstore"):
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        return TestClient(app).get(f"/simulation/tools/{ns}/{name}/generation-status")
+
+
+def test_ready_returns_ready_with_mcp_url():
+    kube = _kube()
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(return_value={"status": "ready", "mcp_url": "http://x/mcp/petstore"}),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.status_code == 200
+    assert r.json() == {"status": "Ready", "reason": None, "mcpUrl": "http://x/mcp/petstore"}
+
+
+def test_harness_404_healthy_pod_within_timeout_is_generating():
+    kube = _kube()
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(side_effect=sim_router.HarnessNotFound()),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.json()["status"] == "Generating"
+
+
+def test_crashloop_pod_returns_error():
+    kube = _kube(
+        pod_status={
+            "ready": False,
+            "waiting_reason": "CrashLoopBackOff",
+            "waiting_message": "no LLM_API_KEY",
+        }
+    )
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(side_effect=sim_router.HarnessUnreachable("down")),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    body = r.json()
+    assert body["status"] == "Error"
+    assert "CrashLoopBackOff" in body["reason"]
+
+
+def test_stalled_past_timeout_returns_failed():
+    old = datetime.now(timezone.utc) - timedelta(seconds=900)
+    kube = _kube(sts=_sts(created=old))
+    with (
+        patch(
+            "app.routers.simulation.get_simulation",
+            new=AsyncMock(side_effect=sim_router.HarnessNotFound()),
+        ),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.json() == {"status": "Failed", "reason": "generation_stalled", "mcpUrl": None}
+
+
+def test_unknown_workload_returns_404():
+    kube = _kube(sts_exc=ApiException(status=404))
+    r = _get(_client(kube))
+    assert r.status_code == 404
+
+
+def test_harness_http_error_degrades_to_pod_state():
+    import httpx as _httpx
+
+    kube = _kube()
+    err = _httpx.HTTPStatusError("500", request=None, response=None)
+    with (
+        patch("app.routers.simulation.get_simulation", new=AsyncMock(side_effect=err)),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_generation_timeout = 600
+        r = _get(_client(kube))
+    assert r.status_code == 200
+    assert r.json()["status"] == "Generating"

--- a/kagenti/backend/tests/test_simulation_status_api.py
+++ b/kagenti/backend/tests/test_simulation_status_api.py
@@ -15,10 +15,10 @@ from app.routers import simulation as sim_router
 from app.services.kubernetes import get_kubernetes_service
 
 
-def _sts(created=None, ready_replicas=1):
+def _sts(created=None, ready_replicas=1, name="petstore", namespace="team1"):
     created = created or datetime.now(timezone.utc)
     return SimpleNamespace(
-        metadata=SimpleNamespace(creation_timestamp=created),
+        metadata=SimpleNamespace(creation_timestamp=created, name=name, namespace=namespace),
         spec=SimpleNamespace(replicas=1),
         status=SimpleNamespace(ready_replicas=ready_replicas),
     )

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -7,9 +7,10 @@ from app.routers.simulation import map_generation_status
 
 
 def _map(harness=None, ready=False, reason=None, message=None, elapsed=1.0, timeout=600):
+    # `ready` is accepted for call-site compatibility; the mapper does not
+    # depend on pod readiness (reachability + waiting reason drive the result).
     return map_generation_status(
         harness=harness,
-        pod_ready=ready,
         pod_waiting_reason=reason,
         pod_waiting_message=message,
         elapsed_seconds=elapsed,

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -84,3 +84,53 @@ def test_failed_message_with_trailing_colon_is_preserved():
     )
     assert out.status == "Failed"
     assert out.reason == "sidecar_start_failed: died: "
+
+
+def test_failed_folds_cause_type_into_reason():
+    # The harness records the underlying cause (e.g. a timed-out generation
+    # stage rewrapped as a generic RuntimeError) in error.details.cause_type.
+    # It must surface in the reason so the UI shows *why* it failed.
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {
+                "code": "skill_generation_failed",
+                "message": "Skill generation failed for 'tasks'",
+                "details": {"cause_type": "TimeoutError", "cause": ""},
+            },
+        }
+    )
+    assert out.status == "Failed"
+    assert (
+        out.reason == "skill_generation_failed (TimeoutError): Skill generation failed for 'tasks'"
+    )
+
+
+def test_failed_cause_type_with_empty_message_uses_code_and_cause():
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {
+                "code": "skill_generation_failed",
+                "message": "",
+                "details": {"cause_type": "TimeoutError"},
+            },
+        }
+    )
+    assert out.status == "Failed"
+    assert out.reason == "skill_generation_failed (TimeoutError)"
+
+
+def test_failed_details_without_cause_type_unchanged():
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {
+                "code": "instance_init_failed",
+                "message": "boom",
+                "details": {"exception": "RuntimeError"},
+            },
+        }
+    )
+    assert out.status == "Failed"
+    assert out.reason == "instance_init_failed: boom"

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -1,0 +1,65 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the generation-status mapping (issue #2162)."""
+
+from app.routers.simulation import map_generation_status
+
+
+def _map(harness=None, ready=False, reason=None, message=None, elapsed=1.0, timeout=600):
+    return map_generation_status(
+        harness=harness,
+        pod_ready=ready,
+        pod_waiting_reason=reason,
+        pod_waiting_message=message,
+        elapsed_seconds=elapsed,
+        timeout_seconds=timeout,
+    )
+
+
+def test_harness_pending_maps_to_generating():
+    assert _map(harness={"status": "pending"}).status == "Generating"
+
+
+def test_harness_initializing_maps_to_generating():
+    assert _map(harness={"status": "initializing"}).status == "Generating"
+
+
+def test_harness_ready_maps_to_ready_with_mcp_url():
+    out = _map(harness={"status": "ready", "mcp_url": "http://x/mcp/petstore"})
+    assert out.status == "Ready"
+    assert out.mcpUrl == "http://x/mcp/petstore"
+
+
+def test_harness_failed_surfaces_error_code_and_message():
+    out = _map(
+        harness={
+            "status": "failed",
+            "error": {"code": "skill_generation_failed", "message": "LLM error"},
+        }
+    )
+    assert out.status == "Failed"
+    assert out.reason == "skill_generation_failed: LLM error"
+
+
+def test_crashloop_pod_maps_to_error_when_harness_unreachable():
+    out = _map(harness=None, ready=False, reason="CrashLoopBackOff", message="back-off")
+    assert out.status == "Error"
+    assert out.reason == "CrashLoopBackOff: back-off"
+
+
+def test_missing_secret_config_error_maps_to_error():
+    out = _map(harness=None, reason="CreateContainerConfigError", message="secret not found")
+    assert out.status == "Error"
+    assert out.reason == "CreateContainerConfigError: secret not found"
+
+
+def test_healthy_pod_no_harness_within_timeout_is_generating():
+    out = _map(harness=None, ready=True, elapsed=30.0, timeout=600)
+    assert out.status == "Generating"
+
+
+def test_no_harness_past_timeout_maps_to_failed_stalled():
+    out = _map(harness=None, ready=True, elapsed=700.0, timeout=600)
+    assert out.status == "Failed"
+    assert out.reason == "generation_stalled"

--- a/kagenti/backend/tests/test_simulation_status_mapping.py
+++ b/kagenti/backend/tests/test_simulation_status_mapping.py
@@ -63,3 +63,23 @@ def test_no_harness_past_timeout_maps_to_failed_stalled():
     out = _map(harness=None, ready=True, elapsed=700.0, timeout=600)
     assert out.status == "Failed"
     assert out.reason == "generation_stalled"
+
+
+def test_failed_missing_code_defaults_to_unknown():
+    out = _map(harness={"status": "failed", "error": {"message": "boom"}})
+    assert out.status == "Failed"
+    assert out.reason == "unknown: boom"
+
+
+def test_failed_empty_message_uses_code_only():
+    out = _map(harness={"status": "failed", "error": {"code": "creation_timeout", "message": ""}})
+    assert out.status == "Failed"
+    assert out.reason == "creation_timeout"
+
+
+def test_failed_message_with_trailing_colon_is_preserved():
+    out = _map(
+        harness={"status": "failed", "error": {"code": "sidecar_start_failed", "message": "died: "}}
+    )
+    assert out.status == "Failed"
+    assert out.reason == "sidecar_start_failed: died: "

--- a/kagenti/backend/tests/test_simulation_trigger.py
+++ b/kagenti/backend/tests/test_simulation_trigger.py
@@ -22,7 +22,7 @@ async def test_trigger_posts_once_on_202():
         await sim._run_generation_trigger("team1", "petstore", {"openapi": "3.0.0"}, 8000)
     post.assert_awaited_once()
     args = post.await_args.args
-    assert args[0] == "http://petstore.team1.svc.cluster.local:8000"
+    assert args[0] == "http://petstore-mcp.team1.svc.cluster.local:8000"
     assert args[1] == {"openapi": "3.0.0"}
     assert args[2] == "petstore"
 

--- a/kagenti/backend/tests/test_simulation_trigger.py
+++ b/kagenti/backend/tests/test_simulation_trigger.py
@@ -1,0 +1,72 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the generation-trigger background task (issue #2162)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.routers import simulation as sim
+
+
+@pytest.mark.asyncio
+async def test_trigger_posts_once_on_202():
+    post = AsyncMock(return_value=202)
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {"openapi": "3.0.0"}, 8000)
+    post.assert_awaited_once()
+    args = post.await_args.args
+    assert args[0] == "http://petstore.team1.svc.cluster.local:8000"
+    assert args[1] == {"openapi": "3.0.0"}
+    assert args[2] == "petstore"
+
+
+@pytest.mark.asyncio
+async def test_trigger_treats_409_as_done():
+    post = AsyncMock(return_value=409)
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_retries_until_harness_accepts():
+    post = AsyncMock(side_effect=[sim.HarnessUnreachable("down"), 202])
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()) as sleep,
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    assert post.await_count == 2
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_gives_up_after_timeout():
+    post = AsyncMock(side_effect=sim.HarnessUnreachable("down"))
+    # monotonic: first read (start) = 0, subsequent reads jump past the deadline.
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()),
+        patch("app.routers.simulation.time.monotonic", side_effect=[0, 1000, 1000]),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    # It attempted at least once and then gave up rather than looping forever.
+    assert post.await_count >= 1

--- a/kagenti/backend/tests/test_simulation_trigger.py
+++ b/kagenti/backend/tests/test_simulation_trigger.py
@@ -68,5 +68,51 @@ async def test_trigger_gives_up_after_timeout():
         s.simulation_trigger_poll_interval = 5
         s.simulation_generation_timeout = 600
         await sim._run_generation_trigger("team1", "petstore", {}, 8000)
-    # It attempted at least once and then gave up rather than looping forever.
-    assert post.await_count >= 1
+    # Deadline (0 + 600) is already passed on the first check (monotonic -> 1000),
+    # so it posts exactly once, then gives up rather than looping.
+    assert post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_trigger_retries_transient_5xx_then_succeeds():
+    post = AsyncMock(side_effect=[503, 202])
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()) as sleep,
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    assert post.await_count == 2
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_terminal_4xx_does_not_retry():
+    post = AsyncMock(return_value=422)
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()) as sleep,
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    post.assert_awaited_once()
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_trigger_swallows_unexpected_exception():
+    # An unexpected error must not escape the fire-and-forget task.
+    post = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+        patch("app.routers.simulation.post_simulation", new=post),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_trigger_poll_interval = 5
+        s.simulation_generation_timeout = 600
+        # Should return normally, not raise.
+        await sim._run_generation_trigger("team1", "petstore", {}, 8000)
+    post.assert_awaited_once()

--- a/kagenti/backend/tests/test_tools_delete_pvc.py
+++ b/kagenti/backend/tests/test_tools_delete_pvc.py
@@ -1,0 +1,54 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Regression: generic delete_tool cleans up StatefulSet PVCs (issue #2163)."""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from kubernetes.client import ApiException
+
+from app.routers import tools as tools_router
+from app.services.kubernetes import get_kubernetes_service
+
+
+def _kube(pvcs):
+    k = MagicMock()
+    # No Shipwright builds / buildruns.
+    k.list_custom_resources.return_value = []
+    k.delete_custom_resource.side_effect = ApiException(status=404)
+    # Deployment absent; StatefulSet present.
+    k.delete_deployment.side_effect = ApiException(status=404)
+    k.list_statefulset_pvcs.return_value = pvcs
+    return k
+
+
+def _client(kube):
+    app = FastAPI()
+    app.include_router(tools_router.router)
+    app.dependency_overrides[get_kubernetes_service] = lambda: kube
+    return app
+
+
+def _delete(app, ns="team1", name="petstore"):
+    with patch("app.core.auth.settings") as auth:
+        auth.enable_auth = False
+        return TestClient(app).delete(f"/tools/{ns}/{name}")
+
+
+def test_delete_tool_removes_statefulset_pvcs():
+    kube = _kube(pvcs=["data-petstore-0"])
+    r = _delete(_client(kube))
+    assert r.status_code == 200
+    # tools.DeleteResponse has only {success, message}; the resource list is
+    # embedded in the message string.
+    assert "PersistentVolumeClaim/data-petstore-0" in r.json()["message"]
+    kube.delete_persistent_volume_claim.assert_called_once_with("team1", "data-petstore-0")
+
+
+def test_delete_tool_deployment_deletes_no_pvcs():
+    kube = _kube(pvcs=[])  # a Deployment tool has no StatefulSet PVCs
+    r = _delete(_client(kube))
+    assert r.status_code == 200
+    kube.delete_persistent_volume_claim.assert_not_called()

--- a/kagenti/ui-v2/src/App.tsx
+++ b/kagenti/ui-v2/src/App.tsx
@@ -13,6 +13,7 @@ import { BuildProgressPage } from './pages/BuildProgressPage';
 import { ToolCatalogPage } from './pages/ToolCatalogPage';
 import { ToolDetailPage } from './pages/ToolDetailPage';
 import { ToolBuildProgressPage } from './pages/ToolBuildProgressPage';
+import { ToolGenerationProgressPage } from './pages/ToolGenerationProgressPage';
 import { MCPGatewayPage } from './pages/MCPGatewayPage';
 import { AIGatewayPage } from './pages/AIGatewayPage';
 import { GatewayPoliciesPage } from './pages/GatewayPoliciesPage';
@@ -99,6 +100,14 @@ function App() {
           element={
             <ProtectedRoute>
               <ToolBuildProgressPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/tools/:namespace/:name/generate"
+          element={
+            <ProtectedRoute>
+              <ToolGenerationProgressPage />
             </ProtectedRoute>
           }
         />

--- a/kagenti/ui-v2/src/components/GenerationProgressView.tsx
+++ b/kagenti/ui-v2/src/components/GenerationProgressView.tsx
@@ -31,13 +31,25 @@ export const GenerationProgressView: React.FC<GenerationProgressViewProps> = ({
   const phase = mapGenerationStatusToPhase(status);
   const progress = getProgressInfo(phase, elapsedSeconds ?? 0);
 
+  // getProgressInfo's label is written for Shipwright builds ("Building...", "Build
+  // Succeeded"/"Build Failed") — swap in generation-appropriate wording here instead of
+  // reusing progress.label, while still relying on getProgressInfo for value/variant.
+  const progressTitle =
+    status === 'Ready'
+      ? 'Generation complete'
+      : status === 'Failed'
+        ? 'Generation failed'
+        : status === 'Error'
+          ? 'Runtime error'
+          : 'Generating tool…';
+
   return (
     <>
       <Flex alignItems={{ default: 'alignItemsCenter' }} style={{ marginBottom: '12px' }}>
         <FlexItem>{getStatusIcon(phase)}</FlexItem>
         <FlexItem>Generation status: {status}</FlexItem>
       </Flex>
-      <Progress value={progress.value} title={progress.label} variant={progress.variant} />
+      <Progress value={progress.value} title={progressTitle} variant={progress.variant} />
       <DescriptionList style={{ marginTop: '16px' }}>
         <DescriptionListGroup>
           <DescriptionListTerm>Status</DescriptionListTerm>

--- a/kagenti/ui-v2/src/components/GenerationProgressView.tsx
+++ b/kagenti/ui-v2/src/components/GenerationProgressView.tsx
@@ -1,0 +1,63 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React from 'react';
+import {
+  Progress,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import { getProgressInfo, getStatusIcon } from './BuildProgressView';
+import { mapGenerationStatusToPhase } from '@/utils/simulation';
+import type { GenerationStatus } from '@/services/api';
+
+interface GenerationProgressViewProps {
+  status: GenerationStatus;
+  reason?: string;
+  mcpUrl?: string;
+  elapsedSeconds?: number;
+}
+
+export const GenerationProgressView: React.FC<GenerationProgressViewProps> = ({
+  status,
+  reason,
+  mcpUrl,
+  elapsedSeconds,
+}) => {
+  const phase = mapGenerationStatusToPhase(status);
+  const progress = getProgressInfo(phase, elapsedSeconds ?? 0);
+
+  return (
+    <>
+      <Flex alignItems={{ default: 'alignItemsCenter' }} style={{ marginBottom: '12px' }}>
+        <FlexItem>{getStatusIcon(phase)}</FlexItem>
+        <FlexItem>Generation status: {status}</FlexItem>
+      </Flex>
+      <Progress value={progress.value} title={progress.label} variant={progress.variant} />
+      <DescriptionList style={{ marginTop: '16px' }}>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Status</DescriptionListTerm>
+          <DescriptionListDescription>{status}</DescriptionListDescription>
+        </DescriptionListGroup>
+        {reason && (
+          <DescriptionListGroup>
+            <DescriptionListTerm>
+              {status === 'Error' ? 'Runtime error' : 'Failure reason'}
+            </DescriptionListTerm>
+            <DescriptionListDescription>{reason}</DescriptionListDescription>
+          </DescriptionListGroup>
+        )}
+        {mcpUrl && (
+          <DescriptionListGroup>
+            <DescriptionListTerm>MCP URL</DescriptionListTerm>
+            <DescriptionListDescription>{mcpUrl}</DescriptionListDescription>
+          </DescriptionListGroup>
+        )}
+      </DescriptionList>
+    </>
+  );
+};

--- a/kagenti/ui-v2/src/components/SeedDatabaseModal.tsx
+++ b/kagenti/ui-v2/src/components/SeedDatabaseModal.tsx
@@ -91,6 +91,7 @@ const SeedDatabaseModal: React.FC<SeedDatabaseModalProps> = ({
             value={text}
             onChange={(_e, value) => {
               setText(value);
+              setFileError('');
               setServerError(null);
             }}
             rows={14}

--- a/kagenti/ui-v2/src/components/SeedDatabaseModal.tsx
+++ b/kagenti/ui-v2/src/components/SeedDatabaseModal.tsx
@@ -1,0 +1,148 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React from 'react';
+import {
+  Modal,
+  ModalVariant,
+  Button,
+  Form,
+  FormGroup,
+  TextArea,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Alert,
+} from '@patternfly/react-core';
+import { useMutation } from '@tanstack/react-query';
+import { simulationService } from '@/services/api';
+import { parseSeedDatabase, extractReseedError } from '@/utils/simulation';
+
+export interface SeedDatabaseModalProps {
+  isOpen: boolean;
+  namespace: string;
+  name: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const SeedDatabaseModal: React.FC<SeedDatabaseModalProps> = ({
+  isOpen,
+  namespace,
+  name,
+  onClose,
+  onSuccess,
+}) => {
+  const [text, setText] = React.useState('');
+  const [fileError, setFileError] = React.useState('');
+  const [serverError, setServerError] = React.useState<{ message: string; jsonPath?: string } | null>(null);
+
+  const parsed = parseSeedDatabase(text);
+  const parseError = text.trim() && !parsed.ok ? parsed.error : '';
+
+  const reseedMutation = useMutation({
+    mutationFn: () => simulationService.reseedDatabase(namespace, name, text),
+    onSuccess: () => {
+      handleClose();
+      onSuccess?.();
+    },
+    onError: (err) => setServerError(extractReseedError(err)),
+  });
+
+  const handleClose = () => {
+    setText('');
+    setFileError('');
+    setServerError(null);
+    onClose();
+  };
+
+  const handleApply = () => {
+    setServerError(null);
+    reseedMutation.mutate();
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title="Seed / edit database"
+      isOpen={isOpen}
+      onClose={handleClose}
+      description="Replace this simulated tool's database with your own test dataset. The dataset is validated against the tool's schema and the session is reset."
+      actions={[
+        <Button
+          key="apply"
+          variant="primary"
+          onClick={handleApply}
+          isLoading={reseedMutation.isPending}
+          isDisabled={reseedMutation.isPending || !parsed.ok}
+        >
+          Apply dataset
+        </Button>,
+        <Button key="cancel" variant="link" onClick={handleClose} isDisabled={reseedMutation.isPending}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Form>
+        <FormGroup label="db.json" isRequired fieldId="seed-db-json">
+          <TextArea
+            id="seed-db-json"
+            aria-label="Database JSON"
+            value={text}
+            onChange={(_e, value) => {
+              setText(value);
+              setServerError(null);
+            }}
+            rows={14}
+            placeholder='Paste db.json here, or upload a file below'
+            validated={parseError ? 'error' : 'default'}
+          />
+          <input
+            type="file"
+            accept=".json,application/json"
+            aria-label="Upload db.json file"
+            style={{ marginTop: '8px' }}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              // Reset so re-selecting the same file re-fires onChange.
+              e.target.value = '';
+              if (!file) return;
+              const reader = new FileReader();
+              reader.onload = () => {
+                setFileError('');
+                setServerError(null);
+                setText(String(reader.result ?? ''));
+              };
+              reader.onerror = () => {
+                setFileError('Failed to read the selected file. Please try again or paste the dataset directly.');
+              };
+              reader.readAsText(file);
+            }}
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant={fileError || parseError ? 'error' : 'default'}>
+                {fileError || parseError || 'Paste a db.json document (a JSON object), or upload a file.'}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+        {serverError && (
+          <Alert
+            variant="danger"
+            isInline
+            title={
+              serverError.jsonPath
+                ? `Dataset invalid at ${serverError.jsonPath}`
+                : 'Re-seed failed'
+            }
+          >
+            {serverError.message}
+          </Alert>
+        )}
+      </Form>
+    </Modal>
+  );
+};
+
+export default SeedDatabaseModal;

--- a/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
+++ b/kagenti/ui-v2/src/hooks/useFeatureFlags.ts
@@ -21,6 +21,8 @@ export interface FeatureFlags {
   externalSkills: boolean;
   /** Trace-analysis Observability card */
   traceAnalysis: boolean;
+  /** Simulated MCP tools generated from an OpenAPI spec */
+  simulatedTools: boolean;
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -34,6 +36,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   admin: false,
   externalSkills: false,
   traceAnalysis: false,
+  simulatedTools: false,
 };
 
 let cachedFlags: FeatureFlags | null = null;
@@ -58,6 +61,7 @@ export function useFeatureFlags(): FeatureFlags {
           admin: data.admin === true,
           externalSkills: data.externalSkills === true,
           traceAnalysis: data.traceAnalysis === true,
+          simulatedTools: data.simulatedTools === true,
           };
         cachedFlags = validated;
         setFlags(validated);

--- a/kagenti/ui-v2/src/pages/AdminPage.tsx
+++ b/kagenti/ui-v2/src/pages/AdminPage.tsx
@@ -76,6 +76,7 @@ const FLAG_LABELS: Record<DisplayedFlag, string> = {
   authbridgeAPI: 'AuthBridge API',
   externalSkills: 'External Skills',
   traceAnalysis: 'Trace Analysis',
+  simulatedTools: 'Simulated Tools',
 };
 
 const PlatformStatusCard: React.FC = () => {

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -34,11 +34,12 @@ import {
   GridItem,
   Checkbox,
   Radio,
+  TextArea,
 } from '@patternfly/react-core';
 import { TrashIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
 import { useMutation } from '@tanstack/react-query';
 
-import { toolService, ShipwrightBuildConfig } from '@/services/api';
+import { toolService, simulationService, ShipwrightBuildConfig } from '@/services/api';
 import { NamespaceSelector } from '@/components/NamespaceSelector';
 import { EnvImportModal, EnvVar } from '@/components/EnvImportModal';
 import { BuildStrategySelector } from '@/components/BuildStrategySelector';
@@ -77,7 +78,7 @@ const REGISTRY_OPTIONS = [
 const DEFAULT_REPO_URL = 'https://github.com/kagenti/agent-examples';
 const DEFAULT_BRANCH = 'main';
 
-type DeploymentMethod = 'source' | 'image';
+type DeploymentMethod = 'source' | 'image' | 'simulated';
 type EnvVarType = 'value' | 'secret' | 'configMap';
 
 interface ServicePort {
@@ -133,6 +134,9 @@ export const ImportToolPage: React.FC = () => {
   // Deploy from image state
   const [containerImage, setContainerImage] = useState('');
   const [imagePullSecret, setImagePullSecret] = useState('');
+
+  // Simulated tool state
+  const [openapiSpec, setOpenapiSpec] = useState('');
 
   // Pod configuration
   const [servicePorts, setServicePorts] = useState<ServicePort[]>([
@@ -195,6 +199,15 @@ export const ImportToolPage: React.FC = () => {
       } else {
         navigate(`/tools/${namespace}/${finalName}`);
       }
+    },
+  });
+
+  const createSimulationMutation = useMutation({
+    mutationFn: (data: Parameters<typeof simulationService.create>[0]) =>
+      simulationService.create(data),
+    onSuccess: (result) => {
+      // Use the backend-returned name (it may be derived from the spec).
+      navigate(`/tools/${namespace}/${result.name}/generate`);
     },
   });
 
@@ -373,10 +386,13 @@ export const ImportToolPage: React.FC = () => {
     let isValid = true;
 
     // Name validation
-    const finalName = name || getNameFromPath();
+    // Simulated tools may omit the name — the backend derives one from the spec.
+    const finalName = name || (deploymentMethod === 'simulated' ? '' : getNameFromPath());
     if (!finalName) {
-      newValidated.name = 'error';
-      isValid = false;
+      if (deploymentMethod !== 'simulated') {
+        newValidated.name = 'error';
+        isValid = false;
+      }
     } else if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(finalName)) {
       newValidated.name = 'error';
       isValid = false;
@@ -409,7 +425,7 @@ export const ImportToolPage: React.FC = () => {
       } else {
         newValidated.registryNamespace = 'success';
       }
-    } else {
+    } else if (deploymentMethod === 'image') {
       // Container image validation: must match [HOST[:PORT]/]NAMESPACE/REPOSITORY[/…]
       if (!containerImage || !isValidContainerImage(containerImage)) {
         newValidated.containerImage = 'error';
@@ -417,24 +433,46 @@ export const ImportToolPage: React.FC = () => {
       } else {
         newValidated.containerImage = 'success';
       }
+    } else if (deploymentMethod === 'simulated') {
+      // OpenAPI spec validation
+      if (!openapiSpec.trim()) {
+        newValidated.openapiSpec = 'error';
+        isValid = false;
+      } else {
+        newValidated.openapiSpec = 'success';
+      }
     }
 
-    // Image tag validation (shared by both deployment methods)
-    if (imageTag && !isValidImageTag(imageTag)) {
-      newValidated.imageTag = 'error';
-      isValid = false;
-    } else if (imageTag) {
-      newValidated.imageTag = 'success';
+    // Image tag validation (shared by the source/image deployment methods)
+    if (deploymentMethod !== 'simulated') {
+      if (imageTag && !isValidImageTag(imageTag)) {
+        newValidated.imageTag = 'error';
+        isValid = false;
+      } else if (imageTag) {
+        newValidated.imageTag = 'success';
+      }
     }
 
     setValidated(newValidated);
     return isValid;
   };
 
+  const isSubmitting = createMutation.isPending || createSimulationMutation.isPending;
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!validateForm()) {
+      return;
+    }
+
+    if (deploymentMethod === 'simulated') {
+      createSimulationMutation.mutate({
+        namespace,
+        openapiSpec,
+        name: name || undefined,
+        envVars: envVars.filter((ev) => ev.name && (ev.value !== undefined || ev.valueFrom)),
+      });
       return;
     }
 
@@ -474,7 +512,7 @@ export const ImportToolPage: React.FC = () => {
         authBridgeEnabled,
         spireEnabled,
         authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
-        outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
+        outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id: _id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
@@ -501,7 +539,7 @@ export const ImportToolPage: React.FC = () => {
         authBridgeEnabled,
         spireEnabled,
         authBridgeMode: authBridgeEnabled && useEnvoyMode ? 'envoy-sidecar' : undefined,
-        outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id, ...r }) => r) : undefined,
+        outboundRoutes: authBridgeEnabled && outboundRoutes.length > 0 ? outboundRoutes.map(({ id: _id, ...r }) => r) : undefined,
         outboundPortsExclude: authBridgeEnabled && outboundPortsExclude ? outboundPortsExclude : undefined,
         inboundPortsExclude: authBridgeEnabled && inboundPortsExclude ? inboundPortsExclude : undefined,
         defaultOutboundPolicy: authBridgeEnabled && defaultOutboundPolicy ? defaultOutboundPolicy : undefined,
@@ -533,6 +571,19 @@ export const ImportToolPage: React.FC = () => {
               >
                 {createMutation.error instanceof Error
                   ? createMutation.error.message
+                  : 'An unexpected error occurred'}
+              </Alert>
+            )}
+
+            {createSimulationMutation.isError && (
+              <Alert
+                variant="danger"
+                title="Failed to create simulated tool"
+                isInline
+                style={{ marginBottom: '16px' }}
+              >
+                {createSimulationMutation.error instanceof Error
+                  ? createSimulationMutation.error.message
                   : 'An unexpected error occurred'}
               </Alert>
             )}
@@ -599,6 +650,17 @@ export const ImportToolPage: React.FC = () => {
                   id="deploymentMethod-image"
                   style={{ marginTop: features.builds ? '8px' : undefined }}
                 />
+                {features.simulatedTools && (
+                  <Radio
+                    name="deploymentMethod"
+                    label="Simulated Tool"
+                    description="Generate a simulated MCP tool from an OpenAPI spec (no source or image needed)"
+                    isChecked={deploymentMethod === 'simulated'}
+                    onChange={() => setDeploymentMethod('simulated')}
+                    id="deploymentMethod-simulated"
+                    style={{ marginTop: '8px' }}
+                  />
+                )}
               </FormGroup>
 
               <Divider style={{ margin: '24px 0' }} />
@@ -893,6 +955,49 @@ export const ImportToolPage: React.FC = () => {
                       <HelperText>
                         <HelperTextItem>
                           Kubernetes secret containing credentials for private registries
+                        </HelperTextItem>
+                      </HelperText>
+                    </FormHelperText>
+                  </FormGroup>
+                </>
+              )}
+
+              {/* Simulated Tool Configuration */}
+              {deploymentMethod === 'simulated' && (
+                <>
+                  <Title headingLevel="h3" size="md" style={{ marginBottom: '16px' }}>
+                    OpenAPI Specification
+                  </Title>
+
+                  <FormGroup label="OpenAPI spec" isRequired fieldId="openapiSpec">
+                    <TextArea
+                      id="openapiSpec"
+                      aria-label="OpenAPI spec"
+                      value={openapiSpec}
+                      onChange={(_e, value) => setOpenapiSpec(value)}
+                      rows={12}
+                      placeholder="Paste openapi.json here, or upload a file below"
+                      validated={validated.openapiSpec}
+                    />
+                    <input
+                      type="file"
+                      accept=".json,.yaml,.yml,application/json"
+                      aria-label="Upload OpenAPI spec file"
+                      style={{ marginTop: '8px' }}
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (!file) return;
+                        const reader = new FileReader();
+                        reader.onload = () => setOpenapiSpec(String(reader.result ?? ''));
+                        reader.readAsText(file);
+                      }}
+                    />
+                    <FormHelperText>
+                      <HelperText>
+                        <HelperTextItem variant={validated.openapiSpec === 'error' ? 'error' : 'default'}>
+                          {validated.openapiSpec === 'error'
+                            ? 'OpenAPI spec is required'
+                            : 'Paste an OpenAPI spec (JSON or YAML), or upload a file'}
                         </HelperTextItem>
                       </HelperText>
                     </FormHelperText>
@@ -1358,16 +1463,20 @@ export const ImportToolPage: React.FC = () => {
                 <Button
                   variant="primary"
                   type="submit"
-                  isLoading={createMutation.isPending}
-                  isDisabled={createMutation.isPending}
+                  isLoading={isSubmitting}
+                  isDisabled={isSubmitting}
                 >
-                  {createMutation.isPending
-                    ? deploymentMethod === 'source'
-                      ? 'Starting Build...'
-                      : 'Deploying...'
-                    : deploymentMethod === 'source'
-                      ? 'Build & Deploy Tool'
-                      : 'Deploy Tool'}
+                  {deploymentMethod === 'simulated'
+                    ? createSimulationMutation.isPending
+                      ? 'Creating Simulated Tool...'
+                      : 'Create Simulated Tool'
+                    : createMutation.isPending
+                      ? deploymentMethod === 'source'
+                        ? 'Starting Build...'
+                        : 'Deploying...'
+                      : deploymentMethod === 'source'
+                        ? 'Build & Deploy Tool'
+                        : 'Deploy Tool'}
                 </Button>
                 <Button variant="link" onClick={() => navigate('/tools')}>
                   Cancel

--- a/kagenti/ui-v2/src/pages/ImportToolPage.tsx
+++ b/kagenti/ui-v2/src/pages/ImportToolPage.tsx
@@ -137,6 +137,7 @@ export const ImportToolPage: React.FC = () => {
 
   // Simulated tool state
   const [openapiSpec, setOpenapiSpec] = useState('');
+  const [openapiSpecFileError, setOpenapiSpecFileError] = useState('');
 
   // Pod configuration
   const [servicePorts, setServicePorts] = useState<ServicePort[]>([
@@ -986,18 +987,28 @@ export const ImportToolPage: React.FC = () => {
                       style={{ marginTop: '8px' }}
                       onChange={(e) => {
                         const file = e.target.files?.[0];
+                        // Reset so re-selecting the same file re-fires onChange.
+                        e.target.value = '';
                         if (!file) return;
                         const reader = new FileReader();
-                        reader.onload = () => setOpenapiSpec(String(reader.result ?? ''));
+                        reader.onload = () => {
+                          setOpenapiSpecFileError('');
+                          setOpenapiSpec(String(reader.result ?? ''));
+                        };
+                        reader.onerror = () => {
+                          setOpenapiSpecFileError('Failed to read the selected file. Please try again or paste the spec directly.');
+                        };
                         reader.readAsText(file);
                       }}
                     />
                     <FormHelperText>
                       <HelperText>
-                        <HelperTextItem variant={validated.openapiSpec === 'error' ? 'error' : 'default'}>
-                          {validated.openapiSpec === 'error'
-                            ? 'OpenAPI spec is required'
-                            : 'Paste an OpenAPI spec (JSON or YAML), or upload a file'}
+                        <HelperTextItem variant={openapiSpecFileError || validated.openapiSpec === 'error' ? 'error' : 'default'}>
+                          {openapiSpecFileError
+                            ? openapiSpecFileError
+                            : validated.openapiSpec === 'error'
+                              ? 'OpenAPI spec is required'
+                              : 'Paste an OpenAPI spec (JSON or YAML), or upload a file'}
                         </HelperTextItem>
                       </HelperText>
                     </FormHelperText>
@@ -1005,49 +1016,53 @@ export const ImportToolPage: React.FC = () => {
                 </>
               )}
 
-              <Divider style={{ margin: '24px 0' }} />
+              {/* Workload Type — out of scope for simulated tools (not sent in the simulation payload) */}
+              {deploymentMethod !== 'simulated' && (
+                <>
+                  <Divider style={{ margin: '24px 0' }} />
 
-              {/* Workload Type */}
-              <Title headingLevel="h3" size="md" style={{ marginBottom: '16px' }}>
-                Workload Type
-              </Title>
+                  <Title headingLevel="h3" size="md" style={{ marginBottom: '16px' }}>
+                    Workload Type
+                  </Title>
 
-              <FormGroup role="radiogroup" fieldId="workloadType">
-                <Radio
-                  name="workloadType"
-                  label="Deployment"
-                  description="Standard Kubernetes Deployment (default, stateless workload)"
-                  isChecked={workloadType === 'deployment'}
-                  onChange={() => setWorkloadType('deployment')}
-                  id="workloadType-deployment"
-                />
-                <Radio
-                  name="workloadType"
-                  label="StatefulSet"
-                  description="Kubernetes StatefulSet with persistent storage (for tools that need data persistence)"
-                  isChecked={workloadType === 'statefulset'}
-                  onChange={() => setWorkloadType('statefulset')}
-                  id="workloadType-statefulset"
-                  style={{ marginTop: '8px' }}
-                />
-              </FormGroup>
+                  <FormGroup role="radiogroup" fieldId="workloadType">
+                    <Radio
+                      name="workloadType"
+                      label="Deployment"
+                      description="Standard Kubernetes Deployment (default, stateless workload)"
+                      isChecked={workloadType === 'deployment'}
+                      onChange={() => setWorkloadType('deployment')}
+                      id="workloadType-deployment"
+                    />
+                    <Radio
+                      name="workloadType"
+                      label="StatefulSet"
+                      description="Kubernetes StatefulSet with persistent storage (for tools that need data persistence)"
+                      isChecked={workloadType === 'statefulset'}
+                      onChange={() => setWorkloadType('statefulset')}
+                      id="workloadType-statefulset"
+                      style={{ marginTop: '8px' }}
+                    />
+                  </FormGroup>
 
-              {workloadType === 'statefulset' && (
-                <FormGroup label="Persistent Volume Size" fieldId="persistentStorageSize">
-                  <TextInput
-                    id="persistentStorageSize"
-                    value={persistentStorageSize}
-                    onChange={(_e, value) => setPersistentStorageSize(value)}
-                    placeholder="1Gi"
-                  />
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem>
-                        Size of the persistent volume claim (e.g., 1Gi, 5Gi, 10Gi)
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                </FormGroup>
+                  {workloadType === 'statefulset' && (
+                    <FormGroup label="Persistent Volume Size" fieldId="persistentStorageSize">
+                      <TextInput
+                        id="persistentStorageSize"
+                        value={persistentStorageSize}
+                        onChange={(_e, value) => setPersistentStorageSize(value)}
+                        placeholder="1Gi"
+                      />
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem>
+                            Size of the persistent volume claim (e.g., 1Gi, 5Gi, 10Gi)
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    </FormGroup>
+                  )}
+                </>
               )}
 
               <Divider style={{ margin: '24px 0' }} />
@@ -1082,250 +1097,253 @@ export const ImportToolPage: React.FC = () => {
                 />
               </FormGroup>
 
-              {/* AuthBridge Sidecar Injection */}
-              <FormGroup fieldId="authBridgeEnabled">
-                <Checkbox
-                  id="authBridgeEnabled"
-                  label="Enable AuthBridge sidecar injection"
-                  isChecked={authBridgeEnabled}
-                  onChange={(_e, checked) => {
-                    setAuthBridgeEnabled(checked);
-                    if (!checked) {
-                      setUseEnvoyMode(false);
-                    }
-                  }}
-                  description="When enabled, the operator injects a combined AuthBridge sidecar for inbound JWT validation and outbound token exchange. Defaults to proxy-sidecar mode (HTTP_PROXY)."
-                />
-              </FormGroup>
+              {/* AuthBridge Sidecar Injection, SPIRE, and Pod Configuration — out of scope for
+                  simulated tools (not sent in the simulation payload). */}
+              {deploymentMethod !== 'simulated' && (
+                <>
+                  <FormGroup fieldId="authBridgeEnabled">
+                    <Checkbox
+                      id="authBridgeEnabled"
+                      label="Enable AuthBridge sidecar injection"
+                      isChecked={authBridgeEnabled}
+                      onChange={(_e, checked) => {
+                        setAuthBridgeEnabled(checked);
+                        if (!checked) {
+                          setUseEnvoyMode(false);
+                        }
+                      }}
+                      description="When enabled, the operator injects a combined AuthBridge sidecar for inbound JWT validation and outbound token exchange. Defaults to proxy-sidecar mode (HTTP_PROXY)."
+                    />
+                  </FormGroup>
 
-              {authBridgeEnabled && (
-                <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
-                  <Checkbox
-                    id="useEnvoyMode"
-                    label="Use envoy-sidecar mode"
-                    isChecked={useEnvoyMode}
-                    onChange={(_e, checked) => setUseEnvoyMode(checked)}
-                    description="Switch from proxy-sidecar (default) to envoy-sidecar mode (Envoy + ext_proc + iptables interception)."
-                  />
-                </FormGroup>
-              )}
-
-              {/* SPIRE Identity */}
-              <FormGroup fieldId="spireEnabled">
-                <Checkbox
-                  id="spireEnabled"
-                  label="Enable SPIRE identity (JWT-SVID via spiffe-helper)"
-                  isChecked={spireEnabled}
-                  onChange={(_e, checked) => setSpireEnabled(checked)}
-                />
-              </FormGroup>
-
-
-              {authBridgeEnabled && (
-              <ExpandableSection
-                toggleText={`Outbound Routing Rules (${outboundRoutes.length} route${outboundRoutes.length !== 1 ? 's' : ''})`}
-                isExpanded={showOutboundRouting}
-                onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
-              >
-                <Text component="p" style={{ marginBottom: '8px' }}>
-                  Configure token exchange rules for outbound HTTP requests. Each route matches a service host and specifies the target audience and OAuth scopes for the exchanged token.
-                </Text>
-                {outboundRoutes.map((route, index) => (
-                  <Grid hasGutter key={route.id} style={{ marginBottom: '8px' }}>
-                    <GridItem span={3}>
-                      <TextInput
-                        aria-label="Host pattern"
-                        value={route.host}
-                        onChange={(_e, v) => updateRoute(index, 'host', v)}
-                        placeholder="e.g. github-tool-mcp"
+                  {authBridgeEnabled && (
+                    <FormGroup fieldId="useEnvoyMode" style={{ marginLeft: '24px' }}>
+                      <Checkbox
+                        id="useEnvoyMode"
+                        label="Use envoy-sidecar mode"
+                        isChecked={useEnvoyMode}
+                        onChange={(_e, checked) => setUseEnvoyMode(checked)}
+                        description="Switch from proxy-sidecar (default) to envoy-sidecar mode (Envoy + ext_proc + iptables interception)."
                       />
-                    </GridItem>
-                    <GridItem span={3}>
-                      <TextInput
-                        aria-label="Target audience"
-                        value={route.target_audience}
-                        onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
-                        placeholder="e.g. github-tool"
-                      />
-                    </GridItem>
-                    <GridItem span={4}>
-                      <TextInput
-                        aria-label="Token scopes"
-                        value={route.token_scopes}
-                        onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
-                        placeholder="openid scope1 scope2"
-                      />
-                    </GridItem>
-                    <GridItem span={2}>
-                      <Button variant="plain" onClick={() => removeRoute(index)}>
-                        Remove
-                      </Button>
-                    </GridItem>
-                  </Grid>
-                ))}
-                <Button variant="link" onClick={addRoute}>
-                  Add Route
-                </Button>
-              </ExpandableSection>
-              )}
+                    </FormGroup>
+                  )}
 
+                  {/* SPIRE Identity */}
+                  <FormGroup fieldId="spireEnabled">
+                    <Checkbox
+                      id="spireEnabled"
+                      label="Enable SPIRE identity (JWT-SVID via spiffe-helper)"
+                      isChecked={spireEnabled}
+                      onChange={(_e, checked) => setSpireEnabled(checked)}
+                    />
+                  </FormGroup>
 
-              {authBridgeEnabled && (
-              <ExpandableSection
-                toggleText="AuthBridge Advanced Configuration"
-              >
-                <FormGroup label="Outbound Ports to Exclude" fieldId="outboundPortsExclude">
-                  <TextInput
-                    id="outboundPortsExclude"
-                    value={outboundPortsExclude}
-                    onChange={(_e, v) => setOutboundPortsExclude(v)}
-                    placeholder="e.g. 11434,443"
-                  />
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem>Comma-separated ports to bypass outbound proxy interception.</HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                </FormGroup>
-                <FormGroup label="Inbound Ports to Exclude" fieldId="inboundPortsExclude">
-                  <TextInput
-                    id="inboundPortsExclude"
-                    value={inboundPortsExclude}
-                    onChange={(_e, v) => setInboundPortsExclude(v)}
-                    placeholder="e.g. 9090"
-                  />
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem>Comma-separated ports to bypass inbound proxy interception.</HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                </FormGroup>
-                <FormGroup label="Default Outbound Policy" fieldId="defaultOutboundPolicy">
-                  <FormSelect
-                    id="defaultOutboundPolicy"
-                    value={defaultOutboundPolicy}
-                    onChange={(_e, v) => setDefaultOutboundPolicy(v)}
-                    aria-label="Default outbound policy"
+                  {authBridgeEnabled && (
+                  <ExpandableSection
+                    toggleText={`Outbound Routing Rules (${outboundRoutes.length} route${outboundRoutes.length !== 1 ? 's' : ''})`}
+                    isExpanded={showOutboundRouting}
+                    onToggle={(_event, expanded) => setShowOutboundRouting(expanded)}
                   >
-                    <FormSelectOption key="passthrough" value="passthrough" label="passthrough — pass traffic through unchanged (default)" />
-                    <FormSelectOption key="exchange" value="exchange" label="exchange — require token exchange for all outbound traffic" />
-                  </FormSelect>
-                </FormGroup>
-              </ExpandableSection>
-              )}
-
-              {/* Pod Configuration */}
-              <ExpandableSection
-                toggleText={`Pod Configuration (${servicePorts.length} port${servicePorts.length !== 1 ? 's' : ''})`}
-                isExpanded={showPodConfig}
-                onToggle={() => setShowPodConfig(!showPodConfig)}
-              >
-                <Card isFlat style={{ marginTop: '8px' }}>
-                  <CardBody>
-                    <Text component="p" style={{ marginBottom: '16px' }}>
-                      Configure service ports for the tool pod.
+                    <Text component="p" style={{ marginBottom: '8px' }}>
+                      Configure token exchange rules for outbound HTTP requests. Each route matches a service host and specifies the target audience and OAuth scopes for the exchanged token.
                     </Text>
-
-                    {servicePorts.map((port, index) => (
-                      <Grid hasGutter key={index} style={{ marginBottom: '8px' }}>
+                    {outboundRoutes.map((route, index) => (
+                      <Grid hasGutter key={route.id} style={{ marginBottom: '8px' }}>
                         <GridItem span={3}>
                           <TextInput
-                            aria-label="Port name"
-                            value={port.name}
-                            onChange={(_e, value) => updateServicePort(index, 'name', value)}
-                            placeholder="http"
+                            aria-label="Host pattern"
+                            value={route.host}
+                            onChange={(_e, v) => updateRoute(index, 'host', v)}
+                            placeholder="e.g. github-tool-mcp"
                           />
-                          {index === 0 && (
-                            <FormHelperText>
-                              <HelperText>
-                                <HelperTextItem>Port Name</HelperTextItem>
-                              </HelperText>
-                            </FormHelperText>
-                          )}
+                        </GridItem>
+                        <GridItem span={3}>
+                          <TextInput
+                            aria-label="Target audience"
+                            value={route.target_audience}
+                            onChange={(_e, v) => updateRoute(index, 'target_audience', v)}
+                            placeholder="e.g. github-tool"
+                          />
+                        </GridItem>
+                        <GridItem span={4}>
+                          <TextInput
+                            aria-label="Token scopes"
+                            value={route.token_scopes}
+                            onChange={(_e, v) => updateRoute(index, 'token_scopes', v)}
+                            placeholder="openid scope1 scope2"
+                          />
                         </GridItem>
                         <GridItem span={2}>
-                          <NumberInput
-                            value={port.port}
-                            min={1}
-                            max={65535}
-                            onMinus={() => updateServicePort(index, 'port', port.port - 1)}
-                            onPlus={() => updateServicePort(index, 'port', port.port + 1)}
-                            onChange={(event) => {
-                              const target = event.target as HTMLInputElement;
-                              updateServicePort(index, 'port', parseInt(target.value, 10) || 8000);
-                            }}
-                            inputAriaLabel="Service port"
-                          />
-                          {index === 0 && (
-                            <FormHelperText>
-                              <HelperText>
-                                <HelperTextItem>Service Port</HelperTextItem>
-                              </HelperText>
-                            </FormHelperText>
-                          )}
-                        </GridItem>
-                        <GridItem span={2}>
-                          <NumberInput
-                            value={port.targetPort}
-                            min={1}
-                            max={65535}
-                            onMinus={() => updateServicePort(index, 'targetPort', port.targetPort - 1)}
-                            onPlus={() => updateServicePort(index, 'targetPort', port.targetPort + 1)}
-                            onChange={(event) => {
-                              const target = event.target as HTMLInputElement;
-                              updateServicePort(index, 'targetPort', parseInt(target.value, 10) || 8000);
-                            }}
-                            inputAriaLabel="Target port"
-                          />
-                          {index === 0 && (
-                            <FormHelperText>
-                              <HelperText>
-                                <HelperTextItem>Target Port</HelperTextItem>
-                              </HelperText>
-                            </FormHelperText>
-                          )}
-                        </GridItem>
-                        <GridItem span={2}>
-                          <FormSelect
-                            value={port.protocol}
-                            onChange={(_e, value) => updateServicePort(index, 'protocol', value)}
-                            aria-label="Protocol"
-                          >
-                            <FormSelectOption value="TCP" label="TCP" />
-                            <FormSelectOption value="UDP" label="UDP" />
-                          </FormSelect>
-                          {index === 0 && (
-                            <FormHelperText>
-                              <HelperText>
-                                <HelperTextItem>Protocol</HelperTextItem>
-                              </HelperText>
-                            </FormHelperText>
-                          )}
-                        </GridItem>
-                        <GridItem span={1}>
-                          <Button
-                            variant="plain"
-                            onClick={() => removeServicePort(index)}
-                            aria-label="Remove port"
-                            isDisabled={servicePorts.length <= 1}
-                            style={{ color: 'var(--pf-v5-global--danger-color--100)' }}
-                          >
-                            <TrashIcon />
+                          <Button variant="plain" onClick={() => removeRoute(index)}>
+                            Remove
                           </Button>
                         </GridItem>
                       </Grid>
                     ))}
-
-                    <Button
-                      variant="link"
-                      icon={<PlusCircleIcon />}
-                      onClick={addServicePort}
-                    >
-                      Add Service Port
+                    <Button variant="link" onClick={addRoute}>
+                      Add Route
                     </Button>
-                  </CardBody>
-                </Card>
-              </ExpandableSection>
+                  </ExpandableSection>
+                  )}
+
+                  {authBridgeEnabled && (
+                  <ExpandableSection
+                    toggleText="AuthBridge Advanced Configuration"
+                  >
+                    <FormGroup label="Outbound Ports to Exclude" fieldId="outboundPortsExclude">
+                      <TextInput
+                        id="outboundPortsExclude"
+                        value={outboundPortsExclude}
+                        onChange={(_e, v) => setOutboundPortsExclude(v)}
+                        placeholder="e.g. 11434,443"
+                      />
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem>Comma-separated ports to bypass outbound proxy interception.</HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    </FormGroup>
+                    <FormGroup label="Inbound Ports to Exclude" fieldId="inboundPortsExclude">
+                      <TextInput
+                        id="inboundPortsExclude"
+                        value={inboundPortsExclude}
+                        onChange={(_e, v) => setInboundPortsExclude(v)}
+                        placeholder="e.g. 9090"
+                      />
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem>Comma-separated ports to bypass inbound proxy interception.</HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    </FormGroup>
+                    <FormGroup label="Default Outbound Policy" fieldId="defaultOutboundPolicy">
+                      <FormSelect
+                        id="defaultOutboundPolicy"
+                        value={defaultOutboundPolicy}
+                        onChange={(_e, v) => setDefaultOutboundPolicy(v)}
+                        aria-label="Default outbound policy"
+                      >
+                        <FormSelectOption key="passthrough" value="passthrough" label="passthrough — pass traffic through unchanged (default)" />
+                        <FormSelectOption key="exchange" value="exchange" label="exchange — require token exchange for all outbound traffic" />
+                      </FormSelect>
+                    </FormGroup>
+                  </ExpandableSection>
+                  )}
+
+                  {/* Pod Configuration */}
+                  <ExpandableSection
+                    toggleText={`Pod Configuration (${servicePorts.length} port${servicePorts.length !== 1 ? 's' : ''})`}
+                    isExpanded={showPodConfig}
+                    onToggle={() => setShowPodConfig(!showPodConfig)}
+                  >
+                    <Card isFlat style={{ marginTop: '8px' }}>
+                      <CardBody>
+                        <Text component="p" style={{ marginBottom: '16px' }}>
+                          Configure service ports for the tool pod.
+                        </Text>
+
+                        {servicePorts.map((port, index) => (
+                          <Grid hasGutter key={index} style={{ marginBottom: '8px' }}>
+                            <GridItem span={3}>
+                              <TextInput
+                                aria-label="Port name"
+                                value={port.name}
+                                onChange={(_e, value) => updateServicePort(index, 'name', value)}
+                                placeholder="http"
+                              />
+                              {index === 0 && (
+                                <FormHelperText>
+                                  <HelperText>
+                                    <HelperTextItem>Port Name</HelperTextItem>
+                                  </HelperText>
+                                </FormHelperText>
+                              )}
+                            </GridItem>
+                            <GridItem span={2}>
+                              <NumberInput
+                                value={port.port}
+                                min={1}
+                                max={65535}
+                                onMinus={() => updateServicePort(index, 'port', port.port - 1)}
+                                onPlus={() => updateServicePort(index, 'port', port.port + 1)}
+                                onChange={(event) => {
+                                  const target = event.target as HTMLInputElement;
+                                  updateServicePort(index, 'port', parseInt(target.value, 10) || 8000);
+                                }}
+                                inputAriaLabel="Service port"
+                              />
+                              {index === 0 && (
+                                <FormHelperText>
+                                  <HelperText>
+                                    <HelperTextItem>Service Port</HelperTextItem>
+                                  </HelperText>
+                                </FormHelperText>
+                              )}
+                            </GridItem>
+                            <GridItem span={2}>
+                              <NumberInput
+                                value={port.targetPort}
+                                min={1}
+                                max={65535}
+                                onMinus={() => updateServicePort(index, 'targetPort', port.targetPort - 1)}
+                                onPlus={() => updateServicePort(index, 'targetPort', port.targetPort + 1)}
+                                onChange={(event) => {
+                                  const target = event.target as HTMLInputElement;
+                                  updateServicePort(index, 'targetPort', parseInt(target.value, 10) || 8000);
+                                }}
+                                inputAriaLabel="Target port"
+                              />
+                              {index === 0 && (
+                                <FormHelperText>
+                                  <HelperText>
+                                    <HelperTextItem>Target Port</HelperTextItem>
+                                  </HelperText>
+                                </FormHelperText>
+                              )}
+                            </GridItem>
+                            <GridItem span={2}>
+                              <FormSelect
+                                value={port.protocol}
+                                onChange={(_e, value) => updateServicePort(index, 'protocol', value)}
+                                aria-label="Protocol"
+                              >
+                                <FormSelectOption value="TCP" label="TCP" />
+                                <FormSelectOption value="UDP" label="UDP" />
+                              </FormSelect>
+                              {index === 0 && (
+                                <FormHelperText>
+                                  <HelperText>
+                                    <HelperTextItem>Protocol</HelperTextItem>
+                                  </HelperText>
+                                </FormHelperText>
+                              )}
+                            </GridItem>
+                            <GridItem span={1}>
+                              <Button
+                                variant="plain"
+                                onClick={() => removeServicePort(index)}
+                                aria-label="Remove port"
+                                isDisabled={servicePorts.length <= 1}
+                                style={{ color: 'var(--pf-v5-global--danger-color--100)' }}
+                              >
+                                <TrashIcon />
+                              </Button>
+                            </GridItem>
+                          </Grid>
+                        ))}
+
+                        <Button
+                          variant="link"
+                          icon={<PlusCircleIcon />}
+                          onClick={addServicePort}
+                        >
+                          Add Service Port
+                        </Button>
+                      </CardBody>
+                    </Card>
+                  </ExpandableSection>
+                </>
+              )}
 
               {/* Environment Variables */}
               <ExpandableSection

--- a/kagenti/ui-v2/src/pages/ToolCatalogPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolCatalogPage.tsx
@@ -137,6 +137,13 @@ export const ToolCatalogPage: React.FC = () => {
         </Label>
       );
     }
+    if (tool.labels.simulated) {
+      labels.push(
+        <Label key="simulated" color="purple" isCompact>
+          SIMULATED
+        </Label>
+      );
+    }
     return <LabelGroup>{labels}</LabelGroup>;
   };
 

--- a/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
@@ -173,7 +173,7 @@ export const ToolDetailPage: React.FC = () => {
   const { data: genStatus } = useQuery({
     queryKey: ['simGenerationStatus', namespace, name],
     queryFn: () => simulationService.getGenerationStatus(namespace!, name!),
-    enabled: !!namespace && !!name && simulatedTool && (specReplicas ?? 0) > 0,
+    enabled: !!namespace && !!name && features.simulatedTools && simulatedTool && (specReplicas ?? 0) > 0,
     refetchInterval: (query) => (query.state.data?.status === 'Generating' ? 5000 : false),
   });
 

--- a/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
@@ -70,6 +70,7 @@ import yaml from 'js-yaml';
 
 import { toolService, configService, toolShipwrightService, ToolShipwrightBuildInfo } from '@/services/api';
 import { initialInvokeArgs, buildInvokeArgs } from '@/utils/toolInvoke';
+import { isSimulatedLabels } from '@/utils/simulation';
 
 interface StatusCondition {
   type: string;
@@ -357,6 +358,11 @@ export const ToolDetailPage: React.FC = () => {
                   <Label color="grey">
                     {tool.workloadType === 'statefulset' ? 'StatefulSet' : 'Deployment'}
                   </Label>
+                </FlexItem>
+              )}
+              {isSimulatedLabels(labels) && (
+                <FlexItem>
+                  <Label color="purple">SIMULATED</Label>
                 </FlexItem>
               )}
               <FlexItem>

--- a/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolDetailPage.tsx
@@ -68,9 +68,16 @@ import {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import yaml from 'js-yaml';
 
-import { toolService, configService, toolShipwrightService, ToolShipwrightBuildInfo } from '@/services/api';
+import { toolService, configService, toolShipwrightService, ToolShipwrightBuildInfo, simulationService } from '@/services/api';
 import { initialInvokeArgs, buildInvokeArgs } from '@/utils/toolInvoke';
-import { isSimulatedLabels } from '@/utils/simulation';
+import {
+  isSimulatedLabels,
+  deriveSimState,
+  availableSimActions,
+  simStateBadgeColor,
+} from '@/utils/simulation';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
+import SeedDatabaseModal from '@/components/SeedDatabaseModal';
 
 interface StatusCondition {
   type: string;
@@ -108,14 +115,24 @@ export const ToolDetailPage: React.FC = () => {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const features = useFeatureFlags();
   const [activeTab, setActiveTab] = React.useState<string | number>(0);
   const [expandedTools, setExpandedTools] = React.useState<Record<string, boolean>>({});
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = React.useState('');
   const [actionsMenuOpen, setActionsMenuOpen] = React.useState(false);
+  const [resetModalOpen, setResetModalOpen] = React.useState(false);
+  const [seedModalOpen, setSeedModalOpen] = React.useState(false);
 
   const deleteMutation = useMutation({
-    mutationFn: () => toolService.delete(namespace!, name!),
+    mutationFn: () => {
+      const cached = queryClient.getQueryData(['tool', namespace, name]) as
+        | { metadata?: { labels?: Record<string, string> } }
+        | undefined;
+      return isSimulatedLabels(cached?.metadata?.labels)
+        ? simulationService.delete(namespace!, name!)
+        : toolService.delete(namespace!, name!);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tools'] });
       navigate('/tools');
@@ -148,6 +165,16 @@ export const ToolDetailPage: React.FC = () => {
       const readyStatus = query.state.data?.readyStatus || '';
       return readyStatus === 'Ready' ? false : 5000;
     },
+  });
+
+  const simulatedTool = isSimulatedLabels(tool?.metadata?.labels);
+  const specReplicas = (tool?.spec as { replicas?: number } | undefined)?.replicas;
+
+  const { data: genStatus } = useQuery({
+    queryKey: ['simGenerationStatus', namespace, name],
+    queryFn: () => simulationService.getGenerationStatus(namespace!, name!),
+    enabled: !!namespace && !!name && simulatedTool && (specReplicas ?? 0) > 0,
+    refetchInterval: (query) => (query.state.data?.status === 'Generating' ? 5000 : false),
   });
 
   const connectMutation = useMutation({
@@ -192,6 +219,31 @@ export const ToolDetailPage: React.FC = () => {
     queryKey: ['toolShipwrightBuildStatus', namespace, shipwrightBuildName],
     queryFn: () => toolShipwrightService.getBuildInfo(namespace!, shipwrightBuildName!),
     enabled: !!namespace && !!shipwrightBuildName && !!tool,
+  });
+
+  const lifecycleMutation = useMutation({
+    mutationFn: (action: 'stop' | 'start' | 'reset') => {
+      if (action === 'stop') return simulationService.stop(namespace!, name!);
+      if (action === 'start') return simulationService.start(namespace!, name!);
+      return simulationService.reset(namespace!, name!);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tool', namespace, name] });
+      queryClient.invalidateQueries({ queryKey: ['simGenerationStatus', namespace, name] });
+    },
+  });
+
+  // Retry an Error tool = restart (stop then start) so the recreated pod re-reads
+  // the (now-fixed) config/secret and autostarts from the on-disk bundle.
+  const retryMutation = useMutation({
+    mutationFn: async () => {
+      await simulationService.stop(namespace!, name!);
+      return simulationService.start(namespace!, name!);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tool', namespace, name] });
+      queryClient.invalidateQueries({ queryKey: ['simGenerationStatus', namespace, name] });
+    },
   });
 
   // Open invoke modal for a specific tool
@@ -273,6 +325,14 @@ export const ToolDetailPage: React.FC = () => {
   const readyStatus = tool.readyStatus || 'Not Ready';
   const isReady = readyStatus === 'Ready';
 
+  const derivedSimState = simulatedTool
+    ? deriveSimState({ specReplicas, generationStatus: genStatus?.status })
+    : undefined;
+  const simActions = derivedSimState ? availableSimActions(derivedSimState) : undefined;
+  const showSimUi = features.simulatedTools && simulatedTool;
+  const lifecycleBusy =
+    lifecycleMutation.isPending || retryMutation.isPending || deleteMutation.isPending;
+
   // If route check fails or is loading, default to false (in-cluster URL is safer default)
   const hasRoute = routeStatusData?.hasRoute ?? false;
 
@@ -327,14 +387,18 @@ export const ToolDetailPage: React.FC = () => {
             <Title headingLevel="h1">{name}</Title>
           </SplitItem>
           <SplitItem>
-            <Label color={
-              readyStatus === 'Ready' ? 'green'
-                : readyStatus === 'Progressing' ? 'blue'
-                : readyStatus === 'Failed' ? 'red'
-                : 'orange'
-            }>
-              {readyStatus}
-            </Label>
+            {showSimUi && derivedSimState ? (
+              <Label color={simStateBadgeColor(derivedSimState)}>{derivedSimState}</Label>
+            ) : (
+              <Label color={
+                readyStatus === 'Ready' ? 'green'
+                  : readyStatus === 'Progressing' ? 'blue'
+                    : readyStatus === 'Failed' ? 'red'
+                      : 'orange'
+              }>
+                {readyStatus}
+              </Label>
+            )}
           </SplitItem>
           <SplitItem isFilled />
           <SplitItem>
@@ -382,6 +446,51 @@ export const ToolDetailPage: React.FC = () => {
                   popperProps={{ position: 'right' }}
                 >
                   <DropdownList>
+                    {showSimUi && simActions?.start && (
+                      <DropdownItem
+                        key="start"
+                        isDisabled={lifecycleBusy}
+                        onClick={() => { setActionsMenuOpen(false); lifecycleMutation.mutate('start'); }}
+                      >
+                        Start
+                      </DropdownItem>
+                    )}
+                    {showSimUi && simActions?.stop && (
+                      <DropdownItem
+                        key="stop"
+                        isDisabled={lifecycleBusy}
+                        onClick={() => { setActionsMenuOpen(false); lifecycleMutation.mutate('stop'); }}
+                      >
+                        Stop
+                      </DropdownItem>
+                    )}
+                    {showSimUi && simActions?.reset && (
+                      <DropdownItem
+                        key="reset"
+                        isDisabled={lifecycleBusy}
+                        onClick={() => { setActionsMenuOpen(false); setResetModalOpen(true); }}
+                      >
+                        Reset session
+                      </DropdownItem>
+                    )}
+                    {showSimUi && simActions?.seed && (
+                      <DropdownItem
+                        key="seed"
+                        isDisabled={lifecycleBusy}
+                        onClick={() => { setActionsMenuOpen(false); setSeedModalOpen(true); }}
+                      >
+                        Seed database…
+                      </DropdownItem>
+                    )}
+                    {showSimUi && simActions?.retry && (
+                      <DropdownItem
+                        key="retry"
+                        isDisabled={lifecycleBusy}
+                        onClick={() => { setActionsMenuOpen(false); retryMutation.mutate(); }}
+                      >
+                        Retry
+                      </DropdownItem>
+                    )}
                     <DropdownItem
                       key="delete"
                       onClick={() => {
@@ -399,6 +508,22 @@ export const ToolDetailPage: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
+
+      {showSimUi && (derivedSimState === 'Failed' || derivedSimState === 'Error') && (
+        <PageSection variant="light" style={{ paddingTop: 0 }}>
+          <Alert
+            variant="danger"
+            isInline
+            title={derivedSimState === 'Failed' ? 'Generation failed' : 'Runtime error'}
+          >
+            {genStatus?.reason || 'No reason was reported by the harness.'}
+            {derivedSimState === 'Failed' &&
+              ' Delete this tool and re-import a corrected OpenAPI spec.'}
+            {derivedSimState === 'Error' &&
+              ' Fix the underlying cause (for example a missing LLM_API_KEY Secret), then use Retry.'}
+          </Alert>
+        </PageSection>
+      )}
 
       <PageSection>
         <Tabs
@@ -1123,6 +1248,56 @@ export const ToolDetailPage: React.FC = () => {
           style={{ marginTop: '8px' }}
         />
       </Modal>
+
+      {/* Reset session confirm */}
+      <Modal
+        variant={ModalVariant.small}
+        title="Reset session?"
+        isOpen={resetModalOpen}
+        onClose={() => setResetModalOpen(false)}
+        actions={[
+          <Button
+            key="reset"
+            variant="primary"
+            isLoading={lifecycleMutation.isPending}
+            isDisabled={lifecycleMutation.isPending}
+            onClick={() => {
+              lifecycleMutation.mutate('reset', { onSuccess: () => setResetModalOpen(false) });
+            }}
+          >
+            Reset session
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => setResetModalOpen(false)}
+            isDisabled={lifecycleMutation.isPending}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        <TextContent>
+          <Text>
+            Resetting clears the running session — call counters and the agent thread.
+            The seeded database and generated bundle are retained.
+          </Text>
+        </TextContent>
+      </Modal>
+
+      {/* Seed / edit database */}
+      {showSimUi && (
+        <SeedDatabaseModal
+          isOpen={seedModalOpen}
+          namespace={namespace!}
+          name={name!}
+          onClose={() => setSeedModalOpen(false)}
+          onSuccess={() => {
+            queryClient.invalidateQueries({ queryKey: ['tool', namespace, name] });
+            queryClient.invalidateQueries({ queryKey: ['simGenerationStatus', namespace, name] });
+          }}
+        />
+      )}
     </>
   );
 };

--- a/kagenti/ui-v2/src/pages/ToolGenerationProgressPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolGenerationProgressPage.tsx
@@ -1,0 +1,127 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate, Navigate } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  PageSection,
+  Title,
+  Split,
+  SplitItem,
+  Label,
+  Spinner,
+  Alert,
+  Button,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import {
+  simulationService,
+  GenerationStatusResponse,
+} from '@/services/api';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
+import { GenerationProgressView } from '@/components/GenerationProgressView';
+import { getStatusIcon } from '@/components/BuildProgressView';
+import { isGenerationTerminal, mapGenerationStatusToPhase } from '@/utils/simulation';
+
+const POLL_INTERVAL = 5000;
+
+export const ToolGenerationProgressPage: React.FC = () => {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const features = useFeatureFlags();
+  const [elapsed, setElapsed] = useState(0);
+
+  const { data, isLoading, error } = useQuery<GenerationStatusResponse>({
+    queryKey: ['simGenerationStatus', namespace, name],
+    queryFn: () => simulationService.getGenerationStatus(namespace!, name!),
+    enabled: !!namespace && !!name && features.simulatedTools,
+    refetchInterval: (query) => {
+      const d = query.state.data;
+      if (d && isGenerationTerminal(d.status)) {
+        return false;
+      }
+      return POLL_INTERVAL;
+    },
+  });
+
+  // Tick an elapsed counter while still generating, for the animated progress bar.
+  useEffect(() => {
+    if (data && isGenerationTerminal(data.status)) {
+      return;
+    }
+    const id = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.status]);
+
+  // On Ready, refresh the catalog and go to the tool detail page.
+  useEffect(() => {
+    if (data?.status === 'Ready') {
+      queryClient.invalidateQueries({ queryKey: ['tools'] });
+      navigate(`/tools/${namespace}/${name}`);
+    }
+  }, [data?.status, namespace, name, navigate, queryClient]);
+
+  if (!features.simulatedTools) {
+    return <Navigate to="/tools" replace />;
+  }
+
+  return (
+    <PageSection>
+      <Split hasGutter>
+        <SplitItem isFilled>
+          <Title headingLevel="h1">
+            <Flex alignItems={{ default: 'alignItemsCenter' }}>
+              <FlexItem>{getStatusIcon(mapGenerationStatusToPhase(data?.status ?? 'Generating'))}</FlexItem>
+              <FlexItem>Generating simulated tool: {name}</FlexItem>
+            </Flex>
+          </Title>
+        </SplitItem>
+        <SplitItem>
+          <Label
+            color={
+              data?.status === 'Ready'
+                ? 'green'
+                : data?.status === 'Failed' || data?.status === 'Error'
+                  ? 'red'
+                  : 'blue'
+            }
+          >
+            {data?.status ?? 'Initializing'}
+          </Label>
+        </SplitItem>
+      </Split>
+
+      {isLoading && <Spinner style={{ marginTop: '16px' }} />}
+
+      {error && (
+        <Alert variant="danger" title="Failed to load generation status" style={{ marginTop: '16px' }}>
+          {(error as Error).message}
+        </Alert>
+      )}
+
+      {data && (
+        <div style={{ marginTop: '16px' }}>
+          <GenerationProgressView
+            status={data.status}
+            reason={data.reason}
+            mcpUrl={data.mcpUrl}
+            elapsedSeconds={elapsed}
+          />
+          {(data.status === 'Failed' || data.status === 'Error') && (
+            <Button
+              variant="link"
+              onClick={() => navigate('/tools')}
+              style={{ marginTop: '16px' }}
+            >
+              Back to tool catalog
+            </Button>
+          )}
+        </div>
+      )}
+    </PageSection>
+  );
+};

--- a/kagenti/ui-v2/src/pages/ToolGenerationProgressPage.tsx
+++ b/kagenti/ui-v2/src/pages/ToolGenerationProgressPage.tsx
@@ -54,6 +54,9 @@ export const ToolGenerationProgressPage: React.FC = () => {
     }
     const id = setInterval(() => setElapsed((s) => s + 1), 1000);
     return () => clearInterval(id);
+    // This effect only reads data.status (to decide whether to keep ticking); keying on the
+    // whole `data` object would tear down and recreate the interval on every 5s poll response,
+    // even when the status hasn't changed, so the narrower dependency here is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.status]);
 

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -1587,3 +1587,53 @@ export const authBridgeService = {
   },
 };
 
+// --- Simulated tools (#2165) ---
+
+export type GenerationStatus = 'Generating' | 'Ready' | 'Failed' | 'Error';
+
+export interface SimulationCreateRequest {
+  namespace: string;
+  openapiSpec: string;
+  name?: string;
+  envVars?: Array<{
+    name: string;
+    value?: string;
+    valueFrom?: {
+      secretKeyRef?: { name: string; key: string };
+      configMapKeyRef?: { name: string; key: string };
+    };
+  }>;
+}
+
+export interface SimulationCreateResponse {
+  success: boolean;
+  name: string;
+  namespace: string;
+  status: string;
+  message: string;
+}
+
+export interface GenerationStatusResponse {
+  status: GenerationStatus;
+  reason?: string;
+  mcpUrl?: string;
+}
+
+export const simulationService = {
+  async create(data: SimulationCreateRequest): Promise<SimulationCreateResponse> {
+    return apiFetch<SimulationCreateResponse>('/simulation/tools', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  },
+
+  async getGenerationStatus(
+    namespace: string,
+    name: string
+  ): Promise<GenerationStatusResponse> {
+    return apiFetch<GenerationStatusResponse>(
+      `/simulation/tools/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/generation-status`
+    );
+  },
+};
+

--- a/kagenti/ui-v2/src/services/api.ts
+++ b/kagenti/ui-v2/src/services/api.ts
@@ -65,10 +65,14 @@ export function setTokenForceRefresher(refresher: () => Promise<string | null>):
  */
 export class ApiError extends Error {
   status: number;
-  constructor(message: string, status: number) {
+  /** Parsed FastAPI `detail` payload (string | array | object), preserved verbatim
+   *  so callers can read structured details such as the reseed 422 `json_path`. */
+  detail?: unknown;
+  constructor(message: string, status: number, detail?: unknown) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
+    this.detail = detail;
   }
 }
 
@@ -147,7 +151,8 @@ async function apiFetch<T>(
     const errorData = await response.json().catch(() => ({}));
     throw new ApiError(
       extractErrorMessage(errorData, `API error: ${response.status} ${response.statusText}`),
-      response.status
+      response.status,
+      (errorData as Record<string, unknown>).detail
     );
   }
 
@@ -1619,6 +1624,36 @@ export interface GenerationStatusResponse {
   mcpUrl?: string;
 }
 
+export interface SimulationLifecycleResponse {
+  success: boolean;
+  name: string;
+  namespace: string;
+  status: string;
+  message: string;
+}
+
+export interface SimulationResetResponse {
+  success: boolean;
+  name: string;
+  namespace: string;
+  message: string;
+}
+
+export interface SimulationDeleteResponse {
+  success: boolean;
+  name: string;
+  namespace: string;
+  deletedResources: string[];
+  message: string;
+}
+
+export interface SimulationDatabaseResponse {
+  success: boolean;
+  name: string;
+  namespace: string;
+  message: string;
+}
+
 export const simulationService = {
   async create(data: SimulationCreateRequest): Promise<SimulationCreateResponse> {
     return apiFetch<SimulationCreateResponse>('/simulation/tools', {
@@ -1633,6 +1668,45 @@ export const simulationService = {
   ): Promise<GenerationStatusResponse> {
     return apiFetch<GenerationStatusResponse>(
       `/simulation/tools/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/generation-status`
+    );
+  },
+
+  async stop(namespace: string, name: string): Promise<SimulationLifecycleResponse> {
+    return apiFetch<SimulationLifecycleResponse>(
+      `/simulation/tools/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/stop`,
+      { method: 'POST' }
+    );
+  },
+
+  async start(namespace: string, name: string): Promise<SimulationLifecycleResponse> {
+    return apiFetch<SimulationLifecycleResponse>(
+      `/simulation/tools/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/start`,
+      { method: 'POST' }
+    );
+  },
+
+  async reset(namespace: string, name: string): Promise<SimulationResetResponse> {
+    return apiFetch<SimulationResetResponse>(
+      `/simulation/tools/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/reset`,
+      { method: 'POST' }
+    );
+  },
+
+  async delete(namespace: string, name: string): Promise<SimulationDeleteResponse> {
+    return apiFetch<SimulationDeleteResponse>(
+      `/simulation/tools/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+      { method: 'DELETE' }
+    );
+  },
+
+  async reseedDatabase(
+    namespace: string,
+    name: string,
+    database: string
+  ): Promise<SimulationDatabaseResponse> {
+    return apiFetch<SimulationDatabaseResponse>(
+      `/simulation/tools/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/database`,
+      { method: 'PUT', body: JSON.stringify({ database }) }
     );
   },
 };

--- a/kagenti/ui-v2/src/types/index.ts
+++ b/kagenti/ui-v2/src/types/index.ts
@@ -158,6 +158,7 @@ export interface ToolLabels {
   framework?: string;
   type?: string;
   transport?: string;
+  simulated?: boolean;
 }
 
 export interface Tool {

--- a/kagenti/ui-v2/src/utils/simulation.test.ts
+++ b/kagenti/ui-v2/src/utils/simulation.test.ts
@@ -6,6 +6,9 @@ import {
   mapGenerationStatusToPhase,
   isGenerationTerminal,
   isSimulatedLabels,
+  deriveSimState,
+  availableSimActions,
+  simStateBadgeColor,
 } from './simulation';
 
 describe('mapGenerationStatusToPhase', () => {
@@ -47,5 +50,63 @@ describe('isSimulatedLabels', () => {
   it('is false for undefined/null', () => {
     expect(isSimulatedLabels(undefined)).toBe(false);
     expect(isSimulatedLabels(null)).toBe(false);
+  });
+});
+
+describe('deriveSimState', () => {
+  it('is Stopped when specReplicas is 0, regardless of generation status', () => {
+    expect(deriveSimState({ specReplicas: 0, generationStatus: 'Ready' })).toBe('Stopped');
+    expect(deriveSimState({ specReplicas: 0, generationStatus: 'Failed' })).toBe('Stopped');
+    expect(deriveSimState({ specReplicas: 0, generationStatus: undefined })).toBe('Stopped');
+  });
+  it('passes through the generation status when replicas > 0', () => {
+    expect(deriveSimState({ specReplicas: 1, generationStatus: 'Ready' })).toBe('Ready');
+    expect(deriveSimState({ specReplicas: 1, generationStatus: 'Generating' })).toBe('Generating');
+    expect(deriveSimState({ specReplicas: 1, generationStatus: 'Failed' })).toBe('Failed');
+    expect(deriveSimState({ specReplicas: 1, generationStatus: 'Error' })).toBe('Error');
+  });
+  it('defaults to Generating when replicas > 0 but status is not yet known', () => {
+    expect(deriveSimState({ specReplicas: 1, generationStatus: undefined })).toBe('Generating');
+  });
+  it('treats undefined replicas (tool not yet loaded) as not-stopped', () => {
+    expect(deriveSimState({ specReplicas: undefined, generationStatus: 'Ready' })).toBe('Ready');
+  });
+});
+
+describe('availableSimActions', () => {
+  it('Ready allows stop, reset, seed, delete (not start/retry)', () => {
+    expect(availableSimActions('Ready')).toEqual({
+      start: false, stop: true, reset: true, seed: true, retry: false, delete: true,
+    });
+  });
+  it('Stopped allows start and delete only', () => {
+    expect(availableSimActions('Stopped')).toEqual({
+      start: true, stop: false, reset: false, seed: false, retry: false, delete: true,
+    });
+  });
+  it('Generating allows delete only', () => {
+    expect(availableSimActions('Generating')).toEqual({
+      start: false, stop: false, reset: false, seed: false, retry: false, delete: true,
+    });
+  });
+  it('Error allows retry and delete', () => {
+    expect(availableSimActions('Error')).toEqual({
+      start: false, stop: false, reset: false, seed: false, retry: true, delete: true,
+    });
+  });
+  it('Failed allows delete only', () => {
+    expect(availableSimActions('Failed')).toEqual({
+      start: false, stop: false, reset: false, seed: false, retry: false, delete: true,
+    });
+  });
+});
+
+describe('simStateBadgeColor', () => {
+  it('maps each state to its color', () => {
+    expect(simStateBadgeColor('Ready')).toBe('green');
+    expect(simStateBadgeColor('Stopped')).toBe('grey');
+    expect(simStateBadgeColor('Generating')).toBe('blue');
+    expect(simStateBadgeColor('Failed')).toBe('red');
+    expect(simStateBadgeColor('Error')).toBe('red');
   });
 });

--- a/kagenti/ui-v2/src/utils/simulation.test.ts
+++ b/kagenti/ui-v2/src/utils/simulation.test.ts
@@ -9,6 +9,8 @@ import {
   deriveSimState,
   availableSimActions,
   simStateBadgeColor,
+  parseSeedDatabase,
+  extractReseedError,
 } from './simulation';
 
 describe('mapGenerationStatusToPhase', () => {
@@ -108,5 +110,63 @@ describe('simStateBadgeColor', () => {
     expect(simStateBadgeColor('Generating')).toBe('blue');
     expect(simStateBadgeColor('Failed')).toBe('red');
     expect(simStateBadgeColor('Error')).toBe('red');
+  });
+});
+
+describe('parseSeedDatabase', () => {
+  it('accepts a JSON object', () => {
+    expect(parseSeedDatabase('{"users": []}')).toEqual({ ok: true, value: { users: [] } });
+  });
+  it('rejects malformed JSON', () => {
+    const r = parseSeedDatabase('not json');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/valid JSON/i);
+  });
+  it('rejects a JSON array', () => {
+    const r = parseSeedDatabase('[]');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/object/i);
+  });
+  it('rejects a JSON scalar', () => {
+    expect(parseSeedDatabase('42').ok).toBe(false);
+    expect(parseSeedDatabase('"x"').ok).toBe(false);
+    expect(parseSeedDatabase('null').ok).toBe(false);
+  });
+  it('rejects empty/whitespace input', () => {
+    expect(parseSeedDatabase('   ').ok).toBe(false);
+  });
+});
+
+describe('extractReseedError', () => {
+  it('pulls json_path and message from a 422 object detail', () => {
+    const err = { status: 422, message: 'x', detail: { message: 'bad row', json_path: '$.users[0].id' } };
+    expect(extractReseedError(err)).toEqual({ message: 'bad row', jsonPath: '$.users[0].id' });
+  });
+  it('falls back to a schema message when the 422 object has no message', () => {
+    const err = { status: 422, message: 'x', detail: { json_path: '$.a' } };
+    expect(extractReseedError(err)).toEqual({
+      message: 'Dataset does not validate against the tool schema',
+      jsonPath: '$.a',
+    });
+  });
+  it('uses the error message for a 422 string detail (pre-flight malformed JSON)', () => {
+    const err = { status: 422, message: 'database is not valid JSON', detail: 'database is not valid JSON' };
+    expect(extractReseedError(err)).toEqual({ message: 'database is not valid JSON' });
+  });
+  it('maps 409 to an in-flight message', () => {
+    expect(extractReseedError({ status: 409, message: 'x' })).toEqual({
+      message: 'Tool calls are in flight — retry the re-seed shortly.',
+    });
+  });
+  it('maps 502 to an unreachable message', () => {
+    expect(extractReseedError({ status: 502, message: 'x' })).toEqual({
+      message: 'Simulated tool is not reachable (it may be stopped).',
+    });
+  });
+  it('falls back to the error message for other statuses', () => {
+    expect(extractReseedError({ status: 500, message: 'boom' })).toEqual({ message: 'boom' });
+  });
+  it('handles a non-ApiError value', () => {
+    expect(extractReseedError('weird')).toEqual({ message: 'Unexpected error re-seeding the database.' });
   });
 });

--- a/kagenti/ui-v2/src/utils/simulation.test.ts
+++ b/kagenti/ui-v2/src/utils/simulation.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { describe, it, expect } from 'vitest';
+import {
+  mapGenerationStatusToPhase,
+  isGenerationTerminal,
+  isSimulatedLabels,
+} from './simulation';
+
+describe('mapGenerationStatusToPhase', () => {
+  it('maps Ready to Succeeded', () => {
+    expect(mapGenerationStatusToPhase('Ready')).toBe('Succeeded');
+  });
+  it('maps Failed to Failed', () => {
+    expect(mapGenerationStatusToPhase('Failed')).toBe('Failed');
+  });
+  it('maps Error to Failed', () => {
+    expect(mapGenerationStatusToPhase('Error')).toBe('Failed');
+  });
+  it('maps Generating to Running', () => {
+    expect(mapGenerationStatusToPhase('Generating')).toBe('Running');
+  });
+});
+
+describe('isGenerationTerminal', () => {
+  it('is true for Ready, Failed, and Error', () => {
+    expect(isGenerationTerminal('Ready')).toBe(true);
+    expect(isGenerationTerminal('Failed')).toBe(true);
+    expect(isGenerationTerminal('Error')).toBe(true);
+  });
+  it('is false for Generating', () => {
+    expect(isGenerationTerminal('Generating')).toBe(false);
+  });
+});
+
+describe('isSimulatedLabels', () => {
+  it('is true when the marker equals "true"', () => {
+    expect(isSimulatedLabels({ 'kagenti.io/simulated': 'true' })).toBe(true);
+  });
+  it('is false when the marker is absent', () => {
+    expect(isSimulatedLabels({ 'kagenti.io/framework': 'python' })).toBe(false);
+  });
+  it('is false when the marker is not "true"', () => {
+    expect(isSimulatedLabels({ 'kagenti.io/simulated': 'false' })).toBe(false);
+  });
+  it('is false for undefined/null', () => {
+    expect(isSimulatedLabels(undefined)).toBe(false);
+    expect(isSimulatedLabels(null)).toBe(false);
+  });
+});

--- a/kagenti/ui-v2/src/utils/simulation.ts
+++ b/kagenti/ui-v2/src/utils/simulation.ts
@@ -100,3 +100,60 @@ export function simStateBadgeColor(state: SimState): 'green' | 'grey' | 'blue' |
       return 'red';
   }
 }
+
+/** Result of parsing a user-supplied db.json seed. */
+export type SeedParseResult =
+  | { ok: true; value: Record<string, unknown> }
+  | { ok: false; error: string };
+
+/**
+ * Validate that a seed string is a JSON object (mirrors the backend's
+ * synchronous 422 for malformed / non-object bodies). Schema validation is the
+ * harness's job; this only gates syntactic validity.
+ */
+export function parseSeedDatabase(text: string): SeedParseResult {
+  if (!text.trim()) {
+    return { ok: false, error: 'Enter a db.json document (a JSON object).' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, error: 'Dataset is not valid JSON.' };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, error: 'Dataset must be a JSON object.' };
+  }
+  return { ok: true, value: parsed as Record<string, unknown> };
+}
+
+/**
+ * Map a reseed failure (an ApiError-shaped value) to a user-facing message,
+ * surfacing the harness `json_path` on a 422. Duck-types the error so the helper
+ * stays import-free and unit-testable.
+ */
+export function extractReseedError(err: unknown): { message: string; jsonPath?: string } {
+  const e = err as { status?: number; message?: string; detail?: unknown } | null;
+  if (!e || typeof e !== 'object' || typeof e.status !== 'number') {
+    return { message: 'Unexpected error re-seeding the database.' };
+  }
+  switch (e.status) {
+    case 422: {
+      const detail = e.detail;
+      if (detail && typeof detail === 'object' && !Array.isArray(detail)) {
+        const d = detail as { message?: string; json_path?: string };
+        return {
+          message: d.message || 'Dataset does not validate against the tool schema',
+          jsonPath: d.json_path,
+        };
+      }
+      return { message: e.message || 'Dataset does not validate against the tool schema' };
+    }
+    case 409:
+      return { message: 'Tool calls are in flight — retry the re-seed shortly.' };
+    case 502:
+      return { message: 'Simulated tool is not reachable (it may be stopped).' };
+    default:
+      return { message: e.message || 'Failed to re-seed the database.' };
+  }
+}

--- a/kagenti/ui-v2/src/utils/simulation.ts
+++ b/kagenti/ui-v2/src/utils/simulation.ts
@@ -1,0 +1,36 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import type { GenerationStatus } from '@/services/api';
+
+/**
+ * Map a simulation generation status onto a Shipwright-style phase so the
+ * shared getProgressInfo/getStatusIcon helpers can render it. Both Failed and
+ * Error render as a Failed phase (the distinct reason is shown separately).
+ */
+export function mapGenerationStatusToPhase(
+  status: GenerationStatus
+): 'Running' | 'Succeeded' | 'Failed' {
+  switch (status) {
+    case 'Ready':
+      return 'Succeeded';
+    case 'Failed':
+    case 'Error':
+      return 'Failed';
+    case 'Generating':
+    default:
+      return 'Running';
+  }
+}
+
+/** True once generation has reached a terminal state and polling should stop. */
+export function isGenerationTerminal(status: GenerationStatus): boolean {
+  return status === 'Ready' || status === 'Failed' || status === 'Error';
+}
+
+/** True when raw Kubernetes labels carry the kagenti.io/simulated marker. */
+export function isSimulatedLabels(
+  labels: Record<string, string> | undefined | null
+): boolean {
+  return labels?.['kagenti.io/simulated'] === 'true';
+}

--- a/kagenti/ui-v2/src/utils/simulation.ts
+++ b/kagenti/ui-v2/src/utils/simulation.ts
@@ -34,3 +34,69 @@ export function isSimulatedLabels(
 ): boolean {
   return labels?.['kagenti.io/simulated'] === 'true';
 }
+
+/** Client-derived lifecycle state for a simulated tool. */
+export type SimState = 'Stopped' | 'Generating' | 'Ready' | 'Failed' | 'Error';
+
+/** Which detail-view actions are available for a given lifecycle state. */
+export interface SimActions {
+  start: boolean;
+  stop: boolean;
+  reset: boolean;
+  seed: boolean;
+  retry: boolean;
+  delete: boolean;
+}
+
+/**
+ * Derive a simulated tool's lifecycle state.
+ *
+ * The backend has no clean "Stopped" signal: a StatefulSet scaled to
+ * replicas 0 reports readyStatus "Ready" (a 0>=0 fall-through) and
+ * generation-status drifts to Failed/generation_stalled. The authoritative
+ * Stopped signal is the desired replica count (spec.replicas === 0), which the
+ * tool detail response passes through. When running (replicas > 0) we trust the
+ * generation-status enum, defaulting to Generating while it is still loading.
+ */
+export function deriveSimState(args: {
+  specReplicas: number | undefined;
+  generationStatus: GenerationStatus | undefined;
+}): SimState {
+  if (args.specReplicas === 0) return 'Stopped';
+  return args.generationStatus ?? 'Generating';
+}
+
+/** The action matrix: which dropdown items render for a given state. */
+export function availableSimActions(state: SimState): SimActions {
+  const none: SimActions = {
+    start: false, stop: false, reset: false, seed: false, retry: false, delete: true,
+  };
+  switch (state) {
+    case 'Ready':
+      return { ...none, stop: true, reset: true, seed: true };
+    case 'Stopped':
+      return { ...none, start: true };
+    case 'Error':
+      return { ...none, retry: true };
+    case 'Generating':
+    case 'Failed':
+    default:
+      return none;
+  }
+}
+
+/** Header badge color for a lifecycle state. */
+export function simStateBadgeColor(state: SimState): 'green' | 'grey' | 'blue' | 'red' {
+  switch (state) {
+    case 'Ready':
+      return 'green';
+    case 'Stopped':
+      return 'grey';
+    case 'Generating':
+      return 'blue';
+    case 'Failed':
+    case 'Error':
+    default:
+      return 'red';
+  }
+}


### PR DESCRIPTION
## Summary

UI slice #7 of epic #2151 — adds lifecycle controls and a database seed/edit action to the **simulated-tool** detail view, wired to the already-merged backend endpoints (#2163 lifecycle, #2164 database). UI-only; no backend change. Everything is gated on `features.simulatedTools` **and** the `kagenti.io/simulated` label, so nothing renders for non-simulated tools or when the flag is off.

Closes #2166.

## What's included

- **Actions dropdown** on `ToolDetailPage` gains state-gated **Start / Stop / Reset session / Seed database… / Retry** items alongside Delete.
- **Client-derived lifecycle state** — the backend has no clean "Stopped" signal (a StatefulSet at `replicas: 0` reports `readyStatus: "Ready"` and `generation-status` drifts to `Failed/generation_stalled`), so `deriveSimState` reads the authoritative `spec.replicas === 0` for **Stopped**, and the `generation-status` poll supplies **Generating / Ready / Failed / Error** + the harness/pod reason. The header badge reflects the derived state for simulated tools only.
- **Retry = restart** (`stop()` → `start()`) for an **Error** tool, so the recreated pod re-reads a fixed config/Secret and autostarts from the on-disk bundle with no regeneration. **Failed** tools offer Delete + re-import guidance (no re-generate endpoint exists).
- **Failed/Error alert** surfaces the reason — no silent hang.
- **`SeedDatabaseModal`** — paste/upload a `db.json`, applied via `PUT …/database`; surfaces `422` (with harness `json_path`) and `409` (calls in flight) inline.
- **Delete** routes simulated tools to `simulationService.delete` (leak-proof, returns `deletedResources`); non-simulated tools are unchanged.
- New `simulationService` methods (`stop`/`start`/`reset`/`delete`/`reseedDatabase`) + `ApiError.detail` to pass the `422` `json_path` through.

## Testing

- Business logic lives in pure helpers in `utils/simulation.ts` (`deriveSimState`, `availableSimActions`, `simStateBadgeColor`, `parseSeedDatabase`, `extractReseedError`), unit-tested with vitest — the repo's convention (no RTL/component harness).
- `npm run build` OK; `npx vitest run` **80/80**; scoped eslint clean on all touched files.

## Stacking

Stacked on **#2185** (#2165 UI import flow), which is itself stacked on the backend PRs of the epic. Base is `main` per the fork workflow (cross-fork base can't target the parent branch); this PR should merge after its parents. Review the top 6 commits (`feat(ui): … (#2166)`) — earlier commits belong to the parent PRs.

## Out of scope (follow-ups)

- Backend `_get_workload_status` `0>=0 → "Ready"` mislabel for scaled-to-0 StatefulSets (worked around in the UI; noted for a backend fix).
- Surfacing lifecycle/reset mutation errors inline (currently matches the existing `deleteMutation` house pattern; state self-corrects via the 5s poll).
- `db.json` prefill for editing, and the worked example + E2E (#2167).

Assisted-By: Claude Code
