### PR TITLE
feat: allow k8sResourceLimits/k8sResourceRequests overrides for agents and tools

### DIFF
--- a/rossoctl/backend/app/models/shipwright.py
+++ b/rossoctl/backend/app/models/shipwright.py
@@ -133,6 +133,12 @@ class ResourceConfigFromBuild(BaseModel):
     envVars: Optional[List[Dict[str, Any]]] = None
     skills: Optional[List[str]] = None
     servicePorts: Optional[List[Dict[str, Any]]] = None
+    # Per-workload resource overrides stashed at form-submit time. Declared here
+    # because this model drops undeclared annotation keys (Pydantic's default
+    # extra="ignore"), so a field absent from the model is invisible to callers
+    # that read it back via model_dump() during Shipwright finalize.
+    k8sResourceLimits: Optional[Dict[str, str]] = None
+    k8sResourceRequests: Optional[Dict[str, str]] = None
 
 
 class ShipwrightBuildInfoResponse(BaseModel):

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -323,7 +323,23 @@ class CreateAgentRequest(BaseModel):
     shipwrightConfig: Optional[ShipwrightBuildConfig] = None
 
     # Optional per-agent overrides for container resource limits/requests
-    # (falls back to DEFAULT_RESOURCE_LIMITS / DEFAULT_RESOURCE_REQUESTS)
+    # (falls back to DEFAULT_RESOURCE_LIMITS / DEFAULT_RESOURCE_REQUESTS).
+    #
+    # These are two flat parameters rather than a single aggregating
+    # ResourceConfig{limits, requests} model on purpose. They map 1:1 onto the
+    # two independent dicts the manifest builders already emit, so each can be
+    # overridden without forcing the caller to supply the other, and each falls
+    # back to its own platform default independently. A wrapper model would add
+    # a nesting level and a partially-populated intermediate object without
+    # changing what reaches the container spec.
+    #
+    # The dict accepts arbitrary keys and unvalidated quantity strings. This is
+    # deliberate: validating them here would mean reimplementing Kubernetes
+    # quantity parsing and the set of valid resource names (including extended
+    # resources such as nvidia.com/gpu), a complex validation path that would
+    # still have to be kept in sync with the API server. Instead the values are
+    # passed through and an invalid entry is rejected by the Kubernetes API at
+    # create time, with its error surfaced to the caller.
     k8sResourceLimits: Optional[Dict[str, str]] = None
     k8sResourceRequests: Optional[Dict[str, str]] = None
 
@@ -2607,6 +2623,10 @@ def _build_agent_shipwright_build_manifest(
         resource_config["tlsBridgeEnabled"] = True
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
+    if request.k8sResourceLimits:
+        resource_config["k8sResourceLimits"] = request.k8sResourceLimits
+    if request.k8sResourceRequests:
+        resource_config["k8sResourceRequests"] = request.k8sResourceRequests
     # Add env vars if present
     if request.envVars:
         resource_config["envVars"] = [ev.model_dump(exclude_none=True) for ev in request.envVars]
@@ -4087,6 +4107,11 @@ class FinalizeShipwrightBuildRequest(BaseModel):
     mcpToolName: Optional[str] = None
     llmPreset: Optional[str] = None
     llmModel: Optional[str] = None
+    # Mirror CreateAgentRequest.k8sResourceLimits/k8sResourceRequests. None →
+    # inherit the value stashed on the BuildRun annotation at form-submit time,
+    # so a build-from-source agent gets the same resources as a direct-image one.
+    k8sResourceLimits: Optional[Dict[str, str]] = None
+    k8sResourceRequests: Optional[Dict[str, str]] = None
 
     @model_validator(mode="after")
     def _check_mtls_compatible_with_mode(self) -> "FinalizeShipwrightBuildRequest":
@@ -4417,6 +4442,21 @@ async def finalize_shipwright_build(
         if final_persistent_storage is None and stored_config.get("persistentStorage"):
             final_persistent_storage = PersistentStorageConfig(**stored_config["persistentStorage"])
 
+        # Per-workload resource overrides. Same store-then-read-back flow as
+        # mtlsMode: None on the finalize request → inherit whatever the form
+        # stashed on the BuildRun annotation, else fall back to the platform
+        # defaults inside the manifest builders.
+        final_k8s_resource_limits = (
+            request.k8sResourceLimits
+            if request.k8sResourceLimits is not None
+            else stored_config.get("k8sResourceLimits")
+        )
+        final_k8s_resource_requests = (
+            request.k8sResourceRequests
+            if request.k8sResourceRequests is not None
+            else stored_config.get("k8sResourceRequests")
+        )
+
         final_mcp_tool_name = (
             request.mcpToolName
             if request.mcpToolName is not None
@@ -4459,6 +4499,8 @@ async def finalize_shipwright_build(
             mcpToolName=final_mcp_tool_name,
             llmPreset=final_llm_preset,
             llmModel=final_llm_model,
+            k8sResourceLimits=final_k8s_resource_limits,
+            k8sResourceRequests=final_k8s_resource_requests,
         )
         agent_request = apply_agent_import_defaults(agent_request, kube)
 

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -325,21 +325,11 @@ class CreateAgentRequest(BaseModel):
     # Optional per-agent overrides for container resource limits/requests
     # (falls back to DEFAULT_RESOURCE_LIMITS / DEFAULT_RESOURCE_REQUESTS).
     #
-    # These are two flat parameters rather than a single aggregating
-    # ResourceConfig{limits, requests} model on purpose. They map 1:1 onto the
-    # two independent dicts the manifest builders already emit, so each can be
-    # overridden without forcing the caller to supply the other, and each falls
-    # back to its own platform default independently. A wrapper model would add
-    # a nesting level and a partially-populated intermediate object without
-    # changing what reaches the container spec.
-    #
-    # The dict accepts arbitrary keys and unvalidated quantity strings. This is
-    # deliberate: validating them here would mean reimplementing Kubernetes
-    # quantity parsing and the set of valid resource names (including extended
+    # Note: The keys and quantity strings are not validated. This is
+    # deliberate: validating them here would mean testing Kubernetes
+    # shapes (including extended
     # resources such as nvidia.com/gpu), a complex validation path that would
-    # still have to be kept in sync with the API server. Instead the values are
-    # passed through and an invalid entry is rejected by the Kubernetes API at
-    # create time, with its error surfaced to the caller.
+    # still have to be kept in sync with the API server.
     k8sResourceLimits: Optional[Dict[str, str]] = None
     k8sResourceRequests: Optional[Dict[str, str]] = None
 
@@ -3026,6 +3016,24 @@ def _build_common_annotations(request: "CreateAgentRequest") -> Dict[str, str]:
     return annotations
 
 
+def build_container_resources(
+    limits: Optional[Dict[str, str]] = None,
+    requests: Optional[Dict[str, str]] = None,
+) -> Dict[str, Dict[str, str]]:
+    """Build a container "resources" block from optional per-workload overrides.
+
+    None means "not specified" and selects the platform default. An empty dict is
+    honored as-is, because {} is how Kubernetes spells "no limits" -- it yields an
+    unbounded container rather than one capped at DEFAULT_RESOURCE_LIMITS. Testing
+    truthiness instead (`limits or DEFAULT_RESOURCE_LIMITS`) would collapse those
+    two cases and silently cap a workload the caller asked to leave uncapped.
+    """
+    return {
+        "limits": DEFAULT_RESOURCE_LIMITS if limits is None else limits,
+        "requests": DEFAULT_RESOURCE_REQUESTS if requests is None else requests,
+    }
+
+
 def _build_selector_labels(request: "CreateAgentRequest") -> Dict[str, str]:
     """
     Build selector labels for matching pods to workloads and services.
@@ -3213,11 +3221,9 @@ def _build_deployment_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests
-                                or DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": build_container_resources(
+                                request.k8sResourceLimits, request.k8sResourceRequests
+                            ),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3417,11 +3423,9 @@ def _build_statefulset_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests
-                                or DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": build_container_resources(
+                                request.k8sResourceLimits, request.k8sResourceRequests
+                            ),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3562,11 +3566,9 @@ def _build_job_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests
-                                or DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": build_container_resources(
+                                request.k8sResourceLimits, request.k8sResourceRequests
+                            ),
                             "env": env_vars,
                             "ports": [
                                 {
@@ -3672,11 +3674,9 @@ def _build_sandbox_manifest(
                             "name": "agent",
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
-                            "resources": {
-                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests
-                                or DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": build_container_resources(
+                                request.k8sResourceLimits, request.k8sResourceRequests
+                            ),
                             "env": env_vars,
                             "ports": [
                                 {

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -3195,7 +3195,8 @@ def _build_deployment_manifest(
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
                                 "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
+                                "requests": request.k8sResourceRequests
+                                or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [
@@ -3398,7 +3399,8 @@ def _build_statefulset_manifest(
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
                                 "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
+                                "requests": request.k8sResourceRequests
+                                or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [
@@ -3542,7 +3544,8 @@ def _build_job_manifest(
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
                                 "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
+                                "requests": request.k8sResourceRequests
+                                or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [
@@ -3651,7 +3654,8 @@ def _build_sandbox_manifest(
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
                                 "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
+                                "requests": request.k8sResourceRequests
+                                or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -322,6 +322,11 @@ class CreateAgentRequest(BaseModel):
     # Shipwright build configuration
     shipwrightConfig: Optional[ShipwrightBuildConfig] = None
 
+    # Optional per-agent overrides for container resource limits/requests
+    # (falls back to DEFAULT_RESOURCE_LIMITS / DEFAULT_RESOURCE_REQUESTS)
+    k8sResourceLimits: Optional[Dict[str, str]] = None
+    k8sResourceRequests: Optional[Dict[str, str]] = None
+
     @field_validator("workloadType")
     @classmethod
     def validate_workload_type(cls, v: str) -> str:
@@ -3189,8 +3194,8 @@ def _build_deployment_manifest(
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
+                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [
@@ -3392,8 +3397,8 @@ def _build_statefulset_manifest(
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
+                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [
@@ -3536,8 +3541,8 @@ def _build_job_manifest(
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
+                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [
@@ -3645,8 +3650,8 @@ def _build_sandbox_manifest(
                             "image": image,
                             "imagePullPolicy": DEFAULT_IMAGE_POLICY,
                             "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                                "limits": request.k8sResourceLimits or DEFAULT_RESOURCE_LIMITS,
+                                "requests": request.k8sResourceRequests or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "env": env_vars,
                             "ports": [

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -2613,9 +2613,9 @@ def _build_agent_shipwright_build_manifest(
         resource_config["tlsBridgeEnabled"] = True
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
-    if request.k8sResourceLimits:
+    if request.k8sResourceLimits is not None:
         resource_config["k8sResourceLimits"] = request.k8sResourceLimits
-    if request.k8sResourceRequests:
+    if request.k8sResourceRequests is not None:
         resource_config["k8sResourceRequests"] = request.k8sResourceRequests
     # Add env vars if present
     if request.envVars:

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -327,9 +327,9 @@ class CreateAgentRequest(BaseModel):
     #
     # Note: The keys and quantity strings are not validated. This is
     # deliberate: validating them here would mean testing Kubernetes
-    # shapes (including extended
-    # resources such as nvidia.com/gpu), a complex validation path that would
-    # still have to be kept in sync with the API server.
+    # shapes (including extended resources such as nvidia.com/gpu),
+    # a complex validation path that would still have to be kept in sync
+    # with the API server.
     k8sResourceLimits: Optional[Dict[str, str]] = None
     k8sResourceRequests: Optional[Dict[str, str]] = None
 

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -659,9 +659,9 @@ def _build_tool_shipwright_build_manifest(
     # Add persistent storage config if present (for StatefulSet)
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
-    if request.k8sResourceLimits:
+    if request.k8sResourceLimits is not None:
         resource_config["k8sResourceLimits"] = request.k8sResourceLimits
-    if request.k8sResourceRequests:
+    if request.k8sResourceRequests is not None:
         resource_config["k8sResourceRequests"] = request.k8sResourceRequests
     # Add env vars if present
     if request.envVars:

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -253,6 +253,11 @@ class CreateToolRequest(BaseModel):
     # Outbound routing rules (authproxy-routes ConfigMap)
     outboundRoutes: Optional[List["OutboundRoute"]] = None
 
+    # Optional per-tool overrides for container resource limits/requests
+    # (falls back to DEFAULT_RESOURCE_LIMITS / DEFAULT_RESOURCE_REQUESTS)
+    k8sResourceLimits: Optional[Dict[str, str]] = None
+    k8sResourceRequests: Optional[Dict[str, str]] = None
+
 
 class FinalizeToolBuildRequest(BaseModel):
     """Request to finalize a tool Shipwright build by creating the Deployment/StatefulSet."""
@@ -1215,6 +1220,8 @@ def _build_tool_deployment_manifest(
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
     auth_bridge_mode: Optional[str] = None,
+    resource_limits: Optional[Dict[str, str]] = None,
+    resource_requests: Optional[Dict[str, str]] = None,
 ) -> dict:
     """
     Build a Kubernetes Deployment manifest for an MCP tool.
@@ -1325,8 +1332,8 @@ def _build_tool_deployment_manifest(
                             "env": all_env_vars,
                             "ports": container_ports,
                             "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                                "limits": resource_limits or DEFAULT_RESOURCE_LIMITS,
+                                "requests": resource_requests or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "volumeMounts": [
                                 {"name": "cache", "mountPath": "/app/.cache"},
@@ -1371,6 +1378,8 @@ def _build_tool_statefulset_manifest(
     outbound_ports_exclude: Optional[str] = None,
     inbound_ports_exclude: Optional[str] = None,
     auth_bridge_mode: Optional[str] = None,
+    resource_limits: Optional[Dict[str, str]] = None,
+    resource_requests: Optional[Dict[str, str]] = None,
 ) -> dict:
     """
     Build a Kubernetes StatefulSet manifest for an MCP tool.
@@ -1486,8 +1495,8 @@ def _build_tool_statefulset_manifest(
                             "env": all_env_vars,
                             "ports": container_ports,
                             "resources": {
-                                "limits": DEFAULT_RESOURCE_LIMITS,
-                                "requests": DEFAULT_RESOURCE_REQUESTS,
+                                "limits": resource_limits or DEFAULT_RESOURCE_LIMITS,
+                                "requests": resource_requests or DEFAULT_RESOURCE_REQUESTS,
                             },
                             "volumeMounts": [
                                 {"name": "data", "mountPath": "/data"},
@@ -1751,6 +1760,8 @@ async def create_tool(
                     outbound_ports_exclude=request.outboundPortsExclude,
                     inbound_ports_exclude=request.inboundPortsExclude,
                     auth_bridge_mode=request.authBridgeMode,
+                    resource_limits=request.k8sResourceLimits,
+                    resource_requests=request.k8sResourceRequests,
                 )
                 kube.create_statefulset(request.namespace, workload_manifest)
                 created.append(("StatefulSet", request.name))
@@ -1774,6 +1785,8 @@ async def create_tool(
                     outbound_ports_exclude=request.outboundPortsExclude,
                     inbound_ports_exclude=request.inboundPortsExclude,
                     auth_bridge_mode=request.authBridgeMode,
+                    resource_limits=request.k8sResourceLimits,
+                    resource_requests=request.k8sResourceRequests,
                 )
                 kube.create_deployment(request.namespace, workload_manifest)
                 created.append(("Deployment", request.name))

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -254,7 +254,12 @@ class CreateToolRequest(BaseModel):
     outboundRoutes: Optional[List["OutboundRoute"]] = None
 
     # Optional per-tool overrides for container resource limits/requests
-    # (falls back to DEFAULT_RESOURCE_LIMITS / DEFAULT_RESOURCE_REQUESTS)
+    # (falls back to DEFAULT_RESOURCE_LIMITS / DEFAULT_RESOURCE_REQUESTS).
+    #
+    # Two flat parameters rather than a single aggregating ResourceConfig, and
+    # arbitrary keys accepted without quantity validation. See the matching
+    # fields on CreateAgentRequest in agents.py for the full rationale on both
+    # choices; the two request models are kept symmetrical on purpose.
     k8sResourceLimits: Optional[Dict[str, str]] = None
     k8sResourceRequests: Optional[Dict[str, str]] = None
 
@@ -276,6 +281,11 @@ class FinalizeToolBuildRequest(BaseModel):
     outboundPortsExclude: Optional[str] = None
     inboundPortsExclude: Optional[str] = None
     defaultOutboundPolicy: Optional[Literal["passthrough", "exchange"]] = None
+    # Mirror CreateToolRequest.k8sResourceLimits/k8sResourceRequests so a tool
+    # built from source gets the same resources as a direct-image one instead of
+    # silently falling back to the platform defaults.
+    k8sResourceLimits: Optional[Dict[str, str]] = None
+    k8sResourceRequests: Optional[Dict[str, str]] = None
 
 
 class ToolShipwrightBuildInfoResponse(BaseModel):  # pylint: disable=too-many-instance-attributes
@@ -650,6 +660,10 @@ def _build_tool_shipwright_build_manifest(
     # Add persistent storage config if present (for StatefulSet)
     if request.persistentStorage:
         resource_config["persistentStorage"] = request.persistentStorage.model_dump()
+    if request.k8sResourceLimits:
+        resource_config["k8sResourceLimits"] = request.k8sResourceLimits
+    if request.k8sResourceRequests:
+        resource_config["k8sResourceRequests"] = request.k8sResourceRequests
     # Add env vars if present
     if request.envVars:
         resource_config["envVars"] = [ev.model_dump() for ev in request.envVars]
@@ -2200,6 +2214,19 @@ async def finalize_tool_shipwright_build(
             if request.defaultOutboundPolicy is not None
             else tool_config_dict.get("defaultOutboundPolicy")
         )
+        # Per-workload resource overrides: explicit on the finalize request wins,
+        # else inherit what the form stashed on the Build annotation, else the
+        # manifest builders fall back to the platform defaults.
+        final_k8s_resource_limits = (
+            request.k8sResourceLimits
+            if request.k8sResourceLimits is not None
+            else tool_config_dict.get("k8sResourceLimits")
+        )
+        final_k8s_resource_requests = (
+            request.k8sResourceRequests
+            if request.k8sResourceRequests is not None
+            else tool_config_dict.get("k8sResourceRequests")
+        )
 
         # Ensure a dedicated ServiceAccount exists so the webhook's
         # SPIFFE identity uses the workload name, not the ReplicaSet hash.
@@ -2253,6 +2280,8 @@ async def finalize_tool_shipwright_build(
                 outbound_ports_exclude=outbound_ports_exclude,
                 inbound_ports_exclude=inbound_ports_exclude,
                 auth_bridge_mode=auth_bridge_mode,
+                resource_limits=final_k8s_resource_limits,
+                resource_requests=final_k8s_resource_requests,
             )
             kube.create_statefulset(namespace, workload_manifest)
             logger.info(
@@ -2276,6 +2305,8 @@ async def finalize_tool_shipwright_build(
                 outbound_ports_exclude=outbound_ports_exclude,
                 inbound_ports_exclude=inbound_ports_exclude,
                 auth_bridge_mode=auth_bridge_mode,
+                resource_limits=final_k8s_resource_limits,
+                resource_requests=final_k8s_resource_requests,
             )
             kube.create_deployment(namespace, workload_manifest)
             logger.info(

--- a/rossoctl/backend/app/routers/tools.py
+++ b/rossoctl/backend/app/routers/tools.py
@@ -44,8 +44,6 @@ from app.core.constants import (
     WORKLOAD_TYPE_DEPLOYMENT,
     WORKLOAD_TYPE_STATEFULSET,
     DEFAULT_IN_CLUSTER_PORT,
-    DEFAULT_RESOURCE_LIMITS,
-    DEFAULT_RESOURCE_REQUESTS,
     DEFAULT_ENV_VARS,
     # Shipwright constants
     SHIPWRIGHT_CRD_GROUP,
@@ -99,6 +97,7 @@ from app.utils.routes import (
 from app.routers.agents import (
     _ensure_authbridge_configmaps,
     _ensure_authproxy_routes,
+    build_container_resources,
     OutboundRoute,
 )
 
@@ -1345,10 +1344,9 @@ def _build_tool_deployment_manifest(
                             },
                             "env": all_env_vars,
                             "ports": container_ports,
-                            "resources": {
-                                "limits": resource_limits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": resource_requests or DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": build_container_resources(
+                                resource_limits, resource_requests
+                            ),
                             "volumeMounts": [
                                 {"name": "cache", "mountPath": "/app/.cache"},
                                 {"name": "tmp", "mountPath": "/tmp"},
@@ -1508,10 +1506,9 @@ def _build_tool_statefulset_manifest(
                             },
                             "env": all_env_vars,
                             "ports": container_ports,
-                            "resources": {
-                                "limits": resource_limits or DEFAULT_RESOURCE_LIMITS,
-                                "requests": resource_requests or DEFAULT_RESOURCE_REQUESTS,
-                            },
+                            "resources": build_container_resources(
+                                resource_limits, resource_requests
+                            ),
                             "volumeMounts": [
                                 {"name": "data", "mountPath": "/data"},
                                 {"name": "cache", "mountPath": "/app/.cache"},

--- a/rossoctl/backend/tests/test_sandbox_manifest.py
+++ b/rossoctl/backend/tests/test_sandbox_manifest.py
@@ -32,6 +32,8 @@ def _make_request(**overrides):
     req.defaultOutboundPolicy = overrides.get("defaultOutboundPolicy", None)
     req.persistentStorage = overrides.get("persistentStorage", None)
     req.skills = overrides.get("skills", None)
+    req.k8sResourceLimits = overrides.get("k8sResourceLimits", None)
+    req.k8sResourceRequests = overrides.get("k8sResourceRequests", None)
     return req
 
 

--- a/rossoctl/backend/tests/test_shipwright.py
+++ b/rossoctl/backend/tests/test_shipwright.py
@@ -50,6 +50,8 @@ from app.core.constants import (
     ROSSOCTL_SPIRE_LABEL,
     ROSSOCTL_SPIRE_ENABLED_VALUE,
     RESOURCE_TYPE_AGENT,
+    DEFAULT_RESOURCE_LIMITS,
+    DEFAULT_RESOURCE_REQUESTS,
 )
 
 
@@ -1050,3 +1052,55 @@ class TestSpireLabel:
 
         pod_labels = manifest["spec"]["template"]["metadata"]["labels"]
         assert pod_labels.get(ROSSOCTL_SPIRE_LABEL) == ROSSOCTL_SPIRE_ENABLED_VALUE
+
+
+class TestResourceOverridePropagation:
+    """Verify k8sResourceLimits/k8sResourceRequests overrides reach the
+    generated container resources, and fall back to platform defaults
+    when not provided."""
+
+    def test_agent_deployment_uses_custom_resources(self):
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            k8sResourceLimits={"cpu": "1", "memory": "2Gi"},
+            k8sResourceRequests={"cpu": "250m", "memory": "512Mi"},
+        )
+        manifest = _build_deployment_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
+        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
+
+    def test_agent_statefulset_falls_back_to_defaults_without_overrides(self):
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            workloadType="statefulset",
+        )
+        manifest = _build_statefulset_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+
+    def test_tool_deployment_uses_custom_resources(self):
+        manifest = _build_tool_deployment_manifest(
+            name="test-tool",
+            namespace="team1",
+            image="registry.example.com/test-tool:v1",
+            resource_limits={"cpu": "1", "memory": "2Gi"},
+            resource_requests={"cpu": "250m", "memory": "512Mi"},
+        )
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
+        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}

--- a/rossoctl/backend/tests/test_shipwright.py
+++ b/rossoctl/backend/tests/test_shipwright.py
@@ -1108,8 +1108,16 @@ class TestResourceOverridePropagation:
         assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
         assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
 
-    def test_tool_statefulset_uses_custom_resources(self):
-        manifest = _build_tool_statefulset_manifest(
+    # Both tool builders emit their own container spec, so every resource case
+    # runs against each one. Covering only the statefulset would let a
+    # deployment-path regression through whenever the wrong values are still
+    # non-empty (a fallback- or {}-only check cannot see that).
+    _TOOL_BUILDERS = [_build_tool_deployment_manifest, _build_tool_statefulset_manifest]
+
+    @pytest.mark.parametrize("builder", _TOOL_BUILDERS)
+    def test_tool_workloads_use_custom_resources(self, builder):
+        """Overrides reach the container spec for both tool workload types."""
+        manifest = builder(
             name="test-tool",
             namespace="team1",
             image="registry.example.com/test-tool:v1",
@@ -1121,10 +1129,7 @@ class TestResourceOverridePropagation:
         assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
         assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
 
-    @pytest.mark.parametrize(
-        "builder",
-        [_build_tool_deployment_manifest, _build_tool_statefulset_manifest],
-    )
+    @pytest.mark.parametrize("builder", _TOOL_BUILDERS)
     def test_tool_workloads_fall_back_to_defaults(self, builder):
         """Tool builders keep the platform defaults when no override is passed."""
         manifest = builder(
@@ -1213,10 +1218,7 @@ class TestResourceOverridePropagation:
         assert resources["limits"] == {}
         assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
 
-    @pytest.mark.parametrize(
-        "builder",
-        [_build_tool_deployment_manifest, _build_tool_statefulset_manifest],
-    )
+    @pytest.mark.parametrize("builder", _TOOL_BUILDERS)
     def test_tool_empty_dict_means_unbounded(self, builder):
         """Tool builders honor {} the same way the agent builders do."""
         manifest = builder(

--- a/rossoctl/backend/tests/test_shipwright.py
+++ b/rossoctl/backend/tests/test_shipwright.py
@@ -1060,52 +1060,6 @@ class TestResourceOverridePropagation:
     generated container resources, and fall back to platform defaults
     when not provided."""
 
-    def test_agent_deployment_uses_custom_resources(self):
-        request = CreateAgentRequest(
-            name="test-agent",
-            namespace="team1",
-            protocol="a2a",
-            framework="LangGraph",
-            deploymentMethod="image",
-            containerImage="registry.example.com/test-agent:v1",
-            k8sResourceLimits={"cpu": "1", "memory": "2Gi"},
-            k8sResourceRequests={"cpu": "250m", "memory": "512Mi"},
-        )
-        manifest = _build_deployment_manifest(request, image="registry.example.com/test-agent:v1")
-
-        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
-        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
-        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
-
-    def test_agent_statefulset_falls_back_to_defaults_without_overrides(self):
-        request = CreateAgentRequest(
-            name="test-agent",
-            namespace="team1",
-            protocol="a2a",
-            framework="LangGraph",
-            deploymentMethod="image",
-            containerImage="registry.example.com/test-agent:v1",
-            workloadType="statefulset",
-        )
-        manifest = _build_statefulset_manifest(request, image="registry.example.com/test-agent:v1")
-
-        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
-        assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
-        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
-
-    def test_tool_deployment_uses_custom_resources(self):
-        manifest = _build_tool_deployment_manifest(
-            name="test-tool",
-            namespace="team1",
-            image="registry.example.com/test-tool:v1",
-            resource_limits={"cpu": "1", "memory": "2Gi"},
-            resource_requests={"cpu": "250m", "memory": "512Mi"},
-        )
-
-        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
-        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
-        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
-
     # Every agent workload type emits its own container spec, so each builder is
     # exercised independently -- a regression in one would otherwise hide behind
     # the deployment-only coverage above. workloadType is left at its default:
@@ -1220,6 +1174,63 @@ class TestResourceOverridePropagation:
         resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
         assert resources["limits"] == {"nvidia.com/gpu": "1"}
 
+    @pytest.mark.parametrize(("builder", "pod_spec_getter"), _AGENT_BUILDERS)
+    def test_empty_dict_means_unbounded_not_default(self, builder, pod_spec_getter):
+        """{} is how Kubernetes spells "no limits", so it must be honored rather
+        than collapsed into the platform defaults. This is the case a truthiness
+        check (`limits or DEFAULT_RESOURCE_LIMITS`) would silently cap."""
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            k8sResourceLimits={},
+            k8sResourceRequests={},
+        )
+        manifest = builder(request, image="registry.example.com/test-agent:v1")
+
+        resources = pod_spec_getter(manifest)["containers"][0]["resources"]
+        assert resources["limits"] == {}
+        assert resources["requests"] == {}
+
+    def test_empty_dict_is_honored_per_field(self):
+        """Clearing only limits leaves requests on its default, so an unbounded
+        ceiling can be combined with a normal scheduling floor."""
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            k8sResourceLimits={},
+        )
+        manifest = _build_deployment_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {}
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+
+    @pytest.mark.parametrize(
+        "builder",
+        [_build_tool_deployment_manifest, _build_tool_statefulset_manifest],
+    )
+    def test_tool_empty_dict_means_unbounded(self, builder):
+        """Tool builders honor {} the same way the agent builders do."""
+        manifest = builder(
+            name="test-tool",
+            namespace="team1",
+            image="registry.example.com/test-tool:v1",
+            resource_limits={},
+            resource_requests={},
+        )
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {}
+        assert resources["requests"] == {}
+
 
 class TestAgentResourceOverrideRoundTrip:
     """A build-from-source agent must get the resources chosen at form-submit
@@ -1248,24 +1259,16 @@ class TestAgentResourceOverrideRoundTrip:
         assert stored_config["k8sResourceLimits"] == {"cpu": "2", "memory": "4Gi"}
         assert stored_config["k8sResourceRequests"] == {"cpu": "500m", "memory": "1Gi"}
 
-    def test_build_manifest_omits_absent_resource_overrides(self):
-        request = CreateAgentRequest(
-            name="plain-agent",
-            namespace="team1",
-            protocol="a2a",
-            framework="LangGraph",
-            deploymentMethod="source",
-            gitUrl="https://github.com/example/repo",
-            gitPath="agents/plain",
-            gitBranch="main",
-            imageTag="v0.0.1",
+        # Absent overrides are omitted rather than stored as null, so the
+        # finalize read-back falls through to the platform defaults.
+        without_overrides = _build_agent_shipwright_build_manifest(
+            request.model_copy(update={"k8sResourceLimits": None, "k8sResourceRequests": None})
         )
-
-        manifest = _build_agent_shipwright_build_manifest(request)
-
-        stored_config = json.loads(manifest["metadata"]["annotations"]["rossoctl.io/agent-config"])
-        assert "k8sResourceLimits" not in stored_config
-        assert "k8sResourceRequests" not in stored_config
+        bare_config = json.loads(
+            without_overrides["metadata"]["annotations"]["rossoctl.io/agent-config"]
+        )
+        assert "k8sResourceLimits" not in bare_config
+        assert "k8sResourceRequests" not in bare_config
 
     def test_stored_overrides_reach_the_container_spec(self):
         """End-to-end on the finalize seam: the annotation written at build time
@@ -1313,24 +1316,3 @@ class TestAgentResourceOverrideRoundTrip:
         resources = deployment["spec"]["template"]["spec"]["containers"][0]["resources"]
         assert resources["limits"] == {"cpu": "2", "memory": "4Gi"}
         assert resources["requests"] == {"cpu": "500m", "memory": "1Gi"}
-
-    def test_finalize_request_overrides_take_precedence(self):
-        """An explicit value on the finalize call wins over the stored one."""
-        stored_config = {"k8sResourceLimits": {"cpu": "2", "memory": "4Gi"}}
-        finalize_request = FinalizeShipwrightBuildRequest(
-            k8sResourceLimits={"cpu": "8", "memory": "16Gi"},
-        )
-
-        resolved = (
-            finalize_request.k8sResourceLimits
-            if finalize_request.k8sResourceLimits is not None
-            else stored_config.get("k8sResourceLimits")
-        )
-
-        assert resolved == {"cpu": "8", "memory": "16Gi"}
-
-    def test_finalize_request_defaults_to_none_for_inheritance(self):
-        request = FinalizeShipwrightBuildRequest()
-
-        assert request.k8sResourceLimits is None
-        assert request.k8sResourceRequests is None

--- a/rossoctl/backend/tests/test_shipwright.py
+++ b/rossoctl/backend/tests/test_shipwright.py
@@ -16,6 +16,7 @@ import pytest
 
 from app.routers.agents import (
     CreateAgentRequest,
+    FinalizeShipwrightBuildRequest,
     ShipwrightBuildConfig,
     EnvVar,
     ServicePort,
@@ -1104,3 +1105,232 @@ class TestResourceOverridePropagation:
         resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
         assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
         assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
+
+    # Every agent workload type emits its own container spec, so each builder is
+    # exercised independently -- a regression in one would otherwise hide behind
+    # the deployment-only coverage above. workloadType is left at its default:
+    # the builder under test determines the shape, and "sandbox" is not an
+    # accepted value on CreateAgentRequest.
+    _AGENT_BUILDERS = [
+        (_build_deployment_manifest, lambda m: m["spec"]["template"]["spec"]),
+        (_build_statefulset_manifest, lambda m: m["spec"]["template"]["spec"]),
+        (_build_job_manifest, lambda m: m["spec"]["template"]["spec"]),
+        (_build_sandbox_manifest, lambda m: m["spec"]["podTemplate"]["spec"]),
+    ]
+
+    @pytest.mark.parametrize(("builder", "pod_spec_getter"), _AGENT_BUILDERS)
+    def test_agent_workloads_use_custom_resources(self, builder, pod_spec_getter):
+        """Overrides reach the container spec for every agent workload type."""
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            k8sResourceLimits={"cpu": "1", "memory": "2Gi"},
+            k8sResourceRequests={"cpu": "250m", "memory": "512Mi"},
+        )
+        manifest = builder(request, image="registry.example.com/test-agent:v1")
+
+        resources = pod_spec_getter(manifest)["containers"][0]["resources"]
+        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
+        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
+
+    @pytest.mark.parametrize(("builder", "pod_spec_getter"), _AGENT_BUILDERS)
+    def test_agent_workloads_fall_back_to_defaults(self, builder, pod_spec_getter):
+        """Omitting the overrides leaves the platform defaults untouched."""
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+        )
+        manifest = builder(request, image="registry.example.com/test-agent:v1")
+
+        resources = pod_spec_getter(manifest)["containers"][0]["resources"]
+        assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+
+    def test_tool_statefulset_uses_custom_resources(self):
+        manifest = _build_tool_statefulset_manifest(
+            name="test-tool",
+            namespace="team1",
+            image="registry.example.com/test-tool:v1",
+            resource_limits={"cpu": "1", "memory": "2Gi"},
+            resource_requests={"cpu": "250m", "memory": "512Mi"},
+        )
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {"cpu": "1", "memory": "2Gi"}
+        assert resources["requests"] == {"cpu": "250m", "memory": "512Mi"}
+
+    @pytest.mark.parametrize(
+        "builder",
+        [_build_tool_deployment_manifest, _build_tool_statefulset_manifest],
+    )
+    def test_tool_workloads_fall_back_to_defaults(self, builder):
+        """Tool builders keep the platform defaults when no override is passed."""
+        manifest = builder(
+            name="test-tool",
+            namespace="team1",
+            image="registry.example.com/test-tool:v1",
+        )
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == DEFAULT_RESOURCE_LIMITS
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+
+    def test_only_the_supplied_override_replaces_its_default(self):
+        """The two parameters are independent: overriding limits alone must not
+        disturb requests. This is the behavior that motivates two flat fields
+        rather than a single aggregating ResourceConfig."""
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            k8sResourceLimits={"cpu": "4", "memory": "8Gi"},
+        )
+        manifest = _build_deployment_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {"cpu": "4", "memory": "8Gi"}
+        assert resources["requests"] == DEFAULT_RESOURCE_REQUESTS
+
+    def test_arbitrary_resource_keys_pass_through(self):
+        """Extended resources (e.g. GPUs) are forwarded verbatim rather than
+        rejected, since quantity/name validation is deferred to the Kubernetes
+        API server instead of being reimplemented here."""
+        request = CreateAgentRequest(
+            name="test-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/test-agent:v1",
+            k8sResourceLimits={"nvidia.com/gpu": "1"},
+        )
+        manifest = _build_deployment_manifest(request, image="registry.example.com/test-agent:v1")
+
+        resources = manifest["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {"nvidia.com/gpu": "1"}
+
+
+class TestAgentResourceOverrideRoundTrip:
+    """A build-from-source agent must get the resources chosen at form-submit
+    time. The finalize path reconstructs a CreateAgentRequest from the Build
+    annotation, so the overrides have to survive that store-then-read-back
+    trip or the workload silently falls back to the platform defaults."""
+
+    def test_build_manifest_stores_resource_overrides(self):
+        request = CreateAgentRequest(
+            name="gpu-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="source",
+            gitUrl="https://github.com/example/repo",
+            gitPath="agents/gpu",
+            gitBranch="main",
+            imageTag="v0.0.1",
+            k8sResourceLimits={"cpu": "2", "memory": "4Gi"},
+            k8sResourceRequests={"cpu": "500m", "memory": "1Gi"},
+        )
+
+        manifest = _build_agent_shipwright_build_manifest(request)
+
+        stored_config = json.loads(manifest["metadata"]["annotations"]["rossoctl.io/agent-config"])
+        assert stored_config["k8sResourceLimits"] == {"cpu": "2", "memory": "4Gi"}
+        assert stored_config["k8sResourceRequests"] == {"cpu": "500m", "memory": "1Gi"}
+
+    def test_build_manifest_omits_absent_resource_overrides(self):
+        request = CreateAgentRequest(
+            name="plain-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="source",
+            gitUrl="https://github.com/example/repo",
+            gitPath="agents/plain",
+            gitBranch="main",
+            imageTag="v0.0.1",
+        )
+
+        manifest = _build_agent_shipwright_build_manifest(request)
+
+        stored_config = json.loads(manifest["metadata"]["annotations"]["rossoctl.io/agent-config"])
+        assert "k8sResourceLimits" not in stored_config
+        assert "k8sResourceRequests" not in stored_config
+
+    def test_stored_overrides_reach_the_container_spec(self):
+        """End-to-end on the finalize seam: the annotation written at build time
+        is what the finalize path reads back, so feeding it into the rebuilt
+        request must produce a container with the overridden resources."""
+        build_request = CreateAgentRequest(
+            name="gpu-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="source",
+            gitUrl="https://github.com/example/repo",
+            gitPath="agents/gpu",
+            gitBranch="main",
+            imageTag="v0.0.1",
+            k8sResourceLimits={"cpu": "2", "memory": "4Gi"},
+            k8sResourceRequests={"cpu": "500m", "memory": "1Gi"},
+        )
+        manifest = _build_agent_shipwright_build_manifest(build_request)
+        stored_config = json.loads(manifest["metadata"]["annotations"]["rossoctl.io/agent-config"])
+
+        # Mirrors how finalize_shipwright_build rebuilds the request: no explicit
+        # override on the finalize call, so the stored values are inherited.
+        finalize_request = FinalizeShipwrightBuildRequest()
+        rebuilt = CreateAgentRequest(
+            name="gpu-agent",
+            namespace="team1",
+            protocol="a2a",
+            framework="LangGraph",
+            deploymentMethod="image",
+            containerImage="registry.example.com/gpu-agent:v1",
+            k8sResourceLimits=(
+                finalize_request.k8sResourceLimits
+                if finalize_request.k8sResourceLimits is not None
+                else stored_config.get("k8sResourceLimits")
+            ),
+            k8sResourceRequests=(
+                finalize_request.k8sResourceRequests
+                if finalize_request.k8sResourceRequests is not None
+                else stored_config.get("k8sResourceRequests")
+            ),
+        )
+        deployment = _build_deployment_manifest(rebuilt, image="registry.example.com/gpu-agent:v1")
+
+        resources = deployment["spec"]["template"]["spec"]["containers"][0]["resources"]
+        assert resources["limits"] == {"cpu": "2", "memory": "4Gi"}
+        assert resources["requests"] == {"cpu": "500m", "memory": "1Gi"}
+
+    def test_finalize_request_overrides_take_precedence(self):
+        """An explicit value on the finalize call wins over the stored one."""
+        stored_config = {"k8sResourceLimits": {"cpu": "2", "memory": "4Gi"}}
+        finalize_request = FinalizeShipwrightBuildRequest(
+            k8sResourceLimits={"cpu": "8", "memory": "16Gi"},
+        )
+
+        resolved = (
+            finalize_request.k8sResourceLimits
+            if finalize_request.k8sResourceLimits is not None
+            else stored_config.get("k8sResourceLimits")
+        )
+
+        assert resolved == {"cpu": "8", "memory": "16Gi"}
+
+    def test_finalize_request_defaults_to_none_for_inheritance(self):
+        request = FinalizeShipwrightBuildRequest()
+
+        assert request.k8sResourceLimits is None
+        assert request.k8sResourceRequests is None

--- a/rossoctl/backend/tests/test_shipwright_tools.py
+++ b/rossoctl/backend/tests/test_shipwright_tools.py
@@ -460,3 +460,94 @@ class TestToolBuildInfoResponse:
         assert response.toolConfig is not None
         assert response.toolConfig.protocol == "streamable_http"
         assert response.toolConfig.createHttpRoute is True
+
+
+class TestToolResourceOverrideRoundTrip:
+    """A tool built from source must end up with the resources chosen at
+    form-submit time. That requires the overrides to survive the whole
+    store-then-read-back path: CreateToolRequest -> Build annotation ->
+    ResourceConfigFromBuild -> finalize. A break anywhere in that chain
+    silently downgrades the workload to the platform defaults."""
+
+    def test_build_manifest_stores_resource_overrides(self):
+        request = CreateToolRequest(
+            name="gpu-tool",
+            namespace="team1",
+            protocol="streamable_http",
+            framework="Python",
+            deploymentMethod="source",
+            gitUrl="https://github.com/example/tools",
+            contextDir="tools/gpu",
+            k8sResourceLimits={"cpu": "2", "memory": "4Gi"},
+            k8sResourceRequests={"cpu": "500m", "memory": "1Gi"},
+        )
+
+        manifest = _build_tool_shipwright_build_manifest(request)
+
+        tool_config = json.loads(manifest["metadata"]["annotations"]["rossoctl.io/tool-config"])
+        assert tool_config["k8sResourceLimits"] == {"cpu": "2", "memory": "4Gi"}
+        assert tool_config["k8sResourceRequests"] == {"cpu": "500m", "memory": "1Gi"}
+
+    def test_build_manifest_omits_absent_resource_overrides(self):
+        request = CreateToolRequest(
+            name="plain-tool",
+            namespace="team1",
+            protocol="streamable_http",
+            framework="Python",
+            deploymentMethod="source",
+            gitUrl="https://github.com/example/tools",
+            contextDir="tools/plain",
+        )
+
+        manifest = _build_tool_shipwright_build_manifest(request)
+
+        tool_config = json.loads(manifest["metadata"]["annotations"]["rossoctl.io/tool-config"])
+        assert "k8sResourceLimits" not in tool_config
+        assert "k8sResourceRequests" not in tool_config
+
+    def test_extracted_config_preserves_resource_overrides(self):
+        """ResourceConfigFromBuild drops annotation keys it does not declare, so
+        this guards against the fields being silently discarded on read-back."""
+        build = {
+            "metadata": {
+                "name": "gpu-tool",
+                "namespace": "team1",
+                "annotations": {
+                    "rossoctl.io/tool-config": json.dumps(
+                        {
+                            "protocol": "streamable_http",
+                            "framework": "Python",
+                            "k8sResourceLimits": {"cpu": "2", "memory": "4Gi"},
+                            "k8sResourceRequests": {"cpu": "500m", "memory": "1Gi"},
+                        }
+                    )
+                },
+            }
+        }
+
+        config = extract_resource_config_from_build(build, ResourceType.TOOL)
+
+        assert config is not None
+        assert config.k8sResourceLimits == {"cpu": "2", "memory": "4Gi"}
+        assert config.k8sResourceRequests == {"cpu": "500m", "memory": "1Gi"}
+        # The finalize path reads this via model_dump(); confirm it survives too.
+        assert config.model_dump()["k8sResourceLimits"] == {"cpu": "2", "memory": "4Gi"}
+
+    def test_finalize_request_accepts_resource_overrides(self):
+        """An explicit override on the finalize call must be representable, so it
+        can take precedence over whatever the annotation stored."""
+        request = FinalizeToolBuildRequest(
+            k8sResourceLimits={"cpu": "8", "memory": "16Gi"},
+            k8sResourceRequests={"cpu": "1", "memory": "2Gi"},
+        )
+
+        assert request.k8sResourceLimits == {"cpu": "8", "memory": "16Gi"}
+        assert request.k8sResourceRequests == {"cpu": "1", "memory": "2Gi"}
+
+    def test_finalize_request_defaults_to_none_for_inheritance(self):
+        """None is the sentinel that means 'inherit the stored value', so it must
+        not be conflated with an empty dict."""
+        request = FinalizeToolBuildRequest()
+
+        assert request.k8sResourceLimits is None
+        assert request.k8sResourceRequests is None

--- a/rossoctl/backend/tests/test_shipwright_tools.py
+++ b/rossoctl/backend/tests/test_shipwright_tools.py
@@ -488,22 +488,16 @@ class TestToolResourceOverrideRoundTrip:
         assert tool_config["k8sResourceLimits"] == {"cpu": "2", "memory": "4Gi"}
         assert tool_config["k8sResourceRequests"] == {"cpu": "500m", "memory": "1Gi"}
 
-    def test_build_manifest_omits_absent_resource_overrides(self):
-        request = CreateToolRequest(
-            name="plain-tool",
-            namespace="team1",
-            protocol="streamable_http",
-            framework="Python",
-            deploymentMethod="source",
-            gitUrl="https://github.com/example/tools",
-            contextDir="tools/plain",
+        # Absent overrides are omitted rather than stored as null, so the
+        # finalize read-back falls through to the platform defaults.
+        without_overrides = _build_tool_shipwright_build_manifest(
+            request.model_copy(update={"k8sResourceLimits": None, "k8sResourceRequests": None})
         )
-
-        manifest = _build_tool_shipwright_build_manifest(request)
-
-        tool_config = json.loads(manifest["metadata"]["annotations"]["rossoctl.io/tool-config"])
-        assert "k8sResourceLimits" not in tool_config
-        assert "k8sResourceRequests" not in tool_config
+        bare_config = json.loads(
+            without_overrides["metadata"]["annotations"]["rossoctl.io/tool-config"]
+        )
+        assert "k8sResourceLimits" not in bare_config
+        assert "k8sResourceRequests" not in bare_config
 
     def test_extracted_config_preserves_resource_overrides(self):
         """ResourceConfigFromBuild drops annotation keys it does not declare, so
@@ -532,22 +526,3 @@ class TestToolResourceOverrideRoundTrip:
         assert config.k8sResourceRequests == {"cpu": "500m", "memory": "1Gi"}
         # The finalize path reads this via model_dump(); confirm it survives too.
         assert config.model_dump()["k8sResourceLimits"] == {"cpu": "2", "memory": "4Gi"}
-
-    def test_finalize_request_accepts_resource_overrides(self):
-        """An explicit override on the finalize call must be representable, so it
-        can take precedence over whatever the annotation stored."""
-        request = FinalizeToolBuildRequest(
-            k8sResourceLimits={"cpu": "8", "memory": "16Gi"},
-            k8sResourceRequests={"cpu": "1", "memory": "2Gi"},
-        )
-
-        assert request.k8sResourceLimits == {"cpu": "8", "memory": "16Gi"}
-        assert request.k8sResourceRequests == {"cpu": "1", "memory": "2Gi"}
-
-    def test_finalize_request_defaults_to_none_for_inheritance(self):
-        """None is the sentinel that means 'inherit the stored value', so it must
-        not be conflated with an empty dict."""
-        request = FinalizeToolBuildRequest()
-
-        assert request.k8sResourceLimits is None
-        assert request.k8sResourceRequests is None

--- a/rossoctl/backend/tests/test_statefulset_manifest.py
+++ b/rossoctl/backend/tests/test_statefulset_manifest.py
@@ -33,6 +33,8 @@ def _make_request(**overrides):
     req.defaultOutboundPolicy = overrides.get("defaultOutboundPolicy", None)
     req.persistentStorage = overrides.get("persistentStorage", None)
     req.skills = overrides.get("skills", None)
+    req.k8sResourceLimits = overrides.get("k8sResourceLimits", None)
+    req.k8sResourceRequests = overrides.get("k8sResourceRequests", None)
     return req
 
 


### PR DESCRIPTION
Resolves #2203

## Summary
- Add optional `k8sResourceLimits`/`k8sResourceRequests` fields to `CreateAgentRequest` and `CreateToolRequest`
- When supplied, override `DEFAULT_RESOURCE_LIMITS`/`DEFAULT_RESOURCE_REQUESTS` in generated manifests

## Test plan
- [x] `uv run pytest tests/` passes (703 passed)

Assisted-By: Claude Code