### PR TITLE
docs: Reframe components security section as Cortex

### DIFF
--- a/docs/Concepts/components.md
+++ b/docs/Concepts/components.md
@@ -13,7 +13,7 @@ This document provides detailed information about each component of the Rossoctl
 - [MCP Gateway](#mcp-gateway)
 - [Plugins adapter](#plugins-adapter)
 - [Rossoctl UI](#rossoctl-ui)
-- [Identity & Auth Bridge](#identity--auth-bridge)
+- [Cortex](#cortex)
 - [Infrastructure Services](#infrastructure-services)
 - [Supported Agent Frameworks](#supported-agent-frameworks)
 - [Communication Protocols](#communication-protocols)
@@ -184,8 +184,8 @@ spec:
 
 ```yaml
 # AgentRuntime - Enrolls the workload with the rossoctl-operator.
-# The operator applies the rossoctl.io/type label and triggers
-# AuthBridge sidecar injection automatically.
+# The operator applies the rossoctl.io/type label and enrolls the
+# workload with Cortex automatically.
 apiVersion: agent.rossoctl.dev/v1alpha1
 kind: AgentRuntime
 metadata:
@@ -475,100 +475,46 @@ kubectl get route rossoctl-ui -n rossoctl-system -o jsonpath='{.status.ingress[0
 
 ---
 
-## Identity & Auth Bridge
+## Cortex
 
-**Repository**: [rossoctl/cortex/AuthBridge](https://github.com/rossoctl/cortex/tree/main/authbridge)
+**Repository**: [rossoctl/cortex](https://github.com/rossoctl/cortex)
 
-Rossoctl provides a unified framework for identity and authorization in agentic systems, replacing static credentials with dynamic, short-lived tokens. We call this collection of assets **Auth Bridge**.
+Cortex is the security layer of Rossoctl for agentic systems. It gives every agent and tool a trusted identity and enforces authentication, secure delegation, access control, and safe behavior at each hop, replacing static credentials with dynamic, short-lived, audience-scoped tokens.
 
-**Auth Bridge** solves a critical challenge in microservices and agentic architectures: **how can workloads authenticate and communicate securely without pre-provisioned static credentials?**
+This solves a critical challenge in microservices and agentic architectures: **how can workloads authenticate and communicate securely without pre-provisioned static credentials, while ensuring each action stays within what the user actually intended?**
 
-### Auth Bridge Components
+### What Cortex provides
 
-| Component | Purpose | Repository |
-|-----------|---------|------------|
-| **[AuthProxy (Cortex)](https://github.com/rossoctl/cortex/tree/main/authbridge)** | Inbound JWT validation (JWKS) and outbound token exchange | `AuthBridge/AuthProxy` |
-| **[SPIRE](https://spiffe.io/docs/latest/spire-about/)** | Workload identity and attestation | External |
-| **[Keycloak](https://www.keycloak.org/)** | Identity provider and access management | External |
+| Capability | Description |
+|------------|-------------|
+| **Trusted Identity** | Cryptographic workload identities issued by SPIFFE/SPIRE, backed by attestation |
+| **Authentication** | Validation of inbound tokens — signature, issuer, and audience |
+| **Secure Delegation** | OAuth 2.0 Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) with per-target audience scoping |
+| **Client Registration** | Automated Keycloak client provisioning for each workload, keyed by its SPIFFE identity |
+| **Access Control** | Policy-driven allow/deny decisions on agent and tool actions |
+| **Guardrails** | Content and behavior safety enforcement around agent activity |
 
-### Keycloak Client Registration (Operator-Managed)
+### Technologies Cortex supports
 
-Keycloak client registration is handled by the rossoctl-operator's ClientRegistrationReconciler controller:
+Cortex delivers these capabilities through a set of security technologies, and that set grows over time. The concepts above stay constant regardless of which technology enforces them.
 
-- Reconciles AgentRuntime CRs to apply `rossoctl.io/type` labels to target workloads and trigger sidecar injection
-- Uses **SPIFFE ID** as client identifier (e.g., `spiffe://localtest.me/ns/team/sa/my-agent`)
-- Reads Keycloak admin credentials from the operator namespace (`rossoctl-system`)
-- Creates a secret in the agent namespace containing client credentials
-- Eliminates the need for admin credentials in agent namespaces
+| Technology | Role | Status |
+|------------|------|--------|
+| **[CPEX](https://github.com/contextforge-org/cpex)** | Policy orchestration and access control — composes PDP verdicts (Cedar, OPA) for agentic entities using a declarative policy language | Supported |
+| **[IBAC](./ibac-plugin.md)** | Intent-Based Access Control — denies outbound actions that do not match the user's most-recent declared intent | Supported |
+| **[SPARC](./sparc-plugin.md)** | Pre-tool reflection — catches hallucinated or ungrounded tool calls before they execute | Supported |
+| **Praxis** | — | Emerging |
 
-### Cortex
+### Foundation
 
-An Envoy-based sidecar that handles both **inbound JWT validation** and **outbound token exchange**, using an external processor (ext-proc) for token operations:
+Cortex builds on two foundational services:
 
-<!--
-The SVG is based on this ASCII art.  To edit the SVG, edit this art and ask a tool to regenerate SVG.
-```
-                 Incoming request
-                       │
-                       ▼
-┌────────────────────────────────────────────────────────────────────┐
-│                          WORKLOAD POD                              │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │                   AuthProxy Sidecar (Envoy + Ext Proc)      │   │
-│  │                                                             │   │
-│  │  INBOUND:  Validate JWT (signature, issuer, audience via    │   │
-│  │            JWKS). Return 401 if invalid.                    │   │
-│  │  OUTBOUND: Exchange token for target audience via Keycloak  │   │
-│  │            (RFC 8693). HTTPS traffic passes through as-is.  │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                          │              │                          │
-│                    ┌─────┘              └─────┐                    │
-│                    ▼                          ▼                    │
-│           ┌──────────────┐           ┌──────────────┐              │
-│           │  Application │           │   Keycloak   │              │
-│           └──────────────┘           └──────────────┘              │
-└────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-                         ┌─────────────────────┐
-                         │   TARGET SERVICE    │
-                         │  (aud: auth-target) │
-                         └─────────────────────┘
-```
+| Service | Role |
+|---------|------|
+| **[SPIRE](https://spiffe.io/docs/latest/spire-about/)** | Issues cryptographic workload identities (SVIDs) via node-level attestation. Identity format: `spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>` |
+| **[Keycloak](https://www.keycloak.org/)** | Identity provider for user authentication, OAuth/OIDC flows, token exchange, and SSO across Rossoctl components |
 
--->
-
-![Cortex AuthProxy sidecar: inbound JWT validation and outbound token exchange within the workload pod, forwarding to the target service](./cortex-authproxy.svg)
-
-**Key Features:**
-
-- **Inbound JWT Validation** — Validates token signature, expiration, and issuer using JWKS keys fetched from Keycloak. Optionally validates the audience claim. Returns HTTP 401 for missing or invalid tokens.
-- **Outbound Token Exchange** — Performs [OAuth 2.0 Token Exchange (RFC 8693)](https://datatracker.ietf.org/doc/html/rfc8693) to replace the caller's token with one scoped to the target service audience
-- **Transparent to applications** — Traffic interception via iptables; no application code changes required
-- **Configuration** — Inbound validation is configured via `ISSUER` (required) and `EXPECTED_AUDIENCE` (optional) environment variables. Outbound exchange uses `TOKEN_URL`, `CLIENT_ID`, `CLIENT_SECRET` (provided by the operator via secret), and `TARGET_AUDIENCE`.
-
-### SPIRE (Workload Identity)
-
-[SPIRE](https://spiffe.io/docs/latest/spire-about/) provides cryptographic workload identities using the SPIFFE standard.
-
-| Component | Purpose |
-|-----------|---------|
-| **SPIRE Server** | Issues SVIDs (SPIFFE Verifiable Identity Documents) |
-| **SPIRE Agent** | Node-level agent that attests workloads |
-| **CSI Driver** | Mounts SVID certificates into pods |
-
-**Identity Format**: `spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>`
-
-### Keycloak (Access Management)
-
-[Keycloak](https://www.keycloak.org/) manages user authentication and OAuth/OIDC flows.
-
-| Feature | Description |
-|---------|-------------|
-| **User Management** | Create and manage Rossoctl users |
-| **Client Registration** | OAuth clients for agents and UI (automated registration via rossoctl-operator's ClientRegistrationReconciler) |
-| **Token Exchange** | Exchange tokens between audiences ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) |
-| **SSO** | Single sign-on across Rossoctl components |
+Client registration with Keycloak is automated per workload, keyed by the workload's SPIFFE identity, so agent namespaces never need admin credentials. SPIRE identities can be inspected through the Tornjak UI (`http://spire-tornjak-ui.localtest.me:8080/`).
 
 ### Authorization Pattern
 
@@ -602,16 +548,9 @@ The SVG is based on this ASCII art.  To edit the SVG, edit this art and ask a to
 - **No Static Secrets** - Credentials are dynamically generated at pod startup
 - **Short-Lived Tokens** - JWT tokens expire and must be refreshed
 - **Audience Scoping** - Tokens are scoped to specific audiences, preventing reuse
-- **Transparent to Application** - Token exchange is handled by the sidecar
+- **Transparent to Application** - Token exchange happens outside application code; no changes required
 
-For detailed overview of Identity and Authorization Patterns, see the [Identity Guide](./identity-guide.md).
-
-### Tornjak (SPIRE Management UI)
-
-```bash
-# UI
-open http://spire-tornjak-ui.localtest.me:8080/
-```
+For a detailed overview of Identity and Authorization Patterns, see the [Identity Guide](./identity-guide.md).
 
 ---
 
@@ -721,7 +660,7 @@ POST /mcp    # MCP JSON-RPC messages
 ## Related Documentation
 
 - [Installation Guide](../getting-started/install.md)
-- [Identity, Security, and Auth Bridge](./identity-guide.md)
+- [Cortex Identity Guide](./identity-guide.md)
 - [MCP Gateway Instructions](https://github.com/Kuadrant/mcp-gateway)
 - [New Agent Guide](../getting-started/new-agent.md)
 - [New Tool Guide](../getting-started/new-tool.md)

--- a/docs/Concepts/identity-guide.md
+++ b/docs/Concepts/identity-guide.md
@@ -235,7 +235,7 @@ Rossoctl implements OAuth2 Token Exchange to enable secure token delegation acro
 
 ![User Authentication Flow](../diagrams/images/png/01-user-authentication-flow.png)
 
-*Figure 1: User Authentication Flow - Shows how users authenticate with Rossoctl UI through Keycloak OIDC flow*
+_Figure 1: User Authentication Flow - Shows how users authenticate with Rossoctl UI through Keycloak OIDC flow_
 
 [View Mermaid Source Code](../diagrams/01-user-authentication-flow.mmd)
 
@@ -277,7 +277,7 @@ This approach provides better security isolation by restricting Keycloak admin c
 
 ![Agent Token Exchange Flow](../diagrams/images/png/04-agent-token-exchange-flow.png)
 
-*Figure 4: Agent Token Exchange Flow - Demonstrates OAuth2 token exchange between agents and Keycloak using SPIFFE identity*
+_Figure 4: Agent Token Exchange Flow - Demonstrates OAuth2 token exchange between agents and Keycloak using SPIFFE identity_
 
 [View Mermaid Source Code](../diagrams/04-agent-token-exchange-flow.mmd)
 
@@ -309,7 +309,7 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 
 ![Internal Tool Access with Delegated Token Flow](../diagrams/images/png/05-tool-access-delegated-token-flow.png)
 
-*Figure 4: Internal Tool Access Flow - Shows how agents call internal tools using delegated tokens with proper permission validation*
+_Figure 4: Internal Tool Access Flow - Shows how agents call internal tools using delegated tokens with proper permission validation_
 
 [View Mermaid Source Code](../diagrams/05-tool-access-delegated-token-flow.mmd)
 
@@ -353,7 +353,7 @@ The **MCP Gateway** acts as an authentication proxy for all Model Context Protoc
 
 ![MCP Gateway Authentication Flow](../diagrams/images/png/06-mcp-gateway-authentication-flow.png)
 
-*Figure 5: MCP Gateway Authentication Flow - Illustrates authentication flow through the MCP Gateway proxy for Model Context Protocol communications*
+_Figure 5: MCP Gateway Authentication Flow - Illustrates authentication flow through the MCP Gateway proxy for Model Context Protocol communications_
 
 [View Mermaid Source Code](../diagrams/06-mcp-gateway-authentication-flow.mmd)
 
@@ -437,7 +437,7 @@ def validate_request(request):
 
 ![External API Access with Delegated Token and Vault Flow](../diagrams/images/png/07-tool-with-external-api-flow.png)
 
-*Figure 6: External API Access with Vault Flow - Shows how agents call internal tools using delegated tokens with proper permission validation and the Vault exchanges this token for external API key for accessing external APIs*
+_Figure 6: External API Access with Vault Flow - Shows how agents call internal tools using delegated tokens with proper permission validation and the Vault exchanges this token for external API key for accessing external APIs_
 
 [View Mermaid Source Code](../diagrams/07-tool-with-external-api-flow.mmd)
 

--- a/docs/superpowers/specs/2026-07-28-cortex-components-doc-design.md
+++ b/docs/superpowers/specs/2026-07-28-cortex-components-doc-design.md
@@ -1,0 +1,167 @@
+# Cortex Component Documentation Redesign
+
+Date: 2026-07-28
+Status: Approved design, implemented in the same PR as this spec
+Target file: `docs/Concepts/components.md` (source of truth in `rossoctl/rossoctl`; the
+docs site at rossoctl.dev mirrors this repo at build time via `scripts/sync-docs.sh`)
+
+## Problem
+
+The components page at `/docs/Concepts/components#identity--auth-bridge` documents the
+platform's security layer under the heading **"Identity & Auth Bridge"**. Two problems:
+
+1. **Stale, inconsistent naming.** The `kagenti-extensions` repo was renamed to
+   **`cortex`** (`rossoctl/cortex`). The newer concept pages already adopt the new
+   model, opening with "X is a **Rossoctl Cortex** plugin..." (see `ibac-plugin.md`,
+   `sparc-plugin.md`). But `components.md` still uses the pre-rename framing:
+   **AuthBridge** as the umbrella term, and confusingly uses **"Cortex"** as a
+   sub-heading for the AuthProxy *sidecar*. The page contradicts its siblings.
+
+2. **Too low-level.** The section leans on implementation detail (Envoy sidecar,
+   ext-proc, iptables interception, JWT env vars) that will change as the security
+   layer evolves toward pluggable technologies.
+
+## Decision
+
+Rewrite the "Identity & Auth Bridge" section of `components.md` as a single unified
+component called **Cortex**, framed by durable security *capabilities* and the
+*technologies* that deliver them, at a higher conceptual level.
+
+### Framing rules (agreed)
+
+- **Retire the name "AuthBridge"** from this page entirely. It is being superseded by
+  Cortex. Where mechanics read "AuthBridge does X", they become "Cortex does X" or are
+  removed.
+- **No "plugin interface" / pipeline / sidecar mechanism language.** How Cortex is
+  wired is an implementation detail that may change; the docs stay at the capability
+  level.
+- **Cortex is Rossoctl's security layer** for agentic systems: trusted identity,
+  authentication, secure delegation (token exchange), client registration, access
+  control, and guardrails for agents and tools.
+- **CPEX, Praxis, IBAC, SPARC** are presented as the **technologies Cortex uses/supports**
+  to deliver those capabilities, framed as an evolving set with room for emerging ones.
+- The durable concepts (SPIFFE/SPIRE identity, token exchange, client registration,
+  access control) stay constant regardless of which technology implements them.
+
+### Scope boundary
+
+- **This change edits `docs/Concepts/components.md` only.**
+- Other files that still say "AuthBridge" (repo `README.md` component table,
+  `docs/Concepts/identity-guide.md`, and any others) are **out of scope** and listed as
+  follow-ups below. Do not touch them in this change.
+
+## New section structure (Proposal A — approved)
+
+Replaces current lines 478–616. Anatomy:
+
+```
+## Cortex
+
+**Repository:** rossoctl/cortex
+
+[Intro, 1–2 sentences: Cortex is Rossoctl's security layer for agentic systems. It gives
+ agents and tools a trusted identity and enforces authentication, secure delegation, and
+ safe behavior at every hop, replacing static credentials with dynamic, short-lived,
+ audience-scoped tokens.]
+
+### What Cortex provides   (functional capabilities — durable concepts)
+| Capability          | Description |
+|---------------------|-------------|
+| Trusted Identity    | SPIFFE/SPIRE workload identities (SVIDs) and attestation |
+| Authentication      | Inbound token validation — signature, issuer, and audience |
+| Secure Delegation   | OAuth2 Token Exchange (RFC 8693) with audience scoping |
+| Client Registration | Automated Keycloak client provisioning per workload |
+| Access Control      | Policy-driven allow/deny on agent and tool actions |
+| Guardrails          | Content and behavior safety enforcement |
+
+### Technologies Cortex supports   (the "how" — evolving set)
+| Technology | Role | Status |
+|------------|------|--------|
+| CPEX  | Policy orchestration and access control (APL policy DSL, Cedar/OPA PDPs, composable effects) | Supported |
+| IBAC  | Intent-Based Access Control — denies actions that don't match the user's declared intent | Supported (see IBAC page) |
+| SPARC | Pre-tool reflection — catches hallucinated / ungrounded tool calls before they execute | Supported (see SPARC page) |
+| Praxis | — | Emerging / planned |
+
+[Note line: the set of supported technologies grows over time; the identity, delegation,
+ and access-control concepts above stay constant.]
+
+### Foundation
+- **SPIRE** — workload identity (SVIDs, attestation). Identity format
+  `spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>`.
+- **Keycloak** — identity provider, OAuth/OIDC flows, token exchange, SSO.
+
+### Authorization Pattern
+[Keep authorization-pattern.svg (User → Keycloak → Agent → Tool, each backed by
+ short-lived SPIRE identities). Reword surrounding prose to drop AuthBridge/sidecar terms.
+ Keep the four security properties: no static secrets, short-lived tokens, audience
+ scoping, transparent to the application.]
+
+[Link to the Identity Guide for the deep dive.]
+```
+
+### Content sourcing notes (accuracy)
+
+- **CPEX** description grounded in `cortex/authbridge/authlib/plugins/cpex/README.md` and
+  `docs/cpex-plugin.md`: CPEX orchestrates policy for agentic entities, using an APL
+  policy DSL, Cedar/OPA PDPs, and composable effects. Link:
+  `https://github.com/contextforge-org/cpex`.
+- **IBAC / SPARC** descriptions grounded in the existing `docs/Concepts/ibac-plugin.md`
+  and `docs/Concepts/sparc-plugin.md`; link to those pages rather than restating detail.
+- **Praxis** — list only, marked "Emerging / planned", no invented capability description.
+- **Client Registration** is handled by the `rossoctl-operator`'s
+  `ClientRegistrationReconciler` (uses SPIFFE ID as client identifier). Describe the
+  outcome (automated per-workload client provisioning), not the reconciler mechanics.
+
+## Same-page consistency edits (all within components.md)
+
+| Location | Current | Change |
+|----------|---------|--------|
+| Line 16 (TOC) | `- [Identity & Auth Bridge](#identity--auth-bridge)` | `- [Cortex](#cortex)` |
+| Line 188 (comment in AgentRuntime YAML) | `# ... triggers AuthBridge sidecar injection automatically.` | Reword to drop the retired name and the mechanism detail: `# ... enrolls the workload with Cortex automatically.` |
+| Lines 478–616 (section) | "Identity & Auth Bridge" section | Replaced with the Cortex structure above |
+| Line 724 (Related Documentation) | `- [Identity, Security, and Auth Bridge](./identity-guide.md)` | `- [Cortex Identity Guide](./identity-guide.md)` |
+
+### Diagrams
+
+- **Keep** `authorization-pattern.svg` (embedded in the Authorization Pattern subsection);
+  reword surrounding prose only.
+- **Remove** the `cortex-authproxy.svg` embed and its ASCII-art source comment (current
+  lines ~508–541): it depicts the Envoy AuthProxy sidecar with inbound/outbound ext-proc
+  mechanics — exactly the implementation detail to de-emphasize. The SVG file stays on
+  disk (not deleted) in case history or other pages reference it; it is simply no longer
+  embedded on this page.
+
+### Anchor change caveat
+
+The section anchor changes from `#identity--auth-bridge` to `#cortex`. Docusaurus does
+not auto-redirect heading anchors. The only in-repo link to the old anchor is the TOC
+entry in this same file (updated above). External bookmarks to the old anchor will break;
+this is accepted.
+
+## Out of scope (follow-ups, do NOT edit in this change)
+
+- Repo `README.md`: "Identity & Auth Bridge" row in the components table (line ~7 area)
+  still points at `./docs/identity-guide.md` and uses the old name.
+- `docs/Concepts/identity-guide.md`: still contains "AuthBridge" references; the H1 is
+  being changed to "Cortex" separately in PR #2300.
+- Any other `docs/` pages containing "AuthBridge" — sweep in a later dedicated change.
+
+## Success criteria
+
+1. `components.md` has a single **Cortex** component section; the word "AuthBridge" no
+   longer appears anywhere on the page.
+2. The section leads with functional capabilities and presents CPEX/IBAC/SPARC as
+   supported technologies plus Praxis as emerging, with no plugin-interface/sidecar
+   mechanism language.
+3. TOC, Related Documentation, and the stray YAML comment are consistent with the rename.
+4. The `authorization-pattern.svg` diagram remains; the `cortex-authproxy.svg` embed is
+   removed.
+5. Markdown Lint (`.markdownlint-cli2.yaml`, MD049 underscore emphasis, MD056 table
+   columns) passes on the changed file; internal links resolve.
+
+## Verification plan
+
+- Run repo `markdownlint-cli2` on `docs/Concepts/components.md`.
+- Grep the file to confirm zero "AuthBridge" / "Auth Bridge" occurrences remain.
+- Confirm the new capability and technology tables have correct column counts (MD056).
+- Confirm all in-section links (identity-guide, IBAC page, SPARC page, CPEX repo) resolve.


### PR DESCRIPTION
## Summary

Reworks the security section of the Concepts **Components** page (`/docs/Concepts/components`), currently titled *"Identity & Auth Bridge"*, into a single unified **Cortex** component, following the `kagenti-extensions` -> `rossoctl/cortex` rename. Cortex is described by durable functional capabilities rather than the specific engine that implements them today.

## What changed

- **New `## Cortex` section** replacing *"Identity & Auth Bridge"*:
  - **What Cortex provides** - trusted identity, authentication, secure delegation, client registration, access control, guardrails.
  - **Technologies Cortex supports** - CPEX, IBAC, SPARC (supported) and Praxis (emerging).
  - **Foundation** - SPIRE and Keycloak.
  - **Authorization Pattern** - kept, with the existing `authorization-pattern.svg` diagram.
- **Retired the "AuthBridge" name** from this page (0 occurrences remain).
- **Dropped** the low-level AuthProxy sidecar diagram embed and env-var/ext-proc mechanism detail. The SVG file is left on disk.
- Same-page consistency: table of contents, related-docs link, and an `AgentRuntime` YAML comment updated.
- **Also fixes** the pre-existing MD049 Markdown Lint failure by converting the five `identity-guide.md` figure captions from asterisk italics to underscore italics (the whole-tree lint that was blocking CI).
- Includes the design spec at `docs/superpowers/specs/2026-07-28-cortex-components-doc-design.md`.

## Scope

Edits `docs/Concepts/components.md` (source of truth), `docs/Concepts/identity-guide.md` (caption lint fix only), and the spec. The repo `README.md` still references "AuthBridge" and is left as a follow-up.

## Notes for reviewers

- **CPEX** marked *Supported* (plugin exists in the `cortex` repo); **Praxis** listed *Emerging* with no role, deliberately not over-claimed.
- Em dashes match this file's established `Term - description` house style.

## Test plan

- [ ] Render `docs/Concepts/components.md` in the docs preview; confirm the Cortex section, tables, and remaining diagram display correctly.

Refs #1472
