### PR TITLE
🐛 Pin operatorSpiffeBootstrap.tag in package-charts CI safety net

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,6 +180,7 @@ jobs:
           yq e ".agentOAuthSecret.tag = \"${REF_NAME}\"" -i values.yaml
           yq e ".apiOAuthSecret.tag = \"${REF_NAME}\"" -i values.yaml
           yq e ".mlflowOAuthSecret.tag = \"${REF_NAME}\"" -i values.yaml
+          yq e ".operatorSpiffeBootstrap.tag = \"${REF_NAME}\"" -i values.yaml
           helm package . --destination . --version ${chartVersion} --app-version ${chartVersion}
           helm push "./${chartPackageName}" oci://${{ env.REGISTRY }}/${{ env.REPO }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,9 @@ jobs:
           - name: spiffe-idp-setup
             context: ./rossoctl
             dockerfile: auth/spiffe-idp-setup/Dockerfile
+          - name: operator-spiffe-bootstrap
+            context: ./rossoctl
+            dockerfile: auth/operator-spiffe-bootstrap/Dockerfile
 
     steps:
       # 1. Checkout the repository code

--- a/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
+++ b/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
@@ -75,12 +75,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: bootstrap
-        # NOTE: operator-spiffe-bootstrap is not published yet and this Job is off
-        # by default (operator-chart.spiffe.operatorAuth.enabled=false). The
-        # default below is a placeholder version to satisfy the release pin-check;
-        # override via operator-chart.spiffe.operatorAuth.bootstrapImage once
-        # the image is built and pushed.
-        image: {{ (index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImage") | default "ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap:0.0.0-unreleased" }}
+        image: "{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImage" }}:{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImageTag" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: KEYCLOAK_URL

--- a/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
+++ b/charts/rossoctl/templates/operator-client-bootstrap-job.yaml
@@ -75,7 +75,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: bootstrap
-        image: "{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImage" }}:{{ index .Values "operator-chart" "spiffe" "operatorAuth" "bootstrapImageTag" }}"
+        image: "{{ .Values.operatorSpiffeBootstrap.image }}:{{ .Values.operatorSpiffeBootstrap.tag }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: KEYCLOAK_URL

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -274,6 +274,16 @@ apiOAuthSecret:
   useServiceAccountCA: false
 
 # ------------------------------------------------------------------
+#  Operator SPIFFE Authentication Bootstrap Job Configuration
+#  Used by charts/rossoctl/templates/operator-client-bootstrap-job.yaml when
+#  operator-chart.spiffe.operatorAuth.enabled=true. Built by this repo's
+#  build.yaml CI workflow — kept in sync via scripts/pin-release-tags.sh.
+# ------------------------------------------------------------------
+operatorSpiffeBootstrap:
+  image: ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap
+  tag: latest
+
+# ------------------------------------------------------------------
 #  Keycloak Configuration
 # ------------------------------------------------------------------
 keycloak:
@@ -382,13 +392,6 @@ operator-chart:
   # the explicit value is required because neither ZTWIM nor spire-bundle exist at startup.
   signatureVerification:
     spireTrustDomain: localtest.me
-  # Operator SPIFFE authentication bootstrap Job image (see
-  # charts/rossoctl/templates/operator-client-bootstrap-job.yaml). Built by this
-  # repo's build.yaml CI workflow — kept in sync via scripts/pin-release-tags.sh.
-  spiffe:
-    operatorAuth:
-      bootstrapImage: ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap
-      bootstrapImageTag: latest
   # Pin sidecar image tags injected by the AuthBridge webhook.
   #
   # After cortex#411 there are three combined images:

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -382,6 +382,13 @@ operator-chart:
   # the explicit value is required because neither ZTWIM nor spire-bundle exist at startup.
   signatureVerification:
     spireTrustDomain: localtest.me
+  # Operator SPIFFE authentication bootstrap Job image (see
+  # charts/rossoctl/templates/operator-client-bootstrap-job.yaml). Built by this
+  # repo's build.yaml CI workflow — kept in sync via scripts/pin-release-tags.sh.
+  spiffe:
+    operatorAuth:
+      bootstrapImage: ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap
+      bootstrapImageTag: latest
   # Pin sidecar image tags injected by the AuthBridge webhook.
   #
   # After cortex#411 there are three combined images:

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -55,7 +55,7 @@ Images pinned (charts/rossoctl/values.yaml):
   - agentOAuthSecret.tag
   - apiOAuthSecret.tag
   - mlflowOAuthSecret.tag
-  - operator-chart.spiffe.operatorAuth.bootstrapImageTag
+  - operatorSpiffeBootstrap.tag
 
 Images pinned (charts/rossoctl-deps/values.yaml):
   - spiffeIdp.image.tag
@@ -140,7 +140,7 @@ PINNABLE_IMAGES=(
     "$ROSSOCTL_VALUES|.agentOAuthSecret.tag|agent-oauth-secret"
     "$ROSSOCTL_VALUES|.apiOAuthSecret.tag|api-oauth-secret"
     "$ROSSOCTL_VALUES|.mlflowOAuthSecret.tag|mlflow-oauth-secret"
-    "$ROSSOCTL_VALUES|.[\"operator-chart\"].spiffe.operatorAuth.bootstrapImageTag|operator-spiffe-bootstrap"
+    "$ROSSOCTL_VALUES|.operatorSpiffeBootstrap.tag|operator-spiffe-bootstrap"
     "$ROSSOCTL_DEPS_VALUES|.spiffeIdp.image.tag|spiffe-idp-setup"
 )
 

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -55,6 +55,7 @@ Images pinned (charts/rossoctl/values.yaml):
   - agentOAuthSecret.tag
   - apiOAuthSecret.tag
   - mlflowOAuthSecret.tag
+  - operator-chart.spiffe.operatorAuth.bootstrapImageTag
 
 Images pinned (charts/rossoctl-deps/values.yaml):
   - spiffeIdp.image.tag
@@ -139,6 +140,7 @@ PINNABLE_IMAGES=(
     "$ROSSOCTL_VALUES|.agentOAuthSecret.tag|agent-oauth-secret"
     "$ROSSOCTL_VALUES|.apiOAuthSecret.tag|api-oauth-secret"
     "$ROSSOCTL_VALUES|.mlflowOAuthSecret.tag|mlflow-oauth-secret"
+    "$ROSSOCTL_VALUES|.[\"operator-chart\"].spiffe.operatorAuth.bootstrapImageTag|operator-spiffe-bootstrap"
     "$ROSSOCTL_DEPS_VALUES|.spiffeIdp.image.tag|spiffe-idp-setup"
 )
 


### PR DESCRIPTION
## Summary

**Stacked on #2338** — branched from that PR's branch since it depends on the `operatorSpiffeBootstrap` values field #2338 introduces. The diff below will include #2338's changes until that merges; only the last commit is new here. Please merge #2338 first.

`package-charts` in `.github/workflows/build.yaml` force-corrects six image tag fields directly in the CI runner's ephemeral checkout, right before `helm package`/`helm push` — independent of whether `scripts/pin-release-tags.sh` was actually run before tagging. This guarantees the **published OCI chart** artifact is correct for those six fields even if that manual release-prep step was skipped (the git tag itself would still be wrong, but the published chart self-corrects).

`operatorSpiffeBootstrap.tag` (added in #2338) was registered in `pin-release-tags.sh`'s `PINNABLE_IMAGES` list, but not in this `package-charts` safety net — leaving it with zero automatic protection. If the release-prep step were ever skipped, this field would ship wrong in *both* the git tag and the published OCI chart, unlike its six siblings.

Key changes (last commit only — rest is #2338):
- Add `yq e ".operatorSpiffeBootstrap.tag = \"${REF_NAME}\"" -i values.yaml` to the `rossoctl` chart's packaging step in `package-charts`, matching its five siblings exactly.

Verified the exact `yq` expression against a copy of the current `values.yaml` — correctly sets `operatorSpiffeBootstrap.tag` without disturbing the sibling `image:` field.

## Related issue(s)

Fixes #2339