### PR TITLE
fix(e2e): stabilize token-exchange E2E (community KC) — #2342 (test-only)

### DIFF
--- a/.github/scripts/token-exchange/70-deploy-test-workloads.sh
+++ b/.github/scripts/token-exchange/70-deploy-test-workloads.sh
@@ -255,7 +255,7 @@ PREV_RV=""; STABLE=0
 for i in $(seq 1 90); do
   RV=$(kubectl get secrets -n "$TX_NAMESPACE" \
         -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.resourceVersion}{"\n"}{end}' 2>/dev/null \
-        | grep rossoctl-keycloak-client-credentials | sort)
+        | grep rossoctl-keycloak-client-credentials | sort || true)
   CNT=$(printf '%s\n' "$RV" | grep -c . || echo 0)
   if [[ "$CNT" -ge 2 && "$RV" == "$PREV_RV" ]]; then
     STABLE=$((STABLE + 1))

--- a/.github/scripts/token-exchange/70-deploy-test-workloads.sh
+++ b/.github/scripts/token-exchange/70-deploy-test-workloads.sh
@@ -256,7 +256,7 @@ for i in $(seq 1 90); do
   RV=$(kubectl get secrets -n "$TX_NAMESPACE" \
         -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.resourceVersion}{"\n"}{end}' 2>/dev/null \
         | grep rossoctl-keycloak-client-credentials | sort || true)
-  CNT=$(printf '%s\n' "$RV" | grep -c . || echo 0)
+  CNT=$(printf '%s\n' "$RV" | grep -c . || true)
   if [[ "$CNT" -ge 2 && "$RV" == "$PREV_RV" ]]; then
     STABLE=$((STABLE + 1))
   else

--- a/.github/scripts/token-exchange/70-deploy-test-workloads.sh
+++ b/.github/scripts/token-exchange/70-deploy-test-workloads.sh
@@ -248,18 +248,29 @@ for deploy in tx-e2e-tool tx-e2e-agent; do
   }
 done
 
-# Wait for keycloak client credentials to be created by the operator
-log_info "Waiting for keycloak client credentials..."
-for i in $(seq 1 60); do
-  CRED_COUNT=$(kubectl get secrets -n "$TX_NAMESPACE" -o name 2>/dev/null | grep -c rossoctl-keycloak-client-credentials || echo "0")
-  if [[ "$CRED_COUNT" -ge 2 ]]; then
-    log_success "Found $CRED_COUNT keycloak credential secrets"
+# Wait for keycloak client credentials to CONVERGE (present + stable) — the
+# operator re-registers asynchronously; a count-only check races (#2342).
+log_info "Waiting for keycloak client credentials to converge..."
+PREV_RV=""; STABLE=0
+for i in $(seq 1 90); do
+  RV=$(kubectl get secrets -n "$TX_NAMESPACE" \
+        -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.resourceVersion}{"\n"}{end}' 2>/dev/null \
+        | grep rossoctl-keycloak-client-credentials | sort)
+  CNT=$(printf '%s\n' "$RV" | grep -c . || echo 0)
+  if [[ "$CNT" -ge 2 && "$RV" == "$PREV_RV" ]]; then
+    STABLE=$((STABLE + 1))
+  else
+    STABLE=0
+  fi
+  PREV_RV="$RV"
+  if [[ "$STABLE" -ge 3 ]]; then
+    log_success "Credentials converged ($CNT secrets, stable across ${STABLE} polls)"
     break
   fi
-  if [[ "$i" -eq 60 ]]; then
-    log_warn "Only found $CRED_COUNT credential secrets after 5 min"
+  if [[ "$i" -eq 90 ]]; then
+    log_warn "Credentials not stable after ~3 min (count=$CNT); proceeding"
   fi
-  sleep 5
+  sleep 2
 done
 
 log_success "Test workloads deployed in $TX_NAMESPACE"

--- a/.github/scripts/token-exchange/80-run-tests.sh
+++ b/.github/scripts/token-exchange/80-run-tests.sh
@@ -24,24 +24,46 @@ export KEYCLOAK_URL="${KEYCLOAK_URL:-$(get_keycloak_url)}"
 
 # Determine Keycloak host for port-forward on Kind
 if [[ "$PLATFORM" == "kind" ]]; then
-  # Start port-forward if keycloak is not externally accessible
   KC_PF_PID=""
+  KC_KEEPALIVE_PID=""
+  AGENT_PF_PID=""
+
+  wait_serving() {  # $1=url  — poll up to 60s until it answers
+    local url="$1" i
+    for i in $(seq 1 30); do
+      curl -sk "$url" -o /dev/null 2>/dev/null && return 0
+      sleep 2
+    done
+    return 1
+  }
+
   if ! curl -sk "$KEYCLOAK_URL/realms/master" -o /dev/null 2>/dev/null; then
     log_info "Starting Keycloak port-forward..."
     kubectl port-forward svc/keycloak-service -n "$KC_NAMESPACE" 8081:8080 &>/dev/null &
     KC_PF_PID=$!
     export KEYCLOAK_URL="http://localhost:8081"
-    sleep 3
+    wait_serving "$KEYCLOAK_URL/realms/master" || log_warn "Keycloak port-forward not serving yet"
+
+    # Keepalive: re-establish the forward if the local port stops answering
+    # (Keycloak cold-start / dropped forward caused ReadTimeout, #2342 Bug B).
+    ( while true; do
+        sleep 5
+        curl -sk "$KEYCLOAK_URL/realms/master" -o /dev/null 2>/dev/null && continue
+        kill "$KC_PF_PID" 2>/dev/null || true
+        kubectl port-forward svc/keycloak-service -n "$KC_NAMESPACE" 8081:8080 &>/dev/null &
+        KC_PF_PID=$!
+      done ) &
+    KC_KEEPALIVE_PID=$!
   fi
 
-  # Start agent port-forward
   log_info "Starting agent port-forward..."
   kubectl port-forward svc/tx-e2e-agent -n "$TX_NAMESPACE" 8082:8080 &>/dev/null &
   AGENT_PF_PID=$!
   export TX_AGENT_URL="http://localhost:8082"
-  sleep 2
+  wait_serving "$TX_AGENT_URL" || true  # agent may 404 on /, that still proves the forward is up
 
   cleanup_pf() {
+    kill "$KC_KEEPALIVE_PID" 2>/dev/null || true
     kill "$KC_PF_PID" 2>/dev/null || true
     kill "$AGENT_PF_PID" 2>/dev/null || true
   }

--- a/.github/scripts/token-exchange/80-run-tests.sh
+++ b/.github/scripts/token-exchange/80-run-tests.sh
@@ -44,14 +44,18 @@ if [[ "$PLATFORM" == "kind" ]]; then
     export KEYCLOAK_URL="http://localhost:8081"
     wait_serving "$KEYCLOAK_URL/realms/master" || log_warn "Keycloak port-forward not serving yet"
 
+    # Use a PID file so the keepalive subshell and parent cleanup can share the forward's PID
+    KC_PF_PIDFILE=$(mktemp)
+    echo "$KC_PF_PID" > "$KC_PF_PIDFILE"
+
     # Keepalive: re-establish the forward if the local port stops answering
     # (Keycloak cold-start / dropped forward caused ReadTimeout, #2342 Bug B).
     ( while true; do
         sleep 5
         curl -sk "$KEYCLOAK_URL/realms/master" -o /dev/null 2>/dev/null && continue
-        kill "$KC_PF_PID" 2>/dev/null || true
+        kill "$(cat "$KC_PF_PIDFILE")" 2>/dev/null || true
         kubectl port-forward svc/keycloak-service -n "$KC_NAMESPACE" 8081:8080 &>/dev/null &
-        KC_PF_PID=$!
+        echo $! > "$KC_PF_PIDFILE"
       done ) &
     KC_KEEPALIVE_PID=$!
   fi
@@ -64,8 +68,9 @@ if [[ "$PLATFORM" == "kind" ]]; then
 
   cleanup_pf() {
     kill "$KC_KEEPALIVE_PID" 2>/dev/null || true
-    kill "$KC_PF_PID" 2>/dev/null || true
+    [ -n "${KC_PF_PIDFILE:-}" ] && kill "$(cat "$KC_PF_PIDFILE" 2>/dev/null)" 2>/dev/null || true
     kill "$AGENT_PF_PID" 2>/dev/null || true
+    [ -n "${KC_PF_PIDFILE:-}" ] && rm -f "$KC_PF_PIDFILE"
   }
   trap cleanup_pf EXIT
 fi

--- a/docs/superpowers/plans/2026-08-07-txe2e-2342-track1.md
+++ b/docs/superpowers/plans/2026-08-07-txe2e-2342-track1.md
@@ -1,0 +1,285 @@
+# #2342 Track 1 (rc.5 test-only) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the community-KC token-exchange E2E leg green with **test-only** changes — no shipped product code — so it can ship in rc.5.
+
+**Architecture:** Three independent test-harness changes. The primary Bug-A fix hardens the `agent_credentials` pytest fixture to return credentials **only after they actually authenticate** (re-reading on `invalid_client` to ride out the operator's async re-registration). A script-side convergence gate is added as belt-and-suspenders. Bug B makes the Kind Keycloak port-forward wait-for-ready and self-heal.
+
+**Tech Stack:** Python (pytest, `requests` aliased `http`, `kubernetes` client), Bash (CI setup scripts), GitHub Actions `release-validation.yaml`.
+
+## Global Constraints
+
+- Land on `main` first, then cherry-pick `-x` to `release-0.7` for rc.5.
+- **Test-only** — do not modify any shipped product code, chart, or image. No operator changes (that is Track 2 / 0.8).
+- Every commit: DCO sign-off (`git commit -s`). Attribution trailer `Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>` — **never** `Co-authored-by`.
+- Behavioral verification is **CI only** (`release-validation.yaml`, Kind leg); a full local E2E run is impractical (needs operator + extensions + Keycloak + SPIRE). Local checks are limited to lint/syntax.
+- Branch: `fix/txe2e-2342` (already created off latest `main`; the design spec is already committed on it).
+
+---
+
+### Task 1: Bug A — harden `agent_credentials` fixture (primary fix)
+
+**Files:**
+- Modify: `rossoctl/tests/e2e/token_exchange/conftest.py` (imports ~line 1-10; constants block ~line 40-45; fixture `agent_credentials` lines 145-158)
+
+**Interfaces:**
+- Produces: `agent_credentials` fixture — unchanged signature `(k8s) -> dict`, still returns `{"agent": {"client_id","client_secret"}, "tool": {...}}`. Behavior change only: the returned creds are validated by a real `client_credentials` grant before return; on `invalid_client` it re-reads the secret and retries up to `CRED_CONVERGE_TIMEOUT`. Consumers (`test_agent_client_credentials`, `test_tool_client_credentials`, token-exchange and ext-proc tests) are unchanged.
+
+- [ ] **Step 1: Add `import time`**
+
+At the top of `conftest.py`, with the other stdlib imports (it already imports `base64`, `json`, `os`), add:
+
+```python
+import time
+```
+
+- [ ] **Step 2: Add convergence constants**
+
+Immediately after the `KEYCLOAK_URL = ...` / `TX_*` env block (around line 45), add:
+
+```python
+# #2342: the operator (re-)registers client credentials asynchronously after
+# 56-enable-spiffe.sh rotates them; wait until a real grant succeeds.
+CRED_CONVERGE_TIMEOUT = int(os.environ.get("TX_CRED_CONVERGE_TIMEOUT", "180"))
+CRED_RETRY_INTERVAL = int(os.environ.get("TX_CRED_RETRY_INTERVAL", "5"))
+```
+
+- [ ] **Step 3: Replace the `agent_credentials` fixture (lines 145-158)**
+
+Replace the existing fixture body with a read-validate-retry loop:
+
+```python
+@pytest.fixture(scope="session")
+def agent_credentials(k8s):
+    """Discover agent/tool keycloak credentials and return them only once they
+    actually authenticate. The operator re-registers asynchronously after the
+    SPIFFE-setup rotation, so a one-shot read can cache a stale secret and every
+    client_credentials grant then fails with invalid_client (#2342). Re-read on
+    failure until a real grant succeeds or the timeout elapses.
+    """
+
+    def _read():
+        found = {}
+        for s in k8s.list_namespaced_secret(TX_NAMESPACE).items:
+            if "rossoctl-keycloak-client-credentials" in s.metadata.name:
+                cid = base64.b64decode(s.data.get("client-id.txt", "")).decode()
+                csecret = base64.b64decode(s.data.get("client-secret.txt", "")).decode()
+                if "agent" in cid.lower():
+                    found["agent"] = {"client_id": cid, "client_secret": csecret}
+                elif "tool" in cid.lower():
+                    found["tool"] = {"client_id": cid, "client_secret": csecret}
+        return found
+
+    def _authenticates(c):
+        resp = http.post(
+            f"{KEYCLOAK_URL}/realms/{TX_REALM}/protocol/openid-connect/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": c["client_id"],
+                "client_secret": c["client_secret"],
+            },
+            timeout=10,
+        )
+        return resp.status_code == 200
+
+    deadline = time.monotonic() + CRED_CONVERGE_TIMEOUT
+    creds = {}
+    while time.monotonic() < deadline:
+        creds = _read()
+        if creds and all(_authenticates(c) for c in creds.values()):
+            return creds
+        time.sleep(CRED_RETRY_INTERVAL)
+    # Best-effort: return the last read so downstream tests surface the real
+    # failure (unchanged behavior in the pathological never-converges case).
+    return creds
+```
+
+- [ ] **Step 4: Lint / syntax check locally**
+
+Run: `cd /Users/cwiklik/dev/aiplatform/public/kagenti-fork/kagenti && uv run ruff check rossoctl/tests/e2e/token_exchange/conftest.py && uv run ruff format --check rossoctl/tests/e2e/token_exchange/conftest.py && python -c "import ast,sys; ast.parse(open('rossoctl/tests/e2e/token_exchange/conftest.py').read())"`
+Expected: ruff reports no errors; `ast.parse` prints nothing (exit 0).
+(If `ruff format --check` fails, run `uv run ruff format rossoctl/tests/e2e/token_exchange/conftest.py` and re-check.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rossoctl/tests/e2e/token_exchange/conftest.py
+git commit -s -m "fix(e2e): validate+retry agent credentials to ride out async re-registration (#2342)
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Bug B — Keycloak port-forward wait-for-ready + self-heal
+
+**Files:**
+- Modify: `.github/scripts/token-exchange/80-run-tests.sh` (lines 26-49, the `if [[ "$PLATFORM" == "kind" ]]` port-forward block)
+
+**Interfaces:**
+- Consumes: `KEYCLOAK_URL`, `KC_NAMESPACE`, `TX_NAMESPACE`, `PLATFORM`, `get_keycloak_url` (all already in scope).
+- Produces: exported `KEYCLOAK_URL=http://localhost:8081` and `TX_AGENT_URL=http://localhost:8082` that are confirmed serving before pytest starts; a background keepalive re-establishes the Keycloak forward if it drops. `cleanup_pf` trap unchanged in intent.
+
+- [ ] **Step 1: Replace the port-forward block (lines 26-49)**
+
+Replace fixed `sleep 3`/`sleep 2` startup and the naked forwards with readiness polling + a keepalive for the Keycloak forward (the one that times out per #2342 Bug B):
+
+```bash
+if [[ "$PLATFORM" == "kind" ]]; then
+  KC_PF_PID=""
+  KC_KEEPALIVE_PID=""
+  AGENT_PF_PID=""
+
+  wait_serving() {  # $1=url  — poll up to 60s until it answers
+    local url="$1" i
+    for i in $(seq 1 30); do
+      curl -sk "$url" -o /dev/null 2>/dev/null && return 0
+      sleep 2
+    done
+    return 1
+  }
+
+  if ! curl -sk "$KEYCLOAK_URL/realms/master" -o /dev/null 2>/dev/null; then
+    log_info "Starting Keycloak port-forward..."
+    kubectl port-forward svc/keycloak-service -n "$KC_NAMESPACE" 8081:8080 &>/dev/null &
+    KC_PF_PID=$!
+    export KEYCLOAK_URL="http://localhost:8081"
+    wait_serving "$KEYCLOAK_URL/realms/master" || log_warn "Keycloak port-forward not serving yet"
+
+    # Keepalive: re-establish the forward if the local port stops answering
+    # (Keycloak cold-start / dropped forward caused ReadTimeout, #2342 Bug B).
+    ( while true; do
+        sleep 5
+        curl -sk "$KEYCLOAK_URL/realms/master" -o /dev/null 2>/dev/null && continue
+        kill "$KC_PF_PID" 2>/dev/null || true
+        kubectl port-forward svc/keycloak-service -n "$KC_NAMESPACE" 8081:8080 &>/dev/null &
+        KC_PF_PID=$!
+      done ) &
+    KC_KEEPALIVE_PID=$!
+  fi
+
+  log_info "Starting agent port-forward..."
+  kubectl port-forward svc/tx-e2e-agent -n "$TX_NAMESPACE" 8082:8080 &>/dev/null &
+  AGENT_PF_PID=$!
+  export TX_AGENT_URL="http://localhost:8082"
+  wait_serving "$TX_AGENT_URL" || true  # agent may 404 on /, that still proves the forward is up
+
+  cleanup_pf() {
+    kill "$KC_KEEPALIVE_PID" 2>/dev/null || true
+    kill "$KC_PF_PID" 2>/dev/null || true
+    kill "$AGENT_PF_PID" 2>/dev/null || true
+  }
+  trap cleanup_pf EXIT
+fi
+```
+
+- [ ] **Step 2: Syntax + shellcheck locally**
+
+Run: `bash -n .github/scripts/token-exchange/80-run-tests.sh && shellcheck -S warning .github/scripts/token-exchange/80-run-tests.sh || true`
+Expected: `bash -n` exits 0 (no syntax errors). shellcheck warnings are advisory; fix any genuine errors it flags in the edited block.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/scripts/token-exchange/80-run-tests.sh
+git commit -s -m "fix(e2e): wait-for-ready + self-heal Keycloak port-forward in tx-e2e (#2342 Bug B)
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3 (insurance — optional): Bug A — credential convergence gate in setup
+
+> With Task 1's validating fixture, this is belt-and-suspenders. Include it for a
+> loud, early signal if registration never settles; it can be dropped if minimal
+> RC surface is preferred.
+
+**Files:**
+- Modify: `.github/scripts/token-exchange/70-deploy-test-workloads.sh` (lines 251-263, the "Wait for keycloak client credentials" loop)
+
+**Interfaces:**
+- Consumes: `TX_NAMESPACE`, `log_info`/`log_success`/`log_warn` (already in scope).
+- Produces: pytest is not started until each credential secret is present **and** its `resourceVersion` is unchanged across consecutive polls (registration settled).
+
+- [ ] **Step 1: Replace the count-only wait (lines 251-263)**
+
+```bash
+# Wait for keycloak client credentials to CONVERGE (present + stable) — the
+# operator re-registers asynchronously; a count-only check races (#2342).
+log_info "Waiting for keycloak client credentials to converge..."
+PREV_RV=""; STABLE=0
+for i in $(seq 1 90); do
+  RV=$(kubectl get secrets -n "$TX_NAMESPACE" \
+        -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.resourceVersion}{"\n"}{end}' 2>/dev/null \
+        | grep rossoctl-keycloak-client-credentials | sort)
+  CNT=$(printf '%s\n' "$RV" | grep -c . || echo 0)
+  if [[ "$CNT" -ge 2 && "$RV" == "$PREV_RV" ]]; then
+    STABLE=$((STABLE + 1))
+  else
+    STABLE=0
+  fi
+  PREV_RV="$RV"
+  if [[ "$STABLE" -ge 3 ]]; then
+    log_success "Credentials converged ($CNT secrets, stable across ${STABLE} polls)"
+    break
+  fi
+  if [[ "$i" -eq 90 ]]; then
+    log_warn "Credentials not stable after ~3 min (count=$CNT); proceeding"
+  fi
+  sleep 2
+done
+```
+
+- [ ] **Step 2: Syntax + shellcheck locally**
+
+Run: `bash -n .github/scripts/token-exchange/70-deploy-test-workloads.sh && shellcheck -S warning .github/scripts/token-exchange/70-deploy-test-workloads.sh || true`
+Expected: `bash -n` exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/scripts/token-exchange/70-deploy-test-workloads.sh
+git commit -s -m "fix(e2e): wait for credential convergence before tx-e2e tests (#2342)
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Verify in CI
+
+**Files:** none (CI trigger).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push origin fix/txe2e-2342
+```
+(Requires explicit user approval to push — do not push without it.)
+
+- [ ] **Step 2: Trigger Kind-only validation from the branch**
+
+Run: `gh workflow run release-validation.yaml --ref fix/txe2e-2342 -f ref=fix/txe2e-2342 -f skip_hypershift=true`
+Then: `sleep 5 && gh run list --workflow=release-validation.yaml --limit 1 --json databaseId,url --jq '.[0].url'`
+
+- [ ] **Step 3: Confirm the token-exchange leg is green**
+
+After the run completes, check the "Kind E2E" job's "Run token exchange E2E tests (community KC — fatal)" step.
+Expected: **all token-exchange tests pass** (the 12 Bug-A + 2 Bug-B tests), **0 xfail** — with the operator unchanged, proving the test-only track is sufficient.
+If still red: read the failed step log (redirect to a file, analyze in a subagent per the context-budget rules) and iterate.
+
+---
+
+## Rollout (after CI green)
+
+- Cherry-pick `-x` the Task 1-3 commits from `main` into `release-0.7`, roll into rc.5. No image/chart re-pin (test-only).
+- Close #2342; open a Track-2 follow-up issue on `rossoctl/operator` for the idempotent-registration hardening (0.8), linked from #2342.
+
+## Self-Review
+
+- **Spec coverage:** Bug A convergence (spec 1a) → Task 3; Bug A fixture retry (spec 1b) → Task 1; Bug B port-forward (spec 1c) → Task 2; verification/rollout → Tasks 4 + Rollout. All spec sections covered.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code; commands have expected output.
+- **Type/name consistency:** `agent_credentials` keeps its dict shape and consumers; `wait_serving`, `CRED_CONVERGE_TIMEOUT`, `CRED_RETRY_INTERVAL`, `PREV_RV`/`STABLE` are defined where used.
+- **Adaptation note:** classic local TDD (write-failing-test → run) does not apply — these are CI-verified test-harness changes; local steps are lint/syntax, behavioral gate is Task 4 (CI). This is intentional and called out in Global Constraints.

--- a/docs/superpowers/specs/2026-08-07-txe2e-2342-design.md
+++ b/docs/superpowers/specs/2026-08-07-txe2e-2342-design.md
@@ -1,0 +1,77 @@
+# Design — Fix #2342: token-exchange E2E (community KC) `invalid_client` + SPIFFE port-forward timeout
+
+**Date:** 2026-08-07
+**Issue:** rossoctl/rossoctl #2342 (supersedes #2129; follows #2341)
+**Status:** approved design, pre-implementation
+**Scope split:** RC-scoped **test-only** fix for rc.5 + operator hardening tracked separately for 0.8
+
+## Problem
+
+The `release-validation` community-KC token-exchange leg (the `… — fatal` step) has been red since ~2026-07-16. #2341 fixed the first bug (client-registration pointed at the public Keycloak URL). Two bugs remain, tracked as #2342.
+
+### Bug A — `invalid_client` (primary; 12 of 14 failures cascade from it)
+Root cause is a **credential-rotation race**, confirmed with timestamps from failing run 30916392962:
+
+| Time (UTC) | Event |
+|-----------|-------|
+| 14:22:04 | `56-enable-spiffe.sh` deletes the credential secrets |
+| 14:22:10 | workloads rollout-restarted → triggers operator re-registration |
+| 14:22:40 | wait step sees "Credentials ready (2)", pods Ready |
+| **14:22:44** | pytest starts; session-scoped `agent_credentials` fixture reads `client-secret.txt` **once** and caches it |
+| 14:22:54 | operator "client registration applied" — **after** the fixture read |
+| **14:23:11** | operator **re-registers again**, rotating the Keycloak secret + rewriting the K8s secret |
+| 14:23:32 | Keycloak logs `CLIENT_LOGIN_ERROR … invalid_client_credentials` |
+
+Four contributing factors:
+1. `56-enable-spiffe.sh` destructively rotates (delete client + delete secret + `kubectl rollout restart`) and races ahead.
+2. `70-deploy-test-workloads.sh:251-263` gates only on secret **count ≥ 2**, never value convergence.
+3. `conftest.py:143-159` `agent_credentials` is **session-scoped, read once, no retry** — one stale read poisons the whole run.
+4. Operator: deleting the client forces `createClient` to mint a new secret, it **re-registers more than once** (Keycloak/Postgres `already exists` conflicts), and the credential is mounted via **`subPath`** (never refreshes in place) — so only a pod restart delivers a new value, and nothing signals convergence.
+
+### Bug B — SPIFFE port-forward read timeout (2 tests, independent)
+`kubectl port-forward` to `svc/keycloak-service` in the harness times out (10s read timeout). Pure test-harness robustness; unrelated to Bug A.
+
+## Approach — two tracks, split by risk and release target
+
+The operator behavior (factor 4) is the deepest cause, but fixing it means changing a **core auth-path product component** used by every workload — too invasive for a release candidate. The test harness (factors 1–3) can be made **deterministic on its own**: re-reading the current secret and retrying `invalid_client` succeeds even while the operator still churns, because the operator *does* converge after its initial delete-triggered churn (steady-state reconciles are idempotent). So:
+
+- **Track 1 (RC / rc.5): test-only changes.** Zero shipped product code — cannot break the release, only changes how CI validates it. Sufficient to make the leg green.
+- **Track 2 (main / 0.8): operator hardening.** The proper root-cause fix, as its own PR with normal review. **Not** gating the RC.
+
+### Track 1 — Platform, test-only (rc.5)
+**Repo:** `rossoctl/rossoctl`.
+
+**1a. Bug A convergence gate** — `.github/scripts/token-exchange/70-deploy-test-workloads.sh` (~:251-263): replace the count-only gate (secret **count ≥ 2**) with a **convergence wait** — poll until each `rossoctl-keycloak-client-credentials-*` secret exists **and** its `resourceVersion` is unchanged for a short settle window (registration has stopped churning) before pytest starts. Bounded overall timeout with a clear failure message.
+
+**1b. Bug A fixture retry** — `rossoctl/tests/e2e/token_exchange/conftest.py` (~:143-159): the `agent_credentials` fixture must **re-read the current secret and retry the client-credentials grant on `invalid_client`** (bounded retries + backoff) rather than caching one value session-wide. This is the deterministic guarantee even if a re-registration lands after the first read.
+
+**1c. Bug B port-forward robustness** — the SPIFFE test harness (port-forward to `svc/keycloak-service`): wait for the service endpoints Ready before forwarding, wrap `kubectl port-forward` in retry/backoff (re-establish on drop), and raise the 10s read timeout to match Keycloak cold-start.
+
+### Track 2 — Operator hardening (main → 0.8, separate PR, NOT in the RC)
+**Repo:** `rossoctl/operator` · `internal/controller/clientregistration_controller.go` (+ `internal/keycloak/admin.go`). Filed as its own issue.
+
+- On create, treat "client already exists" (Keycloak 409 / Postgres unique-constraint conflict) as **adopt-and-fetch**, not re-create.
+- **Do not re-mint the client secret when the client already exists** — read the existing value via the existing `readClientSecret` GET path.
+- Result: after a delete-triggered re-registration, the client is recreated **exactly once** and the secret is stable — no double rotation.
+
+**Implementation risk (resolve in the plan):** the RCA proves it double-registers but not the exact trigger (two watch events vs a requeue). Confirm the create path and reconcile trigger against the actual code before editing. This work is 0.8-targeted and does not block rc.5.
+
+## Verification
+
+Local run is impractical (needs operator + extensions + Keycloak + SPIRE + tx-e2e). Verify via CI, same as #2341/#2098:
+
+1. Push the Track-1 branch to origin.
+2. Because the workflow YAML/scripts change, trigger the workflow definition from the branch: `gh workflow run release-validation.yaml --ref <branch> -f ref=<branch> -f skip_hypershift=true` (Kind-only, faster).
+3. Success = token-exchange leg reports **all pass** (12 Bug-A tests + 2 Bug-B tests), 0 xfail — **with the operator unchanged**, proving the test-only track is sufficient.
+
+## Rollout
+
+- **Track 1 (rc.5):** land the test-only changes on `main`, then cherry-pick `-x` into `rossoctl/rossoctl` `release-0.7`, and roll into **rc.5**. DCO `-s`; `Assisted-By: Claude`. No shipped image changes → no operator/chart re-pin needed.
+- **Track 2 (0.8):** operator idempotency fix as its own issue + PR on `rossoctl/operator` `main`, normal review; ships in 0.8, not cherry-picked to `release-0.7`.
+- Close #2342 when Track 1 makes the leg green; #2129 stays closed (superseded). Track 2 gets its own issue linked from #2342.
+
+## Out of scope
+
+- The SWE-bench sandbox resource-sizing experiment (separate track).
+- Broader operator refactors beyond making the one registration path idempotent (Track 2).
+- Reordering resource creation — the operator handles ordering; the test waits, it does not reorder (consistent with the #2341 philosophy).

--- a/rossoctl/tests/e2e/token_exchange/conftest.py
+++ b/rossoctl/tests/e2e/token_exchange/conftest.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import os
+import time
 
 import pytest
 import requests
@@ -43,6 +44,11 @@ TX_CLIENT_ID = os.environ.get("TX_CLIENT_ID", "tx-e2e-app")
 KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://localhost:8081")
 KEYCLOAK_PROVIDER = os.environ.get("KEYCLOAK_PROVIDER", "community")
 TX_AGENT_URL = os.environ.get("TX_AGENT_URL", "http://localhost:8082")
+
+# #2342: the operator (re-)registers client credentials asynchronously after
+# 56-enable-spiffe.sh rotates them; wait until a real grant succeeds.
+CRED_CONVERGE_TIMEOUT = int(os.environ.get("TX_CRED_CONVERGE_TIMEOUT", "180"))
+CRED_RETRY_INTERVAL = int(os.environ.get("TX_CRED_RETRY_INTERVAL", "5"))
 
 
 # ---------------------------------------------------------------------------
@@ -144,17 +150,46 @@ def kc_client_secret(kc_admin_token):
 
 @pytest.fixture(scope="session")
 def agent_credentials(k8s):
-    """Discover agent keycloak credentials from secrets."""
-    secrets = k8s.list_namespaced_secret(TX_NAMESPACE)
+    """Discover agent/tool keycloak credentials and return them only once they
+    actually authenticate. The operator re-registers asynchronously after the
+    SPIFFE-setup rotation, so a one-shot read can cache a stale secret and every
+    client_credentials grant then fails with invalid_client (#2342). Re-read on
+    failure until a real grant succeeds or the timeout elapses.
+    """
+
+    def _read():
+        found = {}
+        for s in k8s.list_namespaced_secret(TX_NAMESPACE).items:
+            if "rossoctl-keycloak-client-credentials" in s.metadata.name:
+                cid = base64.b64decode(s.data.get("client-id.txt", "")).decode()
+                csecret = base64.b64decode(s.data.get("client-secret.txt", "")).decode()
+                if "agent" in cid.lower():
+                    found["agent"] = {"client_id": cid, "client_secret": csecret}
+                elif "tool" in cid.lower():
+                    found["tool"] = {"client_id": cid, "client_secret": csecret}
+        return found
+
+    def _authenticates(c):
+        resp = http.post(
+            f"{KEYCLOAK_URL}/realms/{TX_REALM}/protocol/openid-connect/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": c["client_id"],
+                "client_secret": c["client_secret"],
+            },
+            timeout=10,
+        )
+        return resp.status_code == 200
+
+    deadline = time.monotonic() + CRED_CONVERGE_TIMEOUT
     creds = {}
-    for s in secrets.items:
-        if "rossoctl-keycloak-client-credentials" in s.metadata.name:
-            cid = base64.b64decode(s.data.get("client-id.txt", "")).decode()
-            csecret = base64.b64decode(s.data.get("client-secret.txt", "")).decode()
-            if "agent" in cid.lower():
-                creds["agent"] = {"client_id": cid, "client_secret": csecret}
-            elif "tool" in cid.lower():
-                creds["tool"] = {"client_id": cid, "client_secret": csecret}
+    while time.monotonic() < deadline:
+        creds = _read()
+        if creds and all(_authenticates(c) for c in creds.values()):
+            return creds
+        time.sleep(CRED_RETRY_INTERVAL)
+    # Best-effort: return the last read so downstream tests surface the real
+    # failure (unchanged behavior in the pathological never-converges case).
     return creds
 
 


### PR DESCRIPTION
## Summary

Test-only stabilization of the community-KC token-exchange E2E leg (the \`… — fatal\` step, red since ~2026-07-16). Per RCA, the root cause is a **credential-rotation race**: the operator re-registers client credentials asynchronously after \`56-enable-spiffe.sh\` rotates them, so a session-scoped fixture that read the secret once cached a stale value → \`invalid_client\` cascading to 12 tests. Plus an independent SPIFFE port-forward read-timeout (2 tests).

This is **Track 1** of a two-track fix, scoped for the RC: **test-only, no product/operator code**.

## Changes (test-only)

- \`rossoctl/tests/e2e/token_exchange/conftest.py\` — \`agent_credentials\` validates creds with a real \`client_credentials\` grant and re-reads/retries on \`invalid_client\`, riding out the async re-registration.
- \`.github/scripts/token-exchange/80-run-tests.sh\` — Keycloak/agent port-forward now waits-for-ready and self-heals (fixes Bug B read-timeout).
- \`.github/scripts/token-exchange/70-deploy-test-workloads.sh\` — credential-convergence gate (present + resourceVersion-stable) replaces the count-only wait (belt-and-suspenders).
- Design + plan under \`docs/superpowers/\`.

## Not in this PR

The operator idempotent client-registration hardening (the root of the re-registration churn) is **Track 2**, deferred to 0.8 as its own PR on \`rossoctl/operator\` — not required to make the leg green.

## Verification

- **Static:** \`bash -n\` + \`shellcheck\` + \`ruff\`/\`ast.parse\` clean; each change peer-reviewed (caught + fixed a keepalive PID leak and a \`pipefail\` abort).
- **Behavioral:** pending this PR's \`release-validation\` Kind run — the real gate.

Refs #2342. Supersedes #2129.

Assisted-By: Claude Code