### PR TITLE
Fix: Rollback partial failure on agent/tool create

### DIFF
--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -12,7 +12,7 @@ import re
 import socket
 import ipaddress
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 import httpx
@@ -107,6 +107,7 @@ from app.routers.skills import _sanitize_k8s_name
 from app.utils.routes import (
     create_route_for_agent_or_tool,
     detect_platform,
+    rollback_workload_resources,
     route_exists,
     sanitize_log,
     select_route_port,
@@ -3757,6 +3758,10 @@ async def create_agent(
 
     request = apply_agent_import_defaults(request, kube)
 
+    # Persistent resources created during this call, tracked so we can roll them
+    # back if a later creation step fails (avoids leaking a workload, Service,
+    # AgentRuntime, or route). Only used by the image-deployment path below.
+    created: List[Tuple[str, str]] = []
     try:
         if request.deploymentMethod == "image":
             # Deploy from existing container image
@@ -3829,6 +3834,7 @@ async def create_agent(
                     namespace=request.namespace,
                     body=workload_manifest,
                 )
+                created.append(("Deployment", request.name))
                 logger.info(
                     f"Created Deployment '{request.name}' in namespace '{request.namespace}'"
                 )
@@ -3846,6 +3852,7 @@ async def create_agent(
                     namespace=request.namespace,
                     body=workload_manifest,
                 )
+                created.append(("StatefulSet", request.name))
                 logger.info(
                     f"Created StatefulSet '{request.name}' in namespace '{request.namespace}'"
                 )
@@ -3863,6 +3870,7 @@ async def create_agent(
                     namespace=request.namespace,
                     body=workload_manifest,
                 )
+                created.append(("Job", request.name))
                 logger.info(f"Created Job '{request.name}' in namespace '{request.namespace}'")
             elif request.workloadType == WORKLOAD_TYPE_SANDBOX:
                 sandbox_manifest = _build_sandbox_manifest(
@@ -3878,6 +3886,7 @@ async def create_agent(
                     namespace=request.namespace,
                     body=sandbox_manifest,
                 )
+                created.append(("Sandbox", request.name))
                 logger.info(f"Created Sandbox '{request.name}' in namespace '{request.namespace}'")
 
             # Create Service (not needed for Jobs).
@@ -3890,6 +3899,7 @@ async def create_agent(
                     service_manifest,
                     request.workloadType,
                 )
+                created.append(("Service", request.name))
 
             # Create AgentRuntime CR so the per-agent AuthBridge config (mtls /
             # authBridgeMode / tlsBridgeMode) is applied. Sandbox is included
@@ -3905,6 +3915,7 @@ async def create_agent(
                     mtls_mode=request.mtlsMode,
                     tls_bridge_enabled=request.tlsBridgeEnabled,
                 )
+                created.append(("AgentRuntime", request.name))
 
             message = f"Agent '{request.name}' deployed as {request.workloadType} successfully."
 
@@ -3924,6 +3935,11 @@ async def create_agent(
                     service_name=request.name,
                     service_port=service_port,
                 )
+                # create_route_for_agent_or_tool makes an HTTPRoute or an OpenShift
+                # Route depending on platform; track both so rollback deletes the
+                # right one (the other 404s and is swallowed).
+                created.append(("HTTPRoute", request.name))
+                created.append(("Route", request.name))
                 message += " HTTPRoute/Route created for external access."
 
         else:
@@ -3992,6 +4008,10 @@ async def create_agent(
         )
 
     except ApiException as e:
+        # Roll back only what THIS call created (tracked in `created`); if the very
+        # first create 409'd, `created` is empty and rollback is a no-op, so a
+        # pre-existing agent is never deleted.
+        rollback_workload_resources(kube, request.namespace, created)
         if e.status == 409:
             raise HTTPException(
                 status_code=409,
@@ -4009,6 +4029,15 @@ async def create_agent(
             )
         logger.error(f"Failed to create agent: {e}")
         raise HTTPException(status_code=e.status, detail=str(e.reason))
+    except HTTPException:
+        # Validation errors (400) raised above — nothing created yet, re-raise as-is.
+        raise
+    except Exception as e:
+        # Non-API failure (e.g. platform detection in route creation) after some
+        # resources were already created — roll back before surfacing a 500.
+        rollback_workload_resources(kube, request.namespace, created)
+        logger.error(f"Unexpected error creating agent '{request.name}': {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to create agent: {e}")
 
 
 class FinalizeShipwrightBuildRequest(BaseModel):

--- a/kagenti/backend/app/routers/agents.py
+++ b/kagenti/backend/app/routers/agents.py
@@ -4036,7 +4036,11 @@ async def create_agent(
         # Non-API failure (e.g. platform detection in route creation) after some
         # resources were already created — roll back before surfacing a 500.
         rollback_workload_resources(kube, request.namespace, created)
-        logger.error(f"Unexpected error creating agent '{request.name}': {e}")
+        logger.error(
+            "Unexpected error creating agent '%s': %s",
+            sanitize_log(request.name),
+            sanitize_log(str(e)),
+        )
         raise HTTPException(status_code=500, detail=f"Failed to create agent: {e}")
 
 

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -1840,7 +1840,11 @@ async def create_tool(
         # Non-API failure (e.g. platform detection in route creation) after some
         # resources were already created — roll back before surfacing a 500.
         rollback_workload_resources(kube, request.namespace, created)
-        logger.error(f"Unexpected error creating tool '{request.name}': {e}")
+        logger.error(
+            "Unexpected error creating tool '%s': %s",
+            sanitize_log(request.name),
+            sanitize_log(str(e)),
+        )
         raise HTTPException(status_code=500, detail=f"Failed to create tool: {e}")
 
 

--- a/kagenti/backend/app/routers/tools.py
+++ b/kagenti/backend/app/routers/tools.py
@@ -9,7 +9,7 @@ Tool API endpoints.
 import asyncio
 import logging
 import re
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from contextlib import AsyncExitStack
 from urllib.parse import urlparse
 
@@ -90,6 +90,7 @@ from app.services.shipwright import (
 from app.utils.routes import (
     create_route_for_agent_or_tool,
     lookup_service_port,
+    rollback_workload_resources,
     route_exists,
     sanitize_log,
     select_route_port,
@@ -1588,6 +1589,10 @@ async def create_tool(
     For source builds, creates a Shipwright Build + BuildRun and returns.
     The Deployment/StatefulSet is created later via the finalize-shipwright-build endpoint.
     """
+    # Persistent resources created during this call, tracked so we can roll them
+    # back if a later creation step fails (avoids leaking a workload, Service,
+    # AgentRuntime, or route). Only used by the image-deployment path below.
+    created: List[Tuple[str, str]] = []
     try:
         # Validate workload type
         if request.workloadType not in [WORKLOAD_TYPE_DEPLOYMENT, WORKLOAD_TYPE_STATEFULSET]:
@@ -1730,6 +1735,7 @@ async def create_tool(
                     auth_bridge_mode=request.authBridgeMode,
                 )
                 kube.create_statefulset(request.namespace, workload_manifest)
+                created.append(("StatefulSet", request.name))
                 logger.info(
                     f"Created StatefulSet '{request.name}' for tool in namespace '{request.namespace}'"
                 )
@@ -1752,6 +1758,7 @@ async def create_tool(
                     auth_bridge_mode=request.authBridgeMode,
                 )
                 kube.create_deployment(request.namespace, workload_manifest)
+                created.append(("Deployment", request.name))
                 logger.info(
                     f"Created Deployment '{request.name}' for tool in namespace '{request.namespace}'"
                 )
@@ -1764,6 +1771,7 @@ async def create_tool(
             )
             kube.create_service(request.namespace, service_manifest)
             service_name = _get_tool_service_name(request.name)
+            created.append(("Service", service_name))
             logger.info(
                 f"Created Service '{service_name}' for tool in namespace '{request.namespace}'"
             )
@@ -1776,6 +1784,7 @@ async def create_tool(
                 workload_type=request.workloadType,
                 auth_bridge_mode=request.authBridgeMode,
             )
+            created.append(("AgentRuntime", request.name))
 
             message = f"Tool '{request.name}' deployment started ({request.workloadType})."
 
@@ -1793,6 +1802,11 @@ async def create_tool(
                     service_name=service_name,
                     service_port=service_port,
                 )
+                # create_route_for_agent_or_tool makes an HTTPRoute or an OpenShift
+                # Route depending on platform; track both so rollback deletes the
+                # right one (the other 404s and is swallowed).
+                created.append(("HTTPRoute", request.name))
+                created.append(("Route", request.name))
                 message += " HTTPRoute/Route created for external access."
 
             return CreateToolResponse(
@@ -1803,6 +1817,10 @@ async def create_tool(
             )
 
     except ApiException as e:
+        # Roll back only what THIS call created (tracked in `created`); if the very
+        # first create 409'd, `created` is empty and rollback is a no-op, so a
+        # pre-existing tool is never deleted.
+        rollback_workload_resources(kube, request.namespace, created)
         if e.status == 409:
             raise HTTPException(
                 status_code=409,
@@ -1815,6 +1833,15 @@ async def create_tool(
             )
         logger.error(f"Failed to create tool: {e}")
         raise HTTPException(status_code=e.status, detail=str(e.reason))
+    except HTTPException:
+        # Validation errors (400) raised above — nothing created yet, re-raise as-is.
+        raise
+    except Exception as e:
+        # Non-API failure (e.g. platform detection in route creation) after some
+        # resources were already created — roll back before surfacing a 500.
+        rollback_workload_resources(kube, request.namespace, created)
+        logger.error(f"Unexpected error creating tool '{request.name}': {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to create tool: {e}")
 
 
 # Shipwright Build Endpoints for Tools

--- a/kagenti/backend/app/utils/routes.py
+++ b/kagenti/backend/app/utils/routes.py
@@ -6,13 +6,19 @@ Utility functions for creating HTTPRoutes (Kubernetes) and Routes (OpenShift).
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from kubernetes.client import ApiException
 
 from app.services.kubernetes import KubernetesService
 from app.core.config import settings
-from app.core.constants import DEFAULT_IN_CLUSTER_PORT, DEFAULT_OFF_CLUSTER_PORT
+from app.core.constants import (
+    AGENTRUNTIMES_PLURAL,
+    CRD_GROUP,
+    CRD_VERSION,
+    DEFAULT_IN_CLUSTER_PORT,
+    DEFAULT_OFF_CLUSTER_PORT,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -402,3 +408,83 @@ def get_agent_url(name: str, namespace: str, port: int = DEFAULT_OFF_CLUSTER_POR
     else:
         domain = settings.domain_name
         return f"http://{name}.{namespace}.{domain}:{port}"
+
+
+def rollback_workload_resources(
+    kube: KubernetesService,
+    namespace: str,
+    created: List[Tuple[str, str]],
+) -> None:
+    """Best-effort delete of resources created earlier in the same create call.
+
+    Shared by the image-deployment paths of create_agent and create_tool to avoid
+    leaking persistent resources when a later creation step fails. ``created`` is a
+    list of ``(kind, name)`` tuples in creation order; this deletes them in reverse
+    and swallows every error (including 404) so a rollback failure never masks the
+    original exception.
+
+    Only workload / Service / route / AgentRuntime resources created by the call are
+    tracked — shared or idempotent resources (ServiceAccount, AuthBridge ConfigMaps,
+    SCC RoleBinding, skill-fetcher ConfigMap) are intentionally left in place.
+
+    Supported ``kind`` values: ``Deployment``, ``StatefulSet``, ``Job``, ``Sandbox``
+    (whose PVCs are also removed), ``Service``, ``AgentRuntime``, ``HTTPRoute``,
+    ``Route``.
+    """
+    for kind, res_name in reversed(created):
+        try:
+            if kind == "Deployment":
+                kube.delete_deployment(namespace=namespace, name=res_name)
+            elif kind == "StatefulSet":
+                kube.delete_statefulset(namespace=namespace, name=res_name)
+            elif kind == "Job":
+                kube.delete_job(namespace=namespace, name=res_name)
+            elif kind == "Sandbox":
+                kube.delete_sandbox(namespace=namespace, name=res_name)
+                # The Sandbox's PVCs are the highest-cost orphan; delete them too
+                # (mirrors delete_agent's label-selector cleanup).
+                for pvc_name in kube.list_persistent_volume_claims(
+                    namespace=namespace,
+                    label_selector=f"app.kubernetes.io/name={res_name}",
+                ):
+                    kube.delete_persistent_volume_claim(namespace=namespace, name=pvc_name)
+            elif kind == "Service":
+                kube.delete_service(namespace=namespace, name=res_name)
+            elif kind == "AgentRuntime":
+                kube.delete_custom_resource(
+                    group=CRD_GROUP,
+                    version=CRD_VERSION,
+                    namespace=namespace,
+                    plural=AGENTRUNTIMES_PLURAL,
+                    name=res_name,
+                )
+            elif kind == "HTTPRoute":
+                kube.delete_custom_resource(
+                    group="gateway.networking.k8s.io",
+                    version="v1",
+                    namespace=namespace,
+                    plural="httproutes",
+                    name=res_name,
+                )
+            elif kind == "Route":
+                kube.delete_custom_resource(
+                    group="route.openshift.io",
+                    version="v1",
+                    namespace=namespace,
+                    plural="routes",
+                    name=res_name,
+                )
+            logger.info(
+                "Rolled back %s '%s' in namespace '%s' after failed creation",
+                kind,
+                sanitize_log(res_name),
+                sanitize_log(namespace),
+            )
+        except Exception as rollback_err:  # noqa: BLE001 - rollback must not raise
+            logger.warning(
+                "Rollback of %s '%s' in namespace '%s' failed: %s",
+                kind,
+                sanitize_log(res_name),
+                sanitize_log(namespace),
+                rollback_err,
+            )

--- a/kagenti/backend/tests/test_workload_rollback.py
+++ b/kagenti/backend/tests/test_workload_rollback.py
@@ -85,9 +85,7 @@ class TestRollbackWorkloadResources:
         rollback_workload_resources(
             kube, "team1", [("HTTPRoute", "my-workload"), ("Route", "my-workload")]
         )
-        groups = {
-            c.kwargs["group"] for c in kube.delete_custom_resource.call_args_list
-        }
+        groups = {c.kwargs["group"] for c in kube.delete_custom_resource.call_args_list}
         assert groups == {"gateway.networking.k8s.io", "route.openshift.io"}
 
     def test_empty_created_is_noop(self):

--- a/kagenti/backend/tests/test_workload_rollback.py
+++ b/kagenti/backend/tests/test_workload_rollback.py
@@ -1,0 +1,118 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Tests for rollback_workload_resources (shared by create_agent and create_tool).
+
+When the image-deployment path of create_agent / create_tool creates persistent
+resources (Deployment/StatefulSet/Job/Sandbox, Service, AgentRuntime,
+HTTPRoute/Route) and a later step fails, the earlier resources must be rolled back
+so they are not leaked. Only resources created during the same call are rolled back
+— shared/idempotent resources (ServiceAccount, AuthBridge ConfigMaps, SCC
+RoleBinding, skill-fetcher ConfigMap) are intentionally left alone.
+"""
+
+from unittest.mock import MagicMock
+
+from kubernetes.client.exceptions import ApiException
+
+from app.core.constants import (
+    CRD_GROUP,
+    CRD_VERSION,
+    AGENTRUNTIMES_PLURAL,
+)
+from app.utils.routes import rollback_workload_resources
+
+
+class TestRollbackWorkloadResources:
+    """Tests for the shared rollback_workload_resources helper."""
+
+    def test_deletes_tracked_resources_in_reverse_order(self):
+        """Every tracked resource is deleted, most-recently-created first."""
+        kube = MagicMock()
+        created = [
+            ("Deployment", "my-workload"),
+            ("Service", "my-workload"),
+            ("AgentRuntime", "my-workload"),
+        ]
+
+        rollback_workload_resources(kube, "team1", created)
+
+        kube.delete_custom_resource.assert_called_once_with(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace="team1",
+            plural=AGENTRUNTIMES_PLURAL,
+            name="my-workload",
+        )
+        kube.delete_service.assert_called_once_with(namespace="team1", name="my-workload")
+        kube.delete_deployment.assert_called_once_with(namespace="team1", name="my-workload")
+
+    def test_statefulset_uses_delete_statefulset(self):
+        kube = MagicMock()
+        rollback_workload_resources(kube, "team1", [("StatefulSet", "my-workload")])
+        kube.delete_statefulset.assert_called_once_with(namespace="team1", name="my-workload")
+        kube.delete_deployment.assert_not_called()
+
+    def test_job_uses_delete_job(self):
+        kube = MagicMock()
+        rollback_workload_resources(kube, "team1", [("Job", "my-workload")])
+        kube.delete_job.assert_called_once_with(namespace="team1", name="my-workload")
+
+    def test_sandbox_also_deletes_its_pvcs(self):
+        """Sandbox rollback deletes the CR and every PVC matching its name label."""
+        kube = MagicMock()
+        kube.list_persistent_volume_claims.return_value = ["my-wl-data-0", "my-wl-data-1"]
+
+        rollback_workload_resources(kube, "team1", [("Sandbox", "my-workload")])
+
+        kube.delete_sandbox.assert_called_once_with(namespace="team1", name="my-workload")
+        kube.list_persistent_volume_claims.assert_called_once_with(
+            namespace="team1",
+            label_selector="app.kubernetes.io/name=my-workload",
+        )
+        assert kube.delete_persistent_volume_claim.call_count == 2
+
+    def test_service_uses_suffixed_name_when_tracked(self):
+        """The Service name is taken verbatim from the tuple (tools track {name}-mcp)."""
+        kube = MagicMock()
+        rollback_workload_resources(kube, "team1", [("Service", "my-tool-mcp")])
+        kube.delete_service.assert_called_once_with(namespace="team1", name="my-tool-mcp")
+
+    def test_deletes_both_route_kinds(self):
+        """Route step tracks HTTPRoute and Route; rollback attempts both."""
+        kube = MagicMock()
+        rollback_workload_resources(
+            kube, "team1", [("HTTPRoute", "my-workload"), ("Route", "my-workload")]
+        )
+        groups = {
+            c.kwargs["group"] for c in kube.delete_custom_resource.call_args_list
+        }
+        assert groups == {"gateway.networking.k8s.io", "route.openshift.io"}
+
+    def test_empty_created_is_noop(self):
+        """A first-step failure leaves `created` empty -> no deletes at all."""
+        kube = MagicMock()
+        rollback_workload_resources(kube, "team1", [])
+        kube.delete_deployment.assert_not_called()
+        kube.delete_service.assert_not_called()
+        kube.delete_custom_resource.assert_not_called()
+
+    def test_rollback_swallows_delete_errors(self):
+        """A failure deleting one resource must not stop rollback of the rest."""
+        kube = MagicMock()
+        kube.delete_service.side_effect = ApiException(status=500, reason="boom")
+
+        rollback_workload_resources(
+            kube, "team1", [("Deployment", "my-workload"), ("Service", "my-workload")]
+        )
+
+        # Deployment (created first, deleted last) is still attempted.
+        kube.delete_deployment.assert_called_once_with(namespace="team1", name="my-workload")
+
+    def test_does_not_touch_untracked_resources(self):
+        """SA / ConfigMaps / RoleBinding are never tracked, so never deleted."""
+        kube = MagicMock()
+        rollback_workload_resources(kube, "team1", [("Deployment", "my-workload")])
+        assert not kube.delete_service_account.called
+        assert not kube.delete_configmap.called


### PR DESCRIPTION
## Summary

Resolves #1906

If Kagenti can create some but not all of the K8s resources for an agent or tool, the tool call fails, leaving the resources partially created.  These partial resources were usually invisible in the Kagenti UI and API.  If the underlying problem (resource exhaustion, etc) is fixed, the remains of the partially created agent or tool prevents the creation retry from being successful.
