### PR TITLE
docs: Relabel identity Concepts page nav to "Cortex"

### DIFF
--- a/docs/Concepts/identity-guide.md
+++ b/docs/Concepts/identity-guide.md
@@ -1,8 +1,11 @@
 ---
+sidebar_label: Cortex
 description: Introduction to Zero-Trust.
 ---
 
-# Identity, Authentication, & Authorization
+# Cortex
+
+**_Identity, Authentication, & Authorization_**
 
 This comprehensive guide covers all aspects of identity, authentication, and authorization in the Rossoctl platform. Rossoctl implements a **Zero-Trust Architecture** that combines SPIFFE/SPIRE workload identity, OAuth2 token exchange, and Keycloak identity management to provide secure, scalable, and dynamic authentication for cloud-native AI agents.
 


### PR DESCRIPTION
## What

Relabels the identity guide page under **Documentation → Concepts** so its left-nav tile reads **Cortex** instead of "Identity, Authentication, & Authorization".

- Adds `sidebar_label: Cortex` to the page frontmatter (sets the sidebar tile).
- Changes the page H1 to `# Cortex`.
- Keeps `Identity, Authentication, & Authorization` as a subtitle line directly under the H1.

Page content, URL (`/docs/Concepts/identity-guide`), and `description` are unchanged.

## Where

Edited only in the source of truth: `docs/Concepts/identity-guide.md` in this repo. The `rossoctl/.github` Docusaurus site mirrors `docs/` from here at build time (`scripts/sync-docs.sh`); its copy is git-ignored, so no changes are needed there.

## Diff

```diff
 ---
+sidebar_label: Cortex
 description: Introduction to Zero-Trust.
 ---

-# Identity, Authentication, & Authorization
+# Cortex
+
+**_Identity, Authentication, & Authorization_**
```

## Notes

- markdownlint passes on the changed lines. Pre-existing MD049 warnings on figure-caption italics elsewhere in the file are untouched and out of scope.

Refs #1472