### PR TITLE
fix(autosync): re-sync skill content on change, not just version

### DIFF
--- a/rossoctl/backend/app/core/constants.py
+++ b/rossoctl/backend/app/core/constants.py
@@ -184,6 +184,10 @@ SKILL_REGISTRY_TYPE_LABEL = "rossoctl.io/registry-type"
 SKILL_REGISTRY_URL_ANNOTATION = "rossoctl.io/registry-url"
 SKILL_REGISTRY_SKILL_NAME_ANNOTATION = "rossoctl.io/registry-skill-name"
 SKILL_REGISTRY_SKILL_VERSION_ANNOTATION = "rossoctl.io/registry-skill-version"
+# Content signature of the synced registry skill, so auto-sync can detect
+# content changes even when the registry version string is unchanged (e.g.
+# always "latest"). Used to re-sync the cached description on updates.
+SKILL_REGISTRY_SKILL_HASH_ANNOTATION = "rossoctl.io/registry-skill-hash"
 SKILL_FETCHER_SCRIPTS_CM = "rossoctl-skill-fetcher-scripts"
 SKILL_FETCHER_IMAGE = "alpine:3.21.3"
 

--- a/rossoctl/backend/app/services/skill_autosync.py
+++ b/rossoctl/backend/app/services/skill_autosync.py
@@ -11,6 +11,8 @@ references when a skill is removed from the registry.
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -28,6 +30,7 @@ from app.core.constants import (
     SKILL_DESCRIPTION_ANNOTATION,
     SKILL_DISPLAY_NAME_ANNOTATION,
     SKILL_NS_TAG_PREFIX,
+    SKILL_REGISTRY_SKILL_HASH_ANNOTATION,
     SKILL_REGISTRY_SKILL_NAME_ANNOTATION,
     SKILL_REGISTRY_SKILL_VERSION_ANNOTATION,
     SKILL_REGISTRY_TYPE_LABEL,
@@ -43,6 +46,24 @@ from app.services.kubernetes import KubernetesService, get_kubernetes_service
 logger = logging.getLogger(__name__)
 
 _ROSSOCTL_SYSTEM = "rossoctl-system"
+
+
+def _skill_signature(skill: Dict[str, Any]) -> str:
+    """Stable content hash of a registry skill's synced fields.
+
+    Lets auto-sync detect content changes even when the version string is
+    unchanged (the store reports "latest" for every version).
+    """
+    payload = json.dumps(
+        {
+            "version": skill.get("version") or "latest",
+            "description": skill.get("description") or "",
+            "uuid": skill.get("uuid") or "",
+            "tags": sorted(skill.get("tags") or []),
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
 def _sanitize_k8s_name(name: str) -> str:
@@ -156,6 +177,7 @@ def _create_autosync_skill(
         SKILL_REGISTRY_URL_ANNOTATION: registry_url,
         SKILL_REGISTRY_SKILL_NAME_ANNOTATION: skill_name,
         SKILL_REGISTRY_SKILL_VERSION_ANNOTATION: version,
+        SKILL_REGISTRY_SKILL_HASH_ANNOTATION: _skill_signature(skill),
     }
     desc = skill.get("description") or ""
     if desc:
@@ -181,22 +203,26 @@ def _create_autosync_skill(
             )
 
 
-def _patch_skill_version(
-    kube: KubernetesService, namespace: str, resource_name: str, new_version: str
+def _patch_skill(
+    kube: KubernetesService, namespace: str, resource_name: str, skill: Dict[str, Any]
 ) -> None:
-    body = {"metadata": {"annotations": {SKILL_REGISTRY_SKILL_VERSION_ANNOTATION: new_version}}}
+    """Refresh the cached annotations (version, description, hash) of a synced skill.
+
+    Called when the registry skill's content signature changed, so the local
+    reference reflects the current registry content (not just the version).
+    """
+    annos = {
+        SKILL_REGISTRY_SKILL_VERSION_ANNOTATION: skill.get("version") or "latest",
+        SKILL_REGISTRY_SKILL_HASH_ANNOTATION: _skill_signature(skill),
+        SKILL_DESCRIPTION_ANNOTATION: skill.get("description") or "",
+    }
     try:
         kube.core_api.patch_namespaced_config_map(
-            name=resource_name, namespace=namespace, body=body
+            name=resource_name, namespace=namespace, body={"metadata": {"annotations": annos}}
         )
-        logger.info(
-            "Auto-sync: updated version for '%s' in '%s' → %s",
-            resource_name,
-            namespace,
-            new_version,
-        )
+        logger.info("Auto-sync: refreshed '%s' in '%s' (content changed)", resource_name, namespace)
     except ApiException as exc:
-        logger.warning("Auto-sync: failed to patch version for '%s': %s", resource_name, exc)
+        logger.warning("Auto-sync: failed to patch '%s': %s", resource_name, exc)
 
 
 def _delete_autosync_skill(kube: KubernetesService, namespace: str, resource_name: str) -> None:
@@ -241,10 +267,15 @@ def _apply_diff(
         if name in local_by_name:
             cm = local_by_name[name]
             annos = cm.metadata.annotations or {}
+            local_hash = annos.get(SKILL_REGISTRY_SKILL_HASH_ANNOTATION)
+            reg_hash = _skill_signature(skill)
             local_ver = annos.get(SKILL_REGISTRY_SKILL_VERSION_ANNOTATION, "latest")
             reg_ver = skill.get("version") or "latest"
-            if local_ver != reg_ver:
-                _patch_skill_version(kube, namespace, cm.metadata.name, reg_ver)
+            # Re-sync when the content signature changed (covers description/content
+            # updates even when the version string stays "latest"), or on any version
+            # bump. Missing hash (pre-upgrade references) is treated as "changed".
+            if local_hash != reg_hash or local_ver != reg_ver:
+                _patch_skill(kube, namespace, cm.metadata.name, skill)
 
     return len(target_by_name)
 

--- a/rossoctl/backend/tests/test_skill_autosync.py
+++ b/rossoctl/backend/tests/test_skill_autosync.py
@@ -153,8 +153,11 @@ class TestApplyDiff:
         local = [_make_local_cm("my-skill", "my-skill", version="1.0", synced_skill=old)]
         _apply_diff(kube, "team1", target, local, "http://reg", "skillberry")
         kube.core_api.patch_namespaced_config_map.assert_called_once()
-        annos = kube.core_api.patch_namespaced_config_map.call_args[1]["body"]["metadata"]["annotations"]
+        annos = kube.core_api.patch_namespaced_config_map.call_args[1]["body"]["metadata"][
+            "annotations"
+        ]
         from app.core.constants import SKILL_DESCRIPTION_ANNOTATION
+
         assert annos[SKILL_DESCRIPTION_ANNOTATION] == "new and improved"
 
 

--- a/rossoctl/backend/tests/test_skill_autosync.py
+++ b/rossoctl/backend/tests/test_skill_autosync.py
@@ -11,27 +11,40 @@ from app.services.skill_autosync import (
     _get_namespace_tags,
     _apply_diff,
     _get_autosync_config,
+    _skill_signature,
     sync_skills_once,
 )
 from app.core.constants import (
     SKILL_REGISTRY_SKILL_NAME_ANNOTATION,
     SKILL_REGISTRY_SKILL_VERSION_ANNOTATION,
+    SKILL_REGISTRY_SKILL_HASH_ANNOTATION,
     SKILL_AUTOSYNC_LABEL,
     SKILL_TYPE_LABEL,
     SKILL_TYPE_VALUE,
 )
 
 
-def _make_registry_skill(name, version="1.0", tags=None):
-    return {"name": name, "version": version, "description": f"Desc {name}", "tags": tags or []}
+def _make_registry_skill(name, version="1.0", tags=None, description=None):
+    return {
+        "name": name,
+        "version": version,
+        "description": description if description is not None else f"Desc {name}",
+        "tags": tags or [],
+    }
 
 
-def _make_local_cm(resource_name, reg_skill_name, version="1.0"):
+def _make_local_cm(resource_name, reg_skill_name, version="1.0", synced_skill=None):
+    """A local synced CM. Its content hash matches *synced_skill* (defaults to the
+    canonical registry skill of the same name/version), so an unchanged registry
+    skill is a no-op."""
+    if synced_skill is None:
+        synced_skill = _make_registry_skill(reg_skill_name, version=version)
     cm = MagicMock()
     cm.metadata.name = resource_name
     cm.metadata.annotations = {
         SKILL_REGISTRY_SKILL_NAME_ANNOTATION: reg_skill_name,
         SKILL_REGISTRY_SKILL_VERSION_ANNOTATION: version,
+        SKILL_REGISTRY_SKILL_HASH_ANNOTATION: _skill_signature(synced_skill),
     }
     cm.metadata.labels = {SKILL_TYPE_LABEL: SKILL_TYPE_VALUE, SKILL_AUTOSYNC_LABEL: "true"}
     return cm
@@ -129,6 +142,20 @@ class TestApplyDiff:
         kube.core_api.create_namespaced_config_map.assert_not_called()
         kube.core_api.delete_namespaced_config_map.assert_not_called()
         kube.core_api.patch_namespaced_config_map.assert_not_called()
+
+    def test_patches_when_content_changed_same_version(self):
+        # Content changed (new description) but version still "latest"/"1.0":
+        # hash-based detection must still re-sync and refresh the description.
+        kube = MagicMock()
+        old = _make_registry_skill("my-skill", version="1.0", description="old")
+        new = _make_registry_skill("my-skill", version="1.0", description="new and improved")
+        target = [new]
+        local = [_make_local_cm("my-skill", "my-skill", version="1.0", synced_skill=old)]
+        _apply_diff(kube, "team1", target, local, "http://reg", "skillberry")
+        kube.core_api.patch_namespaced_config_map.assert_called_once()
+        annos = kube.core_api.patch_namespaced_config_map.call_args[1]["body"]["metadata"]["annotations"]
+        from app.core.constants import SKILL_DESCRIPTION_ANNOTATION
+        assert annos[SKILL_DESCRIPTION_ANNOTATION] == "new and improved"
 
 
 class TestGetAutosyncConfig:


### PR DESCRIPTION
## 🎥 Demo — store edit auto-syncs to Kagenti

**▶ Watch (narrated, live cluster): https://drive.google.com/file/d/1OGWT7YRcNi6EK_nSSs__hfU06s06IhvG/view**
Same `weather-reporting` skill in the store and in Kagenti (in sync) → edit **only** the store's description (a new version, same `latest` string) → within one auto-sync cycle Kagenti's copy updates on its own. Before the fix, the version string was unchanged so this content edit never propagated (stale description).

---

Closes #2213

## Problem
Auto-sync only re-synced a referenced skill when its version string changed, but the store reports every version as `latest`, so **content updates never propagated** — the Kagenti UI showed a stale skill description while the store had the current one.

## Fix
- Detect changes via a **content signature** (`sha256` of version + description + uuid + sorted tags), stored as a `kagenti.io/registry-skill-hash` annotation.
- On change, `_patch_skill` refreshes the **version, hash, and description** annotations (previously only the version).
- Missing hash (pre-upgrade references) is treated as changed → self-heals on the next sync.

## Tests
`test_skill_autosync.py`: added `test_patches_when_content_changed_same_version`; updated the helper to carry a matching hash so unchanged skills stay a genuine no-op. 20 passed.

