### PR TITLE
fix(charts): bump operator image tag to 0.3.0-alpha.9

### DIFF
--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -361,7 +361,7 @@ operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.3.0-alpha.8
+        tag: 0.3.0-alpha.9
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"


### PR DESCRIPTION
The `operator-chart` dependency and `Chart.lock` are at `0.3.0-alpha.9`, but the operator image tag override in `values.yaml` was left at `0.3.0-alpha.8`. That image is gone from ghcr.io (pull returns 403), so every deploy fails with `ImagePullBackOff` on `rossoctl-controller-manager` — breaking the required **Deploy & Test** check on all PRs and on `main`.

This aligns the image tag override with the chart dependency version.

```diff
 operator-chart:
   controllerManager:
     container:
       image:
-        tag: 0.3.0-alpha.8
+        tag: 0.3.0-alpha.9
```

Closes #2247