### PR TITLE
feat: integrate optional Context Service

### DIFF
--- a/charts/rossoctl/templates/ui.yaml
+++ b/charts/rossoctl/templates/ui.yaml
@@ -146,6 +146,10 @@ spec:
             - name: SKILL_REGISTRY_ALLOWED_HOSTS
               value: {{ .Values.ui.backend.skillRegistryAllowedHosts | quote }}
             {{- end }}
+            {{- if .Values.ui.backend.contextServiceUrl }}
+            - name: CONTEXT_SERVICE_URL
+              value: {{ .Values.ui.backend.contextServiceUrl | quote }}
+            {{- end }}
             # Feature flags
             - name: ROSSOCTL_FEATURE_FLAG_SANDBOX
               value: "{{ .Values.featureFlags.sandbox }}"

--- a/charts/rossoctl/tests/ui_test.yaml
+++ b/charts/rossoctl/tests/ui_test.yaml
@@ -34,3 +34,27 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 64Mi
+
+  - it: leaves Context Service disabled when no URL is configured
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: backend
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CONTEXT_SERVICE_URL
+          any: true
+
+  - it: configures Context Service when its URL is set
+    set:
+      ui.backend.contextServiceUrl: http://context-service.example:8080
+    documentSelector:
+      path: spec.template.spec.containers[0].name
+      value: backend
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CONTEXT_SERVICE_URL
+            value: http://context-service.example:8080

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -212,6 +212,10 @@ ui:
   backend:
     image: ghcr.io/rossoctl/rossoctl/backend
     tag: v0.7.0-alpha.6
+    # Optional Context Service API URL. Empty disables context resource APIs and
+    # agent context attachments. Example:
+    # http://context-service.serverless-harness.svc.cluster.local:8080
+    contextServiceUrl: ""
     # Default registry for source-based builds (Kind: registry.cr-system.svc.cluster.local:5000)
     defaultRegistryUrl: ""
     # Default Shipwright build strategy for internal registries

--- a/docs/concepts/context-service.md
+++ b/docs/concepts/context-service.md
@@ -1,0 +1,126 @@
+# Context Service
+
+Rosso can optionally use [Context Service](https://github.com/rossoctl/context-service)
+to provision named storage resources and attach them to StatefulSet or Sandbox agents.
+Context Service is installed separately from Rosso.
+
+## Configure Rosso
+
+The integration is disabled when `CONTEXT_SERVICE_URL` is empty or unset. A cluster
+administrator can enable it through the Rosso Helm chart:
+
+```yaml
+# context-service-values.yaml
+ui:
+  backend:
+    contextServiceUrl: http://context-service.serverless-harness.svc.cluster.local:8080
+```
+
+Apply the setting to an existing installation:
+
+```sh
+helm upgrade rossoctl ./charts/rossoctl \
+  --namespace rossoctl-system \
+  --reuse-values \
+  -f context-service-values.yaml
+```
+
+The equivalent command-line override is:
+
+```sh
+helm upgrade rossoctl ./charts/rossoctl \
+  --namespace rossoctl-system \
+  --reuse-values \
+  --set-string ui.backend.contextServiceUrl=http://context-service.serverless-harness.svc.cluster.local:8080
+```
+
+Change the value and run `helm upgrade` again to move Rosso to another Context
+Service endpoint. Disable the integration by setting the value to an empty string:
+
+```sh
+helm upgrade rossoctl ./charts/rossoctl \
+  --namespace rossoctl-system \
+  --reuse-values \
+  --set-string ui.backend.contextServiceUrl=
+```
+
+For temporary development, the backend environment can be changed directly. A later
+Helm upgrade will replace this manual setting:
+
+```sh
+kubectl -n rossoctl-system set env deployment/rossoctl-backend \
+  CONTEXT_SERVICE_URL=http://context-service.serverless-harness.svc.cluster.local:8080
+```
+
+## Context types
+
+The first integration supports four classifications over the same PVC-backed storage
+contract:
+
+| Type | Intended role |
+| --- | --- |
+| `workspace` | Mutable files used while an agent works |
+| `memory` | Durable observations and experiences |
+| `knowledge` | Synthesized, reusable understanding |
+| `artifacts` | Produced reports, media, and other outputs |
+
+The type is metadata today; it does not change provisioning or lifecycle behavior.
+This keeps the API shape forward-compatible without claiming type-specific semantics
+before they exist.
+
+## Create and attach a context
+
+Create a shared GPFS workspace and inspect it:
+
+```sh
+rossoctl context create research \
+  --shared \
+  --size 1Gi \
+  --storage-class ibm-scale-csi
+
+rossoctl context list
+rossoctl context get research
+```
+
+Other classifications use the same storage options:
+
+```sh
+rossoctl context create research-memory --type memory --size 5Gi
+rossoctl context create research-knowledge --type knowledge --shared --size 10Gi
+rossoctl context create research-results --type artifacts --shared --size 20Gi
+```
+
+Attach it to a StatefulSet agent:
+
+```sh
+rossoctl agents import \
+  --deployment-type statefulset \
+  --context research:/workspace \
+  from-image \
+  --name research-agent \
+  --containerImage IMAGE
+```
+
+The same context can be attached to a Sandbox agent:
+
+```sh
+rossoctl agents import \
+  --deployment-type sandbox \
+  --context research:/workspace \
+  from-image \
+  --name research-sandbox \
+  --containerImage IMAGE
+```
+
+Any currently supported context type can be mounted by choosing an appropriate path,
+for example `--context research-memory:/memory`. Rosso accepts the attachment only
+when Context Service returns a PVC claim.
+
+Deleting an agent does not delete its independently managed context. Delete the
+context explicitly when it is no longer needed:
+
+```sh
+rossoctl agents delete research-agent
+rossoctl agents delete research-sandbox
+rossoctl context delete research
+```

--- a/rossoctl/backend/app/core/config.py
+++ b/rossoctl/backend/app/core/config.py
@@ -132,6 +132,9 @@ class Settings(BaseSettings):
     skill_registry_allowed_hosts: str = ""
     # Trace-analysis Observability card (links to the standalone trace-analysis component)
     rossoctl_feature_flag_trace_analysis: bool = False  # Trace-analysis Observability card
+    # Named context resources and agent attachments. An empty URL disables the integration.
+    context_service_url: str = ""
+    context_service_timeout: float = 10.0
 
     # AuthBridge runtime config (mounted from Helm-managed ConfigMap)
     authbridge_runtime_config_path: str = "/etc/rossoctl/authbridge/config.yaml"

--- a/rossoctl/backend/app/main.py
+++ b/rossoctl/backend/app/main.py
@@ -117,6 +117,17 @@ if settings.rossoctl_feature_flag_skills:
             "SKILLS flag enabled but skills modules not installed — skipping"
         )
 
+_contexts_module_loaded = False
+if settings.context_service_url.strip():
+    try:
+        from app.routers import contexts  # noqa: E402
+
+        _contexts_module_loaded = True
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "CONTEXT_SERVICE flag enabled but context module not installed — skipping"
+        )
+
 _acp_modules_loaded = False
 if settings.rossoctl_feature_flag_acp:
     try:
@@ -290,6 +301,10 @@ if _integrations_modules_loaded:
 if _skills_modules_loaded:
     app.include_router(skills.router, prefix="/api/v1")
     logger.info("Feature flag SKILLS enabled — skills routes registered")
+
+if _contexts_module_loaded:
+    app.include_router(contexts.router, prefix="/api/v1")
+    logger.info("Feature flag CONTEXT_SERVICE enabled — context routes registered")
 
 if _acp_modules_loaded:
     app.include_router(acp.router, prefix="/api/v1")

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -327,7 +327,7 @@ class CreateAgentRequest(BaseModel):
     # Persistent storage (for Sandbox and StatefulSet workloads)
     persistentStorage: Optional[PersistentStorageConfig] = None
 
-    # Named Context Service resources. Requires the context-service feature flag.
+    # Named Context Service resources. Requires CONTEXT_SERVICE_URL.
     contexts: Optional[List[ContextAttachment]] = None
 
     # Shipwright build configuration

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -232,6 +232,14 @@ class PersistentStorageConfig(BaseModel):
     size: str = "1Gi"
 
 
+class ContextAttachment(BaseModel):
+    """A named Context Service resource mounted into the agent."""
+
+    name: str
+    mountPath: str = "/workspace"
+    readOnly: bool = False
+
+
 class CreateAgentRequest(BaseModel):
     """Request to create a new agent."""
 
@@ -318,6 +326,9 @@ class CreateAgentRequest(BaseModel):
 
     # Persistent storage (for Sandbox and StatefulSet workloads)
     persistentStorage: Optional[PersistentStorageConfig] = None
+
+    # Named Context Service resources. Requires the context-service feature flag.
+    contexts: Optional[List[ContextAttachment]] = None
 
     # Shipwright build configuration
     shipwrightConfig: Optional[ShipwrightBuildConfig] = None
@@ -2617,6 +2628,8 @@ def _build_agent_shipwright_build_manifest(
         resource_config["k8sResourceLimits"] = request.k8sResourceLimits
     if request.k8sResourceRequests is not None:
         resource_config["k8sResourceRequests"] = request.k8sResourceRequests
+    if request.contexts:
+        resource_config["contexts"] = [attachment.model_dump() for attachment in request.contexts]
     # Add env vars if present
     if request.envVars:
         resource_config["envVars"] = [ev.model_dump(exclude_none=True) for ev in request.envVars]
@@ -3736,6 +3749,62 @@ def _build_sandbox_manifest(
     return manifest
 
 
+async def _resolve_context_mounts(
+    namespace: str,
+    attachments: Optional[List[ContextAttachment]],
+    workload_type: str,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Resolve named contexts into Kubernetes PVC volumes and mounts."""
+    if not attachments:
+        return [], []
+    if workload_type not in {WORKLOAD_TYPE_STATEFULSET, WORKLOAD_TYPE_SANDBOX}:
+        raise HTTPException(
+            status_code=400,
+            detail="context attachments require a statefulset or sandbox workload",
+        )
+    if not settings.context_service_url.strip():
+        raise HTTPException(status_code=400, detail="Context Service integration is disabled")
+
+    from app.routers.contexts import resolve_context  # pylint: disable=import-outside-toplevel
+
+    volumes: List[Dict[str, Any]] = []
+    mounts: List[Dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    for index, attachment in enumerate(attachments):
+        if not attachment.mountPath.startswith("/"):
+            raise HTTPException(status_code=400, detail="context mountPath must be absolute")
+        if attachment.mountPath in seen_paths:
+            raise HTTPException(status_code=400, detail="context mountPath values must be unique")
+        seen_paths.add(attachment.mountPath)
+        resource = await resolve_context(namespace, attachment.name)
+        resource_attachment = resource.get("attachment", {})
+        if resource_attachment.get("kind") != "pvc":
+            raise HTTPException(
+                status_code=502, detail="Context Service returned a non-PVC attachment"
+            )
+        claim_name = resource_attachment.get("claimName")
+        if not claim_name:
+            raise HTTPException(status_code=502, detail="Context Service returned no PVC claim")
+        volume_name = f"context-{index}"
+        volumes.append(
+            {
+                "name": volume_name,
+                "persistentVolumeClaim": {
+                    "claimName": claim_name,
+                    "readOnly": attachment.readOnly,
+                },
+            }
+        )
+        mounts.append(
+            {
+                "name": volume_name,
+                "mountPath": attachment.mountPath,
+                "readOnly": attachment.readOnly,
+            }
+        )
+    return volumes, mounts
+
+
 @router.post(
     "", response_model=CreateAgentResponse, dependencies=[Depends(require_roles(ROLE_OPERATOR))]
 )
@@ -3784,6 +3853,12 @@ async def create_agent(
         local_skills = [
             s for s in request.skills if s and not _is_skill_external(kube, request.namespace, s)
         ]
+
+    context_volumes, context_mounts = await _resolve_context_mounts(
+        request.namespace, request.contexts, request.workloadType
+    )
+    ext_volumes.extend(context_volumes)
+    ext_volume_mounts.extend(context_mounts)
 
     request = apply_agent_import_defaults(request, kube)
 
@@ -4457,6 +4532,10 @@ async def finalize_shipwright_build(
             else stored_config.get("k8sResourceRequests")
         )
 
+        final_contexts = request.contexts
+        if final_contexts is None and stored_config.get("contexts"):
+            final_contexts = [ContextAttachment(**item) for item in stored_config["contexts"]]
+
         final_mcp_tool_name = (
             request.mcpToolName
             if request.mcpToolName is not None
@@ -4494,6 +4573,7 @@ async def finalize_shipwright_build(
             inboundPortsExclude=final_inbound_ports_exclude,
             defaultOutboundPolicy=final_default_outbound_policy,
             persistentStorage=final_persistent_storage,
+            contexts=final_contexts,
             gitPath=stored_config.get("gitPath")
             or build.get("spec", {}).get("source", {}).get("contextDir", ""),
             mcpToolName=final_mcp_tool_name,
@@ -4503,6 +4583,11 @@ async def finalize_shipwright_build(
             k8sResourceRequests=final_k8s_resource_requests,
         )
         agent_request = apply_agent_import_defaults(agent_request, kube)
+        context_volumes, context_mounts = await _resolve_context_mounts(
+            namespace, final_contexts, final_workload_type
+        )
+        build_ext_volumes.extend(context_volumes)
+        build_ext_volume_mounts.extend(context_mounts)
 
         # Ensure a dedicated ServiceAccount exists so the webhook's
         # SPIFFE identity uses the workload name, not the ReplicaSet hash.

--- a/rossoctl/backend/app/routers/config.py
+++ b/rossoctl/backend/app/routers/config.py
@@ -43,6 +43,7 @@ class FeatureFlagsResponse(BaseModel):
     )
     traceAnalysis: bool = Field(description="Trace-analysis Observability card")
     simulatedTools: bool = Field(description="Simulated MCP tools generated from an OpenAPI spec")
+    contextService: bool = Field(description="Named context resources backed by Context Service")
 
 
 class ComponentStatus(BaseModel):
@@ -97,6 +98,7 @@ async def get_feature_flags(
         agentImportDefaults=settings.rossoctl_feature_flag_agent_import_defaults,
         traceAnalysis=settings.rossoctl_feature_flag_trace_analysis,
         simulatedTools=settings.rossoctl_feature_flag_simulated_tools,
+        contextService=bool(settings.context_service_url.strip()),
     )
 
 

--- a/rossoctl/backend/app/routers/contexts.py
+++ b/rossoctl/backend/app/routers/contexts.py
@@ -1,0 +1,78 @@
+"""Optional proxy for Context Service context resources."""
+
+from typing import Literal
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel
+
+from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
+from app.core.config import settings
+
+router = APIRouter(prefix="/contexts", tags=["contexts"])
+
+
+class ContextStorage(BaseModel):
+    backend: Literal["pvc"] = "pvc"
+    size: str = "1Gi"
+    accessMode: Literal["ReadWriteOnce", "ReadWriteMany"] = "ReadWriteOnce"
+    storageClass: str | None = None
+
+
+class CreateContextRequest(BaseModel):
+    name: str
+    namespace: str
+    type: Literal["workspace", "memory", "knowledge", "artifacts"] = "workspace"
+    storage: ContextStorage
+
+
+def _url(path: str) -> str:
+    return f"{settings.context_service_url.rstrip('/')}{path}"
+
+
+async def _request(method: str, path: str, body: dict | None = None) -> httpx.Response:
+    try:
+        async with httpx.AsyncClient(timeout=settings.context_service_timeout) as client:
+            response = await client.request(method, _url(path), json=body)
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=503, detail=f"Context Service unavailable: {exc}") from exc
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("message", response.text)
+        except ValueError:
+            detail = response.text
+        raise HTTPException(status_code=response.status_code, detail=detail)
+    return response
+
+
+@router.post("", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
+async def create_context(request: CreateContextRequest) -> dict:
+    response = await _request("POST", "/v1/contexts", request.model_dump(exclude_none=True))
+    return response.json()
+
+
+@router.get(
+    "/{namespace}", dependencies=[Depends(require_roles(ROLE_VIEWER, ROLE_OPERATOR))]
+)
+async def list_contexts(namespace: str) -> dict:
+    response = await _request("GET", f"/v1/namespaces/{namespace}/contexts")
+    return response.json()
+
+
+@router.get(
+    "/{namespace}/{name}", dependencies=[Depends(require_roles(ROLE_VIEWER, ROLE_OPERATOR))]
+)
+async def get_context(namespace: str, name: str) -> dict:
+    response = await _request("GET", f"/v1/namespaces/{namespace}/contexts/{name}")
+    return response.json()
+
+
+@router.delete("/{namespace}/{name}", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
+async def delete_context(namespace: str, name: str) -> Response:
+    await _request("DELETE", f"/v1/namespaces/{namespace}/contexts/{name}")
+    return Response(status_code=204)
+
+
+async def resolve_context(namespace: str, name: str) -> dict:
+    response = await _request("GET", f"/v1/namespaces/{namespace}/contexts/{name}")
+    return response.json()

--- a/rossoctl/backend/app/routers/contexts.py
+++ b/rossoctl/backend/app/routers/contexts.py
@@ -1,6 +1,8 @@
 """Optional proxy for Context Service context resources."""
 
+import re
 from typing import Literal
+from urllib.parse import quote
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -10,6 +12,8 @@ from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
 from app.core.config import settings
 
 router = APIRouter(prefix="/contexts", tags=["contexts"])
+
+_KUBERNETES_NAME = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
 
 
 class ContextStorage(BaseModel):
@@ -28,6 +32,16 @@ class CreateContextRequest(BaseModel):
 
 def _url(path: str) -> str:
     return f"{settings.context_service_url.rstrip('/')}{path}"
+
+
+def _path_segment(value: str, field: str, max_length: int = 63) -> str:
+    """Validate and encode a Kubernetes-name URL path segment."""
+    if len(value) > max_length or not _KUBERNETES_NAME.fullmatch(value):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field} must be a lowercase Kubernetes name",
+        )
+    return quote(value, safe="")
 
 
 async def _request(method: str, path: str, body: dict | None = None) -> httpx.Response:
@@ -51,11 +65,10 @@ async def create_context(request: CreateContextRequest) -> dict:
     return response.json()
 
 
-@router.get(
-    "/{namespace}", dependencies=[Depends(require_roles(ROLE_VIEWER, ROLE_OPERATOR))]
-)
+@router.get("/{namespace}", dependencies=[Depends(require_roles(ROLE_VIEWER, ROLE_OPERATOR))])
 async def list_contexts(namespace: str) -> dict:
-    response = await _request("GET", f"/v1/namespaces/{namespace}/contexts")
+    namespace_segment = _path_segment(namespace, "namespace")
+    response = await _request("GET", f"/v1/namespaces/{namespace_segment}/contexts")
     return response.json()
 
 
@@ -63,16 +76,22 @@ async def list_contexts(namespace: str) -> dict:
     "/{namespace}/{name}", dependencies=[Depends(require_roles(ROLE_VIEWER, ROLE_OPERATOR))]
 )
 async def get_context(namespace: str, name: str) -> dict:
-    response = await _request("GET", f"/v1/namespaces/{namespace}/contexts/{name}")
+    namespace_segment = _path_segment(namespace, "namespace")
+    name_segment = _path_segment(name, "name", max_length=50)
+    response = await _request("GET", f"/v1/namespaces/{namespace_segment}/contexts/{name_segment}")
     return response.json()
 
 
 @router.delete("/{namespace}/{name}", dependencies=[Depends(require_roles(ROLE_OPERATOR))])
 async def delete_context(namespace: str, name: str) -> Response:
-    await _request("DELETE", f"/v1/namespaces/{namespace}/contexts/{name}")
+    namespace_segment = _path_segment(namespace, "namespace")
+    name_segment = _path_segment(name, "name", max_length=50)
+    await _request("DELETE", f"/v1/namespaces/{namespace_segment}/contexts/{name_segment}")
     return Response(status_code=204)
 
 
 async def resolve_context(namespace: str, name: str) -> dict:
-    response = await _request("GET", f"/v1/namespaces/{namespace}/contexts/{name}")
+    namespace_segment = _path_segment(namespace, "namespace")
+    name_segment = _path_segment(name, "name", max_length=50)
+    response = await _request("GET", f"/v1/namespaces/{namespace_segment}/contexts/{name_segment}")
     return response.json()

--- a/rossoctl/backend/app/routers/contexts.py
+++ b/rossoctl/backend/app/routers/contexts.py
@@ -45,6 +45,8 @@ def _path_segment(value: str, field: str, max_length: int = 63) -> str:
 
 
 async def _request(method: str, path: str, body: dict | None = None) -> httpx.Response:
+    if not settings.context_service_url.strip():
+        raise HTTPException(status_code=400, detail="Context Service integration is disabled")
     try:
         async with httpx.AsyncClient(timeout=settings.context_service_timeout) as client:
             response = await client.request(method, _url(path), json=body)

--- a/rossoctl/backend/tests/test_contexts.py
+++ b/rossoctl/backend/tests/test_contexts.py
@@ -1,0 +1,140 @@
+"""Tests for optional Context Service resources and agent attachments."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.routers import contexts
+from app.routers.agents import (
+    ContextAttachment,
+    CreateAgentRequest,
+    _build_sandbox_manifest,
+    _build_statefulset_manifest,
+    _resolve_context_mounts,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("context_type", ["workspace", "memory", "knowledge", "artifacts"])
+async def test_create_context_proxies_request(context_type: str) -> None:
+    response = httpx.Response(
+        200,
+        json={"name": "research", "namespace": "team1", "status": "Ready"},
+    )
+    with patch.object(contexts, "_request", new=AsyncMock(return_value=response)) as request:
+        result = await contexts.create_context(
+            contexts.CreateContextRequest(
+                name="research",
+                namespace="team1",
+                type=context_type,
+                storage=contexts.ContextStorage(size="10Gi", accessMode="ReadWriteMany"),
+            )
+        )
+
+    assert result["name"] == "research"
+    request.assert_awaited_once_with(
+        "POST",
+        "/v1/contexts",
+        {
+            "name": "research",
+            "namespace": "team1",
+            "type": context_type,
+            "storage": {
+                "backend": "pvc",
+                "size": "10Gi",
+                "accessMode": "ReadWriteMany",
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_contexts_proxies_namespace() -> None:
+    response = httpx.Response(200, json={"items": [{"name": "research"}]})
+    with patch.object(contexts, "_request", new=AsyncMock(return_value=response)) as request:
+        result = await contexts.list_contexts("team1")
+
+    assert result["items"][0]["name"] == "research"
+    request.assert_awaited_once_with("GET", "/v1/namespaces/team1/contexts")
+
+
+@pytest.mark.asyncio
+async def test_context_attachments_require_service_url() -> None:
+    with patch("app.routers.agents.settings.context_service_url", ""):
+        with pytest.raises(HTTPException, match="disabled"):
+            await _resolve_context_mounts(
+                "team1", [ContextAttachment(name="research")], "sandbox"
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("context_type", ["workspace", "memory", "knowledge", "artifacts"])
+async def test_context_attachments_resolve_pvc_for_sandbox_and_statefulset(
+    context_type: str,
+) -> None:
+    resource = {
+        "type": context_type,
+        "attachment": {"kind": "pvc", "claimName": "context-research"},
+    }
+    attachment = ContextAttachment(name="research", mountPath="/workspace")
+    with (
+        patch("app.routers.agents.settings.context_service_url", "http://context-service:8080"),
+        patch("app.routers.agents.settings.rossoctl_feature_flag_agent_sandbox", True),
+        patch("app.routers.contexts.resolve_context", new=AsyncMock(return_value=resource)),
+    ):
+        for workload_type, builder in (
+            ("sandbox", _build_sandbox_manifest),
+            ("statefulset", _build_statefulset_manifest),
+        ):
+            volumes, mounts = await _resolve_context_mounts(
+                "team1", [attachment], workload_type
+            )
+            agent_request = CreateAgentRequest(
+                name="research-agent",
+                namespace="team1",
+                workloadType="statefulset",
+            )
+            # Sandbox availability is injected into SUPPORTED_WORKLOAD_TYPES at
+            # process startup. The builder itself accepts the same request shape.
+            agent_request.workloadType = workload_type
+            manifest = builder(
+                agent_request,
+                "example/agent:latest",
+                ext_volumes=volumes,
+                ext_volume_mounts=mounts,
+            )
+            pod_spec = (
+                manifest["spec"]["podTemplate"]["spec"]
+                if workload_type == "sandbox"
+                else manifest["spec"]["template"]["spec"]
+            )
+            assert volumes[0]["persistentVolumeClaim"]["claimName"] == "context-research"
+            assert pod_spec["containers"][0]["volumeMounts"][-1]["mountPath"] == "/workspace"
+            context_volume = next(v for v in pod_spec["volumes"] if v["name"] == "context-0")
+            assert context_volume["persistentVolumeClaim"]["claimName"] == "context-research"
+
+
+@pytest.mark.asyncio
+async def test_context_attachments_reject_non_pvc_attachment() -> None:
+    resource = {
+        "type": "artifacts",
+        "attachment": {"kind": "s3", "bucket": "research-results"},
+    }
+    with (
+        patch("app.routers.agents.settings.context_service_url", "http://context-service:8080"),
+        patch("app.routers.contexts.resolve_context", new=AsyncMock(return_value=resource)),
+        pytest.raises(HTTPException, match="non-PVC"),
+    ):
+        await _resolve_context_mounts(
+            "team1", [ContextAttachment(name="research-results")], "sandbox"
+        )
+
+
+@pytest.mark.asyncio
+async def test_context_attachments_reject_deployment() -> None:
+    with pytest.raises(HTTPException, match="statefulset or sandbox"):
+        await _resolve_context_mounts(
+            "team1", [ContextAttachment(name="research")], "deployment"
+        )

--- a/rossoctl/backend/tests/test_contexts.py
+++ b/rossoctl/backend/tests/test_contexts.py
@@ -61,12 +61,32 @@ async def test_list_contexts_proxies_namespace() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "args", "message"),
+    [
+        (contexts.list_contexts, ("../master",), "namespace"),
+        (contexts.get_context, ("team1", "research/../../admin"), "name"),
+        (contexts.delete_context, ("Team1", "research"), "namespace"),
+        (contexts.resolve_context, ("team1", "x" * 51), "name"),
+    ],
+)
+async def test_context_paths_reject_invalid_kubernetes_names(
+    operation, args: tuple[str, ...], message: str
+) -> None:
+    with (
+        patch.object(contexts, "_request", new=AsyncMock()) as request,
+        pytest.raises(HTTPException, match=message),
+    ):
+        await operation(*args)
+
+    request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_context_attachments_require_service_url() -> None:
     with patch("app.routers.agents.settings.context_service_url", ""):
         with pytest.raises(HTTPException, match="disabled"):
-            await _resolve_context_mounts(
-                "team1", [ContextAttachment(name="research")], "sandbox"
-            )
+            await _resolve_context_mounts("team1", [ContextAttachment(name="research")], "sandbox")
 
 
 @pytest.mark.asyncio
@@ -88,9 +108,7 @@ async def test_context_attachments_resolve_pvc_for_sandbox_and_statefulset(
             ("sandbox", _build_sandbox_manifest),
             ("statefulset", _build_statefulset_manifest),
         ):
-            volumes, mounts = await _resolve_context_mounts(
-                "team1", [attachment], workload_type
-            )
+            volumes, mounts = await _resolve_context_mounts("team1", [attachment], workload_type)
             agent_request = CreateAgentRequest(
                 name="research-agent",
                 namespace="team1",
@@ -135,6 +153,4 @@ async def test_context_attachments_reject_non_pvc_attachment() -> None:
 @pytest.mark.asyncio
 async def test_context_attachments_reject_deployment() -> None:
     with pytest.raises(HTTPException, match="statefulset or sandbox"):
-        await _resolve_context_mounts(
-            "team1", [ContextAttachment(name="research")], "deployment"
-        )
+        await _resolve_context_mounts("team1", [ContextAttachment(name="research")], "deployment")

--- a/rossoctl/backend/tests/test_contexts.py
+++ b/rossoctl/backend/tests/test_contexts.py
@@ -61,6 +61,18 @@ async def test_list_contexts_proxies_namespace() -> None:
 
 
 @pytest.mark.asyncio
+async def test_context_proxy_requires_service_url() -> None:
+    with (
+        patch("app.routers.contexts.settings.context_service_url", ""),
+        patch("app.routers.contexts.httpx.AsyncClient") as client,
+        pytest.raises(HTTPException, match="integration is disabled"),
+    ):
+        await contexts.list_contexts("team1")
+
+    client.assert_not_called()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("operation", "args", "message"),
     [


### PR DESCRIPTION
## Summary

- add an optional proxy for Context Service named-resource APIs
- resolve Context Service PVC attachments when creating StatefulSet or Sandbox agents
- configure the integration solely through `CONTEXT_SERVICE_URL`
- expose Helm configuration and document the user workflow
- preserve normal Rosso behavior when Context Service is not configured

## Why

This gives Rosso agents access to independently managed, shared or dedicated context storage without making Context Service a platform requirement. The integration validates the returned attachment contract rather than coupling agent creation to a specific context type.

## Dependency

This integrates with the named context-resource API merged through https://github.com/rossoctl/context-service/pull/1. Context Service remains an optional, separately installed component.

## Validation

- Ruff on changed backend files
- 747 backend tests passed
- Helm rendered with Context Service disabled and enabled
- `git diff --check`

Assisted-By: Codex
