### PR TITLE
feat: expose cpu/memory resource requests and limits in agent/tool deployment API

### DIFF
--- a/rossoctl/backend/app/models/shipwright.py
+++ b/rossoctl/backend/app/models/shipwright.py
@@ -37,7 +37,7 @@ class ResourceConfig(BaseModel):
     limits: Optional[Dict[str, str]] = None
 
 
-def resolve_resources(resources: Optional["ResourceConfig"]) -> Dict[str, Dict[str, str]]:
+def resolve_resources(resources: Optional[ResourceConfig]) -> Dict[str, Dict[str, str]]:
     """Merge a ResourceConfig override over the platform defaults, per requests/limits."""
     return {
         "limits": (resources.limits if resources and resources.limits else DEFAULT_RESOURCE_LIMITS),

--- a/rossoctl/backend/app/models/shipwright.py
+++ b/rossoctl/backend/app/models/shipwright.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 
 from app.core.constants import (
+    DEFAULT_RESOURCE_LIMITS,
+    DEFAULT_RESOURCE_REQUESTS,
     SHIPWRIGHT_DEFAULT_DOCKERFILE,
     SHIPWRIGHT_DEFAULT_TIMEOUT,
 )
@@ -23,6 +25,26 @@ class ResourceType(str, Enum):
 
     AGENT = "agent"
     TOOL = "tool"
+
+
+class ResourceConfig(BaseModel):
+    """Container CPU/memory requests and limits, overriding the platform defaults.
+
+    Shared by agents and tools (source-build and direct-image paths alike).
+    """
+
+    requests: Optional[Dict[str, str]] = None
+    limits: Optional[Dict[str, str]] = None
+
+
+def resolve_resources(resources: Optional["ResourceConfig"]) -> Dict[str, Dict[str, str]]:
+    """Merge a ResourceConfig override over the platform defaults, per requests/limits."""
+    return {
+        "limits": (resources.limits if resources and resources.limits else DEFAULT_RESOURCE_LIMITS),
+        "requests": (
+            resources.requests if resources and resources.requests else DEFAULT_RESOURCE_REQUESTS
+        ),
+    }
 
 
 class ShipwrightBuildConfig(BaseModel):

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -2612,6 +2612,8 @@ def _build_agent_shipwright_build_manifest(
         resource_config["tlsBridgeEnabled"] = True
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
+    if request.resources:
+        resource_config["resources"] = request.resources.model_dump(exclude_none=True)
     # Add env vars if present
     if request.envVars:
         resource_config["envVars"] = [ev.model_dump(exclude_none=True) for ev in request.envVars]
@@ -4083,6 +4085,7 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
     defaultOutboundPolicy: Optional[Literal["passthrough", "exchange"]] = None
+    resources: Optional[ResourceConfig] = None
     persistentStorage: Optional[PersistentStorageConfig] = None
     mcpToolName: Optional[str] = None
     llmPreset: Optional[str] = None
@@ -4417,6 +4420,10 @@ async def finalize_shipwright_build(
         if final_persistent_storage is None and stored_config.get("persistentStorage"):
             final_persistent_storage = PersistentStorageConfig(**stored_config["persistentStorage"])
 
+        final_resources = request.resources
+        if final_resources is None and stored_config.get("resources"):
+            final_resources = ResourceConfig(**stored_config["resources"])
+
         final_mcp_tool_name = (
             request.mcpToolName
             if request.mcpToolName is not None
@@ -4454,6 +4461,7 @@ async def finalize_shipwright_build(
             inboundPortsExclude=final_inbound_ports_exclude,
             defaultOutboundPolicy=final_default_outbound_policy,
             persistentStorage=final_persistent_storage,
+            resources=final_resources,
             gitPath=stored_config.get("gitPath")
             or build.get("spec", {}).get("source", {}).get("contextDir", ""),
             mcpToolName=final_mcp_tool_name,

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -114,6 +114,8 @@ from app.utils.routes import (
 )
 from app.models.shipwright import (
     ResourceType,
+    ResourceConfig,
+    resolve_resources,
     ShipwrightBuildConfig,
     BuildSourceConfig,
     BuildOutputConfig,
@@ -230,13 +232,6 @@ class PersistentStorageConfig(BaseModel):
 
     enabled: bool = False
     size: str = "1Gi"
-
-
-class ResourceConfig(BaseModel):
-    """Container CPU/memory requests and limits, overriding the platform defaults."""
-
-    requests: Optional[Dict[str, str]] = None
-    limits: Optional[Dict[str, str]] = None
 
 
 class CreateAgentRequest(BaseModel):
@@ -3125,17 +3120,6 @@ def _ensure_agentruntime(
             logger.warning("Failed to create AgentRuntime '%s': %s", name, e.reason)
 
 
-def _resolve_resources(request: "CreateAgentRequest") -> Dict[str, Dict[str, str]]:
-    """Merge request.resources over the platform defaults, per requests/limits."""
-    resources = request.resources
-    return {
-        "limits": (resources.limits if resources and resources.limits else DEFAULT_RESOURCE_LIMITS),
-        "requests": (
-            resources.requests if resources and resources.requests else DEFAULT_RESOURCE_REQUESTS
-        ),
-    }
-
-
 def _build_deployment_manifest(
     request: "CreateAgentRequest",
     image: str,
@@ -3211,7 +3195,7 @@ def _build_deployment_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": _resolve_resources(request),
+                            "resources": resolve_resources(request.resources),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3411,7 +3395,7 @@ def _build_statefulset_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": _resolve_resources(request),
+                            "resources": resolve_resources(request.resources),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3552,7 +3536,7 @@ def _build_job_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": _resolve_resources(request),
+                            "resources": resolve_resources(request.resources),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3658,7 +3642,7 @@ def _build_sandbox_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": _resolve_resources(request),
+                            "resources": resolve_resources(request.resources),
                             "env": env_vars,
                             "ports": [
                                 {

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -232,6 +232,13 @@ class PersistentStorageConfig(BaseModel):
     size: str = "1Gi"
 
 
+class ResourceConfig(BaseModel):
+    """Container CPU/memory requests and limits, overriding the platform defaults."""
+
+    requests: Optional[Dict[str, str]] = None
+    limits: Optional[Dict[str, str]] = None
+
+
 class CreateAgentRequest(BaseModel):
     """Request to create a new agent."""
 
@@ -318,6 +325,9 @@ class CreateAgentRequest(BaseModel):
 
     # Persistent storage (for Sandbox and StatefulSet workloads)
     persistentStorage: Optional[PersistentStorageConfig] = None
+
+    # CPU/memory requests and limits, overriding DEFAULT_RESOURCE_REQUESTS/LIMITS
+    resources: Optional[ResourceConfig] = None
 
     # Shipwright build configuration
     shipwrightConfig: Optional[ShipwrightBuildConfig] = None
@@ -3113,6 +3123,17 @@ def _ensure_agentruntime(
             logger.warning("Failed to create AgentRuntime '%s': %s", name, e.reason)
 
 
+def _resolve_resources(request: "CreateAgentRequest") -> Dict[str, Dict[str, str]]:
+    """Merge request.resources over the platform defaults, per requests/limits."""
+    resources = request.resources
+    return {
+        "limits": (resources.limits if resources and resources.limits else DEFAULT_RESOURCE_LIMITS),
+        "requests": (
+            resources.requests if resources and resources.requests else DEFAULT_RESOURCE_REQUESTS
+        ),
+    }
+
+
 def _build_deployment_manifest(
     request: "CreateAgentRequest",
     image: str,
@@ -3188,10 +3209,7 @@ def _build_deployment_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": _resolve_resources(request),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3391,10 +3409,7 @@ def _build_statefulset_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": _resolve_resources(request),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3535,10 +3550,7 @@ def _build_job_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": _resolve_resources(request),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3644,10 +3656,7 @@ def _build_sandbox_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": _resolve_resources(request),
                             "env": env_vars,
                             "ports": [
                                 {

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -44,8 +44,6 @@ from app.core.constants import (
     WORKLOAD_TYPE_DEPLOYMENT,
     WORKLOAD_TYPE_STATEFULSET,
     DEFAULT_IN_CLUSTER_PORT,
-    DEFAULT_RESOURCE_LIMITS,
-    DEFAULT_RESOURCE_REQUESTS,
     DEFAULT_ENV_VARS,
     # Shipwright constants
     SHIPWRIGHT_CRD_GROUP,
@@ -67,6 +65,8 @@ from app.models.responses import (
 )
 from app.models.shipwright import (
     ResourceType,
+    ResourceConfig,
+    resolve_resources,
     ShipwrightBuildConfig,
     BuildSourceConfig,
     BuildOutputConfig,
@@ -186,13 +186,6 @@ class PersistentStorageConfig(BaseModel):
 
     enabled: bool = False
     size: str = "1Gi"
-
-
-class ResourceConfig(BaseModel):
-    """Container CPU/memory requests and limits, overriding the platform defaults."""
-
-    requests: Optional[Dict[str, str]] = None
-    limits: Optional[Dict[str, str]] = None
 
 
 class CreateToolRequest(BaseModel):
@@ -1212,16 +1205,6 @@ def _ensure_tool_agentruntime(
             raise
 
 
-def _resolve_tool_resources(resources: Optional["ResourceConfig"]) -> Dict[str, Dict[str, str]]:
-    """Merge tool resources overrides over the platform defaults, per requests/limits."""
-    return {
-        "limits": (resources.limits if resources and resources.limits else DEFAULT_RESOURCE_LIMITS),
-        "requests": (
-            resources.requests if resources and resources.requests else DEFAULT_RESOURCE_REQUESTS
-        ),
-    }
-
-
 def _build_tool_deployment_manifest(
     name: str,
     namespace: str,
@@ -1348,7 +1331,7 @@ def _build_tool_deployment_manifest(
                             },
                             "env": all_env_vars,
                             "ports": container_ports,
-                            "resources": _resolve_tool_resources(resources),
+                            "resources": resolve_resources(resources),
                             "volumeMounts": [
                                 {"name": "cache", "mountPath": "/app/.cache"},
                                 {"name": "tmp", "mountPath": "/tmp"},
@@ -1507,7 +1490,7 @@ def _build_tool_statefulset_manifest(
                             },
                             "env": all_env_vars,
                             "ports": container_ports,
-                            "resources": _resolve_tool_resources(resources),
+                            "resources": resolve_resources(resources),
                             "volumeMounts": [
                                 {"name": "data", "mountPath": "/data"},
                                 {"name": "cache", "mountPath": "/app/.cache"},

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -281,6 +281,7 @@ class FinalizeToolBuildRequest(BaseModel):
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
     defaultOutboundPolicy: Optional[Literal["passthrough", "exchange"]] = None
+    resources: Optional[ResourceConfig] = None
 
 
 class ToolShipwrightBuildInfoResponse(BaseModel):  # pylint: disable=too-many-instance-attributes
@@ -655,6 +656,8 @@ def _build_tool_shipwright_build_manifest(
     # Add persistent storage config if present (for StatefulSet)
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
+    if request.resources:
+        resource_config["resources"] = request.resources.model_dump(exclude_none=True)
     # Add env vars if present
     if request.envVars:
         resource_config["envVars"] = [ev.model_dump() for ev in request.envVars]
@@ -2205,6 +2208,9 @@ async def finalize_tool_shipwright_build(
             if request.defaultOutboundPolicy is not None
             else tool_config_dict.get("defaultOutboundPolicy")
         )
+        final_resources = request.resources
+        if final_resources is None and tool_config_dict.get("resources"):
+            final_resources = ResourceConfig(**tool_config_dict["resources"])
 
         # Ensure a dedicated ServiceAccount exists so the webhook's
         # SPIFFE identity uses the workload name, not the ReplicaSet hash.
@@ -2258,6 +2264,7 @@ async def finalize_tool_shipwright_build(
                 outbound_ports_exclude=outbound_ports_exclude,
                 inbound_ports_exclude=inbound_ports_exclude,
                 auth_bridge_mode=auth_bridge_mode,
+                resources=final_resources,
             )
             kube.create_statefulset(namespace, workload_manifest)
             logger.info(
@@ -2281,6 +2288,7 @@ async def finalize_tool_shipwright_build(
                 outbound_ports_exclude=outbound_ports_exclude,
                 inbound_ports_exclude=inbound_ports_exclude,
                 auth_bridge_mode=auth_bridge_mode,
+                resources=final_resources,
             )
             kube.create_deployment(namespace, workload_manifest)
             logger.info(

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -1221,7 +1221,7 @@ def _build_tool_deployment_manifest(
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
     auth_bridge_mode: Optional[str] = None,
-    resources: Optional["ResourceConfig"] = None,
+    resources: Optional[ResourceConfig] = None,
 ) -> dict:
     """
     Build a Kubernetes Deployment manifest for an MCP tool.
@@ -1375,7 +1375,7 @@ def _build_tool_statefulset_manifest(
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
     auth_bridge_mode: Optional[str] = None,
-    resources: Optional["ResourceConfig"] = None,
+    resources: Optional[ResourceConfig] = None,
 ) -> dict:
     """
     Build a Kubernetes StatefulSet manifest for an MCP tool.

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -188,6 +188,13 @@ class PersistentStorageConfig(BaseModel):
     size: str = "1Gi"
 
 
+class ResourceConfig(BaseModel):
+    """Container CPU/memory requests and limits, overriding the platform defaults."""
+
+    requests: Optional[Dict[str, str]] = None
+    limits: Optional[Dict[str, str]] = None
+
+
 class CreateToolRequest(BaseModel):
     """Request to create a new MCP tool.
 
@@ -252,6 +259,9 @@ class CreateToolRequest(BaseModel):
 
     # Outbound routing rules (authproxy-routes ConfigMap)
     outboundRoutes: Optional[List["OutboundRoute"]] = None
+
+    # CPU/memory requests and limits, overriding DEFAULT_RESOURCE_REQUESTS/LIMITS
+    resources: Optional[ResourceConfig] = None
 
 
 class FinalizeToolBuildRequest(BaseModel):
@@ -1199,6 +1209,16 @@ def _ensure_tool_agentruntime(
             raise
 
 
+def _resolve_tool_resources(resources: Optional["ResourceConfig"]) -> Dict[str, Dict[str, str]]:
+    """Merge tool resources overrides over the platform defaults, per requests/limits."""
+    return {
+        "limits": (resources.limits if resources and resources.limits else DEFAULT_RESOURCE_LIMITS),
+        "requests": (
+            resources.requests if resources and resources.requests else DEFAULT_RESOURCE_REQUESTS
+        ),
+    }
+
+
 def _build_tool_deployment_manifest(
     name: str,
     namespace: str,
@@ -1215,6 +1235,7 @@ def _build_tool_deployment_manifest(
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
     auth_bridge_mode: Optional[str] = None,
+    resources: Optional["ResourceConfig"] = None,
 ) -> dict:
     """
     Build a Kubernetes Deployment manifest for an MCP tool.
@@ -1324,10 +1345,7 @@ def _build_tool_deployment_manifest(
                             },
                             "env": all_env_vars,
                             "ports": container_ports,
-                            "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": _resolve_tool_resources(resources),
                             "volumeMounts": [
                                 {"name": "cache", "mountPath": "/app/.cache"},
                                 {"name": "tmp", "mountPath": "/tmp"},
@@ -1371,6 +1389,7 @@ def _build_tool_statefulset_manifest(
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
     auth_bridge_mode: Optional[str] = None,
+    resources: Optional["ResourceConfig"] = None,
 ) -> dict:
     """
     Build a Kubernetes StatefulSet manifest for an MCP tool.
@@ -1485,10 +1504,7 @@ def _build_tool_statefulset_manifest(
                             },
                             "env": all_env_vars,
                             "ports": container_ports,
-                            "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": _resolve_tool_resources(resources),
                             "volumeMounts": [
                                 {"name": "data", "mountPath": "/data"},
                                 {"name": "cache", "mountPath": "/app/.cache"},
@@ -1751,6 +1767,7 @@ async def create_tool(
                     outbound_ports_exclude=request.outboundPortsExclude,
                     inbound_ports_exclude=request.inboundPortsExclude,
                     auth_bridge_mode=request.authBridgeMode,
+                    resources=request.resources,
                 )
                 kube.create_statefulset(request.namespace, workload_manifest)
                 created.append(("StatefulSet", request.name))
@@ -1774,6 +1791,7 @@ async def create_tool(
                     outbound_ports_exclude=request.outboundPortsExclude,
                     inbound_ports_exclude=request.inboundPortsExclude,
                     auth_bridge_mode=request.authBridgeMode,
+                    resources=request.resources,
                 )
                 kube.create_deployment(request.namespace, workload_manifest)
                 created.append(("Deployment", request.name))

--- a/rossoctl/backend/tests/test_sandbox_manifest.py
+++ b/rossoctl/backend/tests/test_sandbox_manifest.py
@@ -32,6 +32,7 @@ def _make_request(**overrides):
     req.defaultOutboundPolicy = overrides.get("defaultOutboundPolicy", None)
     req.persistentStorage = overrides.get("persistentStorage", None)
     req.skills = overrides.get("skills", None)
+    req.resources = overrides.get("resources", None)
     return req
 
 

--- a/rossoctl/backend/tests/test_shipwright.py
+++ b/rossoctl/backend/tests/test_shipwright.py
@@ -16,6 +16,7 @@ import pytest
 
 from app.routers.agents import (
     CreateAgentRequest,
+    ResourceConfig,
     ShipwrightBuildConfig,
     EnvVar,
     ServicePort,
@@ -29,7 +30,9 @@ from app.routers.agents import (
 )
 from app.routers.tools import (
     CreateToolRequest,
+    ResourceConfig as ToolResourceConfig,
     _build_tool_deployment_manifest,
+    _build_tool_shipwright_build_manifest,
     _build_tool_statefulset_manifest,
 )
 from app.core.constants import (
@@ -50,6 +53,8 @@ from app.core.constants import (
     ROSSOCTL_SPIRE_LABEL,
     ROSSOCTL_SPIRE_ENABLED_VALUE,
     RESOURCE_TYPE_AGENT,
+    DEFAULT_RESOURCE_LIMITS,
+    DEFAULT_RESOURCE_REQUESTS,
 )
 
 
@@ -1050,3 +1055,132 @@ class TestSpireLabel:
 
         pod_labels = manifest["spec"]["template"]["metadata"]["labels"]
         assert pod_labels.get(ROSSOCTL_SPIRE_LABEL) == ROSSOCTL_SPIRE_ENABLED_VALUE
+
+
+class TestResourceOverridePropagation:
+    """Verify a custom ResourceConfig actually reaches the generated container
+    resources, and falls back to platform defaults when not provided."""
+
+    def test_agent_deployment_uses_custom_resources(self):
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            resources=ResourceConfig(
+                requests={"cpu": "250m", "memory": "512Mi"},
+                limits={"cpu": "1", "memory": "2Gi"},
+            ),
+        )
+        manifest = _build_deployment_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
+        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
+
+    def test_agent_deployment_falls_back_to_defaults_without_resources(self):
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+        )
+        manifest = _build_deployment_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+        assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
+
+    def test_agent_statefulset_uses_custom_resources(self):
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            workloadType="statefulset",
+            resources=ResourceConfig(requests={"cpu": "250m", "memory": "512Mi"}),
+        )
+        manifest = _build_statefulset_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
+        assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
+
+    def test_agent_shipwright_stores_resources_in_config(self):
+        """Resources must be persisted to the Build annotation so the finalize
+        endpoint can restore them when the request omits them."""
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            gitUrl="https://github.com/example/repo",
+            gitPath="agents/test",
+            deploymentMethod="source",
+            resources=ResourceConfig(requests={"cpu": "250m", "memory": "512Mi"}),
+        )
+        manifest = _build_agent_shipwright_build_manifest(request)
+
+        annotations = manifest["metadata"]["annotations"]
+        config = json.loads(annotations["rossoctl.io/agent-config"])
+        assert config["resources"] == {"requests": {"cpu": "250m", "memory": "512Mi"}}
+
+    def test_tool_deployment_uses_custom_resources(self):
+        manifest = _build_tool_deployment_manifest(
+            name="test-tool",
+            namespace="team1",
+            image="registry.example.com/test-tool:v1",
+            resources=ToolResourceConfig(
+                requests={"cpu": "250m", "memory": "512Mi"},
+                limits={"cpu": "1", "memory": "2Gi"},
+            ),
+        )
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
+        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
+
+    def test_tool_deployment_falls_back_to_defaults_without_resources(self):
+        manifest = _build_tool_deployment_manifest(
+            name="test-tool",
+            namespace="team1",
+            image="registry.example.com/test-tool:v1",
+        )
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+        assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
+
+    def test_tool_statefulset_uses_custom_resources(self):
+        manifest = _build_tool_statefulset_manifest(
+            name="test-tool",
+            namespace="team1",
+            image="registry.example.com/test-tool:v1",
+            resources=ToolResourceConfig(limits={"cpu": "1", "memory": "2Gi"}),
+        )
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
+
+    def test_tool_shipwright_stores_resources_in_config(self):
+        """Resources must be persisted to the Build annotation so the tool
+        finalize endpoint can restore them when the request omits them."""
+        request = CreateToolRequest(
+            name="test-tool",
+            namespace="team1",
+            protocol="streamable_http",
+            framework="Python",
+            gitUrl="https://github.com/example/repo",
+            deploymentMethod="source",
+            resources=ToolResourceConfig(requests={"cpu": "250m", "memory": "512Mi"}),
+        )
+        manifest = _build_tool_shipwright_build_manifest(request)
+
+        annotations = manifest["metadata"]["annotations"]
+        config = json.loads(annotations["rossoctl.io/tool-config"])
+        assert config["resources"] == {"requests": {"cpu": "250m", "memory": "512Mi"}}

--- a/rossoctl/backend/tests/test_shipwright.py
+++ b/rossoctl/backend/tests/test_shipwright.py
@@ -14,9 +14,9 @@ Tests cover:
 import json
 import pytest
 
+from app.models.shipwright import ResourceConfig
 from app.routers.agents import (
     CreateAgentRequest,
-    ResourceConfig,
     ShipwrightBuildConfig,
     EnvVar,
     ServicePort,
@@ -30,7 +30,6 @@ from app.routers.agents import (
 )
 from app.routers.tools import (
     CreateToolRequest,
-    ResourceConfig as ToolResourceConfig,
     _build_tool_deployment_manifest,
     _build_tool_shipwright_build_manifest,
     _build_tool_statefulset_manifest,
@@ -1134,7 +1133,7 @@ class TestResourceOverridePropagation:
             name="test-tool",
             namespace="team1",
             image="registry.example.com/test-tool:v1",
-            resources=ToolResourceConfig(
+            resources=ResourceConfig(
                 requests={"cpu": "250m", "memory": "512Mi"},
                 limits={"cpu": "1", "memory": "2Gi"},
             ),
@@ -1160,7 +1159,7 @@ class TestResourceOverridePropagation:
             name="test-tool",
             namespace="team1",
             image="registry.example.com/test-tool:v1",
-            resources=ToolResourceConfig(limits={"cpu": "1", "memory": "2Gi"}),
+            resources=ResourceConfig(limits={"cpu": "1", "memory": "2Gi"}),
         )
 
         resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
@@ -1177,7 +1176,7 @@ class TestResourceOverridePropagation:
             framework="Python",
             gitUrl="https://github.com/example/repo",
             deploymentMethod="source",
-            resources=ToolResourceConfig(requests={"cpu": "250m", "memory": "512Mi"}),
+            resources=ResourceConfig(requests={"cpu": "250m", "memory": "512Mi"}),
         )
         manifest = _build_tool_shipwright_build_manifest(request)
 

--- a/rossoctl/backend/tests/test_statefulset_manifest.py
+++ b/rossoctl/backend/tests/test_statefulset_manifest.py
@@ -33,6 +33,7 @@ def _make_request(**overrides):
     req.defaultOutboundPolicy = overrides.get("defaultOutboundPolicy", None)
     req.persistentStorage = overrides.get("persistentStorage", None)
     req.skills = overrides.get("skills", None)
+    req.resources = overrides.get("resources", None)
     return req
 
 

--- a/rossoctl/tui/internal/api/types.go
+++ b/rossoctl/tui/internal/api/types.go
@@ -84,12 +84,12 @@ type DeleteResponse struct {
 
 // DashboardConfigResponse holds dashboard URLs.
 type DashboardConfigResponse struct {
-	Traces         string `json:"traces"`
-	Network        string `json:"network"`
-	MCPInspector   string `json:"mcpInspector"`
-	MCPProxy       string `json:"mcpProxy"`
+	Traces          string `json:"traces"`
+	Network         string `json:"network"`
+	MCPInspector    string `json:"mcpInspector"`
+	MCPProxy        string `json:"mcpProxy"`
 	KeycloakConsole string `json:"keycloakConsole"`
-	DomainName     string `json:"domainName"`
+	DomainName      string `json:"domainName"`
 }
 
 // AuthConfigResponse is the auth configuration from the backend.
@@ -191,26 +191,32 @@ type PersistentStorageConfig struct {
 	Size    string `json:"size"`
 }
 
+// ResourceConfig overrides the platform's default container CPU/memory requests and limits.
+type ResourceConfig struct {
+	Requests map[string]string `json:"requests,omitempty"`
+	Limits   map[string]string `json:"limits,omitempty"`
+}
+
 // CreateAgentRequest is the request to create an agent.
 type CreateAgentRequest struct {
-	Name              string                   `json:"name"`
-	Namespace         string                   `json:"namespace"`
-	Protocol          string                   `json:"protocol"`
-	Framework         string                   `json:"framework"`
-	DeploymentMethod  string                   `json:"deploymentMethod"`
-	WorkloadType      string                   `json:"workloadType"`
-	EnvVars           []EnvVar                 `json:"envVars,omitempty"`
-	GitURL            string                   `json:"gitUrl,omitempty"`
-	GitPath           string                   `json:"gitPath,omitempty"`
-	GitBranch         string                   `json:"gitBranch,omitempty"`
-	ImageTag          string                   `json:"imageTag,omitempty"`
-	ContainerImage    string                   `json:"containerImage,omitempty"`
-	ImagePullSecret   string                   `json:"imagePullSecret,omitempty"`
-	ServicePorts      []ServicePort            `json:"servicePorts,omitempty"`
-	CreateHTTPRoute   bool                     `json:"createHttpRoute"`
-	AuthBridgeEnabled bool                     `json:"authBridgeEnabled"`
-	SpireEnabled      bool                     `json:"spireEnabled"`
-	AuthBridgeMode    string                   `json:"authBridgeMode,omitempty"`
+	Name              string        `json:"name"`
+	Namespace         string        `json:"namespace"`
+	Protocol          string        `json:"protocol"`
+	Framework         string        `json:"framework"`
+	DeploymentMethod  string        `json:"deploymentMethod"`
+	WorkloadType      string        `json:"workloadType"`
+	EnvVars           []EnvVar      `json:"envVars,omitempty"`
+	GitURL            string        `json:"gitUrl,omitempty"`
+	GitPath           string        `json:"gitPath,omitempty"`
+	GitBranch         string        `json:"gitBranch,omitempty"`
+	ImageTag          string        `json:"imageTag,omitempty"`
+	ContainerImage    string        `json:"containerImage,omitempty"`
+	ImagePullSecret   string        `json:"imagePullSecret,omitempty"`
+	ServicePorts      []ServicePort `json:"servicePorts,omitempty"`
+	CreateHTTPRoute   bool          `json:"createHttpRoute"`
+	AuthBridgeEnabled bool          `json:"authBridgeEnabled"`
+	SpireEnabled      bool          `json:"spireEnabled"`
+	AuthBridgeMode    string        `json:"authBridgeMode,omitempty"`
 	// MTLSMode maps to AgentRuntime.Spec.MTLSMode. Backend rejects
 	// non-disabled values when AuthBridgeMode is "envoy-sidecar"
 	// (Envoy SDS not currently configured by the rossoctl chart).
@@ -219,6 +225,7 @@ type CreateAgentRequest struct {
 	// kubectl-style or future-CLI usage paths don't drop the field.
 	MTLSMode          string                   `json:"mtlsMode,omitempty"`
 	PersistentStorage *PersistentStorageConfig `json:"persistentStorage,omitempty"`
+	Resources         *ResourceConfig          `json:"resources,omitempty"`
 }
 
 // CreateAgentResponse is the response after creating an agent.
@@ -231,29 +238,30 @@ type CreateAgentResponse struct {
 
 // CreateToolRequest is the request to create a tool.
 type CreateToolRequest struct {
-	Name             string        `json:"name"`
-	Namespace        string        `json:"namespace"`
-	Protocol         string        `json:"protocol"`
-	Framework        string        `json:"framework"`
-	Description      string        `json:"description,omitempty"`
-	DeploymentMethod string        `json:"deploymentMethod"`
-	WorkloadType     string        `json:"workloadType"`
-	EnvVars          []EnvVar      `json:"envVars,omitempty"`
-	ContainerImage   string        `json:"containerImage,omitempty"`
-	ImagePullSecret  string        `json:"imagePullSecret,omitempty"`
-	GitURL           string        `json:"gitUrl,omitempty"`
-	GitRevision      string        `json:"gitRevision,omitempty"`
-	ContextDir       string        `json:"contextDir,omitempty"`
-	ImageTag         string        `json:"imageTag,omitempty"`
-	ServicePorts     []ServicePort `json:"servicePorts,omitempty"`
-	CreateHTTPRoute  bool          `json:"createHttpRoute"`
-	AuthBridgeEnabled bool         `json:"authBridgeEnabled"`
-	SpireEnabled     bool          `json:"spireEnabled"`
+	Name              string        `json:"name"`
+	Namespace         string        `json:"namespace"`
+	Protocol          string        `json:"protocol"`
+	Framework         string        `json:"framework"`
+	Description       string        `json:"description,omitempty"`
+	DeploymentMethod  string        `json:"deploymentMethod"`
+	WorkloadType      string        `json:"workloadType"`
+	EnvVars           []EnvVar      `json:"envVars,omitempty"`
+	ContainerImage    string        `json:"containerImage,omitempty"`
+	ImagePullSecret   string        `json:"imagePullSecret,omitempty"`
+	GitURL            string        `json:"gitUrl,omitempty"`
+	GitRevision       string        `json:"gitRevision,omitempty"`
+	ContextDir        string        `json:"contextDir,omitempty"`
+	ImageTag          string        `json:"imageTag,omitempty"`
+	ServicePorts      []ServicePort `json:"servicePorts,omitempty"`
+	CreateHTTPRoute   bool          `json:"createHttpRoute"`
+	AuthBridgeEnabled bool          `json:"authBridgeEnabled"`
+	SpireEnabled      bool          `json:"spireEnabled"`
 	// AuthBridgeMode maps to AgentRuntime.Spec.AuthBridgeMode for
 	// agents (the deprecated rossoctl.io/authbridge-mode annotation
 	// for tools). Valid values: "proxy-sidecar" (default),
 	// "envoy-sidecar", "lite", "waypoint". Empty = cluster default.
-	AuthBridgeMode string `json:"authBridgeMode,omitempty"`
+	AuthBridgeMode string          `json:"authBridgeMode,omitempty"`
+	Resources      *ResourceConfig `json:"resources,omitempty"`
 }
 
 // CreateToolResponse is the response after creating a tool.


### PR DESCRIPTION
## Summary
- Add `resources` (requests/limits) to `CreateAgentRequest`/`CreateToolRequest`, overriding platform defaults
- Wire through all agent workload builders (Deployment, StatefulSet, Job, Sandbox) and tool builders (Deployment, StatefulSet)
- Mirror `ResourceConfig` in the Go TUI types

Fixes #2203

## Test plan
- [ ] `uv run pytest rossoctl/tests/e2e/ -v`
- [x] `go build ./...` in `rossoctl/tui`
- [x] Backend routers import cleanly; `resources` field confirmed on both Pydantic models

Assisted-By: Claude Code