### PR TITLE
fix(e2e): use in-cluster Keycloak URL for token-exchange client registration

### DIFF
--- a/.github/scripts/token-exchange/50-enable-rossoctl-ns.sh
+++ b/.github/scripts/token-exchange/50-enable-rossoctl-ns.sh
@@ -263,7 +263,15 @@ kind: ConfigMap
 metadata:
   name: authbridge-config
 data:
-  KEYCLOAK_URL: "https://${KC_HOST}"
+  # Admin API base for the operator's client-registration controller. This MUST
+  # be the in-cluster Service URL: the controller runs in the operator pod, where
+  # the public host (keycloak.localtest.me) resolves to [::1] and the admin token
+  # call fails ("dial tcp [::1]:443: connect: connection refused"), so the
+  # client-credentials Secret is never created and injected pods wedge on
+  # FailedMount. Token *validation* (ISSUER/*_AUDIENCE below) stays on the public
+  # host. NB the operator preserves this CI-provided value (no-clobber, #433), so
+  # it will not self-correct to the in-cluster default.
+  KEYCLOAK_URL: "${KC_INTERNAL}"
   KEYCLOAK_REALM: "${TX_REALM}"
   KEYCLOAK_NAMESPACE: "${KC_NAMESPACE}"
   ISSUER: "https://${KC_HOST}/realms/${TX_REALM}"


### PR DESCRIPTION
## Summary

The token-exchange E2E (`release-validation`, community-KC leg) fails with the
sidecar-injection tests reporting a single-container pod:

```
AssertionError: envoy-proxy sidecar not found in agent pod. Containers: ['agent']
AssertionError: operator-managed Keycloak client Secret not mounted; volumes referenced: []
Expected 401/403 for unauthenticated request, got 200
```

### Root cause

The mutating webhook **does** inject (the new replicaset pods are `0/2`), but
those pods wedge on `Init:0/1` with a `FailedMount` for
`rossoctl-keycloak-client-credentials-*`, which is never created. The operator's
client-registration controller — running in the operator pod — fails its admin
token call:

```
Keycloak admin token failed ... Post "https://keycloak.localtest.me/realms/master/protocol/openid-connect/token":
dial tcp [::1]:443: connect: connection refused
```

`keycloak.localtest.me` resolves to `[::1]` inside the operator pod. The source
of that public URL is this script: `50-enable-rossoctl-ns.sh` pre-creates the
`authbridge-config` ConfigMap with `KEYCLOAK_URL: "https://${KC_HOST}"`, and the
operator **preserves** the CI-provided value (no-clobber policy, #433) rather
than substituting its in-cluster default. So no secret → wedged rollout → the
old, non-injected pod stays `Running` → the tests inspect it and see no sidecar.

### Fix

Point `KEYCLOAK_URL` at the in-cluster Service URL (`$KC_INTERNAL`,
`http://keycloak-service.<ns>.svc:8080`) — already computed in this script and
the canonical in-cluster URL used across the suite (`lib.sh` `get_keycloak_url`).
`ISSUER` / `*_AUDIENCE` stay on the public host (token validation is unaffected).
This is a CI-env config correction only; no operator/product change and no
resource reordering.

Refs #2129 (same symptom; this addresses the actual cause — a client-registration
reachability failure, not a pod-readiness race).

## Test plan

- [ ] Kind `release-validation` (community-KC leg) — the previously-fatal
      token-exchange E2E turns green (injected pods reach Ready, sidecars present).

Assisted-By: Claude Code