### PR TITLE
feat: Add PUT /{namespace}/{name}/identity-config endpoint

### DIFF
--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -4884,6 +4884,9 @@ async def fetch_env_from_url(request: FetchEnvUrlRequest) -> FetchEnvUrlResponse
         raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
 
 
+_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
 if settings.rossoctl_feature_flag_authbridge_api:
 
     @router.get(
@@ -4939,8 +4942,15 @@ if settings.rossoctl_feature_flag_authbridge_api:
         Set the AuthBridge configuration for an Agent.
         """
 
-        namespace = sanitize_log(namespace)
-        name = sanitize_log(name)
+        if not _K8S_NAME_RE.fullmatch(namespace):
+            raise HTTPException(status_code=400, detail="Invalid namespace")
+        if not _K8S_NAME_RE.fullmatch(name):
+            raise HTTPException(status_code=400, detail="Invalid name")
+
+        try:
+            yaml.safe_load(new_authbridge_config_yaml)
+        except yaml.YAMLError as e:
+            raise HTTPException(status_code=400, detail=f"Invalid YAML: {e}") from e
 
         kube.upsert_configmap(
             namespace=namespace,

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 import httpx
 import yaml
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 import kubernetes.client
 from kubernetes.client import ApiException
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -4925,6 +4925,30 @@ if settings.rossoctl_feature_flag_authbridge_api:
         logger.info("Could not invoke any AuthBridge endpoints for %s/%s", namespace, name)
         # We return HTTP 200 if no pods respond - this might be a valid agent w/o AuthBridge
         return {"AuthBridge": False}
+
+    @router.put(
+        "/{namespace}/{name}/identity-config", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
+    )
+    async def put_agent_identity_config(
+        namespace: str,
+        name: str,
+        new_authbridge_config_yaml: str = Body(media_type="text/plain"),
+        kube: KubernetesService = Depends(get_kubernetes_service),
+    ) -> dict:
+        """
+        Set the AuthBridge configuration for an Agent.
+        """
+
+        namespace = sanitize_log(namespace)
+        name = sanitize_log(name)
+
+        kube.upsert_configmap(
+            namespace=namespace,
+            name=f"authbridge-config-{name}",
+            data={"config.yaml": new_authbridge_config_yaml},
+        )
+
+        return {"status": "ok"}
 
     @router.get(
         "/{namespace}/{name}/identity-status", dependencies=[Depends(require_roles(ROLE_OPERATOR))]


### PR DESCRIPTION
## Summary

- Adds `PUT /{namespace}/{name}/identity-config` as a sibling to the existing `GET` for the same path, under the `rossoctl_feature_flag_authbridge_api` feature flag and gated by the same `ROLE_OPERATOR` permission.
- Accepts the raw request body as the AuthBridge runtime YAML (`Body(media_type="text/plain")` — no JSON envelope required).
- Patches the `config.yaml` key of the `authbridge-config-{name}` ConfigMap in the target namespace via the existing `KubernetesService.upsert_configmap` helper, which creates the ConfigMap if missing or merges the key if it exists.

## Test plan

- [x] Manual: `curl -X PUT -H "Authorization: Bearer <token>" http://rossoctl-ui.localtest.me:8080/api/v1/agents/<namespace>/<name>/identity-config --data-binary "@config.yaml"` and confirm the `authbridge-config-<name>` ConfigMap's `config.yaml` key is updated
- [x] Confirm `GET .../identity-config` still returns the AuthBridge-reported config for the same agent

Assisted-By: Claude Code