### PR TITLE
fix(backend): fall back to legacy agent card endpoint

### DIFF
--- a/rossoctl/backend/app/routers/chat.py
+++ b/rossoctl/backend/app/routers/chat.py
@@ -50,11 +50,11 @@ _invoke_url_cache: dict[tuple[str, str], tuple[str, float]] = {}
 _CACHE_TTL_SECONDS = 30.0
 
 
-async def _fetch_agent_card(client: httpx.AsyncClient, base_url: str) -> httpx.Response:
+async def _fetch_agent_card(client: httpx.AsyncClient) -> httpx.Response:
     """Fetch an agent card, falling back to the deprecated endpoint on 404."""
-    response = await client.get(f"{base_url}{A2A_AGENT_CARD_PATH}")
+    response = await client.get(A2A_AGENT_CARD_PATH)
     if response.status_code == 404:
-        response = await client.get(f"{base_url}{A2A_LEGACY_AGENT_CARD_PATH}")
+        response = await client.get(A2A_LEGACY_AGENT_CARD_PATH)
     response.raise_for_status()
     return response
 
@@ -99,8 +99,8 @@ async def _resolve_invoke_url(name: str, namespace: str, kube: KubernetesService
     safe_ns = ns_match.group(0)
     base_url = resolve_agent_url(safe_name, safe_ns, kube)
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await _fetch_agent_card(client, base_url)
+        async with httpx.AsyncClient(base_url=base_url, timeout=5.0) as client:
+            resp = await _fetch_agent_card(client)
             card_url = resp.json().get("url")
             if card_url:
                 parsed = urlparse(card_url)
@@ -176,11 +176,19 @@ async def get_agent_card(
     The agent card describes the agent's capabilities, skills, and metadata.
     All agents are reached via their cluster-internal URL through AuthBridge.
     """
-    agent_url = resolve_agent_url(name, namespace, kube)
+    name_match = _K8S_NAME_RE.fullmatch(name)
+    ns_match = _K8S_NAME_RE.fullmatch(namespace)
+    if not name_match or not ns_match:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid agent name or namespace",
+        )
+
+    agent_url = resolve_agent_url(name_match.group(0), ns_match.group(0), kube)
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await _fetch_agent_card(client, agent_url)
+        async with httpx.AsyncClient(base_url=agent_url, timeout=10.0) as client:
+            response = await _fetch_agent_card(client)
             card_data = response.json()
 
             # Parse capabilities

--- a/rossoctl/backend/app/routers/chat.py
+++ b/rossoctl/backend/app/routers/chat.py
@@ -29,6 +29,7 @@ router = APIRouter(prefix="/chat", tags=["chat"])
 
 # A2A protocol constants
 A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json"
+A2A_LEGACY_AGENT_CARD_PATH = "/.well-known/agent.json"
 
 # RFC 1123 label: lowercase alphanumeric, may contain hyphens, 1-63 chars.
 _K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
@@ -47,6 +48,15 @@ _SAFE_QUERY_CHARS = frozenset(
 # Eliminates redundant agent-card HTTP fetches during a conversation (SC-5).
 _invoke_url_cache: dict[tuple[str, str], tuple[str, float]] = {}
 _CACHE_TTL_SECONDS = 30.0
+
+
+async def _fetch_agent_card(client: httpx.AsyncClient, base_url: str) -> httpx.Response:
+    """Fetch an agent card, falling back to the deprecated endpoint on 404."""
+    response = await client.get(f"{base_url}{A2A_AGENT_CARD_PATH}")
+    if response.status_code == 404:
+        response = await client.get(f"{base_url}{A2A_LEGACY_AGENT_CARD_PATH}")
+    response.raise_for_status()
+    return response
 
 
 async def _resolve_invoke_url(name: str, namespace: str, kube: KubernetesService) -> str:
@@ -90,8 +100,7 @@ async def _resolve_invoke_url(name: str, namespace: str, kube: KubernetesService
     base_url = resolve_agent_url(safe_name, safe_ns, kube)
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(f"{base_url}{A2A_AGENT_CARD_PATH}")
-            resp.raise_for_status()
+            resp = await _fetch_agent_card(client, base_url)
             card_url = resp.json().get("url")
             if card_url:
                 parsed = urlparse(card_url)
@@ -168,12 +177,10 @@ async def get_agent_card(
     All agents are reached via their cluster-internal URL through AuthBridge.
     """
     agent_url = resolve_agent_url(name, namespace, kube)
-    card_url = f"{agent_url}{A2A_AGENT_CARD_PATH}"
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(card_url)
-            response.raise_for_status()
+            response = await _fetch_agent_card(client, agent_url)
             card_data = response.json()
 
             # Parse capabilities

--- a/rossoctl/backend/tests/test_chat_invoke_url.py
+++ b/rossoctl/backend/tests/test_chat_invoke_url.py
@@ -128,8 +128,8 @@ class TestResolveInvokeUrl:
 
         assert url == "http://myagent.ns.svc.cluster.local:8443/a2a/invoke"
         assert [call.args[0] for call in mock_get.await_args_list] == [
-            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent-card.json",
-            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent.json",
+            "/.well-known/agent-card.json",
+            "/.well-known/agent.json",
         ]
 
     @pytest.mark.asyncio
@@ -256,9 +256,17 @@ class TestGetAgentCard:
 
         assert card.name == "legacy-agent"
         assert [call.args[0] for call in mock_get.await_args_list] == [
-            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent-card.json",
-            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent.json",
+            "/.well-known/agent-card.json",
+            "/.well-known/agent.json",
         ]
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_agent_identity(self, mock_kube, mock_resolve_base):
+        """Reject invalid path parameters before constructing the agent URL."""
+        with pytest.raises(Exception, match="Invalid agent name or namespace"):
+            await get_agent_card("ns", "invalid/name", mock_kube)
+
+        mock_resolve_base.assert_not_called()
 
 
 class TestInvokeUrlCache:

--- a/rossoctl/backend/tests/test_chat_invoke_url.py
+++ b/rossoctl/backend/tests/test_chat_invoke_url.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from app.routers.chat import _invoke_url_cache, _resolve_invoke_url
+from app.routers.chat import _invoke_url_cache, _resolve_invoke_url, get_agent_card
 
 
 @pytest.fixture
@@ -106,14 +106,31 @@ class TestResolveInvokeUrl:
         assert url == "http://myagent.ns.svc.cluster.local:8443"
 
     @pytest.mark.asyncio
-    async def test_falls_back_on_404(self, mock_kube, mock_resolve_base):
-        """When agent card endpoint returns 404, return base URL."""
-        mock_resp = httpx.Response(404, text="not found", request=httpx.Request("GET", "http://x"))
+    async def test_falls_back_to_legacy_card_path_on_404(self, mock_kube, mock_resolve_base):
+        """When the current card endpoint is missing, try the legacy endpoint."""
+        missing = httpx.Response(404, text="not found", request=httpx.Request("GET", "http://x"))
+        legacy_card = {
+            "name": "legacy-agent",
+            "url": "http://myagent.ns.svc.cluster.local:8443/a2a/invoke",
+        }
+        found = httpx.Response(
+            200,
+            json=legacy_card,
+            request=httpx.Request("GET", "http://x"),
+        )
 
-        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_resp):
+        with patch(
+            "httpx.AsyncClient.get",
+            new_callable=AsyncMock,
+            side_effect=[missing, found],
+        ) as mock_get:
             url = await _resolve_invoke_url("myagent", "ns", mock_kube)
 
-        assert url == "http://myagent.ns.svc.cluster.local:8443"
+        assert url == "http://myagent.ns.svc.cluster.local:8443/a2a/invoke"
+        assert [call.args[0] for call in mock_get.await_args_list] == [
+            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent-card.json",
+            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent.json",
+        ]
 
     @pytest.mark.asyncio
     async def test_rejects_path_traversal(self, mock_kube, mock_resolve_base):
@@ -212,6 +229,36 @@ class TestResolveInvokeUrl:
             url = await _resolve_invoke_url("myagent", "ns", mock_kube)
 
         assert url == "http://myagent.ns.svc.cluster.local:8443/a2a/invoke"
+
+
+class TestGetAgentCard:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_legacy_card_path_on_404(self, mock_kube, mock_resolve_base):
+        """The agent-card API supports agents that only expose the legacy endpoint."""
+        missing = httpx.Response(404, text="not found", request=httpx.Request("GET", "http://x"))
+        legacy_card = {
+            "name": "legacy-agent",
+            "version": "1.0.0",
+            "url": "http://myagent.ns.svc.cluster.local:8443",
+        }
+        found = httpx.Response(
+            200,
+            json=legacy_card,
+            request=httpx.Request("GET", "http://x"),
+        )
+
+        with patch(
+            "httpx.AsyncClient.get",
+            new_callable=AsyncMock,
+            side_effect=[missing, found],
+        ) as mock_get:
+            card = await get_agent_card("ns", "myagent", mock_kube)
+
+        assert card.name == "legacy-agent"
+        assert [call.args[0] for call in mock_get.await_args_list] == [
+            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent-card.json",
+            "http://myagent.ns.svc.cluster.local:8443/.well-known/agent.json",
+        ]
 
 
 class TestInvokeUrlCache:


### PR DESCRIPTION
## Summary

- I added a shared agent-card fetch path that tries `/.well-known/agent-card.json` first.
- I fall back to the deprecated `/.well-known/agent.json` endpoint only when the new endpoint returns 404, preserving other HTTP error behavior.
- I added focused regression coverage for both invoke URL resolution and the agent-card API.

## Related issue(s)

Fixes #858

## Testing Instructions

- `uv run --frozen --extra dev pytest tests/test_chat_invoke_url.py -q` (21 passed)
- `uv run --frozen --extra dev ruff check app/routers/chat.py tests/test_chat_invoke_url.py`
- `uv run --frozen --extra dev ruff format --check app/routers/chat.py tests/test_chat_invoke_url.py`
- `python3 -m py_compile app/routers/chat.py tests/test_chat_invoke_url.py`
- `git diff --check origin/main...HEAD`

I did not run the cluster-backed end-to-end suite locally; I left that validation to CI because this change is covered by focused backend unit tests.
