### PR TITLE
docs: Reframe components security section as RossoCortex (interface) vs AuthBridge (I&AC grouping)

### DIFF
--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -13,7 +13,7 @@ This document provides detailed information about each component of the Rossoctl
 - [MCP Gateway](#mcp-gateway)
 - [Plugins adapter](#plugins-adapter)
 - [Rossoctl UI](#rossoctl-ui)
-- [Cortex](#cortex)
+- [RossoCortex](#rossocortex)
 - [Infrastructure Services](#infrastructure-services)
 - [Supported Agent Frameworks](#supported-agent-frameworks)
 - [Communication Protocols](#communication-protocols)
@@ -475,15 +475,45 @@ kubectl get route rossoctl-ui -n rossoctl-system -o jsonpath='{.status.ingress[0
 
 ---
 
-## Cortex
+## RossoCortex
 
 **Repository**: [rossoctl/cortex](https://github.com/rossoctl/cortex)
 
-Cortex is the security layer of Rossoctl for agentic systems. It gives every agent and tool a trusted identity and enforces authentication, secure delegation, access control, and safe behavior at each hop, replacing static credentials with dynamic, short-lived, audience-scoped tokens.
+RossoCortex is Rossoctl's data plane. It is a common interface that sits transparently between an agent and everything it interacts with — models, tools, users, and other agents — and enforces guarantees an agent cannot provide on its own. Its capabilities are delivered as plugins.
 
-This solves a critical challenge in microservices and agentic architectures: **how can workloads authenticate and communicate securely without pre-provisioned static credentials, while ensuring each action stays within what the user actually intended?**
+RossoCortex is framework-neutral: it works with any agent type, including black-box harnesses, and integrates through multiple paths (an SDK, agent hooks, a gateway, or an orchestration layer). It can be implemented in different ways, and is converging on **CPEX** as the plugin pipeline that hosts and chains those plugins under the covers.
 
-### What Cortex provides
+<!--
+The SVG is based on this ASCII art. To edit the SVG, edit this art and ask a tool to regenerate SVG.
+```
+                        Agents integrate via
+        ┌──────────┬──────────┬──────────┬────────────────┐
+        │   SDK    │  Hooks   │ Gateway  │  Orchestration │
+        └────┬─────┴────┬─────┴────┬─────┴───────┬────────┘
+             └──────────┴────┬─────┴─────────────┘
+                             ▼
+        ┌───────────────────────────────────────────────┐
+        │                  RossoCortex                  │
+        │              (common interface)               │
+        │                                               │
+        │  ┌────────────┐ ┌──────┐ ┌───────┐ ┌────────┐ │
+        │  │ AuthBridge │ │ IBAC │ │ SPARC │ │Context-│ │
+        │  │ (Identity  │ │      │ │       │ │  guru  │ │
+        │  │  & Access) │ │      │ │       │ │        │ │
+        │  └────────────┘ └──────┘ └───────┘ └────────┘ │
+        │                    plugins                    │
+        ├───────────────────────────────────────────────┤
+        │        CPEX  —  plugin pipeline (emerging)     │
+        └───────────────────────────────────────────────┘
+```
+
+-->
+
+![RossoCortex overview: a common interface that agents reach through an SDK, hooks, a gateway, or orchestration; capabilities such as the AuthBridge identity and access-control grouping, IBAC, SPARC, and Context-guru run as plugins, hosted by the emerging CPEX pipeline](./rossocortex-overview.svg)
+
+### AuthBridge (Identity & Access Control)
+
+**AuthBridge** is RossoCortex's Identity and Access Control capability grouping. It gives agents and tools a trusted identity and enforces authentication, secure delegation, and access control at every hop, replacing static credentials with dynamic, short-lived, audience-scoped tokens. It can be enabled or disabled.
 
 | Capability | Description |
 |------------|-------------|
@@ -492,22 +522,23 @@ This solves a critical challenge in microservices and agentic architectures: **h
 | **Secure Delegation** | OAuth 2.0 Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) with per-target audience scoping |
 | **Client Registration** | Automated Keycloak client provisioning for each workload, keyed by its SPIFFE identity |
 | **Access Control** | Policy-driven allow/deny decisions on agent and tool actions |
-| **Guardrails** | Content and behavior safety enforcement around agent activity |
 
-### Technologies Cortex supports
+### Plugin pipeline
 
-Cortex delivers these capabilities through a set of security technologies, and that set grows over time. The concepts above stay constant regardless of which technology enforces them.
+RossoCortex's plugins run in a pipeline. It is converging on **[CPEX](https://github.com/contextforge-org/cpex)** — policy orchestration that composes PDP verdicts (Cedar, OPA) for agentic entities through a declarative policy language — as that pipeline. The capabilities above stay constant regardless of which pipeline hosts the plugins.
 
-| Technology | Role | Status |
-|------------|------|--------|
-| **[CPEX](https://github.com/contextforge-org/cpex)** | Policy orchestration and access control — composes PDP verdicts (Cedar, OPA) for agentic entities using a declarative policy language | Supported |
-| **[IBAC](./ibac-plugin.md)** | Intent-Based Access Control — denies outbound actions that do not match the user's most-recent declared intent | Supported |
-| **[SPARC](./sparc-plugin.md)** | Pre-tool reflection — catches hallucinated or ungrounded tool calls before they execute | Supported |
-| **Praxis** | — | Emerging |
+### Related capabilities
+
+Beyond the AuthBridge identity and access-control grouping, other RossoCortex capabilities are delivered as sibling plugins, each documented on its own page:
+
+- **[IBAC](./ibac-plugin.md)** — Intent-Based Access Control; denies outbound actions that do not match the user's most-recent declared intent.
+- **[SPARC](./sparc-plugin.md)** — pre-tool reflection; catches hallucinated or ungrounded tool calls before they execute.
+- **[Context-guru](./contextguru.md)** — context compaction; shrinks an agent's tool-output context before it reaches the model.
+- **Praxis** — emerging.
 
 ### Foundation
 
-Cortex builds on two foundational services:
+AuthBridge builds on two foundational services shared across RossoCortex:
 
 | Service | Role |
 |---------|------|
@@ -660,7 +691,7 @@ POST /mcp    # MCP JSON-RPC messages
 ## Related Documentation
 
 - [Installation Guide](../getting-started/install.md)
-- [Cortex Identity Guide](./identity-guide.md)
+- [RossoCortex Identity Guide](./identity-guide.md)
 - [MCP Gateway Instructions](https://github.com/Kuadrant/mcp-gateway)
 - [New Agent Guide](../getting-started/new-agent.md)
 - [New Tool Guide](../getting-started/new-tool.md)

--- a/docs/concepts/rossocortex-overview.svg
+++ b/docs/concepts/rossocortex-overview.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" font-family="Helvetica, Arial, sans-serif" role="img" aria-label="RossoCortex overview: agents integrate through an SDK, hooks, a gateway, or orchestration into the RossoCortex common interface, whose capabilities run as plugins — the AuthBridge identity and access-control grouping, IBAC, SPARC, and Context-guru — hosted by the emerging CPEX plugin pipeline.">
+  <title>RossoCortex Overview</title>
+  <desc>Four integration paths — SDK, Hooks, Gateway, Orchestration — feed into the RossoCortex common interface. Inside it, capabilities run as plugins: the AuthBridge identity and access-control grouping alongside IBAC, SPARC, and Context-guru. Beneath the plugins sits the emerging CPEX plugin pipeline that hosts and chains them.</desc>
+
+  <!-- Palette (shades of red)
+       path fill    #fee2e2   path border   #ef4444   text #7f1d1d
+       cortex fill  #fecaca   cortex border #ef4444
+       plugin fill  #ffffff   plugin border #ef4444
+       cpex fill    #fca5a5   cpex border   #b91c1c
+       arrows       #b91c1c -->
+
+  <defs>
+    <marker id="redArrow" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#b91c1c"/>
+    </marker>
+  </defs>
+
+  <!-- Caption: integration paths -->
+  <text x="320" y="24" text-anchor="middle" fill="#7f1d1d" font-size="13" font-weight="bold">Agents integrate via</text>
+
+  <!-- Integration path nodes -->
+  <g fill="#fee2e2" stroke="#ef4444" stroke-width="1.5">
+    <rect x="40"  y="36" width="120" height="44" rx="8"/>
+    <rect x="180" y="36" width="120" height="44" rx="8"/>
+    <rect x="320" y="36" width="120" height="44" rx="8"/>
+    <rect x="460" y="36" width="140" height="44" rx="8"/>
+  </g>
+  <g fill="#7f1d1d" font-size="14" font-weight="bold" text-anchor="middle">
+    <text x="100" y="63">SDK</text>
+    <text x="240" y="63">Hooks</text>
+    <text x="380" y="63">Gateway</text>
+    <text x="530" y="63">Orchestration</text>
+  </g>
+
+  <!-- Arrows from each path down into the RossoCortex box -->
+  <g stroke="#b91c1c" stroke-width="2" marker-end="url(#redArrow)">
+    <line x1="100" y1="80" x2="100" y2="112"/>
+    <line x1="240" y1="80" x2="240" y2="112"/>
+    <line x1="380" y1="80" x2="380" y2="112"/>
+    <line x1="530" y1="80" x2="530" y2="112"/>
+  </g>
+
+  <!-- RossoCortex common-interface container -->
+  <rect x="40" y="114" width="560" height="256" rx="12" fill="#fecaca" stroke="#ef4444" stroke-width="2"/>
+  <text x="320" y="140" text-anchor="middle" fill="#7f1d1d" font-size="17" font-weight="bold">RossoCortex</text>
+  <text x="320" y="159" text-anchor="middle" fill="#7f1d1d" font-size="12">common interface</text>
+
+  <!-- Plugin nodes -->
+  <g fill="#ffffff" stroke="#ef4444" stroke-width="1.5">
+    <rect x="64"  y="176" width="150" height="72" rx="8"/>
+    <rect x="230" y="176" width="112" height="72" rx="8"/>
+    <rect x="358" y="176" width="112" height="72" rx="8"/>
+    <rect x="486" y="176" width="90"  height="72" rx="8"/>
+  </g>
+  <g fill="#7f1d1d" text-anchor="middle">
+    <text x="139" y="208" font-size="14" font-weight="bold">AuthBridge</text>
+    <text x="139" y="226" font-size="11">Identity &amp; Access</text>
+    <text x="286" y="216" font-size="14" font-weight="bold">IBAC</text>
+    <text x="414" y="216" font-size="14" font-weight="bold">SPARC</text>
+    <text x="531" y="212" font-size="13" font-weight="bold">Context-</text>
+    <text x="531" y="228" font-size="13" font-weight="bold">guru</text>
+  </g>
+  <text x="320" y="272" text-anchor="middle" fill="#7f1d1d" font-size="12" font-style="italic">plugins</text>
+
+  <!-- CPEX plugin-pipeline band -->
+  <rect x="64" y="292" width="512" height="56" rx="8" fill="#fca5a5" stroke="#b91c1c" stroke-width="2"/>
+  <text x="320" y="317" text-anchor="middle" fill="#7f1d1d" font-size="15" font-weight="bold">CPEX</text>
+  <text x="320" y="335" text-anchor="middle" fill="#7f1d1d" font-size="12">plugin pipeline (emerging)</text>
+</svg>


### PR DESCRIPTION
## What

Reframes the security section of `docs/concepts/components.md` so it correctly distinguishes **RossoCortex** from **AuthBridge**, and adds a conceptual overview diagram.

The section (previously `## Cortex`) framed CPEX/IBAC/SPARC as "technologies Cortex supports." That framing doesn't match how the pieces actually relate. This corrects it:

- **RossoCortex** is the common interface / data plane. Its capabilities are delivered as plugins; it is framework-neutral and integrates through multiple paths (SDK, hooks, gateway, orchestration). It is converging on **CPEX** as the plugin *pipeline* that hosts and chains those plugins under the covers — CPEX is the pipeline, not a "supported technology."
- **AuthBridge** is RossoCortex's **Identity & Access Control** capability grouping (trusted identity, authentication, secure delegation, client registration, access control). It can be enabled or disabled.
- **IBAC**, **SPARC**, and **Context-guru** are sibling RossoCortex plugins, now listed under "Related capabilities" with links to their own pages.

The SPIRE/Keycloak foundation and the Authorization Pattern (with its diagram) are preserved.

## Changes

- `docs/concepts/components.md`: `## Cortex` renamed to `## RossoCortex`; new intro + integration paths; capabilities reframed under an `### AuthBridge (Identity & Access Control)` grouping; `### Technologies Cortex supports` table replaced by a `### Plugin pipeline` (CPEX) subsection and a `### Related capabilities` list; TOC anchor and Related Documentation label updated. The `Guardrails` row was dropped from the AuthBridge grouping (it is broader than identity/access control).
- `docs/concepts/rossocortex-overview.svg`: new conceptual diagram matching the repo's red SVG house style (integration paths, RossoCortex interface, plugins, CPEX pipeline).

## Notes / follow-ups (not in this PR)

- Sibling pages (`ibac-plugin.md`, `sparc-plugin.md`, `contextguru.md`) still open with two-word "Rossoctl Cortex" and describe plugins running in "AuthBridge's pipeline"; reconciling the one-word "RossoCortex" naming and the pipeline-vs-CPEX wording is a later sweep.
- The nav sidebar label for the identity concept page is a separate decision (currently "Cortex").
- `identity-guide.md` still contains some AuthBridge-era wording.

## Verification

- `markdownlint-cli2` passes (0 issues).
- All in-section links resolve (`ibac-plugin.md`, `sparc-plugin.md`, `contextguru.md`, `identity-guide.md`, `authorization-pattern.svg`, `rossocortex-overview.svg`).
- New SVG validated as well-formed XML; geometry and accessibility (role/aria-label/title/desc) checked.

Assisted-By: Claude Code
