### PR TITLE
fix(e2e): best-effort token-exchange readiness wait + exec-script fix; keep xfail (#2129)

### DIFF
--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -256,10 +256,11 @@ jobs:
             echo "Waiting for credentials ($CREDS/2)..."
             sleep 10
           done
-          # Now the injected pods (proxy-init -> spiffe-helper -> envoy) can mount + reach Ready.
-          # Block on it (fatal: the community tx-e2e run below is fatal). See #2129.
-          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s
-          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s
+          # Best-effort readiness — NOT fatal. The operator's client-registration (which creates the
+          # client-credentials Secret the pod mounts) is flaky in CI, so the pod may never reach Ready;
+          # don't gate the job on it. The two exec-based tests stay xfail until that's fixed. See #2129.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=180s || true
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=180s || true
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
 

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -249,14 +249,17 @@ jobs:
         if: success()
         run: |
           sleep 30
-          kubectl rollout status deployment/tx-e2e-agent -n tx-e2e --timeout=300s || true
-          kubectl rollout status deployment/tx-e2e-tool -n tx-e2e --timeout=300s || true
+          # Wait for the client-credentials Secret the injected pod mounts (operator registers it async).
           for i in $(seq 1 30); do
             CREDS=$(kubectl get secrets -n tx-e2e -o name | grep -c kagenti-keycloak-client-credentials || echo "0")
             [ "$CREDS" -ge 2 ] && echo "Credentials ready ($CREDS)" && break
             echo "Waiting for credentials ($CREDS/2)..."
             sleep 10
           done
+          # Now the injected pods (proxy-init -> spiffe-helper -> envoy) can mount + reach Ready.
+          # Block on it (fatal: the community tx-e2e run below is fatal). See #2129.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
 
@@ -285,8 +288,16 @@ jobs:
           bash .github/scripts/token-exchange/56-enable-spiffe.sh
           bash .github/scripts/token-exchange/60-configure-fgap.sh
           sleep 30
-          kubectl rollout status deployment/tx-e2e-agent -n tx-e2e --timeout=300s || true
-          kubectl rollout status deployment/tx-e2e-tool -n tx-e2e --timeout=300s || true
+          # Wait for the client-credentials Secret the injected pod mounts (operator registers it async).
+          for i in $(seq 1 30); do
+            CREDS=$(kubectl get secrets -n tx-e2e -o name | grep -c kagenti-keycloak-client-credentials || echo "0")
+            [ "$CREDS" -ge 2 ] && echo "Credentials ready ($CREDS)" && break
+            echo "Waiting for credentials ($CREDS/2)..."
+            sleep 10
+          done
+          # Non-fatal (exploratory RHBK leg): give the injected pods a chance but don't fail the job.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s || true
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s || true
           bash .github/scripts/token-exchange/80-run-tests.sh
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -185,14 +185,18 @@ jobs:
         if: success()
         run: |
           sleep 30
-          kubectl rollout status deployment/tx-e2e-agent -n tx-e2e --timeout=300s || true
-          kubectl rollout status deployment/tx-e2e-tool -n tx-e2e --timeout=300s || true
+          # Wait for the client-credentials Secret the injected pod mounts (operator registers it async).
           for i in $(seq 1 30); do
             CREDS=$(kubectl get secrets -n tx-e2e -o name | grep -c kagenti-keycloak-client-credentials || echo "0")
             [ "$CREDS" -ge 2 ] && echo "Credentials ready ($CREDS)" && break
             echo "Waiting for credentials ($CREDS/2)..."
             sleep 10
           done
+          # Give the injected pods (proxy-init -> spiffe-helper -> envoy) a chance to reach Ready.
+          # Non-fatal: the tx-e2e run below is continue-on-error (client registration on Kind is
+          # still flaky), so don't gate the workflow on readiness. See #2129.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s || true
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s || true
 
       - name: Run token exchange E2E tests (community KC — non-fatal)
         # Non-fatal: the token-exchange suite is not yet reliably green on Kind

--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -214,14 +214,17 @@ jobs:
         if: success()
         run: |
           sleep 30
-          kubectl rollout status deployment/tx-e2e-agent -n tx-e2e --timeout=300s || true
-          kubectl rollout status deployment/tx-e2e-tool -n tx-e2e --timeout=300s || true
+          # Wait for the client-credentials Secret the injected pod mounts (operator registers it async).
           for i in $(seq 1 30); do
             CREDS=$(kubectl get secrets -n tx-e2e -o name | grep -c kagenti-keycloak-client-credentials || echo "0")
             [ "$CREDS" -ge 2 ] && echo "Credentials ready ($CREDS)" && break
             echo "Waiting for credentials ($CREDS/2)..."
             sleep 10
           done
+          # Now the injected pods (proxy-init -> spiffe-helper -> envoy) can mount + reach Ready.
+          # Block on it (fatal: a stuck pod must fail loudly here, not run the exec tests blind). See #2129.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s
 
       - name: Run token exchange E2E tests (community KC — fatal)
         if: success()
@@ -398,14 +401,17 @@ jobs:
         if: success()
         run: |
           sleep 30
-          kubectl rollout status deployment/tx-e2e-agent -n tx-e2e --timeout=300s || true
-          kubectl rollout status deployment/tx-e2e-tool -n tx-e2e --timeout=300s || true
+          # Wait for the client-credentials Secret the injected pod mounts (operator registers it async).
           for i in $(seq 1 30); do
             CREDS=$(kubectl get secrets -n tx-e2e -o name | grep -c kagenti-keycloak-client-credentials || echo "0")
             [ "$CREDS" -ge 2 ] && echo "Credentials ready ($CREDS)" && break
             echo "Waiting for credentials ($CREDS/2)..."
             sleep 10
           done
+          # Now the injected pods (proxy-init -> spiffe-helper -> envoy) can mount + reach Ready.
+          # Block on it (fatal: a stuck pod must fail loudly here, not run the exec tests blind). See #2129.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
 
@@ -431,8 +437,16 @@ jobs:
           bash .github/scripts/token-exchange/56-enable-spiffe.sh
           bash .github/scripts/token-exchange/60-configure-fgap.sh
           sleep 30
-          kubectl rollout status deployment/tx-e2e-agent -n tx-e2e --timeout=300s || true
-          kubectl rollout status deployment/tx-e2e-tool -n tx-e2e --timeout=300s || true
+          # Wait for the client-credentials Secret the injected pod mounts (operator registers it async).
+          for i in $(seq 1 30); do
+            CREDS=$(kubectl get secrets -n tx-e2e -o name | grep -c kagenti-keycloak-client-credentials || echo "0")
+            [ "$CREDS" -ge 2 ] && echo "Credentials ready ($CREDS)" && break
+            echo "Waiting for credentials ($CREDS/2)..."
+            sleep 10
+          done
+          # Non-fatal (exploratory RHBK leg): give the injected pods a chance but don't fail the job.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s || true
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s || true
           bash .github/scripts/token-exchange/80-run-tests.sh
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}

--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -221,10 +221,11 @@ jobs:
             echo "Waiting for credentials ($CREDS/2)..."
             sleep 10
           done
-          # Now the injected pods (proxy-init -> spiffe-helper -> envoy) can mount + reach Ready.
-          # Block on it (fatal: a stuck pod must fail loudly here, not run the exec tests blind). See #2129.
-          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s
-          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s
+          # Best-effort readiness — NOT fatal. The operator's client-registration (which creates the
+          # client-credentials Secret the pod mounts) is flaky in CI, so the pod may never reach Ready;
+          # don't gate the job on it. The two exec-based tests stay xfail until that's fixed. See #2129.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=180s || true
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=180s || true
 
       - name: Run token exchange E2E tests (community KC — fatal)
         if: success()
@@ -408,10 +409,11 @@ jobs:
             echo "Waiting for credentials ($CREDS/2)..."
             sleep 10
           done
-          # Now the injected pods (proxy-init -> spiffe-helper -> envoy) can mount + reach Ready.
-          # Block on it (fatal: a stuck pod must fail loudly here, not run the exec tests blind). See #2129.
-          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=240s
-          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=240s
+          # Best-effort readiness — NOT fatal. The operator's client-registration (which creates the
+          # client-credentials Secret the pod mounts) is flaky in CI, so the pod may never reach Ready;
+          # don't gate the job on it. The two exec-based tests stay xfail until that's fixed. See #2129.
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=180s || true
+          kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=180s || true
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
 

--- a/kagenti/tests/e2e/token_exchange/test_token_exchange.py
+++ b/kagenti/tests/e2e/token_exchange/test_token_exchange.py
@@ -428,10 +428,6 @@ class TestSpiffeTokenExchange:
         )
         return result
 
-    @pytest.mark.xfail(
-        reason="tx-e2e-agent pod not Ready/exec-able in CI — see #2129",
-        strict=False,
-    )
     def test_spiffe_jwt_svid_present(self, spiffe_mode):
         """JWT SVID file exists in agent's envoy-proxy container."""
         if not spiffe_mode:
@@ -560,7 +556,7 @@ def _call_tool_from_agent(token: str, path: str = "/echo") -> dict:
         "import urllib.request, json, sys; "
         "req = urllib.request.Request("
         f"'http://tx-e2e-tool:8080{path}', "
-        "headers={'Authorization': 'Bearer ' + sys.argv[1]}); "
+        "headers={'Authorization': 'Bearer ' + sys.argv[1]})\n"
         "try:\n"
         "  resp = urllib.request.urlopen(req, timeout=15)\n"
         "  print(resp.read().decode())\n"
@@ -881,7 +877,7 @@ class TestInboundJwtValidation:
         """
         script = (
             "import urllib.request, json; "
-            "req = urllib.request.Request('http://tx-e2e-tool:8080/echo'); "
+            "req = urllib.request.Request('http://tx-e2e-tool:8080/echo')\n"
             "try:\n"
             "  resp = urllib.request.urlopen(req, timeout=10)\n"
             "  print(json.dumps({'status': resp.status}))\n"
@@ -917,10 +913,6 @@ class TestInboundJwtValidation:
                 "Inbound JWT validation may not be configured."
             )
 
-    @pytest.mark.xfail(
-        reason="tx-e2e-agent pod not Ready/exec-able in CI — see #2129",
-        strict=False,
-    )
     def test_invalid_token_rejected(self):
         """Request with a garbage token is rejected by inbound ext_proc."""
         fake_token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.invalid_sig"

--- a/kagenti/tests/e2e/token_exchange/test_token_exchange.py
+++ b/kagenti/tests/e2e/token_exchange/test_token_exchange.py
@@ -428,6 +428,12 @@ class TestSpiffeTokenExchange:
         )
         return result
 
+    @pytest.mark.xfail(
+        reason="tx-e2e-agent pod not Ready in CI: operator client-registration does not "
+        "create the client-credentials Secret (CREDS 0/2), so the injected pod stays "
+        "FailedMount and never becomes exec-able — see #2129",
+        strict=False,
+    )
     def test_spiffe_jwt_svid_present(self, spiffe_mode):
         """JWT SVID file exists in agent's envoy-proxy container."""
         if not spiffe_mode:
@@ -913,6 +919,12 @@ class TestInboundJwtValidation:
                 "Inbound JWT validation may not be configured."
             )
 
+    @pytest.mark.xfail(
+        reason="tx-e2e-agent pod not Ready in CI: operator client-registration does not "
+        "create the client-credentials Secret (CREDS 0/2), so the injected pod stays "
+        "FailedMount and never becomes exec-able — see #2129",
+        strict=False,
+    )
     def test_invalid_token_rejected(self):
         """Request with a garbage token is rejected by inbound ext_proc."""
         fake_token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.invalid_sig"


### PR DESCRIPTION
## Summary

Improves the token-exchange E2E readiness handling and fixes a latent exec-script bug — but, based on a live CI run, **keeps the two exec-based tests `xfail`**, because the real blocker turned out to be different from #2129's original premise.

## What a CI run revealed

Running `release-validation.yaml` (Kind) on this branch showed the **operator never creates the `kagenti-keycloak-client-credentials` Secret** in realm `tx-e2e` (`CREDS` stays **0/2** for the full 5-min loop). The injected `tx-e2e-agent` pod therefore stays `FailedMount`/`Init:0/1` and **never becomes Ready** — the pod-readiness "race" was **not** the blocker; a missing Secret is. (Reproduced identically on a live dev cluster: operator client-registration → Keycloak fails.)

Consequence: a **fatal** `kubectl wait --for=condition=Ready` (my first attempt) turns a previously **soft-passing** run (11 passed + 2 `xfail`, 0 real failures) into a **hard failure**. So gating on readiness is the wrong move until client-registration is reliable.

## Changes

1. **Best-effort readiness wait (non-fatal) in all three token-exchange workflows** — `release-validation.yaml`, `e2e-kind.yaml`, `e2e-hypershift.yaml`. Replaces the swallowed `rollout status || true` with a creds-loop → `kubectl wait --for=condition=Ready pod … || true`: it waits for the pod when the Secret *does* appear (registration is flaky), but never gates the job when it doesn't.
2. **Keep the two `xfail` markers** (`test_spiffe_jwt_svid_present`, `test_invalid_token_rejected`) — they can't be reliably green until client-registration creates the Secret. Reason strings updated to record the real cause.
3. **Fix a latent `SyntaxError` in the inbound-validation exec scripts** — `_call_tool_from_agent` and `test_unauthenticated_request_rejected` built `req = Request(...); try:` on one line (a compound `try:` can't follow a `;`-joined statement). Independent, genuine bug found while testing; changed the `; ` before `try:` to a newline.

## The real fix (separate)

The blocker is **operator client-registration** not creating the `tx-e2e` client-credentials Secret (CREDS 0/2). That's kagenti-operator / cluster-config work and is out of scope here; this PR stops the E2E from being misleading and stops a fatal wait from regressing CI, and documents the cause.

Refs #2129 (root cause now identified; keep open until client-registration is fixed).

Assisted-By: Claude Code
