### PR TITLE
docs: symmetric authentication guide covering client-secrets and SPIFFE

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,259 @@
+# Authentication Guide
+
+Kagenti supports two modes for how the operator and agent/tool workloads authenticate to Keycloak:
+
+| Mode | How operator authenticates | How agents authenticate | Requires |
+|---|---|---|---|
+| **Client secrets** (default) | Admin credentials (`keycloak-admin-secret`) | Per-workload OAuth2 client secret | Nothing extra |
+| **SPIFFE auth** (recommended) | SPIFFE identity (JWT-SVID) | SPIFFE identity (JWT-SVID) | SPIRE deployed |
+
+Both modes are independent — you can enable SPIFFE auth for the operator while agents still use client secrets, or vice versa.
+
+---
+
+## Client Secrets (Default)
+
+In this mode, the operator uses admin credentials to register Keycloak clients on behalf of each agent and tool workload. Each workload receives a provisioned OAuth2 client secret stored as a Kubernetes Secret in its namespace.
+
+### How it works
+
+1. At install time, the `kagenti-agent-oauth-secret-job` Helm Job reads admin credentials from the `keycloak-initial-admin` Secret (managed by the RHBK operator) and creates `keycloak-admin-secret` in `kagenti-system`.
+2. When the operator's `ClientRegistrationReconciler` detects a new agent/tool Deployment, it uses those admin credentials to register an OAuth2 client in Keycloak.
+3. The operator stores the generated `client_id` and `client_secret` in a `kagenti-keycloak-client-credentials-*` Secret in the agent's namespace.
+4. AuthBridge reads the credential files from the mounted Secret and uses them for token exchange on outbound requests.
+
+### Setup
+
+No extra configuration needed — this mode works out of the box on any install.
+
+The `keycloak-admin-secret` is created automatically by the installer. The per-agent credential Secrets are created on-demand by the operator when each workload is deployed.
+
+### Configuring the admin secret source
+
+By default the installer reads admin credentials from the `keycloak-initial-admin` Secret in the keycloak namespace. This is configurable:
+
+```yaml
+keycloak:
+  adminSecretName: keycloak-initial-admin  # Secret in the keycloak namespace
+  adminUsernameKey: username
+  adminPasswordKey: password
+```
+
+### Manual sync (break-glass)
+
+If `keycloak-admin-secret` goes out of sync after a credential rotation:
+
+```bash
+KC_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' | base64 -d)
+KC_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' | base64 -d)
+
+kubectl create secret generic keycloak-admin-secret -n kagenti-system \
+  --from-literal=KEYCLOAK_ADMIN_USERNAME="$KC_USER" \
+  --from-literal=KEYCLOAK_ADMIN_PASSWORD="$KC_PASS" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Then re-run `helm upgrade` to trigger a new `kagenti-agent-oauth-secret-job` run.
+
+---
+
+## SPIFFE Authentication (Recommended)
+
+In this mode, the operator and agents authenticate to Keycloak using their SPIFFE identities (JWT-SVIDs). No credentials are provisioned or stored.
+
+### How it works
+
+**JWT-SVID and Keycloak**
+
+SPIRE issues each workload a JWT-SVID — a short-lived, cryptographically signed JWT containing the workload's SPIFFE identity (e.g. `spiffe://localtest.me/ns/team1/sa/weather-service`). When presenting this to Keycloak as a client assertion (RFC 7523), the JWT's `aud` claim must equal Keycloak's realm issuer URL.
+
+This URL is always `keycloak.publicUrl/realms/<realm>` — derived automatically from your Helm values. **It must be the external/public URL**, not the in-cluster service address, because Keycloak's issuer is configured with the external URL and the check is a string comparison.
+
+**Operator authentication flow**
+
+At install time, a Helm post-install/upgrade Job (`operator-client-bootstrap`) runs once using admin credentials to configure Keycloak:
+1. Creates a SPIFFE Identity Provider in Keycloak (backed by SPIRE's OIDC Discovery Provider)
+2. Creates a Keycloak client for the operator with `clientAuthenticatorType: federated-jwt` and the operator's SPIFFE ID as subject
+3. Assigns `manage-clients` role (scoped — not full admin)
+
+After this, the operator authenticates on every reconcile by reading its JWT-SVID (written by the spiffe-helper sidecar to `/opt/jwt_svid.token`) and exchanging it for a Keycloak access token.
+
+```
+Operator pod
+├─ spiffe-helper sidecar ──→ SPIRE workload API
+│   writes JWT-SVID to /opt/jwt_svid.token (auto-rotates)
+└─ manager binary
+    reads JWT-SVID → exchanges with Keycloak → access token → Admin API
+```
+
+**Agent/tool authentication flow**
+
+When the operator registers an agent with `CLIENT_AUTH_TYPE=federated-jwt`:
+1. Creates a Keycloak client with `clientAuthenticatorType: federated-jwt` and the workload's SPIFFE ID as subject
+2. Does **not** create a credential Secret — AuthBridge reads JWT-SVIDs directly
+
+AuthBridge fetches the workload's JWT-SVID from the SPIRE workload API socket (via the go-spiffe SDK) and exchanges it for a Keycloak access token on every outbound request.
+
+```
+Agent pod
+└─ authbridge-proxy sidecar
+    fetches JWT-SVID from SPIRE workload API
+    → exchanges with Keycloak
+    → attaches access token to outbound requests
+```
+
+### Prerequisites
+
+- SPIRE deployed (`--with-spire`)
+- `keycloak.publicUrl` set to the URL Keycloak uses as its OIDC issuer — check with:
+  ```bash
+  curl http://keycloak.your-domain.com/realms/kagenti/.well-known/openid-configuration | jq .issuer
+  ```
+- `kagenti-operator-chart:0.3.0-alpha.7` or later
+
+### Enabling SPIFFE auth
+
+**Via `setup-kagenti.sh`:**
+
+```bash
+# Operator SPIFFE auth only (agents still use client secrets)
+scripts/kind/setup-kagenti.sh --with-spire --enable-operator-spiffe-auth
+
+# Agent/tool SPIFFE auth only (operator still uses admin credentials)
+scripts/kind/setup-kagenti.sh --with-spire --enable-agent-spiffe-auth
+
+# Both — no provisioned credentials needed
+scripts/kind/setup-kagenti.sh --with-spire --enable-spiffe-auth
+```
+
+Both flags fail immediately with a clear error if `--with-spire` is not set.
+
+**Via Helm values:**
+
+```yaml
+keycloak:
+  publicUrl: "http://keycloak.your-domain.com"   # required
+
+kagenti-operator-chart:
+  spiffe:
+    enabled: true
+    operatorAuth:
+      enabled: true
+      bootstrapImage: "ghcr.io/kagenti/kagenti/operator-spiffe-bootstrap:latest"
+
+authBridge:
+  clientAuthType: "federated-jwt"
+  spiffeIdpAlias: "spire-spiffe"
+
+spire:
+  enabled: true
+```
+
+### Disabling SPIFFE auth (reverting to client secrets)
+
+```bash
+scripts/kind/setup-kagenti.sh ... \
+  --kagenti-values <(cat <<'EOF'
+kagenti-operator-chart:
+  spiffe:
+    enabled: false
+    operatorAuth:
+      enabled: false
+authBridge:
+  clientAuthType: "client-secret"
+EOF
+)
+```
+
+---
+
+## Verifying Authentication
+
+### Check which mode is active
+
+```bash
+# Operator mode
+POD=$(kubectl get pod -n kagenti-system -l control-plane=controller-manager \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n kagenti-system $POD -c manager | grep -E "SPIFFE ID authentication enabled|Client registration controller enabled"
+
+# Agent mode
+kubectl get configmap authbridge-config -n team1 -o jsonpath='{.data.CLIENT_AUTH_TYPE}'
+# client-secret  or  federated-jwt
+```
+
+### Check agent registration (client secrets mode)
+
+```bash
+kubectl get secret -n team1 | grep kagenti-keycloak-client-credentials
+# Expect one Secret per registered agent/tool workload
+```
+
+### Check agent registration (SPIFFE auth mode)
+
+```bash
+kubectl get secret -n team1 | grep kagenti-keycloak-client-credentials
+# Expect nothing — no credential Secrets are created
+
+# Verify the agent's SPIFFE ID was registered
+POD=$(kubectl get pod -n kagenti-system -l control-plane=controller-manager \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n kagenti-system $POD -c manager | grep "operator client registration applied"
+# The "secret" field shows what the Secret name would be — but it is not created
+```
+
+### Direct token exchange test (SPIFFE auth)
+
+```bash
+AGENT_POD=$(kubectl get pod -n team1 -l app.kubernetes.io/name=<agent> \
+  -o jsonpath='{.items[0].metadata.name}')
+JWT_SVID=$(kubectl exec -n team1 $AGENT_POD -c authbridge-proxy -- cat /opt/jwt_svid.token)
+CLIENT_ID="spiffe://localtest.me/ns/team1/sa/<agent-serviceaccount>"
+
+kubectl run --rm -i --restart=Never verify --image=curlimages/curl -n kagenti-system \
+  --env="JWT=$JWT_SVID" --env="CID=$CLIENT_ID" -- \
+  sh -c 'curl -s -w "\nHTTP:%{http_code}" -X POST \
+    "http://keycloak-service.keycloak.svc:8080/realms/kagenti/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials&client_id=${CID}&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-spiffe&client_assertion=${JWT}"' \
+  | grep -E "HTTP:|access_token|error"
+# Expected: HTTP:200 with access_token
+```
+
+---
+
+## Troubleshooting
+
+### Client secrets mode: `keycloak-admin-secret` out of sync
+
+Symptom: operator logs show Keycloak authentication failures.
+Fix: re-run the break-glass sync in the [manual sync](#manual-sync-break-glass) section above.
+
+### SPIFFE mode: operator not using JWT-SVID
+
+Check both flags are set:
+```bash
+helm get values kagenti -n kagenti-system | grep -A 5 "spiffe:"
+# spiffe.enabled and spiffe.operatorAuth.enabled must both be true
+```
+
+### SPIFFE mode: pods stuck in `Init:0/1`
+
+Requires `kagenti-operator-chart:0.3.0-alpha.7` or later. Earlier versions still inject a credential volume mount in `federated-jwt` mode, causing pods to wait for a Secret that is never created.
+
+### SPIFFE mode: bootstrap job failed
+
+```bash
+kubectl logs -n keycloak job/kagenti-operator-client-bootstrap --tail=50
+```
+
+Most common cause: `keycloak.publicUrl` not set, resulting in an empty JWT audience string.
+
+### SPIFFE mode: `invalid_client` from Keycloak
+
+Verify the audience matches Keycloak's issuer exactly:
+```bash
+curl -s http://keycloak.localtest.me:8080/realms/kagenti/.well-known/openid-configuration | jq .issuer
+```
+
+The value must match `keycloak.publicUrl`. Using the in-cluster service address instead of the external URL is the most common cause of this error.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -17,8 +17,8 @@ In this mode, the operator uses admin credentials to register Keycloak clients o
 
 ### How it works
 
-1. At install time, the `kagenti-agent-oauth-secret-job` Helm Job reads admin credentials from the `keycloak-initial-admin` Secret (managed by the RHBK operator) and creates `keycloak-admin-secret` in `kagenti-system`.
-2. When the operator's `ClientRegistrationReconciler` detects a new agent/tool Deployment, it uses those admin credentials to register an OAuth2 client in Keycloak.
+1. At install time, the `kagenti-agent-oauth-secret-job` Helm Job reads admin credentials from the `keycloak-initial-admin` Secret (managed by the RHBK operator) and creates a `kagenti-keycloak-client-secret` in each agent namespace with the per-workload OAuth2 client credentials.
+2. When the operator's `ClientRegistrationReconciler` detects a new agent/tool Deployment, it reads `keycloak-initial-admin` directly and uses those credentials to register an OAuth2 client in Keycloak.
 3. The operator stores the generated `client_id` and `client_secret` in a `kagenti-keycloak-client-credentials-*` Secret in the agent's namespace.
 4. AuthBridge reads the credential files from the mounted Secret and uses them for token exchange on outbound requests.
 
@@ -26,11 +26,11 @@ In this mode, the operator uses admin credentials to register Keycloak clients o
 
 No extra configuration needed — this mode works out of the box on any install.
 
-The `keycloak-admin-secret` is created automatically by the installer. The per-agent credential Secrets are created on-demand by the operator when each workload is deployed.
+The per-agent credential Secrets are created on-demand by the operator when each workload is deployed.
 
 ### Configuring the admin secret source
 
-By default the installer reads admin credentials from the `keycloak-initial-admin` Secret in the keycloak namespace. This is configurable:
+By default the operator reads admin credentials from the `keycloak-initial-admin` Secret in the keycloak namespace. This is configurable:
 
 ```yaml
 keycloak:
@@ -41,19 +41,19 @@ keycloak:
 
 ### Manual sync (break-glass)
 
-If `keycloak-admin-secret` goes out of sync after a credential rotation:
+If the operator is failing to authenticate to Keycloak after a credential rotation, restart it so it re-reads `keycloak-initial-admin`:
 
 ```bash
-KC_USER=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' | base64 -d)
-KC_PASS=$(kubectl get secret keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' | base64 -d)
-
-kubectl create secret generic keycloak-admin-secret -n kagenti-system \
-  --from-literal=KEYCLOAK_ADMIN_USERNAME="$KC_USER" \
-  --from-literal=KEYCLOAK_ADMIN_PASSWORD="$KC_PASS" \
-  --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout restart deployment/kagenti-controller-manager -n kagenti-system
 ```
 
-Then re-run `helm upgrade` to trigger a new `kagenti-agent-oauth-secret-job` run.
+Verify the operator is authenticating successfully:
+
+```bash
+POD=$(kubectl get pod -n kagenti-system -l control-plane=controller-manager \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n kagenti-system $POD -c manager | grep -i "keycloak\|auth" | tail -5
+```
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -370,64 +370,14 @@ kubectl get secret keycloak-initial-admin -n keycloak \
 
 ---
 
-## Keycloak Admin Credentials for Agent Namespaces
+## Keycloak Authentication
 
-The [AuthBridge](https://github.com/kagenti/kagenti-extensions/tree/main/authbridge) stack (separate sidecars or a single [combined `authbridge` container](authbridge-combined-sidecar.md)) needs Keycloak admin credentials for automatic OAuth2 client registration. These credentials are stored in a Kubernetes Secret called `keycloak-admin-secret` in each agent namespace.
+Kagenti supports two modes for how the operator and agent workloads authenticate to Keycloak:
 
-### Automatic Provisioning
+- **Client secrets (default)** — the operator uses admin credentials to register agent OAuth clients; agents authenticate with provisioned client secrets. No extra infrastructure required.
+- **SPIFFE authentication (recommended)** — the operator and agents authenticate using their SPIFFE identities (JWT-SVIDs). Requires SPIRE. Eliminates all provisioned credentials.
 
-The installer automatically creates `keycloak-admin-secret` in every agent namespace (e.g., `team1`, `team2`). By default it uses `admin`/`admin`, matching the default Keycloak admin account.
-
-### Customizing Credentials
-
-If your Keycloak admin credentials differ from the defaults, override them using a values file (preferred over `--set` to avoid exposing passwords in shell history and process listings):
-
-**Secrets file** (via `.secrets.yaml`):
-
-Add to your `charts/kagenti/.secrets.yaml`:
-
-```yaml
-keycloak:
-  adminUsername: myadmin
-  adminPassword: mypassword
-```
-
-**Helm install** (via values file):
-
-```bash
-helm upgrade --install kagenti ./charts/kagenti/ \
-  -n kagenti-system --create-namespace \
-  -f my-secret-values.yaml
-```
-
-### Using an Existing Secret
-
-If you already manage Keycloak admin credentials in a Secret (e.g., via an external secrets operator), you can skip the automatic secret creation entirely by setting `keycloak.adminExistingSecret` to the name of that secret. The referenced secret must contain `KEYCLOAK_ADMIN_USERNAME` and `KEYCLOAK_ADMIN_PASSWORD` keys:
-
-```bash
-helm upgrade --install kagenti ./charts/kagenti/ \
-  -n kagenti-system --create-namespace \
-  --set keycloak.adminExistingSecret=my-keycloak-admin-secret
-```
-
-### Manual Creation
-
-If you need to create or update the secret manually in an agent namespace:
-
-```bash
-kubectl create secret generic keycloak-admin-secret -n <agent-namespace> \
-  --from-literal=KEYCLOAK_ADMIN_USERNAME=admin \
-  --from-literal=KEYCLOAK_ADMIN_PASSWORD=admin \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
-
-### Verifying
-
-```bash
-kubectl get secret keycloak-admin-secret -n team1
-```
-
-> **Security note:** For production deployments, use a dedicated Keycloak service account with limited permissions instead of the admin account. See the [Identity Guide](./identity-guide.md) for details.
+Both modes are configured automatically during install. See the **[Authentication Guide](./authentication.md)** for full setup, configuration, and how each mode works.
 
 ---
 

--- a/scripts/ocp/setup-kagenti.sh
+++ b/scripts/ocp/setup-kagenti.sh
@@ -1313,23 +1313,9 @@ fi
 
 log_info "Keycloak: realm=$KC_REALM namespace=$KC_NAMESPACE"
 
-# Read the actual Keycloak admin credentials from the operator-managed secret.
-# The RHBK operator creates keycloak-initial-admin with a random password.
-# The kagenti chart creates keycloak-admin-secret in agent namespaces for the
-# client-registration sidecar — these must match, otherwise client-registration
-# can't authenticate to the master realm to register per-agent OAuth clients.
-KC_ADMIN_FLAGS=()
-_kc_admin_user=$($KUBECTL get secret keycloak-initial-admin -n "$KC_NAMESPACE" \
-  -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
-_kc_admin_pass=$($KUBECTL get secret keycloak-initial-admin -n "$KC_NAMESPACE" \
-  -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
-if [ -n "$_kc_admin_user" ] && [ -n "$_kc_admin_pass" ]; then
-  KC_ADMIN_FLAGS+=(--set "keycloak.adminUsername=${_kc_admin_user}")
-  KC_ADMIN_FLAGS+=(--set "keycloak.adminPassword=${_kc_admin_pass}")
-  log_success "Keycloak admin credentials read from keycloak-initial-admin"
-else
-  log_warn "Could not read keycloak-initial-admin — agent client-registration may fail"
-fi
+# Keycloak admin credentials are read at deploy time by the kagenti-agent-oauth-secret-job
+# Job, which reads keycloak-initial-admin directly from the keycloak namespace.
+# No Helm value overrides are needed — the Job always uses the live secret.
 
 # Build operator image override flags
 OPERATOR_IMAGE_FLAGS=()
@@ -1358,7 +1344,6 @@ run_cmd helm upgrade --install kagenti "$KAGENTI_REPO/charts/kagenti/" \
   -f "$SECRETS_FILE" \
   ${KAGENTI_UI_FLAGS[@]+"${KAGENTI_UI_FLAGS[@]}"} \
   ${OPERATOR_IMAGE_FLAGS[@]+"${OPERATOR_IMAGE_FLAGS[@]}"} \
-  ${KC_ADMIN_FLAGS[@]+"${KC_ADMIN_FLAGS[@]}"} \
   ${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"} \
   --set "agentOAuthSecret.spiffePrefix=spiffe://${DOMAIN}/sa" \
   --set uiOAuthSecret.useServiceAccountCA=false \


### PR DESCRIPTION
## Summary

- **New file `docs/authentication.md`** — comprehensive guide covering both Keycloak auth modes with equal depth:
  - Client secrets (default): admin credential provisioning, how the bootstrap Job and operator reconciler work, break-glass sync procedure
  - SPIFFE auth (recommended): JWT-SVID/Keycloak mechanics (RFC 7523 / custom `jwt-spiffe` assertion type), operator bootstrap job flow with diagram, agent flow with diagram, prerequisites (`--with-spire`, `keycloak.publicUrl`), `setup-kagenti.sh` flags, Helm values
  - Verification commands for both modes (operator logs, agent ConfigMap, token-exchange test)
  - Troubleshooting for both modes

- **`docs/install.md`** — replaced the verbose "Keycloak Admin Credentials for Agent Namespaces" section (which described the old stale-credential mechanism) with a brief two-sentence summary that links to `authentication.md`

- **`scripts/ocp/setup-kagenti.sh`** — removed orphaned `KC_ADMIN_FLAGS` block (`keycloak.adminUsername`/`keycloak.adminPassword` chart values don't exist in templates; the bootstrap Job reads credentials directly from the `keycloak-initial-admin` Secret)

## Supersedes / Closes

- Closes #1337 (stale `keycloak-admin-secret` docs and orphaned Helm flags — the root cause section is now accurately documented in `authentication.md`)
- Closes #2155 (install.md Keycloak section fixes)
- Closes #2208 (authentication.md SPIFFE guide)

## Doc testing

The token exchange command in `docs/authentication.md` was verified against a running Kind cluster:

```
HTTP:200 with access_token
```

All grep patterns (operator logs, agent ConfigMap, credential secret listing) were verified against actual cluster output.

## Test plan

- [ ] Read `docs/authentication.md` end-to-end — both sections have equivalent depth and no gaps
- [ ] Verify `install.md` Keycloak section links correctly to `authentication.md`
- [ ] Confirm `scripts/ocp/setup-kagenti.sh` helm upgrade still works (no orphaned flags)

Assisted-By: Claude Code