### PR TITLE
ci(e2e): make community-KC token-exchange leg non-fatal (#2342)

### DIFF
--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -227,8 +227,13 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app=tx-e2e-agent -n tx-e2e --timeout=180s || true
           kubectl wait --for=condition=Ready pod -l app=tx-e2e-tool -n tx-e2e --timeout=180s || true
 
-      - name: Run token exchange E2E tests (community KC — fatal)
+      - name: Run token exchange E2E tests (community KC — non-fatal, known issue #2342)
         if: success()
+        # Non-fatal: the SPIFFE/federated-jwt token-exchange leg is a known issue (#2342),
+        # deferred to 0.8. AuthBridge/token-exchange is opt-in (rossoctl_feature_flag_authbridge_api,
+        # off by default) and was not a v0.7.0 milestone item. Re-enable (drop continue-on-error)
+        # once #2342 is fixed.
+        continue-on-error: true
         run: bash .github/scripts/token-exchange/80-run-tests.sh
         env:
           KEYCLOAK_PROVIDER: community
@@ -417,8 +422,13 @@ jobs:
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}
 
-      - name: Run token exchange E2E tests (community KC — fatal)
+      - name: Run token exchange E2E tests (community KC — non-fatal, known issue #2342)
         if: success()
+        # Non-fatal: the SPIFFE/federated-jwt token-exchange leg is a known issue (#2342),
+        # deferred to 0.8. AuthBridge/token-exchange is opt-in (rossoctl_feature_flag_authbridge_api,
+        # off by default) and was not a v0.7.0 milestone item. Re-enable (drop continue-on-error)
+        # once #2342 is fixed.
+        continue-on-error: true
         run: bash .github/scripts/token-exchange/80-run-tests.sh
         env:
           KUBECONFIG: ${{ steps.create-cluster.outputs.cluster_kubeconfig }}


### PR DESCRIPTION
## Summary

Marks both community-KC token-exchange E2E steps (Kind + OCP) in \`release-validation.yaml\` as \`continue-on-error: true\`, so release-validation is **not gated** on the SPIFFE/federated-jwt token-exchange leg.

**Why:** that leg is a known issue (**#2342**, now on the v0.8.0 milestone). AuthBridge/token-exchange is an **opt-in** feature (\`rossoctl_feature_flag_authbridge_api\`, off by default) and was **not a v0.7.0 milestone item** (all milestoned 0.7 work is closed). The observed failure is a Kind CI-harness truststore-wiring gap, not a demonstrated product regression.

This unblocks v0.7.0 rc.5 validation without shipping a speculative fix for #2342.

## Scope
- **Test-only** (workflow). No product/chart/operator changes.
- The tests still **run** (results visible); they just no longer fail the job.
- **Temporary quarantine** — the step comment + #2342 track re-enabling (drop \`continue-on-error\`) once #2342 is fixed in 0.8.

## Rollout
To take effect for rc.5, cherry-pick \`-x\` to \`release-0.7\` after merge (validation runs the workflow from the RC ref).

Refs #2342.

Assisted-By: Claude Code