### PR TITLE
Fix: bump operator-chart dependency to 0.3.0-alpha.9

### DIFF
--- a/charts/rossoctl/Chart.lock
+++ b/charts/rossoctl/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: operator-chart
   repository: oci://ghcr.io/rossoctl/operator
-  version: 0.3.0-alpha.8
-digest: sha256:19ad1e5b329e1f9c46c99db91ee3fc3dba6e00a19dd31c446645e3d58f9b8b44
-generated: "2026-07-17T16:51:52.784408-04:00"
+  version: 0.3.0-alpha.9
+digest: sha256:553e4e83a6f5cf7de212708bb2e6f39faee091ded55d1850a705dc72adaa666d
+generated: "2026-07-21T14:18:37.300606-04:00"

--- a/charts/rossoctl/Chart.yaml
+++ b/charts/rossoctl/Chart.yaml
@@ -7,6 +7,6 @@ appVersion: "0.7.0-alpha.5"
 
 dependencies:
 - name: operator-chart
-  version: 0.3.0-alpha.8
+  version: 0.3.0-alpha.9
   repository: oci://ghcr.io/rossoctl/operator
   condition: components.agentOperator.enabled


### PR DESCRIPTION
## Summary

The flagship pinned `operator-chart` `0.3.0-alpha.8`, which was only ever published under the **pre-rename** package name (`kagenti-kagenti-operator-chart`). After the kagenti to rossoctl rename, `oci://ghcr.io/rossoctl/operator/operator-chart:0.3.0-alpha.8` did not resolve, so `chart-tests` and E2E-Kind failed with `403 / denied` on the OCI pull.

`operator-chart` `0.3.0-alpha.9` is now published under the correct new name and org (`ghcr.io/rossoctl/operator/operator-chart`) and is publicly pullable.

## Change

- Bump the `operator-chart` dependency pin `0.3.0-alpha.8` to `0.3.0-alpha.9` in `charts/rossoctl/Chart.yaml`.
- Regenerate `charts/rossoctl/Chart.lock` against it via `helm dependency update` with the OCI dependency actually pulled (digest recomputed, not hand-edited).

Unblocks the flagship CI + E2E-Kind. Part of the Kagenti to rossoctl rename CI cleanup.
