### PR TITLE
docs: order Troubleshooting before Authentication Guide in sidebar

### DIFF
--- a/docs/users-guides/authentication.md
+++ b/docs/users-guides/authentication.md
@@ -1,5 +1,6 @@
 ---
 draft: true       # excluded from https://www.rossoctl.dev/
+sidebar_position: 2
 description: SPIFFE, Oauth2, and Keycloak
 ---
 

--- a/docs/users-guides/troubleshooting.md
+++ b/docs/users-guides/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
+sidebar_position: 1
 description: What can go wrong?
 ---
 


### PR DESCRIPTION
## Summary

- Neither `docs/users-guides/troubleshooting.md` nor `docs/users-guides/authentication.md` had an explicit `sidebar_position`, so the autogenerated User's Guides sidebar fell back to alphabetical order (Authentication before Troubleshooting).
- Add `sidebar_position: 1` to Troubleshooting and `sidebar_position: 2` to Authentication Guide so Troubleshooting appears first, following the `sidebar_position` convention already used in `docs/getting-started/install.md`.

## Test plan

- [ ] Confirm the User's Guides sidebar shows Troubleshooting before Authentication Guide once `authentication.md`'s `draft: true` is removed (tracked separately in #2320)

Assisted-By: Claude Code