### PR TITLE
chore(release): pin image tags for v0.7.0-alpha.5

### DIFF
--- a/charts/kagenti-deps/values.yaml
+++ b/charts/kagenti-deps/values.yaml
@@ -118,7 +118,7 @@ spiffeIdp:
   # - Standalone Helm users must create job manually (see docs)
   image:
     repository: ghcr.io/kagenti/kagenti/spiffe-idp-setup
-    tag: v0.6.0-rc.1
+    tag: v0.7.0-alpha.5
     pullPolicy: IfNotPresent
 
 

--- a/charts/kagenti/Chart.lock
+++ b/charts/kagenti/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kagenti-operator-chart
   repository: oci://ghcr.io/kagenti/kagenti-operator
-  version: 0.3.0-alpha.6
-digest: sha256:63167c2bf316a4045a1199a31fa4fcbb6dc252cfb0ee9f23dd289505e58c51a6
-generated: "2026-06-29T15:44:16.84951-04:00"
+  version: 0.3.0-alpha.8
+digest: sha256:6a51019293663bc08a44202438a00936c3c4b378045f344fd92061ec7b197d19
+generated: "2026-07-17T16:51:52.784408-04:00"

--- a/charts/kagenti/Chart.yaml
+++ b/charts/kagenti/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: kagenti
 description: A Helm chart for deploying the kagenti platform
 type: application
-version: 0.7.0-alpha.3
-appVersion: "0.7.0-alpha.3"
+version: 0.7.0-alpha.5
+appVersion: "0.7.0-alpha.5"
 
 dependencies:
 - name: kagenti-operator-chart
-  version: 0.3.0-alpha.6
+  version: 0.3.0-alpha.8
   repository: oci://ghcr.io/kagenti/kagenti-operator
   condition: components.agentOperator.enabled

--- a/charts/kagenti/templates/operator-client-bootstrap-job.yaml
+++ b/charts/kagenti/templates/operator-client-bootstrap-job.yaml
@@ -75,10 +75,12 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: bootstrap
-        # NOTE: operator-spiffe-bootstrap has not been published yet; :latest is a placeholder
-        # until the image is built and pushed as part of the release pipeline.
-        # Override via kagenti-operator-chart.spiffe.operatorAuth.bootstrapImage.
-        image: {{ (index .Values "kagenti-operator-chart" "spiffe" "operatorAuth" "bootstrapImage") | default "ghcr.io/kagenti/kagenti/operator-spiffe-bootstrap:latest" }}
+        # NOTE: operator-spiffe-bootstrap is not published yet and this Job is off
+        # by default (kagenti-operator-chart.spiffe.operatorAuth.enabled=false). The
+        # default below is a placeholder version to satisfy the release pin-check;
+        # override via kagenti-operator-chart.spiffe.operatorAuth.bootstrapImage once
+        # the image is built and pushed.
+        image: {{ (index .Values "kagenti-operator-chart" "spiffe" "operatorAuth" "bootstrapImage") | default "ghcr.io/kagenti/kagenti/operator-spiffe-bootstrap:0.0.0-unreleased" }}
         imagePullPolicy: IfNotPresent
         env:
         - name: KEYCLOAK_URL

--- a/charts/kagenti/values.yaml
+++ b/charts/kagenti/values.yaml
@@ -190,7 +190,7 @@ ui:
   frontend:
     enabled: true
     image: ghcr.io/kagenti/kagenti/ui-v2
-    tag: v0.7.0-alpha.3
+    tag: v0.7.0-alpha.5
     resources:
       limits:
         cpu: 100m
@@ -207,7 +207,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/kagenti/kagenti/backend
-    tag: v0.7.0-alpha.3
+    tag: v0.7.0-alpha.5
     # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
     defaultRegistryUrl: ""
     # Default Shipwright build strategy for internal registries
@@ -233,7 +233,7 @@ ui:
 # ------------------------------------------------------------------
 uiOAuthSecret:
   image: ghcr.io/kagenti/kagenti/ui-oauth-secret
-  tag: v0.7.0-alpha.3
+  tag: v0.7.0-alpha.5
   # When true, mount the in-cluster serviceaccount CA
   # into the ui-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -245,7 +245,7 @@ uiOAuthSecret:
 # ------------------------------------------------------------------
 agentOAuthSecret:
   image: ghcr.io/kagenti/kagenti/agent-oauth-secret
-  tag: v0.7.0-alpha.3
+  tag: v0.7.0-alpha.5
   # When true, mount the in-cluster serviceaccount CA
   # into the agent-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -263,7 +263,7 @@ agentOAuthSecret:
 apiOAuthSecret:
   enabled: false
   image: ghcr.io/kagenti/kagenti/api-oauth-secret
-  tag: v0.7.0-alpha.3
+  tag: v0.7.0-alpha.5
   # Client ID for the API service account
   clientId: kagenti-api
   # Name of the K8s secret to store credentials
@@ -350,7 +350,7 @@ authBridge:
 spiffeIdp:
   image:
     repository: ghcr.io/kagenti/kagenti/spiffe-idp-setup
-    tag: v0.7.0-alpha.3
+    tag: v0.7.0-alpha.5
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
@@ -361,7 +361,7 @@ kagenti-operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.3.0-alpha.6
+        tag: 0.3.0-alpha.8
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -448,7 +448,7 @@ phoenix:
 # ------------------------------------------------------------------
 phoenixOAuthSecret:
   image: ghcr.io/kagenti/kagenti/phoenix-oauth-secret
-  tag: v0.7.0-alpha.3
+  tag: v0.7.0-alpha.5
   # Keycloak client ID for Phoenix
   clientId: phoenix
   # Kubernetes secret name to store OAuth credentials
@@ -476,7 +476,7 @@ mlflow:
 # ------------------------------------------------------------------
 mlflowOAuthSecret:
   image: ghcr.io/kagenti/kagenti/mlflow-oauth-secret
-  tag: v0.7.0-alpha.3
+  tag: v0.7.0-alpha.5
   # Keycloak client ID for MLflow
   clientId: mlflow
   # Kubernetes secret name to store OAuth credentials
@@ -494,7 +494,11 @@ mlflowOAuthSecret:
 traceAnalysis:
   image:
     repository: ghcr.io/kagenti/trace-analysis
-    tag: latest
+    # TODO: external component (owner: Yoav Katz) not yet released. Feature is
+    # OFF by default (featureFlags.traceAnalysis=false), so this image is never
+    # pulled in a normal install. Placeholder version to satisfy the release
+    # pin-check (no floating tags); replace with a real published tag post-alpha.
+    tag: "0.0.0-unreleased"
     pullPolicy: IfNotPresent
   replicaCount: 1
   # MLflow tracking endpoint the service reads traces from (in-cluster DNS).


### PR DESCRIPTION
## Summary

Pin release artifacts for the **`v0.7.0-alpha.5`** pre-rename alpha (last repo in the
alpha line-in-the-sand; operator `v0.3.0-alpha.8`, extensions `v0.6.0-alpha.11`, and
agent-examples `v0.2.0-alpha.1` are already tagged and verified).

## Changes

- `Chart.yaml`: `version`/`appVersion` → `0.7.0-alpha.5`; `kagenti-operator-chart` dependency → `0.3.0-alpha.8`
- `Chart.lock`: regenerated via `helm dependency update` (operator chart `0.3.0-alpha.8`)
- `charts/kagenti/values.yaml`: 8 kagenti platform image tags → `v0.7.0-alpha.5`; operator controller image override → `0.3.0-alpha.8`
- `charts/kagenti-deps/values.yaml`: `spiffe-idp-setup` → `v0.7.0-alpha.5`

## Deferred placeholders (off-by-default, not-yet-published images)

To pass `check-release-pins.sh` (no floating tags), two images that have no published
artifact are pinned to a `0.0.0-unreleased` placeholder. Both features are OFF by default,
so neither image is pulled in a normal install. To be replaced with real tags post-alpha:

- **trace-analysis** — `featureFlags.traceAnalysis=false` (owner: Yoav Katz)
- **operator-spiffe-bootstrap** — `kagenti-operator-chart.spiffe.operatorAuth.enabled=false` (owner: Alan Cha); the `operator-client-bootstrap-job` comment was reworded accordingly. Deferral approved by project lead.

## Validation

- `scripts/check-release-pins.sh` → all checks pass ✅
- `helm lint charts/kagenti/` → clean ✅
- `helm template charts/kagenti/ --set mcpGateway.openshiftDomain=…` → renders (3533 lines) ✅

Assisted-By: Claude Code
