### PR TITLE
docs: Rename workload-harness demo to Run Well-Known Benchmarks

### DIFF
--- a/docs/demos/demo-workload-harness.md
+++ b/docs/demos/demo-workload-harness.md
@@ -1,13 +1,13 @@
 ---
-description: Stress-test Rossoctl and evaluate load.
-sidebar_label: Run well-known benchmarks
+description: Run the gsm8k, tau2, and appworld benchmarks against Rossoctl agents.
+sidebar_label: Run Well-Known Benchmarks
 ---
 
-### Rossoctl Workload Harness
+### Run Well-Known Benchmarks Demo
 
-Workload harnesses drive test and evaluation traffic to Rossoctl agents. The current implementation is the **Exgentic A2A Runner** — a standalone Python runner that integrates Exgentic benchmarks with Rossoctl agents using the A2A (Agent-to-Agent) protocol.
+This demo runs three well-known agent benchmarks — [`gsm8k`](#benchmarks), [`tau2`](#benchmarks), and [`appworld`](#benchmarks) — against Rossoctl agents to exercise them under realistic load and validate that the platform is reliable, scalable, and observable.
 
-The harness exists to robustly exercise agents and validate that the Rossoctl platform is reliable, scalable, and observable.
+It is driven by a **workload harness** that sends test and evaluation traffic to Rossoctl agents. The current implementation is the **Exgentic A2A Runner** — a standalone Python runner that integrates Exgentic benchmarks with Rossoctl agents using the A2A (Agent-to-Agent) protocol.
 
 #### Features
 


### PR DESCRIPTION
## What

Renames the "Rossoctl Workload Harness" demo to **Run Well-Known Benchmarks Demo**, so the page leads with what the demo does — run the `gsm8k`, `tau2`, and `appworld` benchmarks against Rossoctl agents — rather than naming it after the underlying tool.

## Changes

Single file, `docs/demos/demo-workload-harness.md`:

- **H1**: `# Rossoctl Workload Harness` → `# Run Well-Known Benchmarks Demo`.
- **Intro**: reframed to lead with the three well-known benchmarks (`gsm8k`, `tau2`, `appworld`), linked to the existing `## Benchmarks` section. The second paragraph still introduces the **workload harness** and the **Exgentic A2A Runner** as the tool that drives it.
- **`sidebar_label`**: `Run well-known benchmarks` → `Run Well-Known Benchmarks` (capitalization aligned with the title).
- **`description` frontmatter**: `Stress-test Rossoctl and evaluate load.` → `Run the gsm8k, tau2, and appworld benchmarks against Rossoctl agents.`

The `sidebar_label` and `description` also drive the card on the auto-generated **[Tutorials and Demos](https://www.rossoctl.dev/docs/category/tutorials-and-demos)** category page (a Docusaurus `generated-index`), so that card updates automatically — its title and subtitle now match the benchmark framing. No separate category file needed editing.

## Scope notes

- The actual tool and repo names — **Workload Harness** (`rossoctl/workload-harness`) and the **Exgentic A2A Runner** — are intentionally preserved where they refer to the real implementation.
- The filename and URL slug (`demo-workload-harness`) are unchanged, so existing links and bookmarks keep working.

## Verification

- `markdownlint-cli2` passes (0 issues).
- The intro's `#benchmarks` anchor resolves to the existing `## Benchmarks` section.
- No other doc references this demo by its old title text.

Assisted-By: Claude Code
