### PR TITLE
Docs: Link to IBAC, SPARC, and Context-guru demos.  Revise what/why docs.  Add teaser for RossoCortex install

### DIFF
--- a/docs/concepts/contextguru.md
+++ b/docs/concepts/contextguru.md
@@ -50,7 +50,6 @@ The SVG is based on this ASCII art.  To edit the SVG, edit this art and ask a to
 
 ![context-guru architecture: the finance-agent routes outbound LLM calls through AuthBridge's forward proxy, whose OUTBOUND pipeline runs inference-parser then the context-guru plugin to compact tool context before the request reaches Ollama](./contextguru-architecture.svg)
 
-The pipeline is `inference-parser → context-guru`. context-guru is the single
-outbound `WritesBody` plugin (mutually exclusive with `sparc`).
+## Try the Demo!
 
-See the [Cortex](https://github.com/rossoctl/cortex) repo for details and architecture.
+- [Context-guru demo](https://github.com/rossoctl/cortex/tree/main/authbridge/demos/context-guru)

--- a/docs/concepts/ibac-plugin.md
+++ b/docs/concepts/ibac-plugin.md
@@ -103,4 +103,8 @@ The SVG is based on this ASCII art.  To edit the SVG, edit this art and ask a to
 
 ![IBAC plugin architecture: a user intent enters the agent pod's inbound reverse proxy, flows through the agent application, then the outbound forward proxy runs the IBAC plugin which consults a Judge LLM to allow, deny, or return 503](./ibac-architecture.svg)
 
-See the [Cortex](https://github.com/rossoctl/cortex) repo for details and flows.
+---
+
+## Try the Demo!
+
+- [IBAC demo](https://github.com/rossoctl/cortex/tree/main/authbridge/demos/ibac)

--- a/docs/concepts/sparc-plugin.md
+++ b/docs/concepts/sparc-plugin.md
@@ -20,55 +20,8 @@ returns SPARC's verdict.
 It is **complementary to [`ibac`](ibac-plugin.md)**: SPARC verifies argument *grounding*;
 IBAC verifies *intent alignment* (prompt-injection / exfiltration).
 
-## Generic by design — works for any agent
+---
 
-SPARC's three inputs are collected from exactly what the agent produces, with no per-agent
-wiring or out-of-band data:
+## Try the Demo!
 
-- **conversation history, including the system prompt** — from the agent's LLM call captured
-  by `inference-parser` (`pctx.Extensions.Inference.Messages`, every role preserved);
-- **tool specifications in OpenAI function-calling format** — from the same call
-  (`pctx.Extensions.Inference.Tools`);
-- **the proposed tool call** — from the outbound MCP `tools/call` (`mcp` mode) or from the LLM
-  response (`inference` mode).
-
-If the conversation/tool context isn't available (no `inference-parser`, or session tracking
-off), the plugin **skips** (`no_inference_context`) rather than reflect on partial data.
-
-## Enforcement is format-aware
-
-The verdict is returned to the agent in the shape it expects, selected by `enforcement`:
-
-- **`mcp` (default — the rossoctl norm).** Gate the outbound MCP `tools/call`. The tool call
-  comes from the MCP request; conversation + tool specs are correlated from the session's most
-  recent inference request (robust to LLM streaming). On a reflected reject, return SPARC's
-  clarification as a **JSON-RPC MCP tool result** (`Reject` + `Violation{Status:200, Body}`);
-  the agent's MCP client consumes it like any tool output.
-- **`inference` (for non-MCP agents).** Gate the agent's LLM response, where all three inputs
-  are co-located. On a reflected reject, rewrite the completion (via `SetResponseBody`) so the
-  assistant turn carries the clarification and the tool_call is dropped — norms-correct for any
-  OpenAI-style agent.
-
-## On-reject policy
-
-When SPARC returns `reject`, `on_reject_action` decides, with optional score escalation:
-
-| `on_reject_action` | Behavior | Session record |
-|---|---|---|
-| `observe` | Log only, let the call through (shadow). | `observe` / `reject_observed` |
-| `reflect` (default) | Return SPARC's clarification to the agent (MCP result or rewritten completion). | `modify` / `reflected` |
-| `deny` | Hard block (403 in `mcp` mode; refusal completion in `inference` mode). | `deny` / `blocked` |
-
-When `deny_score_threshold > 0` and SPARC's `overall_avg_score` (normalized 0..1, higher = better
-grounded) is `<=` it, any reject is escalated to `deny`.
-
-> **`fail_policy` defaults to `open`** — when SPARC is unreachable, times out, or returns
-> `decision=error`, the proposed tool call is allowed through (and recorded). This is deliberate
-> and **diverges from `ibac`, which fails closed**: SPARC is a grounding *quality gate*, not an
-> auth control, so reflector downtime shouldn't take the agent's tools offline. Set
-> `fail_policy: closed` when you want tool execution gated on reflector availability (e.g. a
-> high-assurance deployment where an unverified call is worse than a failed one). The same policy
-> governs the case where the conversation/tool context is missing (no `inference-parser` event):
-> `open` skips and records `no_inference_context`; `closed` blocks.
-
-See the [Cortex](https://github.com/rossoctl/cortex) repo for configuration and flows.
+- [SPARC demo](https://github.com/rossoctl/cortex/blob/main/authbridge/demos/finance-sparc)

--- a/docs/getting-started/install-local.md
+++ b/docs/getting-started/install-local.md
@@ -1,0 +1,12 @@
+---
+title: Install for laptop
+description: CLI and RossoCortex guide.
+sidebar_label: Install for laptop
+sidebar_position: 2
+---
+
+:::tip
+
+Check back in early August for the quickstart guide for local rossoctl without Kubernetes.
+
+:::

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 :::tip
 
-This document describes rossoctl's Kubernetes deployment.  Check back in August for a guide to local rossoctl without Kubernetes.
+This document describes rossoctl's Kubernetes deployment. Check back in August for a guide to local rossoctl without Kubernetes.
 
 :::
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,16 +1,23 @@
 ---
+title: Install on Kubernetes
 description: Full Rossoctl installation guide.
-sidebar_label: Installation Guide
+sidebar_label: Install (Kubernetes)
 sidebar_position: 1
 ---
 
-# Rossoctl Installation Guide
+:::tip
+
+This document describes rossoctl's Kubernetes deployment.  Check back in August for a guide to local rossoctl without Kubernetes.
+
+:::
+
+## Kubernetes Rossoctl Installation Guide
 
 This guide covers installation on both local [Kind](https://kind.sigs.k8s.io) clusters and OpenShift environments.
 
 ## Table of Contents
 
-- [Prerequisites](#prerequisites)
+- [Kubernetes Prerequisites](#prerequisites)
   - [macOS Quick Start (New Machine)](#macos-quick-start-new-machine)
 - [Kind Installation (Local Development)](#kind-installation-local-development)
 - [OpenShift Installation](#openshift-installation)

--- a/docs/overview/1-what-is.md
+++ b/docs/overview/1-what-is.md
@@ -1,41 +1,22 @@
 ---
 title: What is Rossoctl?
-description: Introduction to the Rossoctl agent platform
+description: Introduction to the agent platform.
 ---
 
-Rossoctl is a *framework-neutral*, *scalable*, and *secure* platform for deploying and orchestrating AI agents through standardized agent communication protocols (A2A, MCP).
+## Rossoctl: Solving Real Problems in Agentic AI
 
-Rossoctl gives you:
+As a user of AI agents, you are asking how to rein in their token use, manage their access permissions, ensure they don't drift from the goal, prevent mistakes from affecting your system, and ensure the skills you use are safe and optimal. As a platform provider, you want to know how you can help platform users answer these questions and get answers to them yourself.
 
-- Zero-Trust Security Architecture
-- Authentication and Authorization
-- Trusted workload identity (SPIRE)
-- Deployment and Configuration
-- Scaling and Fault-tolerance
-- Discovery of agents and tools
-- State Persistence
+**Rossoctl** provides solutions to these problems. It comes in the form of RossoCortex — a data plane controller for agent interactions. We are also working on a set of services agents will be able to use.
 
-Rossoctl addresses these challenges by enhancing existing agent frameworks with production-ready, framework-neutral infrastructure.
+**RossoCortex** sits on the path of each interaction of an agent with the external world: LLMs, users, tools, and other agents. It observes and modifies them. It uses this visibility and control to provide pluggable capabilities: identity and access control (AuthBridge), context compaction ([ContextGuru](../concepts/contextguru.md)), semantic tool reflection ([SPARC](../concepts/sparc-plugin.md)), and intent-based access control ([IBAC](../concepts/ibac-plugin.md)).
 
-## Supported AI Use‑Case Types
+There are three types of agents:
 
-Rossoctl is designed to support a broad range of AI‑agent deployment patterns, including knowledge services, synchronous and asynchronous user‑authorized assistants, continuous monitoring agents, and event‑driven workflows.
+- Agent harnesses like Claude or OpenClaw, which users customize using skills and prompts
+- Agents built with custom agent loops on top of popular frameworks like LangGraph or CrewAI
+- Agents that rely on low-level SDKs such as OpenAI and MCP, which target specific tasks and are often AI-generated
 
-## Architecture
+Today, realizing RossoCortex capabilities means depending on a harness to build them in, a framework to provide the right abstractions, or building them yourself.
 
-The goal of Rossoctl is to provide a pluggable agentic platform blueprint. Key functionalities are currently organized into four key pillars:
-1. Lifecycle Orchestration
-2. Networking
-3. Security
-4. Observability
-
-## Core Components
-
-Rossoctl provides a set of components and assets that make it easier to manage AI agents and tools and integrate their fine-grained authorization into modern cloud-native environments.
-
-| Component | Description |
-|-----------|-------------|
-| **Rossoctl UI** | Dashboard for deploying agents/tools as Kubernetes Deployments, interactive testing, and monitoring |
-| **[Identity & Auth Bridge](/docs/concepts/identity-guide)** | Identity pattern assets that capture common authorization scenarios and provide reusable building blocks for implementing consistent authorization across services |
-| **[Agent Lifecycle Operator](https://github.com/rossoctl/operator)** | Kubernetes admission webhook for building agents from source, managing lifecycle, and coordinating platform services |
-| **[MCP Gateway](https://github.com/Kuadrant/mcp-gateway/)** | Unified gateway for Model Context Protocol (MCP) servers and tools. It acts as the entry point for policy enforcement, handling requests and routing them through the appropriate authorization patterns |
+RossoCortex provides a uniform control surface that works with all styles of agents. It can be deployed as a gateway or sidecar proxy, packaged as a CLI and plugged into harness hooks, or integrated into agent frameworks or SDKs.

--- a/docs/overview/1-what-is.md
+++ b/docs/overview/1-what-is.md
@@ -5,7 +5,7 @@ description: Introduction to the agent platform.
 
 ## Rossoctl: Solving Real Problems in Agentic AI
 
-As a user of AI agents, you are asking how to rein in their token use, manage their access permissions, ensure they don't drift from the goal, prevent mistakes from affecting your system, and ensure the skills you use are safe and optimal. As a platform provider, you want to know how you can help platform users answer these questions and get answers to them yourself.
+As a user of AI agents, you want to rein in their token use, manage their access permissions, ensure they don't drift from the goal, prevent mistakes from affecting your system, and ensure the skills you use are safe and optimal. As a platform provider, you want to know how you can help platform users answer these questions and get answers to them yourself.
 
 **Rossoctl** provides solutions to these problems. It comes in the form of RossoCortex — a data plane controller for agent interactions. We are also working on a set of services agents will be able to use.
 
@@ -17,6 +17,6 @@ There are three types of agents:
 - Agents built with custom agent loops on top of popular frameworks like LangGraph or CrewAI
 - Agents that rely on low-level SDKs such as OpenAI and MCP, which target specific tasks and are often AI-generated
 
-Today, realizing RossoCortex capabilities means depending on a harness to build them in, a framework to provide the right abstractions, or building them yourself.
+RossoCortex delivers capabilities and abstractions required for secure deployments, saving you the work of building them yourself.
 
 RossoCortex provides a uniform control surface that works with all styles of agents. It can be deployed as a gateway or sidecar proxy, packaged as a CLI and plugged into harness hooks, or integrated into agent frameworks or SDKs.

--- a/docs/overview/3-why-choose.md
+++ b/docs/overview/3-why-choose.md
@@ -1,15 +1,35 @@
 ---
 title: Why Choose Rossoctl?
-description: Rossoctl value proposition
+description: Rossoctl value proposition.
 ---
 
-Despite the extensive variety of frameworks available for developing agent-based applications (LangGraph, OpenClaw, etc.), there is a lack of standardized methods for deploying and operating agent code in production environments. Agents are adept at reasoning, planning, and interacting with tools, but their full potential is often limited by:
+Despite the extensive variety of frameworks available for developing agent-based applications, there is a lack of standardized methods for deploying and applying policy to agent code in production environments.
 
-- **Deployment Complexity** - Each framework requires custom deployment scripts and infrastructure
-- **Security Gaps** - No standardized approach to authentication, authorization, and workload identity
-- **Protocol Fragmentation** - Agents and tools use different communication patterns
-- **Operational Overhead** - Scaling, monitoring, and lifecycle management require custom solutions
+Agents are adept at reasoning, planning, and interacting with tools, but their full potential is often limited by **Deployment Complexity**, **Security Gaps**, **Protocol Fragmentation**, and **Operational Overhead**.
 
-Despite the extensive variety of frameworks available for developing agent-based applications, there is a distinct lack of standardized methods for deploying and operating agent code in production environments, as well as for exposing it through a standardized API. Agents are adept at reasoning, planning, and interacting with various tools, but their full potential can be limited by deployment challenges.
+_Rossoctl_ addresses this gap by enhancing existing agent frameworks with production-ready infrastructure.
 
-Rossoctl addresses this gap by enhancing existing agent frameworks with production-ready infrastructure.
+Rossoctl is a *framework-neutral*, *scalable*, and *secure* platform for deploying and orchestrating AI agents through standardized agent communication protocols (A2A, MCP).
+
+Rossoctl gives you:
+
+- Zero-Trust Security Architecture
+- Authentication and Authorization
+- Trusted workload identity (SPIRE)
+- Deployment and Configuration
+- Scaling and Fault-tolerance
+- Discovery of agents and tools
+- State Persistence
+
+## Supported AI Use‑Case Types
+
+Rossoctl is designed to support a broad range of AI‑agent deployment patterns, including knowledge services, synchronous and asynchronous user‑authorized assistants, continuous monitoring agents, and event‑driven workflows.
+
+## Core Components
+
+Rossoctl provides a set of components and assets that make it easier to manage AI agents and tools and integrate their fine-grained authorization into modern cloud-native environments.
+
+| Component | Description |
+|-----------|-------------|
+| **Rossoctl UI** | Dashboard for deploying agents/tools as Kubernetes Deployments, interactive testing, and monitoring |
+| **[Identity & Auth Bridge](/docs/concepts/identity-guide)** | Identity pattern assets that capture common authorization scenarios and provide reusable building blocks for implementing consistent authorization across services |

--- a/docs/overview/3-why-choose.md
+++ b/docs/overview/3-why-choose.md
@@ -9,7 +9,7 @@ Agents are adept at reasoning, planning, and interacting with tools, but their f
 
 _Rossoctl_ addresses this gap by enhancing existing agent frameworks with production-ready infrastructure.
 
-Rossoctl is a *framework-neutral*, *scalable*, and *secure* platform for deploying and orchestrating AI agents through standardized agent communication protocols (A2A, MCP).
+Rossoctl is a **framework-neutral**, **scalable**, and **secure** platform for deploying and orchestrating AI agents through standardized agent communication protocols (A2A, MCP).
 
 Rossoctl gives you:
 

--- a/docs/overview/5-quickstart.md
+++ b/docs/overview/5-quickstart.md
@@ -1,9 +1,17 @@
 ---
 title: Quickstart
-description: Install Rossoctl on a Kubernetes cluster
+description: Install Rossoctl on a Kubernetes cluster.
 ---
 
-## Prerequisites
+Rossoctl can be deployed as a managed Kubernetes-based control plane, or locally on a laptop for testing identity and authorization before deploying to the cloud.
+
+:::tip
+
+This document describes rossoctl's Kubernetes deployment.  Check back in August for the quickstart guide for local rossoctl without Kubernetes.
+
+:::
+
+## Prerequisites for local Kubernetes (Kind) install of Rossoctl
 
 For this Quickstart, we'll install on a laptop-hosted Kubernetes using `kind`.
 
@@ -14,7 +22,7 @@ For more install options, see the [Installation Guide](../getting-started/instal
 - (optional) [Ollama](https://ollama.com/download) for local LLM inference.
   - Alternatively, use OpenAI or a [cloud-hosted LLM](../getting-started/llms/cloud-models.md).
 
-## Install
+## Install Rossoctl on Kubernetes
 
 Clone the repository:
 

--- a/docs/overview/5-quickstart.md
+++ b/docs/overview/5-quickstart.md
@@ -7,7 +7,7 @@ Rossoctl can be deployed as a managed Kubernetes-based control plane, or locally
 
 :::tip
 
-This document describes rossoctl's Kubernetes deployment.  Check back in August for the quickstart guide for local rossoctl without Kubernetes.
+This document describes rossoctl's Kubernetes deployment. Check back in August for the quickstart guide for local rossoctl without Kubernetes.
 
 :::
 


### PR DESCRIPTION
## Summary

- Updates the what/why documents.
- Adds a teaser so readers know that the Kubernetes requirement is going away soon.
- Direct links to the Context-guru, IBAC, and SPARC demos from their Concept page.
