### PR TITLE
fix(simulated-tools): adopt workloads via AgentRuntime instead of self-labeling

### DIFF
--- a/rossoctl/backend/app/core/config.py
+++ b/rossoctl/backend/app/core/config.py
@@ -102,6 +102,11 @@ class Settings(BaseSettings):
     simulation_harness_request_timeout: float = 10.0
     # Seconds between trigger-task POST attempts while the harness is still starting.
     simulation_trigger_poll_interval: int = 5
+    # Max seconds to wait for the operator to adopt the workload (AgentRuntime
+    # targetRef) and roll the pod onto the configured revision before the trigger
+    # task posts the spec. Bounds the "provisioning" wait so a stuck operator does
+    # not hang generation forever; on timeout the trigger proceeds best-effort.
+    simulation_provision_timeout: int = 180
     # Auto-inject MCP_URL / LLM env vars on agent import (TUI parity; weather demo defaults)
     rossoctl_feature_flag_agent_import_defaults: bool = False
     skill_autosync_interval: int = (

--- a/rossoctl/backend/app/routers/simulation.py
+++ b/rossoctl/backend/app/routers/simulation.py
@@ -28,7 +28,10 @@ from pydantic import BaseModel, field_validator
 from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.core.config import settings
 from app.core.constants import (
+    AGENTRUNTIMES_PLURAL,
     APP_KUBERNETES_IO_NAME,
+    CRD_GROUP,
+    CRD_VERSION,
     DEFAULT_IN_CLUSTER_PORT,
     ROSSOCTL_SIMULATED_LABEL,
     TOOL_SERVICE_SUFFIX,
@@ -45,6 +48,7 @@ from app.services.simulation_harness_client import (
 from app.services.simulation_manifests import (
     MAX_SIMULATION_NAME_LEN,
     EnvVar,
+    build_simulation_agentruntime,
     build_simulation_env_vars,
     build_simulation_service,
     build_simulation_statefulset,
@@ -87,21 +91,75 @@ def _harness_base_url(name: str, namespace: str, port: int) -> str:
     return f"http://{name}{TOOL_SERVICE_SUFFIX}.{namespace}.svc.cluster.local:{port}"
 
 
-async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
-    """Wait for the harness pod to accept connections, then POST the spec once.
+async def _wait_for_runtime_configured(namespace: str, name: str) -> bool:
+    """Poll the tool's AgentRuntime until the operator reports it Configured.
 
-    The harness generates in the background after a 202; this task's only job is
-    to deliver the spec, retrying while the pod is still starting (connection
-    failures) or briefly warming up (5xx). A 202/409 is terminal success; any
-    other 4xx is a terminal rejection. Bounded by ``simulation_generation_timeout``
-    so it never loops forever; a give-up is later surfaced by the status
-    endpoint's watchdog as Failed/generation_stalled.
+    Adopting the workload rolls the pod once — the operator writes a config-hash
+    annotation onto the pod template that the backend cannot precompute, so the
+    first reconcile always mutates the StatefulSet and recreates the pod. Posting
+    the spec before that would target a pod about to be replaced, losing the
+    generation. We wait until the AgentRuntime's Ready condition is True and at
+    least one pod is on the configured revision (``status.configuredPods >= 1``),
+    bounded by ``simulation_provision_timeout``.
+
+    Best-effort: transient read errors (CR not created yet, API blips) are retried;
+    returns False on timeout so the caller can proceed anyway rather than hang.
+    """
+    kube = get_kubernetes_service()
+    deadline = time.monotonic() + settings.simulation_provision_timeout
+    interval = settings.simulation_trigger_poll_interval
+    while True:
+        try:
+            cr = kube.get_custom_resource(
+                group=CRD_GROUP,
+                version=CRD_VERSION,
+                namespace=namespace,
+                plural=AGENTRUNTIMES_PLURAL,
+                name=name,
+            )
+            status = (cr or {}).get("status") or {}
+            conditions = status.get("conditions") or []
+            ready = any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
+            if ready and (status.get("configuredPods") or 0) >= 1:
+                return True
+        except ApiException as e:
+            # The AgentRuntime is gone (tool deleted mid-provisioning, or never
+            # created) — nothing left to wait for. Give up now rather than retry
+            # a 404 for the whole timeout.
+            if e.status == 404:
+                return False
+            # Other API errors are transient — retry until the deadline.
+        except Exception:
+            pass  # transient — retry until the deadline
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(interval)
+
+
+async def _run_generation_trigger(namespace: str, name: str, spec: dict, port: int) -> None:
+    """Wait for the workload to be operator-configured, then POST the spec once.
+
+    First defers to ``_wait_for_runtime_configured`` so the one-time pod roll from
+    AgentRuntime adoption completes before we post (otherwise the spec could land
+    on a pod about to be recreated). The harness then generates in the background
+    after a 202; this task's only job is to deliver the spec, retrying while the
+    pod is still starting (connection failures) or briefly warming up (5xx). A
+    202/409 is terminal success; any other 4xx is a terminal rejection. Bounded by
+    ``simulation_generation_timeout`` so it never loops forever; a give-up is later
+    surfaced by the status endpoint's watchdog as Failed/generation_stalled.
 
     Runs fire-and-forget via ``asyncio.create_task``, so it must never let an
     exception escape (an unretrieved task exception would only surface as log
     noise); any unexpected error is logged and ends the task.
     """
     base_url = _harness_base_url(name, namespace, port)
+    # Wait out the operator's adopt-and-roll before delivering the spec.
+    if not await _wait_for_runtime_configured(namespace, name):
+        logger.warning(
+            "AgentRuntime for '%s' not Configured within provision timeout; "
+            "posting spec best-effort",
+            sanitize_log(name),
+        )
     deadline = time.monotonic() + settings.simulation_generation_timeout
     interval = settings.simulation_trigger_poll_interval
     try:
@@ -405,10 +463,24 @@ async def create_simulated_tool(
         image_pull_policy=settings.simulation_image_pull_policy,
     )
     service = build_simulation_service(name, request.namespace, port=port)
+    agentruntime = build_simulation_agentruntime(
+        name, request.namespace, auth_bridge_mode=request.authBridgeMode
+    )
 
     try:
         kube.create_statefulset(request.namespace, statefulset)
         kube.create_service(request.namespace, service)
+        # Adopt the bare workload via an AgentRuntime CR so the operator (the only
+        # SA the agent-label-protection VAP exempts) stamps rossoctl.io/type=tool.
+        # The first reconcile rolls the pod once; generation is deferred until the
+        # workload is Configured (see _run_generation_trigger).
+        kube.create_custom_resource(
+            group=CRD_GROUP,
+            version=CRD_VERSION,
+            namespace=request.namespace,
+            plural=AGENTRUNTIMES_PLURAL,
+            body=agentruntime,
+        )
     except ApiException as e:
         if e.status == 409:
             raise HTTPException(
@@ -650,7 +722,17 @@ async def delete_simulated_tool(
                     sanitize_log(str(e)),
                 )
 
+    # Delete the workload first, then its AgentRuntime CR. Deleting the CR while
+    # the StatefulSet still exists would make the operator's finalizer strip the
+    # rossoctl.io/type label back off — a pointless teardown roll. With the target
+    # already gone, the finalizer no-ops.
     _try(lambda: kube.delete_statefulset(namespace, name), f"StatefulSet/{name}")
+    _try(
+        lambda: kube.delete_custom_resource(
+            CRD_GROUP, CRD_VERSION, namespace, AGENTRUNTIMES_PLURAL, name
+        ),
+        f"AgentRuntime/{name}",
+    )
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
     _try(lambda: kube.delete_service(namespace, service_name), f"Service/{service_name}")
     for pvc in pvc_names:
@@ -658,6 +740,11 @@ async def delete_simulated_tool(
             lambda pvc=pvc: kube.delete_persistent_volume_claim(namespace, pvc),
             f"PersistentVolumeClaim/{pvc}",
         )
+    # NOTE: the create path provisions a per-tool ServiceAccount
+    # (ensure_service_account), but the backend SA has create-but-not-delete RBAC
+    # on serviceaccounts in agent namespaces, so we do not delete it here. Cleaning
+    # it up needs either an ownerReference (GC on StatefulSet delete) or a scoped
+    # RBAC grant — tracked separately as it is orthogonal to operator adoption.
 
     logger.info(
         "Deleted simulated tool '%s' in '%s' (%d resources)",

--- a/rossoctl/backend/app/services/simulation_manifests.py
+++ b/rossoctl/backend/app/services/simulation_manifests.py
@@ -17,6 +17,8 @@ from pydantic import BaseModel, field_validator
 from app.core.constants import (
     APP_KUBERNETES_IO_MANAGED_BY,
     APP_KUBERNETES_IO_NAME,
+    CRD_GROUP,
+    CRD_VERSION,
     DEFAULT_ENV_VARS,
     DEFAULT_IN_CLUSTER_PORT,
     DEFAULT_RESOURCE_LIMITS,
@@ -197,13 +199,18 @@ def build_simulation_statefulset(
     service_name = f"{name}{TOOL_SERVICE_SUFFIX}"
     inject = "enabled" if auth_bridge_enabled else "disabled"
 
+    # NOTE: rossoctl.io/type is intentionally NOT set here. The
+    # agent-label-protection ValidatingAdmissionPolicy forbids any principal but
+    # the operator SA from setting it on a Deployment/StatefulSet. The workload is
+    # created bare and adopted by an AgentRuntime CR (build_simulation_agentruntime);
+    # the operator stamps rossoctl.io/type=tool onto the workload during
+    # reconciliation. This mirrors the regular-tool path.
     labels = {
         APP_KUBERNETES_IO_NAME: name,
         _MCP_PROTOCOL_LABEL: "",
         ROSSOCTL_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
         ROSSOCTL_FRAMEWORK_LABEL: framework,
         ROSSOCTL_WORKLOAD_TYPE_LABEL: WORKLOAD_TYPE_STATEFULSET,
-        ROSSOCTL_TYPE_LABEL: RESOURCE_TYPE_TOOL,
         ROSSOCTL_SIMULATED_LABEL: "true",
         APP_KUBERNETES_IO_MANAGED_BY: ROSSOCTL_UI_CREATOR_LABEL,
         ROSSOCTL_INJECT_LABEL: inject,
@@ -213,7 +220,6 @@ def build_simulation_statefulset(
         _MCP_PROTOCOL_LABEL: "",
         ROSSOCTL_TRANSPORT_LABEL: VALUE_TRANSPORT_STREAMABLE_HTTP,
         ROSSOCTL_FRAMEWORK_LABEL: framework,
-        ROSSOCTL_TYPE_LABEL: RESOURCE_TYPE_TOOL,
         ROSSOCTL_SIMULATED_LABEL: "true",
         ROSSOCTL_INJECT_LABEL: inject,
     }
@@ -336,6 +342,51 @@ def build_simulation_service(
             "ports": [{"name": "http", "port": port, "targetPort": port, "protocol": "TCP"}],
         },
     }
+
+
+def build_simulation_agentruntime(
+    name: str,
+    namespace: str,
+    *,
+    auth_bridge_mode: Optional[str] = None,
+) -> dict:
+    """Build an AgentRuntime CR that adopts the simulated-tool StatefulSet.
+
+    The StatefulSet is created without the ``rossoctl.io/type`` label because the
+    agent-label-protection ValidatingAdmissionPolicy only lets the operator SA set
+    it. This CR references the workload via ``spec.targetRef``; the operator adopts
+    the StatefulSet and stamps ``rossoctl.io/type=tool`` (plus its config-hash /
+    mtls annotations) as the exempt controller-manager SA — the same mechanism the
+    regular-tool path uses (``app.routers.tools._ensure_tool_agentruntime``).
+
+    Kept here rather than imported from app.routers.tools so this module stays
+    standalone (see module docstring). The CR shape is CRD-stable (required fields
+    are only ``type`` and ``targetRef``).
+    """
+    manifest: Dict[str, Any] = {
+        "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
+        "kind": "AgentRuntime",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": {
+                APP_KUBERNETES_IO_NAME: name,
+                APP_KUBERNETES_IO_MANAGED_BY: ROSSOCTL_UI_CREATOR_LABEL,
+                ROSSOCTL_SIMULATED_LABEL: "true",
+            },
+        },
+        "spec": {
+            "type": RESOURCE_TYPE_TOOL,
+            "targetRef": {
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "name": name,
+            },
+        },
+    }
+    if auth_bridge_mode:
+        manifest["spec"]["authBridgeMode"] = auth_bridge_mode
+    return manifest
 
 
 def validate_openapi_spec(text: str) -> dict:

--- a/rossoctl/backend/tests/test_simulation_lifecycle_api.py
+++ b/rossoctl/backend/tests/test_simulation_lifecycle_api.py
@@ -158,11 +158,15 @@ def test_delete_removes_statefulset_service_and_pvcs():
     body = r.json()
     assert body["success"] is True
     assert "StatefulSet/petstore" in body["deletedResources"]
+    assert "AgentRuntime/petstore" in body["deletedResources"]
     assert "Service/petstore-mcp" in body["deletedResources"]
     assert "PersistentVolumeClaim/data-petstore-0" in body["deletedResources"]
     kube.delete_statefulset.assert_called_once_with("team1", "petstore")
     kube.delete_service.assert_called_once_with("team1", "petstore-mcp")
     kube.delete_persistent_volume_claim.assert_called_once_with("team1", "data-petstore-0")
+    # AgentRuntime CR removed (adopted-workload teardown).
+    args = kube.delete_custom_resource.call_args.args
+    assert args[2] == "team1" and args[4] == "petstore"
 
 
 def test_delete_is_idempotent_on_missing_service_and_pvc():
@@ -208,6 +212,7 @@ def test_delete_removes_multiple_pvcs_in_order():
 def test_delete_all_404_still_returns_200():
     kube = _kube(pvcs=["data-petstore-0"])
     kube.delete_statefulset.side_effect = ApiException(status=404)
+    kube.delete_custom_resource.side_effect = ApiException(status=404)
     kube.delete_service.side_effect = ApiException(status=404)
     kube.delete_persistent_volume_claim.side_effect = ApiException(status=404)
     r = _delete(_client(kube))

--- a/rossoctl/backend/tests/test_simulation_manifests.py
+++ b/rossoctl/backend/tests/test_simulation_manifests.py
@@ -90,13 +90,18 @@ def test_statefulset_core_shape():
 
 
 def test_statefulset_labels_and_markers():
-    labels = _sts()["metadata"]["labels"]
+    m = _sts()
+    labels = m["metadata"]["labels"]
     assert labels["protocol.rossoctl.io/mcp"] == ""
-    assert labels["rossoctl.io/type"] == "tool"
     assert labels["rossoctl.io/simulated"] == "true"
     assert labels["rossoctl.io/workload-type"] == "statefulset"
     assert labels["rossoctl.io/inject"] == "disabled"
-    assert _sts()["metadata"]["annotations"]["rossoctl.io/autoscaling"] == "disabled"
+    assert m["metadata"]["annotations"]["rossoctl.io/autoscaling"] == "disabled"
+    # rossoctl.io/type must NOT be set on the workload by the backend — the
+    # agent-label-protection VAP reserves that label for the operator, which
+    # stamps it via the AgentRuntime CR. Guard both metadata and pod template.
+    assert "rossoctl.io/type" not in labels
+    assert "rossoctl.io/type" not in m["spec"]["template"]["metadata"]["labels"]
 
 
 def test_statefulset_pvc_mounted_at_skills_dir():
@@ -156,6 +161,32 @@ def test_service_shape_and_labels():
     assert labels["protocol.rossoctl.io/mcp"] == ""
     assert labels["rossoctl.io/simulated"] == "true"
     assert labels["rossoctl.io/type"] == "tool"
+
+
+from app.services.simulation_manifests import build_simulation_agentruntime
+
+
+def test_agentruntime_adopts_statefulset_as_tool():
+    m = build_simulation_agentruntime("petstore", "team1")
+    assert m["kind"] == "AgentRuntime"
+    assert m["apiVersion"].endswith("/v1alpha1")
+    assert m["metadata"]["name"] == "petstore"
+    assert m["metadata"]["namespace"] == "team1"
+    assert m["metadata"]["labels"]["rossoctl.io/simulated"] == "true"
+    # Required CRD fields: type + targetRef pointing at the bare StatefulSet.
+    assert m["spec"]["type"] == "tool"
+    assert m["spec"]["targetRef"] == {
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "name": "petstore",
+    }
+    # authBridgeMode only present when requested.
+    assert "authBridgeMode" not in m["spec"]
+
+
+def test_agentruntime_includes_authbridge_mode_when_set():
+    m = build_simulation_agentruntime("petstore", "team1", auth_bridge_mode="lite")
+    assert m["spec"]["authBridgeMode"] == "lite"
 
 
 import pytest

--- a/rossoctl/backend/tests/test_simulation_provision_wait.py
+++ b/rossoctl/backend/tests/test_simulation_provision_wait.py
@@ -1,0 +1,129 @@
+# Copyright 2026 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the provisioning gate that defers the spec POST until the operator
+has adopted the simulated-tool workload via its AgentRuntime.
+
+Kept in a separate module from test_simulation_trigger.py so it is not affected
+by that module's autouse fixture, which stubs _wait_for_runtime_configured to
+exercise the POST loop in isolation.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kubernetes.client import ApiException
+
+from app.routers import simulation as sim
+
+
+def _runtime_cr(*, ready: bool, configured_pods: int) -> dict:
+    return {
+        "status": {
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+            "configuredPods": configured_pods,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_returns_true_when_ready_and_pod_configured():
+    kube = MagicMock()
+    kube.get_custom_resource.return_value = _runtime_cr(ready=True, configured_pods=1)
+    with (
+        patch("app.routers.simulation.get_kubernetes_service", return_value=kube),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_provision_timeout = 180
+        s.simulation_trigger_poll_interval = 5
+        assert await sim._wait_for_runtime_configured("team1", "petstore") is True
+    kube.get_custom_resource.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_polls_until_configured():
+    kube = MagicMock()
+    kube.get_custom_resource.side_effect = [
+        _runtime_cr(ready=False, configured_pods=0),  # not ready yet
+        _runtime_cr(ready=True, configured_pods=0),  # ready, pod still rolling
+        _runtime_cr(ready=True, configured_pods=1),  # configured
+    ]
+    sleep = AsyncMock()
+    with (
+        patch("app.routers.simulation.get_kubernetes_service", return_value=kube),
+        patch("app.routers.simulation.asyncio.sleep", new=sleep),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_provision_timeout = 180
+        s.simulation_trigger_poll_interval = 5
+        assert await sim._wait_for_runtime_configured("team1", "petstore") is True
+    assert kube.get_custom_resource.call_count == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_returns_false_on_timeout():
+    kube = MagicMock()
+    kube.get_custom_resource.return_value = _runtime_cr(ready=False, configured_pods=0)
+    with (
+        patch("app.routers.simulation.get_kubernetes_service", return_value=kube),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_provision_timeout = 0  # deadline already passed -> one look, then bail
+        s.simulation_trigger_poll_interval = 5
+        assert await sim._wait_for_runtime_configured("team1", "petstore") is False
+
+
+@pytest.mark.asyncio
+async def test_transient_read_error_is_retried_not_fatal():
+    kube = MagicMock()
+    kube.get_custom_resource.side_effect = [
+        RuntimeError("api blip"),
+        _runtime_cr(ready=True, configured_pods=1),
+    ]
+    with (
+        patch("app.routers.simulation.get_kubernetes_service", return_value=kube),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_provision_timeout = 180
+        s.simulation_trigger_poll_interval = 5
+        assert await sim._wait_for_runtime_configured("team1", "petstore") is True
+    assert kube.get_custom_resource.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_agentruntime_404_short_circuits_immediately():
+    # Tool deleted mid-provisioning: a 404 on the CR means there's nothing left to
+    # wait for, so give up at once rather than retrying (and log-spamming) until
+    # the provision timeout.
+    kube = MagicMock()
+    kube.get_custom_resource.side_effect = ApiException(status=404)
+    with (
+        patch("app.routers.simulation.get_kubernetes_service", return_value=kube),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()) as sleep,
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_provision_timeout = 180
+        s.simulation_trigger_poll_interval = 5
+        assert await sim._wait_for_runtime_configured("team1", "petstore") is False
+    kube.get_custom_resource.assert_called_once()
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_404_api_error_is_retried():
+    kube = MagicMock()
+    kube.get_custom_resource.side_effect = [
+        ApiException(status=500),  # transient server error — retry
+        _runtime_cr(ready=True, configured_pods=1),
+    ]
+    with (
+        patch("app.routers.simulation.get_kubernetes_service", return_value=kube),
+        patch("app.routers.simulation.asyncio.sleep", new=AsyncMock()),
+        patch("app.routers.simulation.settings") as s,
+    ):
+        s.simulation_provision_timeout = 180
+        s.simulation_trigger_poll_interval = 5
+        assert await sim._wait_for_runtime_configured("team1", "petstore") is True
+    assert kube.get_custom_resource.call_count == 2

--- a/rossoctl/backend/tests/test_simulation_trigger.py
+++ b/rossoctl/backend/tests/test_simulation_trigger.py
@@ -10,6 +10,18 @@ import pytest
 from app.routers import simulation as sim
 
 
+@pytest.fixture(autouse=True)
+def _skip_provision_wait():
+    """These tests exercise the spec-POST loop; stub out the operator-adoption
+    wait (_wait_for_runtime_configured) so it resolves immediately. The wait
+    itself is covered by TestWaitForRuntimeConfigured below."""
+    with patch(
+        "app.routers.simulation._wait_for_runtime_configured",
+        new=AsyncMock(return_value=True),
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_trigger_posts_once_on_202():
     post = AsyncMock(return_value=202)

--- a/scripts/kind/setup-rossoctl.sh
+++ b/scripts/kind/setup-rossoctl.sh
@@ -10,7 +10,8 @@
 # Optional:        --with-istio (ambient mesh), --with-spire, --with-backend,
 #                  --with-ui, --with-mcp-gateway, --with-kuadrant, --with-otel,
 #                  --with-mlflow, --with-builds, --with-kiali,
-#                  --with-agent-sandbox, --with-skills, --with-all
+#                  --with-agent-sandbox, --with-skills, --with-simulated-tools,
+#                  --with-all
 #
 # Idempotent: safe to re-run. Uses helm upgrade --install and kubectl apply.
 # Re-running with additional --with-* flags adds components incrementally.
@@ -49,6 +50,7 @@ WITH_KIALI=false
 WITH_KUADRANT=false
 WITH_AGENT_SANDBOX=false
 WITH_SKILLS=false
+WITH_SIMULATED_TOOLS=false
 SKILL_REGISTRY_ALLOWED_HOSTS=""
 WITH_ALL=false
 SKIP_CLUSTER=false
@@ -217,6 +219,7 @@ while [[ $# -gt 0 ]]; do
     --with-kiali)       WITH_KIALI=true; shift ;;
     --with-agent-sandbox) WITH_AGENT_SANDBOX=true; shift ;;
     --with-skills)      WITH_SKILLS=true; shift ;;
+    --with-simulated-tools) WITH_SIMULATED_TOOLS=true; shift ;;
     --skill-registry-allowed-hosts) SKILL_REGISTRY_ALLOWED_HOSTS="$2"; shift 2 ;;
     --with-all)         WITH_ALL=true; shift ;;
     --skip-cluster)     SKIP_CLUSTER=true; shift ;;
@@ -256,6 +259,10 @@ while [[ $# -gt 0 ]]; do
       echo "                      autosync against it; auto-enables --with-backend and --with-ui)."
       echo "                      Override the store image with the SKILLBERRY_STORE_IMAGE /"
       echo "                      SKILLBERRY_STORE_TAG env vars (default tag 0.2.0)."
+      echo "  --with-simulated-tools"
+      echo "                      Enable simulated MCP tools generated from OpenAPI"
+      echo "                      specs (enables featureFlags.simulatedTools;"
+      echo "                      auto-enables --with-backend and --with-ui)."
       echo "  --skill-registry-allowed-hosts HOSTS"
       echo "                      Comma-separated hosts/IPs/CIDRs allowed past the registry-URL"
       echo "                      SSRF block (e.g. \"192.168.50.16\" or \"192.168.0.0/16\")."
@@ -319,6 +326,11 @@ fi
 if $WITH_SKILLS && ! $WITH_UI; then
   WITH_UI=true
 fi
+# Simulated tools surface in the UI and set a feature-flag env var on the backend,
+# so it is useless without both. Resolve before the UI→backend rule so it cascades.
+if $WITH_SIMULATED_TOOLS && ! $WITH_UI; then
+  WITH_UI=true
+fi
 # UI requires backend API
 if $WITH_UI && ! $WITH_BACKEND; then
   WITH_BACKEND=true
@@ -367,6 +379,7 @@ echo "    Builds:        $WITH_BUILDS"
 echo "    Kiali:         $WITH_KIALI"
 echo "    Agent Sandbox: $WITH_AGENT_SANDBOX"
 echo "    Skills:        $WITH_SKILLS"
+echo "    Simulated Tools: $WITH_SIMULATED_TOOLS"
 echo "    Skill reg allow: ${SKILL_REGISTRY_ALLOWED_HOSTS:-<none>}"
 echo "    Skip cluster:  $SKIP_CLUSTER"
 echo "    Build images:  $BUILD_IMAGES"
@@ -1236,6 +1249,7 @@ ROSSOCTL_FLAGS=(
   --set "featureFlags.agentSandbox=${WITH_AGENT_SANDBOX}"
   --set "featureFlags.skills=${WITH_SKILLS}"
   --set "featureFlags.externalSkills=${WITH_SKILLS}"
+  --set "featureFlags.simulatedTools=${WITH_SIMULATED_TOOLS}"
   --set "components.skillberryStore.enabled=${WITH_SKILLS}"
   --set "components.mlflow.enabled=${WITH_MLFLOW}"
   --set "ui.auth.enabled=$($WITH_SPIRE && echo true || echo false)"


### PR DESCRIPTION
## Summary

Makes the simulated-tools feature actually functional when the `agent-label-protection` ValidatingAdmissionPolicy is installed. The backend was baking `rossoctl.io/type=tool` directly onto the StatefulSet (metadata + pod template), which the VAP reserves for the operator SA — so every create from the `rossoctl-backend` SA was denied (`403 -> API 502`) and the feature was non-functional. This routes simulated tools through the same operator-adoption path regular tools already use, so no VAP exemption is needed.

> **Depends on #2250** (the `--with-simulated-tools` flag). This branch is stacked on it; until #2250 merges, the diff here also includes that flag commit. Please merge after #2250.

## Key changes

- **Bare workload + AgentRuntime adoption.** The StatefulSet is created without `rossoctl.io/type`; a new `AgentRuntime{type: tool, targetRef -> StatefulSet}` CR lets the operator (the only VAP-exempt SA) stamp the label during reconciliation. Mirrors the regular-tool path.
- **Generation gating.** Adoption rolls the pod exactly once (the operator writes a `config-hash` annotation onto the pod template that the backend cannot precompute). Generation is therefore deferred until the AgentRuntime reports `Ready/Configured` with `configuredPods >= 1`, then the spec is posted to the settled pod — so it can't land on a pod about to be recreated. The gate short-circuits if the AgentRuntime 404s (tool deleted mid-provisioning).
- **Delete path.** Removes the AgentRuntime CR (after the workload, so the operator finalizer no-ops).
- **Standalone.** `build_simulation_agentruntime` lives in `simulation_manifests` and uses the generic `create`/`delete_custom_resource` helpers, so `app/routers/tools.py` is untouched.

## Testing

- Backend unit tests: **674 passed** (new manifest / AgentRuntime-builder / provision-wait / lifecycle coverage added); pylint 9.97/10.
- E2E on Kind (`tests/e2e/common/test_simulated_tool.py`) with **no VAP exemption** — both happy and failure paths pass. Verified: create returns 202 (no 403/502), the operator adopts the workload and stamps `rossoctl.io/type=tool`, the gate defers generation ~35s until `Configured` with no mid-generation pod restart, then generation -> Ready -> MCP CRUD -> clean delete (StatefulSet, AgentRuntime, Service, PVC).

## Follow-ups (out of scope here)

- **Orphan per-tool ServiceAccount.** The backend has create-but-not-delete RBAC on serviceaccounts in agent namespaces, so the per-tool SA is not removed on delete. This is a pre-existing, platform-wide leak (agents and regular tools do the same). Preferred fix: ownerReference-based GC in `ensure_service_account` so all workload types are covered uniformly.
- **CI coverage.** No workflow runs `--with-simulated-tools` (and `--with-all` excludes it), so this path is not yet exercised in CI. Worth adding a job that deploys with the flag and runs the simulated-tool E2E.

Related: epic #2151, issue #2167.

Assisted-By: Claude Code
