### PR TITLE
Refactor: Rename rossocortex → cortex; fix cortex webhook-chart name

### DIFF
--- a/.claude/skills/github:last-week-org/SKILL.md
+++ b/.claude/skills/github:last-week-org/SKILL.md
@@ -75,7 +75,7 @@ Use this format for **every** repo, including rossoctl itself:
 
 Examples:
 - `[rossoctl/rossoctl#960](https://github.com/rossoctl/rossoctl/issues/960)`
-- `[rossoctl/rossocortex#239](https://github.com/rossoctl/rossocortex/pull/239)`
+- `[rossoctl/cortex#239](https://github.com/rossoctl/cortex/pull/239)`
 
 ### Phase 2: Deep Dive per Active Repo
 

--- a/.claude/skills/github:pr-review/SKILL.md
+++ b/.claude/skills/github:pr-review/SKILL.md
@@ -509,7 +509,7 @@ Use the diff file for all analysis.
 
 ### Cross-repo reviews
 
-When verifying cross-repo dependency files (e.g. checking whether `rossocortex`
+When verifying cross-repo dependency files (e.g. checking whether `cortex`
 already handles something being removed from `$OWNER/$REPO`), **always fetch directly
 from GitHub — never trust a local clone:**
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -81,8 +81,8 @@ Gather the current release landscape before making any changes.
 echo "=== rossoctl/rossoctl ==="
 gh release list --repo rossoctl/rossoctl --limit 5
 
-echo "=== rossoctl/rossocortex ==="
-gh release list --repo rossoctl/rossocortex --limit 5
+echo "=== rossoctl/cortex ==="
+gh release list --repo rossoctl/cortex --limit 5
 
 echo "=== rossoctl/operator ==="
 gh release list --repo rossoctl/operator --limit 5
@@ -121,11 +121,11 @@ Present the user with a summary built from live data:
 ```
 Current state:
   rossoctl:            <latest tag> | release branch: <exists/not>
-  rossocortex: <latest tag> | release branch: <exists/not>
+  cortex: <latest tag> | release branch: <exists/not>
   rossoctl-operator:   <latest tag> | release branch: <exists/not>
 
 Chart.yaml pins:
-  rossoctl-webhook-chart: <version>
+  cortex-webhook-chart: <version>
   operator-chart: <version>
 
 Image tag issues:
@@ -149,7 +149,7 @@ All repos must be tagged in this order. Wait for CI to complete between each:
 
 ```
 1. rossoctl/operator     →  first
-2. rossoctl/rossocortex   →  second
+2. rossoctl/cortex   →  second
 3. rossoctl/examples       →  third (if applicable)
 4. rossoctl/rossoctl              →  last (update Chart.yaml + values.yaml, then tag)
 ```
@@ -294,7 +294,7 @@ After tagging, verify that CI produced all expected artifacts.
 ### 3.1 GitHub Releases
 
 ```bash
-for repo in rossoctl rossocortex rossoctl-operator; do
+for repo in rossoctl cortex rossoctl-operator; do
   echo "=== rossoctl/$repo ==="
   gh release view <version> --repo rossoctl/$repo --json tagName,isPrerelease,publishedAt 2>/dev/null || echo "  Not found"
 done
@@ -313,10 +313,10 @@ for img in ui-v2 backend ui-oauth-secret agent-oauth-secret api-oauth-secret; do
     && echo "OK" || echo "MISSING"
 done
 
-# rossocortex images
+# cortex images
 for img in envoy-with-processor proxy-init client-registration; do
   echo -n "$img:$VERSION ... "
-  docker manifest inspect ghcr.io/rossoctl/rossocortex/$img:$VERSION >/dev/null 2>&1 \
+  docker manifest inspect ghcr.io/rossoctl/cortex/$img:$VERSION >/dev/null 2>&1 \
     && echo "OK" || echo "MISSING"
 done
 ```
@@ -324,7 +324,7 @@ done
 ### 3.3 Helm charts
 
 ```bash
-helm show chart oci://ghcr.io/rossoctl/rossocortex/rossoctl-webhook-chart --version <chart-version> 2>/dev/null \
+helm show chart oci://ghcr.io/rossoctl/cortex/cortex-webhook-chart --version <chart-version> 2>/dev/null \
   && echo "webhook chart OK" || echo "webhook chart MISSING"
 
 helm show chart oci://ghcr.io/rossoctl/operator/operator-chart --version <chart-version> 2>/dev/null \
@@ -373,8 +373,8 @@ gh pr list --repo rossoctl/rossoctl --state merged --base main \
   --jq '.[] | "#\(.number) \(.title) [\(.mergeCommit.oid[:12])] labels:\([.labels[].name] | join(","))"'
 
 echo ""
-echo "=== PRs merged to rossoctl/rossocortex main since $LAST_RC ==="
-gh pr list --repo rossoctl/rossocortex --state merged --base main \
+echo "=== PRs merged to rossoctl/cortex main since $LAST_RC ==="
+gh pr list --repo rossoctl/cortex --state merged --base main \
   --search "merged:>$LAST_RC_DATE" --json number,title,mergeCommit \
   --jq '.[] | "#\(.number) \(.title) [\(.mergeCommit.oid[:12])]"'
 
@@ -401,7 +401,7 @@ rossoctl/rossoctl:
   2. #1660 - fix(ui): dashboard crash on empty state [abc123]
   3. #1670 - chore(deps): bump go to 1.22 [def456]
 
-rossocortex:
+cortex:
   4. #89 - fix(webhook): handle nil annotations [aaa111]
 
 rossoctl-operator:
@@ -421,15 +421,15 @@ For each selected fix, cherry-pick into the appropriate release branch.
 
 #### If fixes touch dependency repos (extensions or operator)
 
-**ASK:** "PR #89 is in rossocortex. Does that repo have a release-X.Y
+**ASK:** "PR #89 is in cortex. Does that repo have a release-X.Y
 branch yet?"
 
 If no release branch exists for the dependency repo:
 
 ```bash
 # Create release branch in the dependency repo
-gh repo clone rossoctl/rossocortex /tmp/rossoctl-release/rossocortex
-cd /tmp/rossoctl-release/rossocortex
+gh repo clone rossoctl/cortex /tmp/rossoctl-release/cortex
+cd /tmp/rossoctl-release/cortex
 git checkout -b release-X.Y main
 git push origin release-X.Y
 ```
@@ -437,7 +437,7 @@ git push origin release-X.Y
 Then cherry-pick and tag:
 
 ```bash
-cd /tmp/rossoctl-release/rossocortex
+cd /tmp/rossoctl-release/cortex
 git checkout release-X.Y
 git pull origin release-X.Y
 git cherry-pick -x <merge-commit-sha>
@@ -609,7 +609,7 @@ If dependency repos were also tagged, include them:
 
 ```bash
 gh workflow run release-validation.yaml -f ref=<version> \
-  -f dep_builds='[{"repo":"rossoctl/rossocortex","ref":"<ext-version>"}]'
+  -f dep_builds='[{"repo":"rossoctl/cortex","ref":"<ext-version>"}]'
 ```
 
 After triggering, show the run URL:
@@ -666,7 +666,7 @@ Full release notes with component compatibility table:
 | Component | Version |
 |-----------|---------|
 | rossoctl (platform) | vX.Y.0 |
-| rossocortex (webhook) | vA.B.0 |
+| cortex (webhook) | vA.B.0 |
 | rossoctl-operator | vC.D.0 |
 | agent-examples | vE.F.0 |
 
@@ -771,7 +771,7 @@ When fixes span multiple repos, cherry-pick and tag in dependency order:
 
 ```
 1. rossoctl-operator (if affected)     → cherry-pick, tag RC
-2. rossocortex (if affected)   → cherry-pick, tag RC
+2. cortex (if affected)   → cherry-pick, tag RC
 3. rossoctl/rossoctl                    → update Chart.yaml deps, cherry-pick fixes, tag RC
 ```
 
@@ -810,7 +810,7 @@ cat > /tmp/rossoctl/release/v0.6.0/rc-fixes.md << 'EOF'
 <!-- - [ ] PR #NNN - description -->
 
 ### Dependency repo fixes
-<!-- - [ ] rossocortex PR #NN - description -->
+<!-- - [ ] cortex PR #NN - description -->
 <!-- - [ ] rossoctl-operator PR #NN - description -->
 
 ## Previous RCs

--- a/.claude/skills/tdd:hypershift/SKILL.md
+++ b/.claude/skills/tdd:hypershift/SKILL.md
@@ -247,7 +247,7 @@ Only when the cluster itself is broken:
 
 ## Building Custom Images from Dependency Repos
 
-When debugging issues in agent-examples or rossocortex, build custom images directly on the cluster using Shipwright/OpenShift Builds:
+When debugging issues in agent-examples or cortex, build custom images directly on the cluster using Shipwright/OpenShift Builds:
 
 ```bash
 # Point build spec to your fork/branch

--- a/.github/scripts/common/30-build-dep-image.sh
+++ b/.github/scripts/common/30-build-dep-image.sh
@@ -17,10 +17,10 @@
 #   pr/<number>          — fetch PR head ref (works with forks)
 #
 # Examples:
-#   /run-e2e --build rossoctl/rossocortex=fix/my-branch
-#   /run-e2e --build rossoctl/rossocortex=pr/234
+#   /run-e2e --build rossoctl/cortex=fix/my-branch
+#   /run-e2e --build rossoctl/cortex=pr/234
 #   /run-e2e --build rossoctl/operator=feat/new-crd
-#   /run-e2e --build rossoctl/rossocortex=pr/234 --build rossoctl/operator=pr/100
+#   /run-e2e --build rossoctl/cortex=pr/234 --build rossoctl/operator=pr/100
 #
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,7 +28,7 @@ source "$SCRIPT_DIR/../lib/env-detect.sh"
 source "$SCRIPT_DIR/../lib/logging.sh"
 
 # Required env vars
-: "${DEP_REPO:?DEP_REPO is required (e.g., rossoctl/rossocortex)}"
+: "${DEP_REPO:?DEP_REPO is required (e.g., rossoctl/cortex)}"
 : "${DEP_REF:?DEP_REF is required (e.g., fix/my-branch or pr/234)}"
 : "${DEP_CONTEXT:?DEP_CONTEXT is required (subdirectory with Dockerfile)}"
 : "${DEP_IMAGE_NAME:?DEP_IMAGE_NAME is required (e.g., proxy-init)}"
@@ -151,7 +151,7 @@ EOF
 else
     # ── Kind / vanilla Kubernetes: local build + kind load ──
     # Use the GHCR path as the image name so it matches what the webhook
-    # references (e.g., ghcr.io/rossoctl/rossocortex/proxy-init:latest).
+    # references (e.g., ghcr.io/rossoctl/cortex/proxy-init:latest).
     # Tag as both :local and :latest so the webhook's default reference works.
     BASE_IMAGE="ghcr.io/${DEP_REPO}/${DEP_IMAGE_NAME}"
     CUSTOM_IMAGE="${BASE_IMAGE}:local"

--- a/.github/scripts/common/31-build-deps-from-refs.sh
+++ b/.github/scripts/common/31-build-deps-from-refs.sh
@@ -4,10 +4,10 @@
 # Reads ROSSOCTL_DEP_BUILDS env var (JSON array) and builds each dependency.
 # Called from 70-deploy-rossoctl.sh between platform install and agent deploy.
 #
-# Format: ROSSOCTL_DEP_BUILDS='[{"repo":"rossoctl/rossocortex","ref":"fix/branch"}]'
+# Format: ROSSOCTL_DEP_BUILDS='[{"repo":"rossoctl/cortex","ref":"fix/branch"}]'
 #
 # Supported dependencies (add new ones to the registry below):
-#   rossoctl/rossocortex  — webhook + AuthBridge images
+#   rossoctl/cortex  — webhook + AuthBridge images
 #   rossoctl/operator    — operator image
 #
 set -euo pipefail
@@ -38,11 +38,11 @@ build_dep() {
     local ref="$2"
 
     case "$repo" in
-        rossoctl/rossocortex)
-            # Build the proxy-init image from rossocortex.
+        rossoctl/cortex)
+            # Build the proxy-init image from cortex.
             # (The sidecar-injection webhook formerly built here moved to
             # rossoctl/operator — see that case below. The only
-            # image still built from rossocortex is proxy-init.)
+            # image still built from cortex is proxy-init.)
             # DEP_SKIP_PATCH=true because proxy-init is an init container
             # image, not a deployment.
             log_info "Building proxy-init from ${repo}@${ref}"

--- a/.github/scripts/hypershift/ci/70-deploy-rossoctl.sh
+++ b/.github/scripts/hypershift/ci/70-deploy-rossoctl.sh
@@ -20,7 +20,7 @@ echo "=================================================="
 # ── Backwards compatibility: accept legacy ROSSOCTL_EXTENSIONS_REF ──
 if [[ -n "${ROSSOCTL_EXTENSIONS_REF:-}" && -z "${ROSSOCTL_DEP_BUILDS:-}" ]]; then
     echo "Converting legacy ROSSOCTL_EXTENSIONS_REF=${ROSSOCTL_EXTENSIONS_REF} to ROSSOCTL_DEP_BUILDS"
-    export ROSSOCTL_DEP_BUILDS="[{\"repo\":\"rossoctl/rossocortex\",\"ref\":\"${ROSSOCTL_EXTENSIONS_REF}\"}]"
+    export ROSSOCTL_DEP_BUILDS="[{\"repo\":\"rossoctl/cortex\",\"ref\":\"${ROSSOCTL_EXTENSIONS_REF}\"}]"
 fi
 
 # Detect main repo root for worktree compatibility (secrets stay in main repo)

--- a/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
+++ b/.github/scripts/kind/91-run-authbridge-weather-e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # AuthBridge Weather (advanced) E2E — Keycloak token exchange + MCP inbound JWT
 #
-# Runs the verify flow from rossocortex (authbridge/demos/weather-agent):
+# Runs the verify flow from cortex (authbridge/demos/weather-agent):
 #   deploy_and_verify_advanced.sh
 #
 # Prerequisites (same as platform E2E):
@@ -10,12 +10,12 @@
 #
 # Source tree:
 #   - Set ROSSOCTL_EXTENSIONS_ROOT to a local clone (faster, offline dev, or optional
-#     companion rossocortex PR checkout in CI), or
-#   - Leave unset: this script shallow-clones rossoctl/rossocortex (see refs below).
+#     companion cortex PR checkout in CI), or
+#   - Leave unset: this script shallow-clones rossoctl/cortex (see refs below).
 #
 # Environment:
-#   ROSSOCTL_EXTENSIONS_ROOT   Path to rossocortex repo (optional)
-#   ROSSOCTL_EXTENSIONS_GIT_URL  Clone URL (default: https://github.com/rossoctl/rossocortex.git)
+#   ROSSOCTL_EXTENSIONS_ROOT   Path to cortex repo (optional)
+#   ROSSOCTL_EXTENSIONS_GIT_URL  Clone URL (default: https://github.com/rossoctl/cortex.git)
 #   ROSSOCTL_EXTENSIONS_GIT_REF  Branch or tag (default: main). Pin in CI to a release tag once
 #     authbridge/demos/weather-agent is included; verify with: git ls-remote --tags URL
 #   NAMESPACE                 K8s namespace (default: team1)
@@ -35,7 +35,7 @@ source "$SCRIPT_DIR/../lib/env-detect.sh"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/../lib/logging.sh"
 
-log_step "91" "AuthBridge Weather (advanced) E2E (rossocortex)"
+log_step "91" "AuthBridge Weather (advanced) E2E (cortex)"
 
 if ! command -v jq &>/dev/null; then
     log_error "jq is required. Install jq or run from an environment with test deps."
@@ -43,7 +43,7 @@ if ! command -v jq &>/dev/null; then
 fi
 
 if ! command -v git &>/dev/null; then
-    log_error "git is required to fetch rossocortex when ROSSOCTL_EXTENSIONS_ROOT is unset."
+    log_error "git is required to fetch cortex when ROSSOCTL_EXTENSIONS_ROOT is unset."
     exit 1
 fi
 
@@ -91,10 +91,10 @@ if [[ -n "$EXT_ROOT" ]]; then
     fi
     log_info "Using ROSSOCTL_EXTENSIONS_ROOT: $EXT_ROOT"
 else
-    ROSSOCTL_EXTENSIONS_GIT_URL="${ROSSOCTL_EXTENSIONS_GIT_URL:-https://github.com/rossoctl/rossocortex.git}"
+    ROSSOCTL_EXTENSIONS_GIT_URL="${ROSSOCTL_EXTENSIONS_GIT_URL:-https://github.com/rossoctl/cortex.git}"
     ROSSOCTL_EXTENSIONS_GIT_REF="${ROSSOCTL_EXTENSIONS_GIT_REF:-main}"
-    CLONE_DIR="${TMPDIR:-/tmp}/rossocortex-authbridge-e2e-$$"
-    log_info "Cloning rossocortex (ref: $ROSSOCTL_EXTENSIONS_GIT_REF) to $CLONE_DIR"
+    CLONE_DIR="${TMPDIR:-/tmp}/cortex-authbridge-e2e-$$"
+    log_info "Cloning cortex (ref: $ROSSOCTL_EXTENSIONS_GIT_REF) to $CLONE_DIR"
     if ! git clone --depth 1 --single-branch --branch "$ROSSOCTL_EXTENSIONS_GIT_REF" \
         "$ROSSOCTL_EXTENSIONS_GIT_URL" "$CLONE_DIR" 2>/dev/null; then
         log_info "Shallow single-branch clone failed; trying full clone + checkout ($ROSSOCTL_EXTENSIONS_GIT_REF)"
@@ -116,7 +116,7 @@ fi
 DEMO_DIR="$EXT_ROOT/authbridge/demos/weather-agent"
 if [[ ! -f "$DEMO_DIR/deploy_and_verify_advanced.sh" ]]; then
     log_error "deploy_and_verify_advanced.sh not found at $DEMO_DIR/"
-    log_error "This ref of rossocortex does not include the AuthBridge weather advanced demo yet."
+    log_error "This ref of cortex does not include the AuthBridge weather advanced demo yet."
     log_error "Use ROSSOCTL_EXTENSIONS_ROOT pointing at a tree that contains authbridge/demos/weather-agent/, or merge the demo to upstream and retry."
     exit 1
 fi
@@ -125,7 +125,7 @@ if [[ ! -x "$DEMO_DIR/deploy_and_verify_advanced.sh" ]]; then
 fi
 
 export SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
-# See rossocortex authbridge/demos/weather-agent/deploy_and_verify_advanced.sh for defaults
+# See cortex authbridge/demos/weather-agent/deploy_and_verify_advanced.sh for defaults
 # (align with spec.progressDeadlineSeconds: 1800 on the advanced Deployments).
 export WEATHER_TOOL_ROLLOUT_TIMEOUT="${WEATHER_TOOL_ROLLOUT_TIMEOUT:-1800s}"
 export WEATHER_AGENT_ROLLOUT_TIMEOUT="${WEATHER_AGENT_ROLLOUT_TIMEOUT:-1800s}"

--- a/.github/scripts/kind/run-e2e-tests.sh
+++ b/.github/scripts/kind/run-e2e-tests.sh
@@ -5,7 +5,7 @@
 #   ./.github/scripts/kind/run-e2e-tests.sh
 #   ROSSOCTL_CONFIG_FILE=deployments/envs/dev_values.yaml ./.github/scripts/kind/run-e2e-tests.sh
 #   RUN_AUTHBRIDGE_WEATHER_E2E=1 ./.github/scripts/kind/run-e2e-tests.sh
-#   RUN_AUTHBRIDGE_WEATHER_E2E=1 ROSSOCTL_EXTENSIONS_ROOT=../rossocortex ./.github/scripts/kind/run-e2e-tests.sh
+#   RUN_AUTHBRIDGE_WEATHER_E2E=1 ROSSOCTL_EXTENSIONS_ROOT=../cortex ./.github/scripts/kind/run-e2e-tests.sh
 
 set -euo pipefail
 
@@ -49,7 +49,7 @@ echo ""
 
 cd "$REPO_ROOT"
 
-# Optional: AuthBridge Weather (advanced) E2E from rossocortex (wave 91).
+# Optional: AuthBridge Weather (advanced) E2E from cortex (wave 91).
 # Set RUN_AUTHBRIDGE_WEATHER_E2E=1 to run after pytest. Requires network (git clone)
 # unless ROSSOCTL_EXTENSIONS_ROOT points at a local clone.
 RUN_AUTHBRIDGE_WEATHER_E2E="${RUN_AUTHBRIDGE_WEATHER_E2E:-0}"
@@ -82,7 +82,7 @@ bash .github/scripts/operator/90-run-e2e-tests.sh
 
 TEST_RESULT=$?
 
-# Step 4: AuthBridge Weather (advanced) — rossocortex deploy + verify
+# Step 4: AuthBridge Weather (advanced) — cortex deploy + verify
 if [[ "$RUN_AUTHBRIDGE_WEATHER_E2E" == "1" ]]; then
     if [[ $TEST_RESULT -ne 0 ]]; then
         echo -e "${RED}Skipping AuthBridge E2E (pytest failed)${NC}"

--- a/.github/scripts/local-setup/kind-full-test.sh
+++ b/.github/scripts/local-setup/kind-full-test.sh
@@ -295,10 +295,10 @@ fi
 # with the old chart binaries. Build from source to match.
 # ============================================================================
 if [ -z "${ROSSOCTL_DEP_BUILDS:-}" ] || [ "${ROSSOCTL_DEP_BUILDS:-}" = "[]" ]; then
-    # Default: build proxy-init from rossocortex main so the packaged
+    # Default: build proxy-init from cortex main so the packaged
     # chart deps pick up the latest init-container fixes even when the chart
     # is pinned to an older release.
-    export ROSSOCTL_DEP_BUILDS='[{"repo":"rossoctl/rossocortex","ref":"main"}]'
+    export ROSSOCTL_DEP_BUILDS='[{"repo":"rossoctl/cortex","ref":"main"}]'
 fi
 if [ "${ROSSOCTL_DEP_BUILDS:-}" != "[]" ] && [ "$RUN_INSTALL" = "true" ]; then
     DEP_BUILD_SCRIPT="./.github/scripts/common/31-build-deps-from-refs.sh"

--- a/.github/scripts/token-exchange/10-build-extensions.sh
+++ b/.github/scripts/token-exchange/10-build-extensions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build rossocortex images from source.
+# Build cortex images from source.
 #
 # Environment:
 #   ROSSOCTL_EXTENSIONS_ROOT   Local clone (optional; clones from GitHub if unset)
@@ -8,7 +8,7 @@
 set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
-log_step "10" "Build rossocortex images"
+log_step "10" "Build cortex images"
 
 PLATFORM="${PLATFORM:-$(detect_platform)}"
 EXTENSIONS_REF="${ROSSOCTL_EXTENSIONS_REF:-main}"
@@ -16,16 +16,16 @@ EXT_ROOT="${ROSSOCTL_EXTENSIONS_ROOT:-}"
 CLONE_DIR=""
 
 if [[ -z "$EXT_ROOT" ]]; then
-  CLONE_DIR="${TMPDIR:-/tmp}/rossocortex-tx-e2e-$$"
-  log_info "Cloning rossocortex (ref: $EXTENSIONS_REF)"
+  CLONE_DIR="${TMPDIR:-/tmp}/cortex-tx-e2e-$$"
+  log_info "Cloning cortex (ref: $EXTENSIONS_REF)"
   git clone --depth 1 --single-branch --branch "$EXTENSIONS_REF" \
-    "https://github.com/rossoctl/rossocortex.git" "$CLONE_DIR" 2>/dev/null || \
-  git clone "https://github.com/rossoctl/rossocortex.git" "$CLONE_DIR" && \
+    "https://github.com/rossoctl/cortex.git" "$CLONE_DIR" 2>/dev/null || \
+  git clone "https://github.com/rossoctl/cortex.git" "$CLONE_DIR" && \
     (cd "$CLONE_DIR" && git checkout "$EXTENSIONS_REF")
   EXT_ROOT="$CLONE_DIR"
 fi
 
-# Images to build. After rossocortex#411 the unified binary was
+# Images to build. After cortex#411 the unified binary was
 # split into three mode-specific binaries, each with its own combined
 # image (spiffe-helper bundled inside, gated by SPIRE_ENABLED). The
 # old client-registration and standalone spiffe-helper images are gone
@@ -37,12 +37,12 @@ IMAGES=(
   "proxy-init:authbridge/proxy-init:Dockerfile.init"
 )
 
-REGISTRY="ghcr.io/rossoctl/rossocortex"
+REGISTRY="ghcr.io/rossoctl/cortex"
 
 # Extract pinned tags from values.yaml so locally-built images replace them
 PINNED_TAGS=()
 VALUES_FILE="$REPO_ROOT/charts/rossoctl/values.yaml"
-for tag in $(grep -oP '(?<=rossocortex/)[^:]+:\S+' "$VALUES_FILE" 2>/dev/null | sort -u); do
+for tag in $(grep -oP '(?<=cortex/)[^:]+:\S+' "$VALUES_FILE" 2>/dev/null | sort -u); do
   img="${tag%%:*}"
   ver="${tag#*:}"
   PINNED_TAGS+=("${img}:${ver}")
@@ -84,4 +84,4 @@ if [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]]; then
   rm -rf "$CLONE_DIR"
 fi
 
-log_success "All rossocortex images built"
+log_success "All cortex images built"

--- a/.github/workflows/e2e-hypershift-pr.yaml
+++ b/.github/workflows/e2e-hypershift-pr.yaml
@@ -105,7 +105,7 @@ jobs:
             console.log('Parsing comment:', commentBody);
 
             // Allowed repos (security: only build from trusted orgs/repos)
-            const ALLOWED_REPOS = ['rossoctl/rossocortex', 'rossoctl/operator'];
+            const ALLOWED_REPOS = ['rossoctl/cortex', 'rossoctl/operator'];
             // Allowed ref pattern: alphanumeric, dots, dashes, slashes, underscores
             const REF_PATTERN = /^[\w.\-\/]+$/;
 
@@ -113,9 +113,9 @@ jobs:
 
             // Parse --build org/repo=ref flags
             // Examples:
-            //   /run-e2e --build rossoctl/rossocortex=fix/my-branch
-            //   /run-e2e --build rossoctl/rossocortex=pr/234
-            //   /run-e2e --build rossoctl/rossocortex=pr/234 --build rossoctl/operator=feat/new-crd
+            //   /run-e2e --build rossoctl/cortex=fix/my-branch
+            //   /run-e2e --build rossoctl/cortex=pr/234
+            //   /run-e2e --build rossoctl/cortex=pr/234 --build rossoctl/operator=feat/new-crd
             const buildPattern = /--build\s+(\S+)/g;
             let match;
             while ((match = buildPattern.exec(commentBody)) !== null) {
@@ -141,14 +141,14 @@ jobs:
               builds.push({ repo, ref });
             }
 
-            // Legacy: --extensions-ref maps to rossoctl/rossocortex build
+            // Legacy: --extensions-ref maps to rossoctl/cortex build
             if (builds.length === 0) {
               const legacyMatch = commentBody.match(/--extensions-ref\s+(\S+)/);
               if (legacyMatch) {
                 const ref = legacyMatch[1];
                 if (REF_PATTERN.test(ref)) {
                   console.log(`Legacy --extensions-ref: ${ref}`);
-                  builds.push({ repo: 'rossoctl/rossocortex', ref });
+                  builds.push({ repo: 'rossoctl/cortex', ref });
                 } else {
                   core.setFailed(`Invalid extensions-ref: ${ref}`);
                   return;

--- a/.github/workflows/e2e-hypershift.yaml
+++ b/.github/workflows/e2e-hypershift.yaml
@@ -34,7 +34,7 @@ on:
         required: false
         default: '6'
       dep_builds:
-        description: 'JSON array of dependency builds, e.g. [{"repo":"rossoctl/rossocortex","ref":"fix/branch"}]'
+        description: 'JSON array of dependency builds, e.g. [{"repo":"rossoctl/cortex","ref":"fix/branch"}]'
         required: false
         default: '[]'
 

--- a/.github/workflows/e2e-kind-pr.yaml
+++ b/.github/workflows/e2e-kind-pr.yaml
@@ -26,14 +26,14 @@ permissions:
 # Version tracking - keep in sync with kind-config in scripts/kind/setup-rossoctl.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # rossocortex#347 merged: AuthBridge weather advanced fixes on main; 91 clones default org URL.
+  # cortex#347 merged: AuthBridge weather advanced fixes on main; 91 clones default org URL.
   ROSSOCTL_EXTENSIONS_GIT_REF: 'main'
 
 jobs:
   e2e-dev-rossoctl-operator:
     name: Deploy & Test
     runs-on: ubuntu-latest
-    # Includes rossocortex AuthBridge E2E (clone, Keycloak, advanced deploys).
+    # Includes cortex AuthBridge E2E (clone, Keycloak, advanced deploys).
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -29,14 +29,14 @@ permissions:
 # Version tracking - keep in sync with kind-config in scripts/kind/setup-rossoctl.sh
 env:
   K8S_VERSION: '1.35.0'  # Must match kindest/node version in kind-config
-  # rossocortex ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
+  # cortex ref for AuthBridge weather E2E (pin to a release tag once the demo is in a tagged release).
   ROSSOCTL_EXTENSIONS_GIT_REF: 'main'
 
 jobs:
   e2e-dev-rossoctl-operator:
     name: Deploy & Test
     runs-on: ubuntu-latest
-    # Includes rossocortex AuthBridge E2E (clone, Keycloak, advanced deploys).
+    # Includes cortex AuthBridge E2E (clone, Keycloak, advanced deploys).
     timeout-minutes: 90
 
     steps:
@@ -137,7 +137,7 @@ jobs:
         env:
           NAMESPACE: team1
 
-      # rossocortex: authbridge/demos/weather-agent (token exchange + tool inbound JWT). Not a lightweight check.
+      # cortex: authbridge/demos/weather-agent (token exchange + tool inbound JWT). Not a lightweight check.
       - name: AuthBridge Weather (advanced) E2E
         if: success()
         run: bash .github/scripts/kind/91-run-authbridge-weather-e2e.sh

--- a/.github/workflows/e2e-release-validation.yaml
+++ b/.github/workflows/e2e-release-validation.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       rossoctl_extensions_ref:
-        description: 'rossocortex git ref for AuthBridge E2E (consumed by .github/scripts/kind/91-run-authbridge-weather-e2e.sh when cloning the demo). Typically pin this to the matching release tag.'
+        description: 'cortex git ref for AuthBridge E2E (consumed by .github/scripts/kind/91-run-authbridge-weather-e2e.sh when cloning the demo). Typically pin this to the matching release tag.'
         required: false
         type: string
         default: 'main'
@@ -28,7 +28,7 @@ permissions:
 env:
   K8S_VERSION: '1.35.0'
   # Consumed by .github/scripts/kind/91-run-authbridge-weather-e2e.sh when it
-  # clones rossocortex for the AuthBridge weather demo.
+  # clones cortex for the AuthBridge weather demo.
   ROSSOCTL_EXTENSIONS_GIT_REF: ${{ inputs.rossoctl_extensions_ref }}
 
 jobs:

--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -29,7 +29,7 @@ on:
         type: boolean
         default: false
       dep_builds:
-        description: 'JSON array of dependency builds (used by both Kind and HyperShift), e.g. [{"repo":"rossoctl/rossocortex","ref":"v0.6.0-rc.1"}]. Kind uses the rossocortex ref for weather-agent deploy; HyperShift passes the full array to the deploy script.'
+        description: 'JSON array of dependency builds (used by both Kind and HyperShift), e.g. [{"repo":"rossoctl/cortex","ref":"v0.6.0-rc.1"}]. Kind uses the cortex ref for weather-agent deploy; HyperShift passes the full array to the deploy script.'
         required: false
         default: '[]'
 
@@ -164,13 +164,13 @@ jobs:
           EXTENSIONS_REF="${{ inputs.ref }}"
           DEP_BUILDS='${{ inputs.dep_builds }}'
           if [ "$DEP_BUILDS" != "[]" ] && [ -n "$DEP_BUILDS" ]; then
-            REF=$(echo "$DEP_BUILDS" | jq -r '.[] | select(.repo == "rossoctl/rossocortex") | .ref // empty')
+            REF=$(echo "$DEP_BUILDS" | jq -r '.[] | select(.repo == "rossoctl/cortex") | .ref // empty')
             if [ -n "$REF" ]; then
               EXTENSIONS_REF="$REF"
             fi
           fi
           echo "extensions_ref=${EXTENSIONS_REF}" >> "$GITHUB_OUTPUT"
-          echo "Using rossocortex ref: ${EXTENSIONS_REF}"
+          echo "Using cortex ref: ${EXTENSIONS_REF}"
 
       - name: Deploy weather-service agent
         run: bash .github/scripts/operator/74-deploy-weather-agent.sh

--- a/CLAUDE-ORG.md
+++ b/CLAUDE-ORG.md
@@ -20,7 +20,7 @@ The Rossoctl organization consists of the following repositories:
 | **[rossoctl-operator](https://github.com/rossoctl/operator)** | Go | Kubernetes operator for agent/tool lifecycle management |
 | **[mcp-gateway](https://github.com/rossoctl/mcp-gateway)** | Go | Envoy-based MCP Gateway for tool federation |
 | **[agent-examples](https://github.com/rossoctl/examples)** | Python | Sample agents and tools for the platform |
-| **[rossocortex](https://github.com/rossoctl/rossocortex)** | Go | Extensions and plugins |
+| **[cortex](https://github.com/rossoctl/cortex)** | Go | Extensions and plugins |
 | **[agentic-control-plane](https://github.com/rossoctl/agentic-control-plane)** | Python | Control plane of specialized A2A agents |
 | **[plugins-adapter](https://github.com/rossoctl/plugins-adapter)** | Python | Guardrails configuration for MCP Gateway |
 | **[.github](https://github.com/rossoctl/.github)** | HTML | Project website (Hugo-based) |
@@ -244,7 +244,7 @@ agent_name/
 
 ---
 
-### 6. rossocortex
+### 6. cortex
 
 **Purpose**: Extensions and plugins for the Rossoctl platform.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,6 @@ The work is the developer's; Claude Code assists. This applies to:
 - [Components](docs/components.md)
 - [AI Ops / Claude Code](docs/ai-ops/README.md)
 - [Demos](docs/demos/README.md)
-- [AuthBridge Demos](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/README.md) — Zero-trust agent demos (weather agent, github issue, webhook, multi-target) in rossocortex
+- [AuthBridge Demos](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/README.md) — Zero-trust agent demos (weather agent, github issue, webhook, multi-target) in cortex
 - [Skills and Patterns](docs/skills/README.md)
 - [Keycloak Patterns](docs/auth/keycloak-patterns.md)

--- a/PERSONAS_AND_ROLES.md
+++ b/PERSONAS_AND_ROLES.md
@@ -148,7 +148,7 @@ Rossoctl is a cloud-native middleware platform that provides framework-neutral, 
 
 **Primary Repositories**:
 
-- [rossocortex](https://github.com/rossoctl/rossocortex) - Core extensions (Go)
+- [cortex](https://github.com/rossoctl/cortex) - Core extensions (Go)
 - [plugins-adapter](https://github.com/rossoctl/plugins-adapter) - Guardrails and policy plugins (Python)
 - [agentic-control-plane](https://github.com/rossoctl/agentic-control-plane) - A2A control plane agents (Python)
 
@@ -162,7 +162,7 @@ Rossoctl is a cloud-native middleware platform that provides framework-neutral, 
 
 **Technical Skills**:
 
-- Go programming (for rossocortex)
+- Go programming (for cortex)
 - Python programming (for plugins-adapter, agentic-control-plane)
 - Kubernetes API and controller development
 - Plugin architecture design
@@ -387,7 +387,7 @@ Review Identity Patterns in [identity documentation](docs/identity-guide.md) for
 | **[agent-examples](https://github.com/rossoctl/examples)** | Agent Developer, Tool Developer |
 | **[mcp-gateway](https://github.com/rossoctl/mcp-gateway)** | MCP Gateway Developer, MCP Gateway Operator |
 | **[rossoctl-operator](https://github.com/rossoctl/operator)** | Operator Developer, Platform Operator |
-| **[rossocortex](https://github.com/rossoctl/rossocortex)** | Extensions Developer |
+| **[cortex](https://github.com/rossoctl/cortex)** | Extensions Developer |
 | **[agentic-control-plane](https://github.com/rossoctl/agentic-control-plane)** | Extensions Developer, Agent Developer |
 | **[plugins-adapter](https://github.com/rossoctl/plugins-adapter)** | Extensions Developer, Security Specialist |
 | **[.github](https://github.com/rossoctl/.github)** | UI Developer |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ From the UI you can:
 - Test agents interactively
 - Monitor traces and network traffic
 
-To learn how to deploy agents and MCP tools, follow the **[Weather Agent Demo](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)** — the recommended getting-started tutorial that walks you through deploying an agent and tool via the UI and chatting with it end-to-end. For more demos, see the [full demo list](./docs/demos/README.md).
+To learn how to deploy agents and MCP tools, follow the **[Weather Agent Demo](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)** — the recommended getting-started tutorial that walks you through deploying an agent and tool via the UI and chatting with it end-to-end. For more demos, see the [full demo list](./docs/demos/README.md).
 
 ## Documentation
 

--- a/charts/rossoctl/templates/_helpers.tpl
+++ b/charts/rossoctl/templates/_helpers.tpl
@@ -93,7 +93,7 @@ gates a top-level `spiffe:` block into the rendered authbridge config.
 Without that, the new authbridge image fails to Configure with
 "spiffe identity requires a SPIFFE provider to be injected" at boot.
 Failing here at helm template time gives a clearer message than a
-CrashLoopBackOff. See rossocortex#332.
+CrashLoopBackOff. See cortex#332.
 */}}
 {{- define "rossoctl.authBridge.validateSpiffeIdentity" -}}
 {{- if and (eq .Values.authBridge.clientAuthType "federated-jwt") (not .Values.spire.enabled) -}}

--- a/charts/rossoctl/templates/agent-namespace-resources.yaml
+++ b/charts/rossoctl/templates/agent-namespace-resources.yaml
@@ -282,7 +282,7 @@ data:
 # ——————————————————————————————————————————————————————————————————————————————
 #  ConfigMap for AuthBridge in Namespace: {{ . }}
 #  YAML config for the authbridge binaries (authbridge-proxy / -envoy /
-#  -lite — see rossocortex#411). Supports envoy-sidecar,
+#  -lite — see cortex#411). Supports envoy-sidecar,
 #  proxy-sidecar (default), and lite shapes. The operator resolves the
 #  per-workload mode via the chain
 #    AgentRuntime.Spec.AuthBridgeMode → this ConfigMap's `mode:` field
@@ -302,7 +302,7 @@ data:
   # Per-plugin config. Plugin-level defaults (audience_file,
   # bypass_paths, identity file paths, etc.) are applied by the
   # authbridge binary itself — see
-  # authbridge/authlib/plugins/CONVENTIONS.md in rossocortex.
+  # authbridge/authlib/plugins/CONVENTIONS.md in cortex.
   #
   # No top-level `mode:` — see the matching template-configmap in
   # authbridge-template-configmaps.yaml for the rationale.
@@ -335,7 +335,7 @@ subjects:
 # ——————————————————————————————————————————————————————————————————————————————
 #  SCC RoleBinding for AuthBridge in Namespace: {{ . }}
 #  Grants the rossoctl-authbridge custom SCC to all service accounts so that
-#  the webhook-injected AuthBridge stack can run. After rossocortex#411
+#  the webhook-injected AuthBridge stack can run. After cortex#411
 #  there's a single combined sidecar per mode (spiffe-helper bundled inside,
 #  client-registration is operator-managed):
 #    - proxy-sidecar (default): authbridge container (UID 1337)
@@ -344,7 +344,7 @@ subjects:
 #  Agent SAs are created dynamically by the operator (name = agent name),
 #  so we use the namespace service accounts group.
 #
-#  Requires rossocortex#234 (webhook uses capabilities instead of
+#  Requires cortex#234 (webhook uses capabilities instead of
 #  privileged mode). Use --extensions-ref to test:
 #    /run-e2e --extensions-ref fix/proxy-init-drop-privileged
 # ——————————————————————————————————————————————————————————————————————————————

--- a/charts/rossoctl/templates/authbridge-template-configmaps.yaml
+++ b/charts/rossoctl/templates/authbridge-template-configmaps.yaml
@@ -41,7 +41,7 @@ data:
   # Per-plugin config. Plugin-level defaults (audience_file,
   # bypass_paths, identity file paths, etc.) are applied by the
   # authbridge binary itself — see
-  # authbridge/authlib/plugins/CONVENTIONS.md in rossocortex.
+  # authbridge/authlib/plugins/CONVENTIONS.md in cortex.
   #
   # No top-level `mode:` is set here. After rossoctl-operator#361 the
   # operator resolves mode per workload from

--- a/charts/rossoctl/templates/rossoctl-authbridge-scc.yaml
+++ b/charts/rossoctl/templates/rossoctl-authbridge-scc.yaml
@@ -3,7 +3,7 @@
 #  Custom SCC for AuthBridge sidecars in agent namespaces.
 #
 #  The rossoctl-webhook injects an AuthBridge sidecar stack into agent pods.
-#  After rossocortex#411 there's a single combined sidecar per mode
+#  After cortex#411 there's a single combined sidecar per mode
 #  (spiffe-helper bundled inside, client-registration is operator-managed):
 #    - proxy-sidecar (default): container "authbridge-proxy"
 #      from the "authbridge" image (UID 1337)

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -384,7 +384,7 @@ operator-chart:
     spireTrustDomain: localtest.me
   # Pin sidecar image tags injected by the AuthBridge webhook.
   #
-  # After rossocortex#411 there are three combined images:
+  # After cortex#411 there are three combined images:
   #   * authbridge      — proxy-sidecar mode (default), full plugin set
   #                       including the a2a/mcp/inference parsers.
   #   * authbridge-envoy — envoy-sidecar mode, full plugin set, expects
@@ -397,10 +397,10 @@ operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/rossoctl/rossocortex/authbridge:v0.6.0-alpha.10
-      envoyProxy: ghcr.io/rossoctl/rossocortex/authbridge-envoy:v0.6.0-alpha.10
-      authbridgeLite: ghcr.io/rossoctl/rossocortex/authbridge-lite:v0.6.0-alpha.10
-      proxyInit: ghcr.io/rossoctl/rossocortex/proxy-init:v0.6.0-alpha.10
+      authbridge: ghcr.io/rossoctl/cortex/authbridge:v0.6.0-alpha.10
+      envoyProxy: ghcr.io/rossoctl/cortex/authbridge-envoy:v0.6.0-alpha.10
+      authbridgeLite: ghcr.io/rossoctl/cortex/authbridge-lite:v0.6.0-alpha.10
+      proxyInit: ghcr.io/rossoctl/cortex/proxy-init:v0.6.0-alpha.10
 
 # ------------------------------------------------------------------
 #  SPIFFE Configuration

--- a/deployments/sandbox/repo_manager.py
+++ b/deployments/sandbox/repo_manager.py
@@ -8,7 +8,7 @@ handles token exchange (SPIFFE SVID → scoped GitHub token) transparently.
 Usage:
     from repo_manager import RepoManager
     mgr = RepoManager("/workspace", "/workspace/repo/sources.json")
-    mgr.clone("https://github.com/rossoctl/rossocortex")  # allowed
+    mgr.clone("https://github.com/rossoctl/cortex")  # allowed
     mgr.clone("https://github.com/evil-org/malware")  # blocked by policy
 """
 
@@ -129,7 +129,7 @@ if __name__ == "__main__":
 
     # Test policy
     test_urls = [
-        "https://github.com/rossoctl/rossocortex",
+        "https://github.com/rossoctl/cortex",
         "https://github.com/rossoctl/rossoctl",
         "https://github.com/evil-org/malware",
         "https://github.com/random/other-repo",

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This directory contains the official Rossoctl project documentation.
 If you are new to Rossoctl, we recommend the following flow to get started with a local Kind cluster. 
 
 1. [Installation Guide](./install.md): Step-by-step instructions to start a Kind cluster and install all prerequisite components
-2. [Quickstart Weather Agent](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md): Deploy your first agent with AuthBridge security.
+2. [Quickstart Weather Agent](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md): Deploy your first agent with AuthBridge security.
 
 Rossoctl is built on existing open-source cloud-native technologies. 
 

--- a/docs/authbridge/README.md
+++ b/docs/authbridge/README.md
@@ -141,9 +141,9 @@ For a progressive walkthrough: [Demos](demos.md)
 
 For deep implementation details:
 
-- [AuthBridge Binary README](https://github.com/rossoctl/rossocortex/blob/main/authbridge/cmd/README.md) — modes, YAML config, logging
-- [AuthBridge Architecture](https://github.com/rossoctl/rossocortex/blob/main/authbridge/README.md) — sequence diagrams, protocol flows
-- [AuthBridge Demos](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/README.md) — step-by-step demo instructions
+- [AuthBridge Binary README](https://github.com/rossoctl/cortex/blob/main/authbridge/cmd/README.md) — modes, YAML config, logging
+- [AuthBridge Architecture](https://github.com/rossoctl/cortex/blob/main/authbridge/README.md) — sequence diagrams, protocol flows
+- [AuthBridge Demos](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/README.md) — step-by-step demo instructions
 - [Identity Guide](../identity-guide.md) — platform-level SPIFFE/SPIRE and Keycloak architecture
 
 ## Blog Posts

--- a/docs/authbridge/demos.md
+++ b/docs/authbridge/demos.md
@@ -21,7 +21,7 @@ agent stays focused on its job; the sidecar handles the zero-trust security arou
 
 This walkthrough demonstrates each of those behaviors, one layer at a time. You first
 deploy the weather agent by following the
-[weather demo UI guide](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)
+[weather demo UI guide](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)
 — that guide is where you learn the deployment steps themselves — and then run the checks
 below to observe what AuthBridge is doing at each stage.
 
@@ -36,7 +36,7 @@ scripts/kind/setup-rossoctl.sh --with-istio --with-spire --with-ui --with-backen
 Before continuing, make sure the weather agent and its tool are deployed and running in
 the `team1` namespace (`weather-service` and `weather-tool`). If you have not deployed them
 yet, follow the
-[weather demo UI guide](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md);
+[weather demo UI guide](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md);
 see the [Deployment Guide](deployment-guide.md) for broader platform details.
 
 **Resource tip:** On a machine with only 4 CPUs, building the agent from source with
@@ -45,7 +45,7 @@ from image** in the UI instead and point it at the prebuilt image
 (`ghcr.io/rossoctl/examples/weather_service:latest`).
 
 Once you finish the basic demo, the
-[advanced demo](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui-advanced.md)
+[advanced demo](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui-advanced.md)
 adds **token exchange** and per-tool JWTs. That is what powers Layer 2 and beyond, where
 you watch the sidecar mint delegated tokens for downstream calls.
 
@@ -93,7 +93,7 @@ Use the table below to pick the right client for what you are doing:
 ## Verify deployment
 
 After completing the UI deploy steps in
-[demo-ui.md](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md),
+[demo-ui.md](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md),
 confirm that everything came up correctly. Each command below checks one thing; the comment
 above it describes what a healthy result looks like.
 
@@ -206,7 +206,7 @@ kubectl exec -n team1 test-client -- \
 
 In this basic demo, the agent's call out to the MCP weather tool is a simple
 **passthrough** — no token exchange happens yet. For more CLI variations, see
-[demo-ui Step 6](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-6-test-via-cli).
+[demo-ui Step 6](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-6-test-via-cli).
 
 ## Layer 2: Watch the token flow
 
@@ -218,7 +218,7 @@ token is powerful enough to be reused elsewhere.
 
 This layer needs the advanced deployment (or an `authproxy-routes` config with an exchange
 policy), so set that up first via
-[demo-ui-advanced](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui-advanced.md).
+[demo-ui-advanced](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui-advanced.md).
 Then turn up the sidecar's logging and repeat the Layer 1 request against the advanced
 agent:
 
@@ -258,7 +258,7 @@ claim, so a downstream service can see both the original caller and the agent ac
 their behalf.
 
 Follow the
-[token-exchange routes guide](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/token-exchange-routes/README.md),
+[token-exchange routes guide](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/token-exchange-routes/README.md),
 which covers both single-target and multi-target exchange. As you drive the demo, watch the
 sidecar logs for the `act` claims and the per-hop exchanges — that is the delegation chain
 being built.
@@ -278,10 +278,10 @@ denied by policy.
 
 | Demo | Difficulty | What it adds | Link |
 |------|:----------:|--------------|------|
-| Weather (basic) | Beginner | Inbound JWT validation, outbound passthrough | [demo-ui.md](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md) |
-| Weather (advanced) | Intermediate | Token exchange, per-tool JWTs | [demo-ui-advanced.md](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui-advanced.md) |
-| GitHub Issue | Intermediate | Calling an external API with scoped tokens | [README](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/README.md#github-issue-agent-full-authbridge-flow) |
-| Multi-Target | Advanced | Delegation across multiple tools | [token-exchange-routes](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/token-exchange-routes/README.md) |
+| Weather (basic) | Beginner | Inbound JWT validation, outbound passthrough | [demo-ui.md](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md) |
+| Weather (advanced) | Intermediate | Token exchange, per-tool JWTs | [demo-ui-advanced.md](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui-advanced.md) |
+| GitHub Issue | Intermediate | Calling an external API with scoped tokens | [README](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/README.md#github-issue-agent-full-authbridge-flow) |
+| Multi-Target | Advanced | Delegation across multiple tools | [token-exchange-routes](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/token-exchange-routes/README.md) |
 
 ## Further reading
 

--- a/docs/authbridge/deployment-guide.md
+++ b/docs/authbridge/deployment-guide.md
@@ -3,7 +3,7 @@
 ## Deployment Modes
 
 AuthBridge ships three combined sidecar images, each hardcoded to its
-deployment shape (rossocortex#411):
+deployment shape (cortex#411):
 
 | | `authbridge` (proxy-sidecar, default) | `authbridge-envoy` (envoy-sidecar, advanced) | `authbridge-lite` (proxy-sidecar, auth-only) |
 |---|---|---|---|
@@ -86,13 +86,13 @@ only when you need protocol-level transparent interception.
 AuthBridge is configured via YAML with `${ENV_VAR}` expansion. The operator
 mounts the configuration from a ConfigMap such as `authbridge-config-weather-service`.
 
-After rossocortex#411 the runtime config uses a per-plugin
+After cortex#411 the runtime config uses a per-plugin
 schema: every plugin-specific setting lives under its own `config:`
 block inside `pipeline.inbound.plugins[]` or
 `pipeline.outbound.plugins[]`. Plugin-level defaults (audience_file,
 bypass_paths, identity file paths) are applied by the authbridge
 binary itself — see `authbridge/authlib/plugins/CONVENTIONS.md` in
-rossocortex for the full reference. The chart-rendered
+cortex for the full reference. The chart-rendered
 ConfigMaps and the backend's per-agent ConfigMap renderer both emit
 this shape.
 
@@ -125,7 +125,7 @@ pipeline:
 
 The fields below appear inside each plugin's `config:` block, not at
 the top level. See `authbridge/docs/plugin-reference.md` in
-rossocortex for the per-plugin authoritative reference.
+cortex for the per-plugin authoritative reference.
 
 | Field | Plugin | Description | Default |
 |---|---|---|---|
@@ -254,5 +254,5 @@ injects defaults that can be overridden via Helm values.
 
 - [Sidecar Injection](sidecar-injection.md) — expected containers per mode, label vocabulary, feature gates, how to switch modes
 - [Authentication Guide](../authentication.md) — how `CLIENT_AUTH_TYPE=federated-jwt` (SPIFFE auth) works, how to enable it, and how it compares to client-secret mode
-- [AuthBridge Binary README](https://github.com/rossoctl/rossocortex/blob/main/authbridge/cmd/README.md) — full YAML config reference, all listener modes
-- [AuthBridge Architecture](https://github.com/rossoctl/rossocortex/blob/main/authbridge/README.md) — sequence diagrams, protocol details
+- [AuthBridge Binary README](https://github.com/rossoctl/cortex/blob/main/authbridge/cmd/README.md) — full YAML config reference, all listener modes
+- [AuthBridge Architecture](https://github.com/rossoctl/cortex/blob/main/authbridge/README.md) — sequence diagrams, protocol details

--- a/docs/authbridge/security-model.md
+++ b/docs/authbridge/security-model.md
@@ -189,4 +189,4 @@ cannot forge credentials (only the proxy has the workload identity to exchange t
 - [Security in and around MCP, Part 2: MCP in Deployment](https://medium.com/rossoctl-the-agentic-platform/security-in-and-around-mcp-part-2-mcp-in-deployment-65bdd0ba9dc6)
 - [Security in and around MCP, Part 3: MCP Server Identity](https://medium.com/rossoctl-the-agentic-platform/security-in-and-around-mcp-part-3-mcp-server-identity-10d6768d96c1)
 - [Rossoctl Identity Guide](../identity-guide.md)
-- [AuthBridge Architecture](https://github.com/rossoctl/rossocortex/blob/main/authbridge/README.md)
+- [AuthBridge Architecture](https://github.com/rossoctl/cortex/blob/main/authbridge/README.md)

--- a/docs/authbridge/sidecar-injection.md
+++ b/docs/authbridge/sidecar-injection.md
@@ -152,4 +152,4 @@ Pod admitted by webhook
 
 - [Deployment Guide](deployment-guide.md) — mode details, configuration, troubleshooting
 - [Security Model](security-model.md) — mTLS, SPIFFE identity, token exchange
-- [AuthBridge Architecture](https://github.com/rossoctl/rossocortex/blob/main/authbridge/README.md) — sequence diagrams, protocol details
+- [AuthBridge Architecture](https://github.com/rossoctl/cortex/blob/main/authbridge/README.md) — sequence diagrams, protocol details

--- a/docs/automation-health.md
+++ b/docs/automation-health.md
@@ -87,7 +87,7 @@ Headline impact — median time-to-merge before vs. after the bot became active 
 | PRs reviewed (cumulative) | 79 | failed: 0 |
 | Currently queued for review | 1 | |
 
-> Per-repo activation: rossoctl/rossoctl since 2026-06-12; rossoctl/rossocortex since 2026-06-13; rossoctl/automation since 2026-06-16; rossoctl/agent-skills since 2026-06-16
+> Per-repo activation: rossoctl/rossoctl since 2026-06-12; rossoctl/cortex since 2026-06-13; rossoctl/automation since 2026-06-16; rossoctl/agent-skills since 2026-06-16
 
 Reviewed vs. unreviewed (secondary — interpret with care):
 
@@ -124,7 +124,7 @@ Reviewed vs. unreviewed (secondary — interpret with care):
 | automation | no | no | yes | 1 |
 | ecosystem-guide | yes | no | no | 1 |
 | rossoctl | yes | no | yes | 2 |
-| rossocortex | no | no | yes | 1 |
+| cortex | no | no | yes | 1 |
 | rossoctl-operator | yes | yes | no | 2 |
 | OpenShell | yes | yes | no | 2 |
 | pi | yes | no | no | 1 |

--- a/docs/components.md
+++ b/docs/components.md
@@ -464,7 +464,7 @@ kubectl get route rossoctl-ui -n rossoctl-system -o jsonpath='{.status.ingress[0
 
 ## Identity & Auth Bridge
 
-**Repository**: [rossoctl/rossocortex/AuthBridge](https://github.com/rossoctl/rossocortex/tree/main/authbridge)
+**Repository**: [rossoctl/cortex/AuthBridge](https://github.com/rossoctl/cortex/tree/main/authbridge)
 
 Rossoctl provides a unified framework for identity and authorization in agentic systems, replacing static credentials with dynamic, short-lived tokens. We call this collection of assets **Auth Bridge**.
 
@@ -474,7 +474,7 @@ Rossoctl provides a unified framework for identity and authorization in agentic 
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| **[AuthProxy](https://github.com/rossoctl/rossocortex/tree/main/authbridge)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
+| **[AuthProxy](https://github.com/rossoctl/cortex/tree/main/authbridge)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
 | **[SPIRE](https://spiffe.io/docs/latest/spire-about/)** | Workload identity and attestation | External |
 | **[Keycloak](https://www.keycloak.org/)** | Identity provider and access management | External |
 

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -8,9 +8,9 @@ Detailed overview of the identity concepts are covered in the [Rossoctl Identity
 
 Check the details for running various demos:
 
-- **AuthBridge Demos (with zero-trust security)** - [All AuthBridge demos](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/README.md) in rossocortex, including:
-  - [Weather Agent](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md) — Getting-started demo with inbound JWT validation
-  - [GitHub Issue Agent](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/github-issue/demo.md) — Full demo with token exchange and scope-based access control ([demo recording](https://youtu.be/5SpTwERN2jU))
+- **AuthBridge Demos (with zero-trust security)** - [All AuthBridge demos](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/README.md) in cortex, including:
+  - [Weather Agent](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md) — Getting-started demo with inbound JWT validation
+  - [GitHub Issue Agent](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/github-issue/demo.md) — Full demo with token exchange and scope-based access control ([demo recording](https://youtu.be/5SpTwERN2jU))
 - **Interactive online demo at KubeCon NA 2025**: [Tutorial: Build-a-Bot Workshop: Enabling Trusted Agents With SPIRE + MCP](https://red.ht/3WL5Loc)
 - **Identity & Auth Demo** - [Slack Authentication](./demo-slack-research-agent.md): Deploy an agent and MCP Server tool to talk to the Slack API
 - **Generic Agent Demo** - [Generic Agent](./demo-generic-agent.md): Deploy a generic agent and two MCP Server tools
@@ -22,9 +22,9 @@ Check the details for running various demos:
 
 Different demos showcase capabilities relevant to different personas:
 
-- **Agent Developers** → Start with the [Weather Agent with AuthBridge](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md) for framework basics with zero-trust security
+- **Agent Developers** → Start with the [Weather Agent with AuthBridge](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md) for framework basics with zero-trust security
 - **Tool Developers** → Try [Slack Authentication](./demo-slack-research-agent.md) for MCP integration
-- **Security Specialists** → Focus on the [GitHub Issue Agent with AuthBridge](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/github-issue/demo.md) for token exchange and scope-based access control
+- **Security Specialists** → Focus on the [GitHub Issue Agent with AuthBridge](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/github-issue/demo.md) for token exchange and scope-based access control
 - **Platform Operators** → All demos showcase operational aspects
 
 **👥 [Find Your Persona](../../PERSONAS_AND_ROLES.md#overview)** to understand which demo best matches your role.

--- a/docs/demos/demo-github-issue.md
+++ b/docs/demos/demo-github-issue.md
@@ -1,7 +1,7 @@
 # GitHub Issue Demo
 
 > **This demo has moved.** The GitHub Issue Agent demo is now maintained in
-> [rossocortex](https://github.com/rossoctl/rossocortex) with
+> [cortex](https://github.com/rossoctl/cortex) with
 > AuthBridge integration for zero-trust security.
 
 ## New Location
@@ -10,13 +10,13 @@ Choose your deployment method:
 
 | Guide | Description |
 |-------|-------------|
-| **[UI Deployment](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/github-issue/demo-ui.md)** | Import agent and tool via the Rossoctl dashboard |
-| **[Manual Deployment](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/github-issue/demo-manual.md)** | Deploy everything via `kubectl` and YAML manifests |
+| **[UI Deployment](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/github-issue/demo-ui.md)** | Import agent and tool via the Rossoctl dashboard |
+| **[Manual Deployment](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/github-issue/demo-manual.md)** | Deploy everything via `kubectl` and YAML manifests |
 
 ## Why It Moved
 
 The original demo in this file used an older version of the Rossoctl UI and did
-not include AuthBridge security features. The new demos in `rossocortex`:
+not include AuthBridge security features. The new demos in `cortex`:
 
 - Use the **current Rossoctl UI** (Import Agent / Import Tool workflow)
 - Add **AuthBridge inbound JWT validation** — requests are validated (signature,
@@ -38,5 +38,5 @@ to create fine-grained PAT tokens:
 
 ## All Available Demos
 
-See the [AuthBridge Demos Index](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/README.md)
+See the [AuthBridge Demos Index](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/README.md)
 for a complete list of demos with a recommended learning path.

--- a/docs/demos/demo-weather-agent.md
+++ b/docs/demos/demo-weather-agent.md
@@ -1,12 +1,12 @@
 # Weather Agent Demo
 
 > **This demo has moved.** The Weather Agent demo is now maintained in
-> [rossocortex](https://github.com/rossoctl/rossocortex) with
+> [cortex](https://github.com/rossoctl/cortex) with
 > AuthBridge integration for zero-trust security.
 
 ## New Location
 
-**[Weather Agent Demo with AuthBridge](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)**
+**[Weather Agent Demo with AuthBridge](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)**
 — Deploy the Weather Agent via the Rossoctl UI with automatic SPIFFE identity
 registration and inbound JWT validation.
 
@@ -15,7 +15,7 @@ This is the recommended **getting-started** demo for new users.
 ## Why It Moved
 
 The original demo in this file used an older version of the Rossoctl UI and did
-not include AuthBridge security features. The new demo in `rossocortex`:
+not include AuthBridge security features. The new demo in `cortex`:
 
 - Uses the **current Rossoctl UI** (Import Agent / Import Tool workflow)
 - Adds **AuthBridge inbound JWT validation** — requests are validated before
@@ -27,5 +27,5 @@ not include AuthBridge security features. The new demo in `rossocortex`:
 
 ## All Available Demos
 
-See the [AuthBridge Demos Index](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/README.md)
+See the [AuthBridge Demos Index](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/README.md)
 for a complete list of demos with a recommended learning path.

--- a/docs/design-proposals/consolidated-compositional-agent-platform-design.md
+++ b/docs/design-proposals/consolidated-compositional-agent-platform-design.md
@@ -12,8 +12,8 @@
 
 - [ ] AgentRuntime CR implementation (identity + observability)
 - [ ] AgentCard CR adaptation (selector change)
-- [x] Mutating webhook implementation (Pod-level targeting, [PR #183](https://github.com/rossoctl/rossocortex/pull/183))
-- [x] ConfigMap-based defaults mechanism ([PR #134](https://github.com/rossoctl/rossocortex/pull/134))
+- [x] Mutating webhook implementation (Pod-level targeting, [PR #183](https://github.com/rossoctl/cortex/pull/183))
+- [x] ConfigMap-based defaults mechanism ([PR #134](https://github.com/rossoctl/cortex/pull/134))
 - [ ] AgentRuntime controller (applies labels, manages lifecycle)
 - [ ] Controller consolidation (istiod pattern)
 - [ ] Migration tooling
@@ -1081,9 +1081,9 @@ Unchanged from original proposal:
 ## Implementation Phases
 
 **Phase 1: Webhook Foundation + AgentRuntime CR** (Q1 2026)
-- [x] Pod-level webhook targeting (Pods at CREATE, not Deployments/StatefulSets) — [rossocortex PR #183](https://github.com/rossoctl/rossocortex/pull/183)
-- [x] ConfigMap-based platform defaults (`rossoctl-webhook-defaults`, `rossoctl-webhook-feature-gates`) — [rossocortex PR #134](https://github.com/rossoctl/rossocortex/pull/134)
-- [x] Per-sidecar feature gates and precedence system — [rossocortex PRs #110-#116](https://github.com/rossoctl/rossocortex/issues/109)
+- [x] Pod-level webhook targeting (Pods at CREATE, not Deployments/StatefulSets) — [cortex PR #183](https://github.com/rossoctl/cortex/pull/183)
+- [x] ConfigMap-based platform defaults (`rossoctl-webhook-defaults`, `rossoctl-webhook-feature-gates`) — [cortex PR #134](https://github.com/rossoctl/cortex/pull/134)
+- [x] Per-sidecar feature gates and precedence system — [cortex PRs #110-#116](https://github.com/rossoctl/cortex/issues/109)
 - [x] Optional namespace gating (`rossoctl-enabled: "true"` namespaceSelector)
 - [ ] Define lean AgentRuntime v1alpha1 CRD (`targetRef`, `identity`, `trace`)
 - [ ] Implement AgentRuntime controller with targetRef resolution

--- a/docs/design-proposals/repository-tiers-proposal.md
+++ b/docs/design-proposals/repository-tiers-proposal.md
@@ -256,7 +256,7 @@ The 17 public repos in the Rossoctl org as of 2026-06-03:
 | `rossoctl-operator` | Lifecycle controller — production deployments depend on it. |
 | `agent-examples` | Reference samples users copy from; examples are an API. |
 | `adk` | Agent Development Kit; explicitly a "Kit" with a contract to downstream developers. |
-| `rossocortex` | Houses AuthBridge and related stable extensions. *(May be renamed to `rossoctl-authbridge` in a future update — separate decision.)* |
+| `cortex` | Houses AuthBridge and related stable extensions. *(May be renamed to `rossoctl-authbridge` in a future update — separate decision.)* |
 | `.github` | Org profile and landing surface; Core by definition. |
 
 ### Incubator (9)
@@ -436,7 +436,7 @@ own CI and policies.
 
 Separate proposal. Candidates discussed informally:
 
-- `rossocortex` → `rossoctl-authbridge`.
+- `cortex` → `rossoctl-authbridge`.
 - Prefixing incubator repos (e.g., `lab-`).
 
 Not part of this proposal. Listed here only to acknowledge it as a known

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -34,7 +34,7 @@ mcp-controller-666f8cf9bf-dcpbc      1/1     Running   0          30h
 
 ### Register Weather MCP Server
 
-The Weather Service Tool can be installed using the Rossoctl UI [as usual](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-3-import-the-weather-tool-via-rossoctl-ui). Once it is
+The Weather Service Tool can be installed using the Rossoctl UI [as usual](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-3-import-the-weather-tool-via-rossoctl-ui). Once it is
 installed, to register it with the Gateway, create an [`HTTPRoute`](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/):
 
 ```
@@ -118,7 +118,7 @@ kubectl delete pod -n <namespace> -l app.kubernetes.io/name=weather-service
 Once the Gateway implementation has stabilized, `MCP_URL` will be set to this
 value by default, so we do not need to set this environment variable for every
 agent. To check if the weather service is working, simply use the chatbot
-exposed by the Weather Service Agent to query for weather information. Instructions for chatting with the agent can be referred to [here](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-7-chat-via-rossoctl-ui).
+exposed by the Weather Service Agent to query for weather information. Instructions for chatting with the agent can be referred to [here](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md#step-7-chat-via-rossoctl-ui).
 
 ### Limitations
 

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -11,7 +11,7 @@ In practice, the Authorization Pattern within the Agentic Platform enables:
 ## 📚 Related Documentation
 
 - **[Rossoctl Identity Overview](./2025-10.Rossoctl-Identity.pdf)** - High-level architectural concepts
-- **[AuthBridge Component](https://github.com/rossoctl/rossocortex/tree/main/authbridge)** - Complete end-to-end installation and demo with SPIFFE, Client Registration, and AuthProxy
+- **[AuthBridge Component](https://github.com/rossoctl/cortex/tree/main/authbridge)** - Complete end-to-end installation and demo with SPIFFE, Client Registration, and AuthProxy
 - **[Token Exchange Deep Dive](../rossoctl/examples/identity/token_exchange.md)** - Detailed OAuth2 token exchange flows
 - **[Client Registration Examples](../rossoctl/examples/identity/keycloak_token_exchange/README.md)** - Practical integration examples
 - **[Personas and Roles](../PERSONAS_AND_ROLES.md#23-security-and-identity-specialist)** - Security and identity specialist persona
@@ -556,7 +556,7 @@ tool_response = requests.post(
 
 ## 🌉 AuthBridge Component
 
-The [AuthBridge Component](https://github.com/rossoctl/rossocortex/tree/main/authbridge) provides a complete, hands-on implementation of Rossoctl's identity and authorization patterns. It combines **Client Registration** and **AuthProxy** to demonstrate the full zero-trust authentication flow.
+The [AuthBridge Component](https://github.com/rossoctl/cortex/tree/main/authbridge) provides a complete, hands-on implementation of Rossoctl's identity and authorization patterns. It combines **Client Registration** and **AuthProxy** to demonstrate the full zero-trust authentication flow.
 
 ### What AuthBridge Demonstrates
 
@@ -631,17 +631,17 @@ The [AuthBridge Component](https://github.com/rossoctl/rossocortex/tree/main/aut
 
 For step-by-step AuthBridge demos with real working examples, see:
 
-- **[AuthBridge Weather Demo](https://github.com/rossoctl/rossocortex/tree/main/authbridge/demos/weather-agent)** — Complete end-to-end example showing token exchange between a weather agent and weather tool
-- **[AuthBridge Documentation](https://github.com/rossoctl/rossocortex/tree/main/authbridge)** — Component documentation and additional examples
+- **[AuthBridge Weather Demo](https://github.com/rossoctl/cortex/tree/main/authbridge/demos/weather-agent)** — Complete end-to-end example showing token exchange between a weather agent and weather tool
+- **[AuthBridge Documentation](https://github.com/rossoctl/cortex/tree/main/authbridge)** — Component documentation and additional examples
 
 ### AuthBridge Documentation
 
 For complete documentation, see:
 
-- **[AuthBridge README](https://github.com/rossoctl/rossocortex/tree/main/authbridge)** - Full demo instructions
-- **[AuthProxy](https://github.com/rossoctl/rossocortex/tree/main/authbridge)** - Token validation and exchange proxy
+- **[AuthBridge README](https://github.com/rossoctl/cortex/tree/main/authbridge)** - Full demo instructions
+- **[AuthProxy](https://github.com/rossoctl/cortex/tree/main/authbridge)** - Token validation and exchange proxy
 
-> **Note**: The AuthBridge demo in rossocortex includes client-registration components for demonstration purposes. In production Rossoctl deployments, client registration is handled by the rossoctl-operator controller.
+> **Note**: The AuthBridge demo in cortex includes client-registration components for demonstration purposes. In production Rossoctl deployments, client registration is handled by the rossoctl-operator controller.
 
 ---
 

--- a/docs/new-tool.md
+++ b/docs/new-tool.md
@@ -268,4 +268,4 @@ This approach allows agents to access multiple tools through a single endpoint, 
 - [Importing a New Agent](./new-agent.md)
 - [MCP Gateway Instructions](./gateway.md)
 - [Components Overview](./components.md)
-- [Demo: Weather Agent and Tool](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)
+- [Demo: Weather Agent and Tool](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md)

--- a/docs/plans/2026-02-24-orchestrate-ci-expansion-design.md
+++ b/docs/plans/2026-02-24-orchestrate-ci-expansion-design.md
@@ -21,7 +21,7 @@ full standard.
 | rossoctl-operator | 3.5/5 | Nested workflow structure, no security scanning |
 | plugins-adapter | 3/5 | No dependabot, no security scanning |
 | .github | 3/5 | Org config, reusable workflows |
-| rossocortex | 2/5 | Tests commented out, no security scanning |
+| cortex | 2/5 | Tests commented out, no security scanning |
 | agent-examples | 1.5/5 | Tests commented out, no pre-commit |
 | agentic-control-plane | 1/5 | No CI at all |
 | workload-harness | 0.5/5 | No CI at all |

--- a/docs/release-sop.md
+++ b/docs/release-sop.md
@@ -179,7 +179,7 @@ Rossoctl spans multiple repositories. Tags must be created in dependency order:
 
 ```
 1. rossoctl/operator      →  tag, wait for CI
-2. rossoctl/rossocortex    →  tag, wait for CI
+2. rossoctl/cortex    →  tag, wait for CI
 3. rossoctl/rossoctl               →  update Chart.yaml + values.yaml, tag
 ```
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,7 +47,7 @@ GA release notes should include a compatibility table:
 | Component | Version |
 |-----------|---------|
 | rossoctl (platform) | v0.6.0 |
-| rossocortex (webhook) | v0.5.0 |
+| cortex (webhook) | v0.5.0 |
 | rossoctl-operator | v0.3.0 |
 | agent-examples | v0.2.0 |
 ```
@@ -64,7 +64,7 @@ artifacts when a tag is pushed:
 | Repository | Artifacts on tag push | CI workflow(s) |
 |------------|----------------------|----------------|
 | [rossoctl/rossoctl](https://github.com/rossoctl/rossoctl) | Container images (ui-v2, backend, oauth-secrets), Helm charts (rossoctl, rossoctl-deps) | `build.yaml` |
-| [rossoctl/rossocortex](https://github.com/rossoctl/rossocortex) | Container images (envoy-with-processor, proxy-init, client-registration), webhook binary + ko image, Helm chart (rossoctl-webhook-chart) | `build.yaml`, `goreleaser.yml` |
+| [rossoctl/cortex](https://github.com/rossoctl/cortex) | Container images (envoy-with-processor, proxy-init, client-registration), webhook binary + ko image, Helm chart (cortex-webhook-chart) | `build.yaml`, `goreleaser.yml` |
 | [rossoctl/operator](https://github.com/rossoctl/operator) | Operator image, Helm chart (operator-chart) | repo-specific |
 | [rossoctl/examples](https://github.com/rossoctl/examples) | Sample agent/tool images | repo-specific |
 
@@ -76,7 +76,7 @@ The `rossoctl/rossoctl` Helm chart depends on sub-charts from other repos
 
 ```
 1. rossoctl/operator     →  tag & wait for CI
-2. rossoctl/rossocortex   →  tag & wait for CI
+2. rossoctl/cortex   →  tag & wait for CI
 3. rossoctl/examples       →  tag (if applicable)
 4. rossoctl/rossoctl              →  update Chart.yaml, tag
 ```
@@ -113,14 +113,14 @@ Alpha releases are tagged from `main` during active development.
 
 ### Updating rossoctl/rossoctl after dependency alphas
 
-After tagging `rossocortex` and `rossoctl-operator`, update the sub-chart
+After tagging `cortex` and `rossoctl-operator`, update the sub-chart
 versions in `charts/rossoctl/Chart.yaml`:
 
 ```yaml
 dependencies:
-- name: rossoctl-webhook-chart
+- name: cortex-webhook-chart
   version: X.Y.0-alpha.N    # <-- new version
-  repository: oci://ghcr.io/rossoctl/rossocortex
+  repository: oci://ghcr.io/rossoctl/cortex
 - name: operator-chart
   version: X.Y.0-alpha.N    # <-- new version
   repository: oci://ghcr.io/rossoctl/operator
@@ -284,7 +284,7 @@ A GA release is the final, stable, production-ready version.
    | Component | Version |
    |-----------|---------|
    | rossoctl (platform) | vX.Y.0 |
-   | rossocortex (webhook) | vA.B.0 |
+   | cortex (webhook) | vA.B.0 |
    | rossoctl-operator | vC.D.0 |
    | agent-examples | vE.F.0 |
 
@@ -333,7 +333,7 @@ gh workflow run release-validation.yaml -f ref=v0.6.0-rc.9
 
 # Validate with a specific extensions dependency
 gh workflow run release-validation.yaml -f ref=v0.6.0-rc.9 \
-  -f dep_builds='[{"repo":"rossoctl/rossocortex","ref":"v0.6.0-rc.1"}]'
+  -f dep_builds='[{"repo":"rossoctl/cortex","ref":"v0.6.0-rc.1"}]'
 
 # Quick iteration: HyperShift only, keep cluster alive for debugging
 gh workflow run release-validation.yaml -f ref=v0.6.0-rc.9 \
@@ -513,7 +513,7 @@ Tag repos in this order. Wait for CI between each:
 
 ```
 1. rossoctl/operator     →  tag, wait for CI + images
-2. rossoctl/rossocortex   →  tag, wait for CI + images
+2. rossoctl/cortex   →  tag, wait for CI + images
 3. rossoctl/examples       →  tag (if applicable)
 4. rossoctl/rossoctl              →  update Chart.yaml + values.yaml, tag
 ```
@@ -605,7 +605,7 @@ gh pr list --repo rossoctl/rossoctl --state merged --base main \
   --jq '.[] | "#\(.number) \(.title) [\(.mergeCommit.oid[:12])]"'
 
 # Check dependency repos too
-gh pr list --repo rossoctl/rossocortex --state merged --base main \
+gh pr list --repo rossoctl/cortex --state merged --base main \
   --search "merged:>$LAST_RC_DATE" --json number,title,mergeCommit \
   --jq '.[] | "#\(.number) \(.title) [\(.mergeCommit.oid[:12])]"'
 ```
@@ -775,7 +775,7 @@ for img in ui-v2 backend ui-oauth-secret agent-oauth-secret api-oauth-secret; do
 done
 
 # Helm charts
-helm show chart oci://ghcr.io/rossoctl/rossocortex/rossoctl-webhook-chart --version <version>
+helm show chart oci://ghcr.io/rossoctl/cortex/cortex-webhook-chart --version <version>
 helm show chart oci://ghcr.io/rossoctl/operator/operator-chart --version <version>
 
 # Pre-release flag (should be true for alpha/RC, false for GA)
@@ -823,7 +823,7 @@ Release candidate for vX.Y.0.
 | Component | Version |
 |-----------|---------|
 | rossoctl (platform) | vX.Y.0 |
-| rossocortex | vA.B.0 |
+| cortex | vA.B.0 |
 | rossoctl-operator | vC.D.0 |
 
 ## Upgrade Notes

--- a/rossoctl/auth/spiffe-idp-setup/README.md
+++ b/rossoctl/auth/spiffe-idp-setup/README.md
@@ -108,7 +108,7 @@ kubectl logs -n spire-server deployment/spire-spiffe-oidc-discovery-provider
 
 **Solution:**
 ```bash
-# From rossocortex repo:
+# From cortex repo:
 ./spiffe-keycloak/patch_spire_config.sh
 ```
 
@@ -118,6 +118,6 @@ This is normal and expected - the script is idempotent and will update the exist
 
 ## Related Documentation
 
-- [SPIFFE_KEYCLOAK_SETUP.md](../../../../../../../rossocortex/SPIFFE_KEYCLOAK_SETUP.md) - Full setup and testing guide
-- [CONFIGURATION_CHANGES.md](../../../../../../../rossocortex/spiffe-keycloak/CONFIGURATION_CHANGES.md) - Configuration changes summary
-- [keycloak_federated_client.py](../../../../../../../rossocortex/spiffe-keycloak/keycloak_federated_client.py) - Reference implementation
+- [SPIFFE_KEYCLOAK_SETUP.md](../../../../../../../cortex/SPIFFE_KEYCLOAK_SETUP.md) - Full setup and testing guide
+- [CONFIGURATION_CHANGES.md](../../../../../../../cortex/spiffe-keycloak/CONFIGURATION_CHANGES.md) - Configuration changes summary
+- [keycloak_federated_client.py](../../../../../../../cortex/spiffe-keycloak/keycloak_federated_client.py) - Reference implementation

--- a/rossoctl/backend/app/core/constants.py
+++ b/rossoctl/backend/app/core/constants.py
@@ -40,7 +40,7 @@ ROSSOCTL_AUTOSCALING_ANNOTATION = "rossoctl.io/autoscaling"  # HPA-off marker (d
 SIMULATION_HARNESS_SKILLS_MOUNT = "/app/skills-store"  # HARNESS_SKILLS_FOLDER mount path
 
 # Per-sidecar opt-out labels (envoy-proxy / spiffe-helper /
-# client-registration) are gone after rossocortex#411 — they
+# client-registration) are gone after cortex#411 — they
 # referenced separate sidecars that no longer exist. The master enable
 # /disable trigger is still ROSSOCTL_INJECT_LABEL above; per-workload
 # mode now lives on AgentRuntime.Spec.AuthBridgeMode.

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -343,7 +343,7 @@ class CreateAgentRequest(BaseModel):
         as defense-in-depth in front of the operator's webhook gate.
         Both have been lifted now that the operator + extensions
         support the full matrix (rossoctl-operator#381,
-        rossocortex#441), so today there are no rejected
+        cortex#441), so today there are no rejected
         combinations.
 
         TODO(future-incompatibility): re-enable cross-field rejections

--- a/rossoctl/backend/tests/test_agentruntime_manifest.py
+++ b/rossoctl/backend/tests/test_agentruntime_manifest.py
@@ -69,7 +69,7 @@ def test_create_agent_request_allows_envoy_with_strict():
 
     Pairs with rossoctl-operator#381 (operator wires Spec.MTLSMode
     into a per-agent envoy-config CM with TLS blocks) and
-    rossocortex#441 (proxy-sidecar permissive consistency).
+    cortex#441 (proxy-sidecar permissive consistency).
     """
     from app.routers.agents import CreateAgentRequest
 

--- a/rossoctl/backend/tests/test_authbridge_runtime_config.py
+++ b/rossoctl/backend/tests/test_authbridge_runtime_config.py
@@ -50,7 +50,7 @@ def test_build_authbridge_runtime_yaml_client_secret():
     jwt = _plugin_config(cfg, "inbound", "jwt-validation")
     assert jwt["issuer"] == "http://keycloak.example.com/realms/rossoctl"
     # keycloak_url + keycloak_realm let jwt-validation derive jwks_url
-    # from the INTERNAL keycloak URL (see rossocortex#383).
+    # from the INTERNAL keycloak URL (see cortex#383).
     # Pinning the full jwks_url was the pre-plugin-fix workaround; the
     # two hints are the supported contract now.
     assert jwt["keycloak_url"] == "http://keycloak:8080"
@@ -97,7 +97,7 @@ def test_build_authbridge_runtime_yaml_spire_enabled():
     tok = _plugin_config(cfg, "outbound", "token-exchange")
     assert tok["identity"]["type"] == "spiffe"
     # JWT-SVID client-assertion audience — must equal the realm issuer
-    # URL Keycloak's SPIFFE IdP expects. See rossocortex#332.
+    # URL Keycloak's SPIFFE IdP expects. See cortex#332.
     assert tok["identity"]["jwt_audience"] == "http://keycloak.example.com/realms/rossoctl"
     # jwt_svid_path is not emitted — the plugin applies
     # /opt/jwt_svid.token as its default when identity.type is spiffe.

--- a/rossoctl/demo-setup/keycloak-config/github/README.md
+++ b/rossoctl/demo-setup/keycloak-config/github/README.md
@@ -1,7 +1,7 @@
 # Keycloak Configuration for GitHub Issue Demo
 
 This script configures Keycloak for the
-[GitHub Issue Demo](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/github-issue/demo.md).
+[GitHub Issue Demo](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/github-issue/demo.md).
 Logging into Rossoctl with accounts of different
 permissions affects the results those accounts receive.
 

--- a/rossoctl/examples/app-demo/README.md
+++ b/rossoctl/examples/app-demo/README.md
@@ -8,7 +8,7 @@ A standalone demo application that shows how a third-party app integrates with t
 
 **Prerequisites:**
 - A running Rossoctl Kind cluster with UI enabled
-- At least one agent deployed in any namespace (e.g., follow the [Weather Agent Demo](https://github.com/rossoctl/rossocortex/blob/main/authbridge/demos/weather-agent/demo-ui.md))
+- At least one agent deployed in any namespace (e.g., follow the [Weather Agent Demo](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/weather-agent/demo-ui.md))
 - Users created in Keycloak (default users: `alice`, `bob`, `charlie`)
 
 > **💡 Note:** The app-demo works with the `rossoctl` realm in Keycloak and can discover agents in any namespace. You don't need a specific namespace like "team1" - the app dynamically lists all available namespaces with agents.

--- a/rossoctl/tests/e2e/token_exchange/test_token_exchange.py
+++ b/rossoctl/tests/e2e/token_exchange/test_token_exchange.py
@@ -851,7 +851,7 @@ class TestAuthbridgeExtProc:
         ]
         has_evidence = any(marker in logs.lower() for marker in exchange_markers)
         # This is a soft check — log format may vary. The legacy
-        # authbridge-light container is gone after rossocortex#411
+        # authbridge-light container is gone after cortex#411
         # (everything's bundled into the envoy-proxy container in
         # envoy-sidecar mode), so we only inspect that one container now.
         # The token comparison tests above are the definitive proof.

--- a/rossoctl/ui-v2/src/pages/ImportAgentPage.tsx
+++ b/rossoctl/ui-v2/src/pages/ImportAgentPage.tsx
@@ -235,7 +235,7 @@ export const ImportAgentPage: React.FC = () => {
   // value (default 'disabled'). Force-reset to 'disabled' when SPIRE
   // is off — mTLS requires SPIRE-issued X.509 SVIDs in either deployment
   // mode. envoy-sidecar + non-disabled used to be rejected here; that
-  // gate has been lifted (rossoctl-operator#381 + rossocortex#441
+  // gate has been lifted (rossoctl-operator#381 + cortex#441
   // wire the combination end-to-end).
   const [mtlsMode, setMtlsMode] = useState<'disabled' | 'permissive' | 'strict'>('disabled');
   useEffect(() => {


### PR DESCRIPTION
## Summary
Follow-up to the Rossoctl rename: #2230 merged the rename + Chart.lock fix, but **not** the later rossocortex→cortex change.

- **rossocortex → cortex** (55 files): image refs `ghcr.io/rossoctl/rossocortex/*` → `ghcr.io/rossoctl/cortex/*`, cross-repo doc links (AuthBridge demos), prose
- **Fix the extensions webhook-chart name** (it tracks the extensions repo name): `rossoctl-webhook-chart` → `cortex-webhook-chart` (`oci://ghcr.io/rossoctl/cortex/cortex-webhook-chart`) in release docs + skill

## Verification
- `git grep` clean of `rossocortex`, `kagenti`, and `rossoctl-webhook-chart`
- TUI `go build` ✅; `ruff check` + `format` ✅
- `Chart.lock` digest already correct on `main`

## Related issue(s)
Related to #1972