### PR TITLE
fix: 🐛 Publish operator-spiffe-bootstrap image via CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,9 @@ jobs:
           - name: spiffe-idp-setup
             context: ./rossoctl
             dockerfile: auth/spiffe-idp-setup/Dockerfile
+          - name: operator-spiffe-bootstrap
+            context: ./rossoctl
+            dockerfile: auth/operator-spiffe-bootstrap/Dockerfile
 
     steps:
       # 1. Checkout the repository code

--- a/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
+++ b/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
@@ -75,12 +75,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: bootstrap
-        # NOTE: operator-spiffe-bootstrap is not published yet and this Job is off
-        # by default (operator-chart.spiffe.operatorAuth.enabled=false). The
-        # default below is a placeholder version to satisfy the release pin-check;
-        # override via operator-chart.spiffe.operatorAuth.bootstrapImage once
-        # the image is built and pushed.
-        image: {{ (index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImage") | default "ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap:0.0.0-unreleased" }}
+        image: "{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImage" }}:{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImageTag" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: KEYCLOAK_URL

--- a/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
+++ b/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
@@ -75,7 +75,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: bootstrap
-        image: "{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImage" }}:{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImageTag" }}"
+        image: "{{ .Values.operatorSpiffeBootstrap.image }}:{{ .Values.operatorSpiffeBootstrap.tag }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: KEYCLOAK_URL

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -274,6 +274,16 @@ apiOAuthSecret:
   useServiceAccountCA: false
 
 # ------------------------------------------------------------------
+#  Operator SPIFFE Authentication Bootstrap Job Configuration
+#  Used by charts/rossoctl/templates/operator-client-bootstrap-job.yaml when
+#  operator-chart.spiffe.operatorAuth.enabled=true. Built by this repo's
+#  build.yaml CI workflow — kept in sync via scripts/pin-release-tags.sh.
+# ------------------------------------------------------------------
+operatorSpiffeBootstrap:
+  image: ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap
+  tag: latest
+
+# ------------------------------------------------------------------
 #  Keycloak Configuration
 # ------------------------------------------------------------------
 keycloak:
@@ -382,13 +392,6 @@ operator-chart:
   # the explicit value is required because neither ZTWIM nor spire-bundle exist at startup.
   signatureVerification:
     spireTrustDomain: localtest.me
-  # Operator SPIFFE authentication bootstrap Job image (see
-  # charts/rossoctl/templates/operator-client-bootstrap-job.yaml). Built by this
-  # repo's build.yaml CI workflow — kept in sync via scripts/pin-release-tags.sh.
-  spiffe:
-    operatorAuth:
-      bootstrapImage: ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap
-      bootstrapImageTag: latest
   # Pin sidecar image tags injected by the AuthBridge webhook.
   #
   # After cortex#411 there are three combined images:

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -382,6 +382,13 @@ operator-chart:
   # the explicit value is required because neither ZTWIM nor spire-bundle exist at startup.
   signatureVerification:
     spireTrustDomain: localtest.me
+  # Operator SPIFFE authentication bootstrap Job image (see
+  # charts/rossoctl/templates/operator-client-bootstrap-job.yaml). Built by this
+  # repo's build.yaml CI workflow — kept in sync via scripts/pin-release-tags.sh.
+  spiffe:
+    operatorAuth:
+      bootstrapImage: ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap
+      bootstrapImageTag: latest
   # Pin sidecar image tags injected by the AuthBridge webhook.
   #
   # After cortex#411 there are three combined images:

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -55,7 +55,7 @@ Images pinned (charts/rossoctl/values.yaml):
   - agentOAuthSecret.tag
   - apiOAuthSecret.tag
   - mlflowOAuthSecret.tag
-  - operator-chart.spiffe.operatorAuth.bootstrapImageTag
+  - operatorSpiffeBootstrap.tag
 
 Images pinned (charts/rossoctl-deps/values.yaml):
   - spiffeIdp.image.tag
@@ -140,7 +140,7 @@ PINNABLE_IMAGES=(
     "$ROSSOCTL_VALUES|.agentOAuthSecret.tag|agent-oauth-secret"
     "$ROSSOCTL_VALUES|.apiOAuthSecret.tag|api-oauth-secret"
     "$ROSSOCTL_VALUES|.mlflowOAuthSecret.tag|mlflow-oauth-secret"
-    "$ROSSOCTL_VALUES|.[\"operator-chart\"].spiffe.operatorAuth.bootstrapImageTag|operator-spiffe-bootstrap"
+    "$ROSSOCTL_VALUES|.operatorSpiffeBootstrap.tag|operator-spiffe-bootstrap"
     "$ROSSOCTL_DEPS_VALUES|.spiffeIdp.image.tag|spiffe-idp-setup"
 )
 

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -55,6 +55,7 @@ Images pinned (charts/rossoctl/values.yaml):
   - agentOAuthSecret.tag
   - apiOAuthSecret.tag
   - mlflowOAuthSecret.tag
+  - operator-chart.spiffe.operatorAuth.bootstrapImageTag
 
 Images pinned (charts/rossoctl-deps/values.yaml):
   - spiffeIdp.image.tag
@@ -139,6 +140,7 @@ PINNABLE_IMAGES=(
     "$ROSSOCTL_VALUES|.agentOAuthSecret.tag|agent-oauth-secret"
     "$ROSSOCTL_VALUES|.apiOAuthSecret.tag|api-oauth-secret"
     "$ROSSOCTL_VALUES|.mlflowOAuthSecret.tag|mlflow-oauth-secret"
+    "$ROSSOCTL_VALUES|.[\"operator-chart\"].spiffe.operatorAuth.bootstrapImageTag|operator-spiffe-bootstrap"
     "$ROSSOCTL_DEPS_VALUES|.spiffeIdp.image.tag|spiffe-idp-setup"
 )
 


### PR DESCRIPTION
## Summary

`--enable-operator-spiffe-auth` breaks the entire `helm install rossoctl` release because the bootstrap Job's image was never built or published by CI, even though the Dockerfile and source (`rossoctl/auth/operator-spiffe-bootstrap/`) have been in-repo since the feature was added. The chart fell back to a nonsensical placeholder tag (`ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap:0.0.0-unreleased`), which 403s on pull and times out the post-install hook, failing the whole release.

Key changes:
- Add `operator-spiffe-bootstrap` to the `build.yaml` image matrix, matching the sibling `spiffe-idp-setup` entry (same Dockerfile shape, no smoke test).
- Add a dedicated `operatorSpiffeBootstrap: { image, tag }` block to `charts/rossoctl/values.yaml`, matching the plain `image`/`tag` shape every sibling `*OAuthSecret` block already uses (kept separate from `operator-chart.spiffe.operatorAuth`, which only needs to hold the `enabled` flag shared with the operator subchart).
- Register `operatorSpiffeBootstrap.tag` in `scripts/pin-release-tags.sh`'s `PINNABLE_IMAGES` list so future releases pin it automatically, same as every other image (verified via `--dry-run`).
- Remove the stale "not published yet" comment and placeholder fallback from `charts/rossoctl/templates/operator-client-bootstrap-job.yaml`.

The resulting `tag: latest` is expected and non-blocking — confirmed via `scripts/check-release-pins.sh` and `.github/workflows/ci-release-pins.yaml` that the hard release-pin gate only runs on PRs targeting `release/*` branches or manual dispatch, precisely so `tag: latest` is allowed during normal development (same as every other image before its first release pin).

Verified the rendered template produces the correct `image:` string via an isolated `helm template` run.

## Related issue(s)

Fixes #2333