### PR TITLE
fix(kind): enforce safe SPIFFE CSI driver minimum

### DIFF
--- a/scripts/kind/setup-rossoctl.sh
+++ b/scripts/kind/setup-rossoctl.sh
@@ -97,7 +97,9 @@ log_warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
 log_error()   { echo -e "${RED}✗${NC} $1"; }
 
 version_at_least() {
-  local version="${1#v}" minimum="${2#v}"
+  # Image tags use numeric X.Y.Z releases. Reject prefixes and pre-release
+  # suffixes so a version can pass validation only if that exact tag is usable.
+  local version="$1" minimum="$2"
   local version_major version_minor version_patch
   local minimum_major minimum_minor minimum_patch
 
@@ -264,7 +266,8 @@ while [[ $# -gt 0 ]]; do
       echo "  --with-istio        Enable full Istio ambient mesh (mTLS, waypoints)"
       echo "                      Gateway API controller is always installed as core"
       echo "  --with-spire        Install SPIRE + SPIFFE IdP setup"
-      echo "                      Override CSI with SPIFFE_CSI_DRIVER_VERSION (minimum 0.2.12)"
+      echo "                      Override CSI with SPIFFE_CSI_DRIVER_VERSION"
+      echo "                      (numeric X.Y.Z tag; minimum 0.2.12)"
       echo "  --with-backend      Install Rossoctl backend API"
       echo "  --with-ui           Install Rossoctl UI (auto-enables backend)"
       echo "  --with-mcp-gateway  Install MCP Gateway"
@@ -374,7 +377,7 @@ if $WITH_KUADRANT && ! $WITH_MCP_GATEWAY; then
 fi
 
 if $WITH_SPIRE && ! version_at_least "$SPIFFE_CSI_DRIVER_VERSION" "$SPIFFE_CSI_DRIVER_MIN_VERSION"; then
-  log_error "SPIFFE_CSI_DRIVER_VERSION must be a semantic version at least"
+  log_error "SPIFFE_CSI_DRIVER_VERSION must be a numeric X.Y.Z image tag at least"
   log_error "${SPIFFE_CSI_DRIVER_MIN_VERSION}; got ${SPIFFE_CSI_DRIVER_VERSION}"
   exit 1
 fi

--- a/scripts/kind/setup-rossoctl.sh
+++ b/scripts/kind/setup-rossoctl.sh
@@ -70,6 +70,10 @@ CERT_MANAGER_VERSION="v1.17.2"
 ISTIO_VERSION="1.28.0"
 SPIRE_CRD_VERSION="0.5.0"
 SPIRE_VERSION="0.27.0"
+# v0.2.12 fixed a mount leak that can exhaust the host mount table and disrupt
+# node services. Allow newer versions while enforcing the safe minimum.
+SPIFFE_CSI_DRIVER_MIN_VERSION="0.2.12"
+SPIFFE_CSI_DRIVER_VERSION="${SPIFFE_CSI_DRIVER_VERSION:-0.2.13}"
 GATEWAY_API_VERSION="v1.4.0"
 TEKTON_VERSION="v0.66.0"
 SHIPWRIGHT_VERSION="v0.14.0"
@@ -91,6 +95,22 @@ log_info()    { echo -e "${BLUE}→${NC} $1"; }
 log_success() { echo -e "${GREEN}✓${NC} $1"; }
 log_warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
 log_error()   { echo -e "${RED}✗${NC} $1"; }
+
+version_at_least() {
+  local version="${1#v}" minimum="${2#v}"
+  local version_major version_minor version_patch
+  local minimum_major minimum_minor minimum_patch
+
+  IFS=. read -r version_major version_minor version_patch <<<"$version"
+  IFS=. read -r minimum_major minimum_minor minimum_patch <<<"$minimum"
+
+  [[ "$version_major" =~ ^[0-9]+$ && "$version_minor" =~ ^[0-9]+$ && "$version_patch" =~ ^[0-9]+$ &&
+     "$minimum_major" =~ ^[0-9]+$ && "$minimum_minor" =~ ^[0-9]+$ && "$minimum_patch" =~ ^[0-9]+$ ]] || return 1
+
+  (( version_major > minimum_major )) ||
+    (( version_major == minimum_major && version_minor > minimum_minor )) ||
+    (( version_major == minimum_major && version_minor == minimum_minor && version_patch >= minimum_patch ))
+}
 
 run_cmd() {
   if $DRY_RUN; then echo "  [dry-run] $*"; else "$@"; fi
@@ -244,6 +264,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --with-istio        Enable full Istio ambient mesh (mTLS, waypoints)"
       echo "                      Gateway API controller is always installed as core"
       echo "  --with-spire        Install SPIRE + SPIFFE IdP setup"
+      echo "                      Override CSI with SPIFFE_CSI_DRIVER_VERSION (minimum 0.2.12)"
       echo "  --with-backend      Install Rossoctl backend API"
       echo "  --with-ui           Install Rossoctl UI (auto-enables backend)"
       echo "  --with-mcp-gateway  Install MCP Gateway"
@@ -350,6 +371,12 @@ fi
 # Kuadrant provides AuthPolicy for MCP Gateway
 if $WITH_KUADRANT && ! $WITH_MCP_GATEWAY; then
   WITH_MCP_GATEWAY=true
+fi
+
+if $WITH_SPIRE && ! version_at_least "$SPIFFE_CSI_DRIVER_VERSION" "$SPIFFE_CSI_DRIVER_MIN_VERSION"; then
+  log_error "SPIFFE_CSI_DRIVER_VERSION must be a semantic version at least"
+  log_error "${SPIFFE_CSI_DRIVER_MIN_VERSION}; got ${SPIFFE_CSI_DRIVER_VERSION}"
+  exit 1
 fi
 
 # ── Pre-flight ──────────────────────────────────────────────────────────────
@@ -675,6 +702,7 @@ if $WITH_SPIRE; then
     --set-string "global.spire.namespaces.server.labels.shared-gateway-access=true" \
     --set global.spire.ingressControllerType="" \
     --set global.spire.clusterName=agent-platform \
+    --set-string "spiffe-csi-driver.image.tag=${SPIFFE_CSI_DRIVER_VERSION}" \
     --set "global.spire.trustDomain=${DOMAIN}" \
     --set "global.spire.caSubject.country=US" \
     --set "global.spire.caSubject.organization=AgenticPlatformDemo" \


### PR DESCRIPTION
## What changed

- Default the SPIFFE CSI driver used by the Kind installer to `0.2.13`.
- Allow newer versions through the `SPIFFE_CSI_DRIVER_VERSION` environment variable while rejecting versions below the safe minimum, `0.2.12`, or tags outside the numeric `X.Y.Z` image-tag format.
- Pass the selected image tag explicitly to the SPIRE Helm release instead of inheriting the SPIRE chart's current `0.2.7` default.

## Why

SPIFFE CSI driver versions through `0.2.11` do not make `NodePublishVolume` idempotent. Kubelet reconciliation or restart can therefore create duplicate bind mounts. With bidirectional mount propagation, those mounts can accumulate rapidly and exhaust node resources.

The defect is documented in [spiffe/spiffe-csi#331](https://github.com/spiffe/spiffe-csi/issues/331) and fixed by [spiffe/spiffe-csi#332](https://github.com/spiffe/spiffe-csi/pull/332). The fix was released in `0.2.12`; this change defaults to the current patch release, `0.2.13`, while permitting later safe versions.

The SPIRE `0.27.0` chart currently embeds SPIFFE CSI driver `0.2.7`, so an explicit override is needed until a fixed chart version is available and adopted.

The observed mount explosion, node-level impact, root cause, and recovery are documented in #2288.

The change covers both Kind and vanilla Kubernetes: `scripts/k8s/setup-rossoctl.sh` delegates installation to the patched script with the Kubernetes setup flavor. It does not change the OpenShift/ZTWIM path, where OLM controls the CSI driver image and the operator bundle must be verified separately.

Fixes #2288.

## Validation

- `bash -n scripts/kind/setup-rossoctl.sh`
- `git diff --check`
- Verified that `0.2.11`, `v0.2.13`, `0.2.13-rc1`, and malformed values are rejected, while `0.2.12`, `0.2.13`, `0.3.0`, and `1.0.0` are accepted.
- Confirmed that `spiffe-csi-driver.image.tag=0.2.13` renders and deploys successfully with SPIRE chart `0.27.0` in a live Kubernetes cluster.
