### PR TITLE
fix(ui): surface actual backend cause for 409/502 reseed failures in extractReseedError

### DIFF
--- a/rossoctl/ui-v2/src/utils/simulation.test.ts
+++ b/rossoctl/ui-v2/src/utils/simulation.test.ts
@@ -153,13 +153,28 @@ describe('extractReseedError', () => {
     const err = { status: 422, message: 'database is not valid JSON', detail: 'database is not valid JSON' };
     expect(extractReseedError(err)).toEqual({ message: 'database is not valid JSON' });
   });
-  it('maps 409 to an in-flight message', () => {
-    expect(extractReseedError({ status: 409, message: 'x' })).toEqual({
+  it('surfaces the backend detail for a 409 (in-flight)', () => {
+    expect(
+      extractReseedError({ status: 409, message: 'Tool calls are in flight; retry the re-seed shortly' })
+    ).toEqual({ message: 'Tool calls are in flight; retry the re-seed shortly' });
+  });
+  it('surfaces the remap-409 "no active simulation" detail', () => {
+    expect(
+      extractReseedError({ status: 409, message: 'Simulated tool has no active, ready simulation to re-seed' })
+    ).toEqual({ message: 'Simulated tool has no active, ready simulation to re-seed' });
+  });
+  it('falls back to a friendly 409 message when the detail is empty', () => {
+    expect(extractReseedError({ status: 409, message: '' })).toEqual({
       message: 'Tool calls are in flight — retry the re-seed shortly.',
     });
   });
-  it('maps 502 to an unreachable message', () => {
-    expect(extractReseedError({ status: 502, message: 'x' })).toEqual({
+  it('surfaces the unexpected-status detail for a 502', () => {
+    expect(
+      extractReseedError({ status: 502, message: 'Failed to re-seed simulated-tool database' })
+    ).toEqual({ message: 'Failed to re-seed simulated-tool database' });
+  });
+  it('falls back to a friendly 502 message when the detail is empty', () => {
+    expect(extractReseedError({ status: 502, message: '' })).toEqual({
       message: 'Simulated tool is not reachable (it may be stopped).',
     });
   });

--- a/rossoctl/ui-v2/src/utils/simulation.ts
+++ b/rossoctl/ui-v2/src/utils/simulation.ts
@@ -150,9 +150,12 @@ export function extractReseedError(err: unknown): { message: string; jsonPath?: 
       return { message: e.message || 'Dataset does not validate against the tool schema' };
     }
     case 409:
-      return { message: 'Tool calls are in flight — retry the re-seed shortly.' };
+      // Two distinct backend causes share this code (in-flight calls vs. the
+      // 404/503→409 "no active simulation" remap); prefer the actual detail.
+      return { message: e.message || 'Tool calls are in flight — retry the re-seed shortly.' };
     case 502:
-      return { message: 'Simulated tool is not reachable (it may be stopped).' };
+      // Likewise: harness-unreachable vs. an unexpected harness status.
+      return { message: e.message || 'Simulated tool is not reachable (it may be stopped).' };
     default:
       return { message: e.message || 'Failed to re-seed the database.' };
   }


### PR DESCRIPTION
## Summary

`extractReseedError` in `kagenti/ui-v2/src/utils/simulation.ts` hardcoded a single message for the `409` and `502` reseed-failure branches, but the backend `reseed_simulated_tool_database` returns **two distinct `detail` strings per code**, so the remapped cases were mislabeled in the UI.

| Code | Variant A (was shown) | Variant B (was hidden) |
|------|-----------------------|------------------------|
| 409 | `Tool calls are in flight; retry the re-seed shortly` | `Simulated tool has no active, ready simulation to re-seed` (404/503→409 remap) |
| 502 | `Simulated tool is not reachable (it may be stopped)` | `Failed to re-seed simulated-tool database` (unexpected harness status) |

`ApiError.message` already carries the backend `detail` (via `extractErrorMessage`), and the `422`/`default` branches already prefer it. This makes `409`/`502` consistent — prefer `e.message`, keep the friendly wording as the `||` fallback for empty messages.

## Changes

- `simulation.ts`: `409`/`502` branches now return `e.message || <friendly fallback>`.
- `simulation.test.ts`: cover both backend detail variants per code plus the empty-message fallback.

## Testing

`npx vitest run src/utils/simulation.test.ts` → 35 passed.

Closes #2215. Part of epic #2151.

Assisted-By: Claude Code