### PR TITLE
Feat(scripts): add --enable-spiffe-auth flag

### DIFF
--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1224,6 +1224,7 @@ KAGENTI_FLAGS=(
   --set "kagenti-operator-chart.spiffe.operatorAuth.enabled=${ENABLE_OPERATOR_SPIFFE_AUTH}"
   --set "kagenti-operator-chart.keycloak.publicUrl=http://keycloak.${DOMAIN}:8080"
   --set "authBridge.clientAuthType=$($ENABLE_AGENT_SPIFFE_AUTH && echo federated-jwt || echo client-secret)"
+  --set "spire.enabled=${WITH_SPIRE}"
 )
 
 # Allow-list hosts/IPs/CIDRs past the registry-URL SSRF block (for LAN / in-cluster

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -61,6 +61,7 @@ DRY_RUN=false
 SECRETS_FILE_ARG=""
 CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
 ENABLE_OPERATOR_SPIFFE_AUTH=false
+ENABLE_AGENT_SPIFFE_AUTH=false
 
 # Versions
 CERT_MANAGER_VERSION="v1.17.2"
@@ -230,6 +231,8 @@ while [[ $# -gt 0 ]]; do
     --kagenti-deps-values) KAGENTI_DEPS_VALUES_FILES+=("--values" "$2"); shift 2 ;;
     --with-examples)    INSTALL_EXAMPLES=true; shift ;;
     --enable-operator-spiffe-auth) ENABLE_OPERATOR_SPIFFE_AUTH=true; shift ;;
+    --enable-agent-spiffe-auth)   ENABLE_AGENT_SPIFFE_AUTH=true; shift ;;
+    --enable-spiffe-auth)         ENABLE_OPERATOR_SPIFFE_AUTH=true; ENABLE_AGENT_SPIFFE_AUTH=true; shift ;;
     --dry-run)          DRY_RUN=true; shift ;;
     -h|--help)
       echo "Usage: $0 [OPTIONS]"
@@ -280,7 +283,15 @@ while [[ $# -gt 0 ]]; do
       echo "                      Helm override file to apply to Kagenti-deps chart"
       echo "  --with-examples     Install weather agent and weather tool examples"
       echo "  --enable-operator-spiffe-auth"
-      echo "                      Enable SPIFFE authentication for operator (requires SPIRE)"
+      echo "                      Operator authenticates to Keycloak using JWT-SVID instead"
+      echo "                      of admin credentials. Requires --with-spire."
+      echo "  --enable-agent-spiffe-auth"
+      echo "                      Agent/tool workloads authenticate to Keycloak using"
+      echo "                      JWT-SVID (federated-jwt) instead of client secrets."
+      echo "                      Requires --with-spire."
+      echo "  --enable-spiffe-auth"
+      echo "                      Shorthand for both --enable-operator-spiffe-auth and"
+      echo "                      --enable-agent-spiffe-auth. Requires --with-spire."
       echo "  --dry-run           Show commands without executing"
       echo "  -h, --help          Show this help"
       exit 0 ;;
@@ -360,6 +371,16 @@ echo "    Examples:      $INSTALL_EXAMPLES"
 echo "    Kagenti helm --values overrides: ${KAGENTI_VALUES_FILES[*]:-}"
 echo "    Kagenti-deps helm --values overrides: ${KAGENTI_DEPS_VALUES_FILES[*]:-}"
 echo ""
+
+# Validate flag combinations
+if $ENABLE_OPERATOR_SPIFFE_AUTH && ! $WITH_SPIRE; then
+  log_error "--enable-operator-spiffe-auth requires --with-spire (SPIRE must be installed for SPIFFE identities)"
+  exit 1
+fi
+if $ENABLE_AGENT_SPIFFE_AUTH && ! $WITH_SPIRE; then
+  log_error "--enable-agent-spiffe-auth requires --with-spire (SPIRE must be installed for SPIFFE identities)"
+  exit 1
+fi
 
 for cmd in helm kubectl; do
   if ! command -v "$cmd" &>/dev/null; then
@@ -1200,6 +1221,7 @@ KAGENTI_FLAGS=(
   --set "kagenti-operator-chart.featureGates.injectTools=true"
   --set "kagenti-operator-chart.kuadrant.enable=${WITH_KUADRANT}"
   --set "kagenti-operator-chart.spiffe.operatorAuth.enabled=${ENABLE_OPERATOR_SPIFFE_AUTH}"
+  --set "authBridge.clientAuthType=$($ENABLE_AGENT_SPIFFE_AUTH && echo federated-jwt || echo client-secret)"
 )
 
 # Allow-list hosts/IPs/CIDRs past the registry-URL SSRF block (for LAN / in-cluster

--- a/scripts/kind/setup-kagenti.sh
+++ b/scripts/kind/setup-kagenti.sh
@@ -1220,7 +1220,9 @@ KAGENTI_FLAGS=(
   --set "mlflow.auth.enabled=${WITH_MLFLOW}"
   --set "kagenti-operator-chart.featureGates.injectTools=true"
   --set "kagenti-operator-chart.kuadrant.enable=${WITH_KUADRANT}"
+  --set "kagenti-operator-chart.spiffe.enabled=${ENABLE_OPERATOR_SPIFFE_AUTH}"
   --set "kagenti-operator-chart.spiffe.operatorAuth.enabled=${ENABLE_OPERATOR_SPIFFE_AUTH}"
+  --set "kagenti-operator-chart.keycloak.publicUrl=http://keycloak.${DOMAIN}:8080"
   --set "authBridge.clientAuthType=$($ENABLE_AGENT_SPIFFE_AUTH && echo federated-jwt || echo client-secret)"
 )
 


### PR DESCRIPTION
## Summary

Adds three new flags to `setup-kagenti.sh` for enabling SPIFFE-based Keycloak authentication. Tracks [#2174](https://github.com/kagenti/kagenti/issues/2174).

## Changes

- `--enable-operator-spiffe-auth` — operator authenticates to Keycloak using JWT-SVID instead of admin credentials. Sets `kagenti-operator-chart.spiffe.operatorAuth.enabled=true`. Requires `--with-spire`.
- `--enable-agent-spiffe-auth` — agent/tool workloads authenticate using JWT-SVID (`authBridge.clientAuthType=federated-jwt`). Requires `--with-spire`.
- `--enable-spiffe-auth` — convenience shorthand that sets both.
- Guard: both SPIFFE flags now exit immediately with a clear error if `--with-spire` is not passed.

## Dependency

`--enable-operator-spiffe-auth` requires a `kagenti-operator-chart` OCI release that includes the conditional spiffe-helper sidecar template from kagenti-operator#473. That PR is merged to main but a new chart version has not been published yet. The current OCI chart (`0.3.0-alpha.6`) predates it, so the flag is a no-op until a new release is cut.

## Related

- Tracks: #2174
- Depends on (for operator SPIFFE auth): kagenti-operator#473, kagenti-operator#476, new `kagenti-operator-chart` OCI release

## Checklist

- [x] All commits signed-off (DCO)
- [x] Feature gated (default: disabled, requires explicit flags)
- [x] Backward compatible

Assisted-By: Claude Code