### PR TITLE
test: Add transparent inbound interception E2E suite

### DIFF
--- a/.github/scripts/operator/90-run-e2e-tests.sh
+++ b/.github/scripts/operator/90-run-e2e-tests.sh
@@ -44,7 +44,11 @@ fi
 # Support filtering tests via PYTEST_FILTER or PYTEST_ARGS
 # PYTEST_FILTER: pytest -k filter expression (e.g., "test_mlflow" or "TestGenAI")
 # PYTEST_ARGS: additional pytest arguments (e.g., "-x" for stop on first failure)
-PYTEST_TARGETS="${PYTEST_TARGETS:-tests/e2e/common tests/e2e/rossoctl_operator}"
+# transparent_inbound self-gates: it skips with a named reason when the deployed
+# platform predates transparent inbound interception, or when the per-agent
+# Keycloak credentials Secret cannot be created. So including it here is safe on
+# older images and becomes a real gate as soon as they carry the feature.
+PYTEST_TARGETS="${PYTEST_TARGETS:-tests/e2e/common tests/e2e/rossoctl_operator tests/e2e/transparent_inbound}"
 PYTEST_OPTS="-v --timeout=300 --tb=short"
 
 if [ -n "${PYTEST_FILTER:-}" ]; then

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -20,6 +20,27 @@ be retired with it.
 - A cluster with the operator + authbridge images built from this branch.
 - `proxy.allowedInboundInterception` must permit `transparent` (the default).
 - Linux nodes: the feature is iptables-based. Skipped elsewhere.
+- **A namespace the platform can onboard.** The injected sidecar mounts a
+  per-agent Keycloak client-credentials Secret, created by the operator's
+  client-registration path. If that path is broken — e.g. the Keycloak CRD
+  (`k8s.keycloak.org/v2alpha1`) is absent, as on a cluster installed with the
+  community Keycloak provider — every injected pod stays `Pending` on
+  `FailedMount` and the suite errors in fixture setup regardless of this
+  feature. Check `kubectl describe pod` for a missing
+  `rossoctl-keycloak-client-credentials-*` Secret before debugging the
+  interception rules.
+
+Three platform constraints the fixtures satisfy, each of which otherwise
+produces a silently meaningless run:
+
+- The namespace needs `rossoctl-enabled=true`, or the injection webhook's
+  `namespaceSelector` skips it and the pod comes up with no sidecar at all.
+- `rossoctl.io/type` cannot be applied by hand — the `agent-label-protection`
+  ValidatingAdmissionPolicy rejects it. Injection is driven through an
+  AgentRuntime CR, which is how agents are deployed for real.
+- Readiness alone is not a usable gate: the AgentRuntime controller labels the
+  pod template *after* the Deployment exists, so the first ready pod predates
+  injection. The fixtures wait for the `authbridge-proxy` container.
 
 ```sh
 uv run pytest rossoctl/tests/e2e/transparent_inbound/ -v

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -15,20 +15,38 @@ port answers without validation. If that test ever fails because the bypass is
 gone, the default changed — which is a decision, not a bug, and the test should
 be retired with it.
 
+## Namespaces
+
+Runs in **pre-onboarded** namespaces (`team1`/`team2` by default, override with
+`TI_NS_TRANSPARENT` / `TI_NS_CONTROL`) rather than creating its own. A fresh
+namespace lacks the platform's per-namespace plumbing — `authbridge-config`, and
+the Keycloak client registration that produces each agent's credentials Secret —
+so an injected pod there never starts, for reasons unrelated to this feature.
+
+Each fixture flips the namespace's `inboundInterception` in place and **restores
+the original body on teardown**. These are shared namespaces: leaving one flipped
+would silently change every other agent in it on its next pod recreation.
+
 ## Requirements
 
 - A cluster with the operator + authbridge images built from this branch.
 - `proxy.allowedInboundInterception` must permit `transparent` (the default).
 - Linux nodes: the feature is iptables-based. Skipped elsewhere.
-- **A namespace the platform can onboard.** The injected sidecar mounts a
-  per-agent Keycloak client-credentials Secret, created by the operator's
-  client-registration path. If that path is broken — e.g. the Keycloak CRD
-  (`k8s.keycloak.org/v2alpha1`) is absent, as on a cluster installed with the
-  community Keycloak provider — every injected pod stays `Pending` on
-  `FailedMount` and the suite errors in fixture setup regardless of this
-  feature. Check `kubectl describe pod` for a missing
-  `rossoctl-keycloak-client-credentials-*` Secret before debugging the
-  interception rules.
+- **Working Keycloak client registration.** The injected sidecar mounts a
+  per-agent credentials Secret created by the operator. Where that path is broken
+  — e.g. the `k8s.keycloak.org/v2alpha1` CRD is absent, as on a cluster installed
+  with the community Keycloak provider — every injected pod stays `Pending` on
+  `FailedMount`, including default reverse-proxy ones. The suite **skips with that
+  cause named** rather than failing and pointing suspicion at the interception
+  rules.
+
+  To test the boundary anyway on such a cluster, set `TI_STUB_CREDENTIALS=1` to
+  create a placeholder Secret. This is opt-in on purpose: stubbing by default
+  would let the suite go green on a cluster whose Keycloak registration is
+  broken. The stub is sound for these assertions — the Secret is for *outbound*
+  token-exchange, and inbound validation rejects a request with no Authorization
+  header before any IdP contact — but it would **not** be sound for any test
+  needing a valid token.
 
 Three platform constraints the fixtures satisfy, each of which otherwise
 produces a silently meaningless run:

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -1,0 +1,26 @@
+# Transparent inbound E2E
+
+Gates the inbound half of the AuthBridge interception story
+(rossoctl/cortex#330): with `inboundInterception: transparent`, JWT validation
+must not be sidestepped by another pod dialing the agent's real port.
+
+The assertion that matters is `test_direct_pod_dial_is_validated`. Everything
+else exists to prove the shape is actually the one under test, and that turning
+the feature on did not break the things it runs alongside (health probes, the
+session-events API, egress enforcement).
+
+`test_reverse_proxy_control_bypass_is_reachable` deliberately documents the
+*old* behavior: under the default `reverse-proxy` mechanism the relocated agent
+port answers without validation. If that test ever fails because the bypass is
+gone, the default changed — which is a decision, not a bug, and the test should
+be retired with it.
+
+## Requirements
+
+- A cluster with the operator + authbridge images built from this branch.
+- `proxy.allowedInboundInterception` must permit `transparent` (the default).
+- Linux nodes: the feature is iptables-based. Skipped elsewhere.
+
+```sh
+uv run pytest rossoctl/tests/e2e/transparent_inbound/ -v
+```

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -27,6 +27,18 @@ Each fixture flips the namespace's `inboundInterception` in place and **restores
 the original body on teardown**. These are shared namespaces: leaving one flipped
 would silently change every other agent in it on its next pod recreation.
 
+## Where it runs
+
+Included in the shared e2e target list in
+`.github/scripts/operator/90-run-e2e-tests.sh`, so it runs wherever that runner
+does (Kind and HyperShift e2e, release validation) rather than only by hand.
+
+It **self-gates** so that is safe on clusters running older images: if the injected
+sidecar declares no `transparent-in` port, the deployed operator ignored the
+namespace's `inboundInterception` and the suite skips with that cause named. It
+becomes a real gate as soon as the cluster's operator and authbridge carry the
+feature.
+
 ## Requirements
 
 - A cluster with the operator + authbridge images built from this branch.

--- a/rossoctl/tests/e2e/transparent_inbound/__init__.py
+++ b/rossoctl/tests/e2e/transparent_inbound/__init__.py
@@ -1,0 +1,1 @@
+"""E2E tests for transparent inbound interception (rossoctl/cortex#330)."""

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -15,9 +15,13 @@ import time
 import pytest
 
 NAMESPACE = os.environ.get("TI_NAMESPACE", "ti-e2e")
+# A stand-in agent, not a real one: the suite tests the interception boundary,
+# not agent behavior. nginx-unprivileged is Alpine-based (so the same image
+# doubles as the probe, via busybox wget) and is already cached on Kind nodes.
 AGENT_IMAGE = os.environ.get(
-    "TI_AGENT_IMAGE", "ghcr.io/rossoctl/cortex/demos/echo-upstream:latest"
+    "TI_AGENT_IMAGE", "docker.io/nginxinc/nginx-unprivileged:1.29.1-alpine"
 )
+PROBE_IMAGE = os.environ.get("TI_PROBE_IMAGE", AGENT_IMAGE)
 # The port the agent binds. Under transparent interception it must stay this;
 # under reverse-proxy the operator relocates the agent off it.
 AGENT_PORT = int(os.environ.get("TI_AGENT_PORT", "8000"))
@@ -70,8 +74,17 @@ def _wait_ready(namespace: str, name: str, timeout: int):
             check=False,
         )
         last = out
-        if out.strip() in ("1/1",):
-            return
+        if out.strip() == "1/1":
+            # Ready alone is not enough: the AgentRuntime controller labels the
+            # pod template after the Deployment exists, so the FIRST ready pod
+            # may predate injection. Require the sidecar to be present.
+            pods = kubectl(
+                "get", "pods", "-n", namespace, "-l", f"app={name}",
+                "-o", "jsonpath={.items[*].spec.containers[*].name}",
+                check=False,
+            )
+            if "authbridge-proxy" in pods:
+                return
         time.sleep(3)
     # Dump enough to triage without re-running: pod status is where an
     # iptables/init failure or a port collision shows up.
@@ -98,8 +111,6 @@ kind: Deployment
 metadata:
   name: {name}
   namespace: {namespace}
-  labels:
-    rossoctl.io/type: agent
 spec:
   replicas: 1
   selector:
@@ -109,12 +120,24 @@ spec:
     metadata:
       labels:
         app: {name}
-        rossoctl.io/type: agent
     spec:
       containers:
         - name: agent
           image: {AGENT_IMAGE}
           imagePullPolicy: IfNotPresent
+          # Rewrite nginx's listen directive from PORT so this stand-in behaves
+          # like a PORT-honoring agent framework. Without that the reverse-proxy
+          # control could not be exercised: an agent that ignores PORT collides
+          # with AuthBridge on the stolen port and the pod never starts (which is
+          # itself one of the failure modes transparent interception removes).
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              sed -i "s/listen  *8080/listen ${{PORT:-{AGENT_PORT}}}/" /etc/nginx/conf.d/default.conf
+              exec nginx -g 'daemon off;'
+          env:
+            - name: PORT
+              value: "{AGENT_PORT}"
           ports:
             - containerPort: {AGENT_PORT}
 ---
@@ -129,11 +152,33 @@ spec:
   ports:
     - port: {AGENT_PORT}
       targetPort: {AGENT_PORT}
+---
+# The AgentRuntime is what marks this workload as an agent. The platform's
+# agent-label-protection ValidatingAdmissionPolicy rejects a hand-applied
+# rossoctl.io/type label, so injection must be driven through the CR — which is
+# also how agents are deployed for real.
+apiVersion: agent.rossoctl.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: {name}
+  namespace: {namespace}
+spec:
+  type: agent
+  mtlsMode: disabled
+  tlsBridgeMode: disabled
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {name}
 """
 
 
 def _ensure_namespace(namespace: str, mechanism: str):
     kubectl("create", "namespace", namespace, check=False)
+    # The injection webhook's namespaceSelector requires this label, so without
+    # it the pod comes up with no sidecar at all and every assertion here would
+    # be measuring an unprotected workload.
+    kubectl("label", "namespace", namespace, "rossoctl-enabled=true", "--overwrite")
     # Render then apply via stdin so a re-run updates rather than conflicts.
     cm = kubectl(
         "create", "configmap", "authbridge-runtime-config",
@@ -211,14 +256,22 @@ def curl_from_probe(namespace: str, url: str) -> int:
     path. Dialing from inside the agent pod would traverse loopback, which is
     inside the trust boundary and deliberately not intercepted.
     """
+    # busybox wget rather than curl: it ships in the Alpine agent image, which is
+    # already cached on the nodes, so the probe needs no registry pull. It writes
+    # the status line to stderr, hence the 2>&1.
     out = kubectl(
         "run", f"ti-probe-{int(time.time() * 1000) % 100000}",
         "-n", namespace, "--rm", "-i", "--restart=Never",
-        "--image=curlimages/curl:8.11.1", "--quiet", "--",
-        "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-        "--max-time", "15", url,
+        f"--image={PROBE_IMAGE}",
+        "--image-pull-policy=IfNotPresent", "--quiet",
+        "--command", "--",
+        "sh", "-c",
+        f"wget -q -S -T 15 -O /dev/null '{url}' 2>&1 | head -1",
         check=False,
     )
-    digits = "".join(ch for ch in out if ch.isdigit())
-    assert digits, f"probe produced no HTTP status for {url}; raw output: {out!r}"
-    return int(digits[-3:])
+    for token in out.split():
+        if token.isdigit() and len(token) == 3 and token[0] in "12345":
+            return int(token)
+    raise AssertionError(
+        f"probe produced no HTTP status for {url}; raw output: {out!r}"
+    )

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -14,7 +14,13 @@ import time
 
 import pytest
 
-NAMESPACE = os.environ.get("TI_NAMESPACE", "ti-e2e")
+# Pre-onboarded namespaces rather than fresh ones. A new namespace lacks the
+# platform's per-namespace plumbing (authbridge-config, and the Keycloak client
+# registration that produces each agent's credentials Secret), so an injected pod
+# there never starts — for reasons that have nothing to do with this feature. The
+# installer creates team1/team2 already onboarded; use those.
+NS_TRANSPARENT = os.environ.get("TI_NS_TRANSPARENT", "team1")
+NS_CONTROL = os.environ.get("TI_NS_CONTROL", "team2")
 # A stand-in agent, not a real one: the suite tests the interception boundary,
 # not agent behavior. nginx-unprivileged is Alpine-based (so the same image
 # doubles as the probe, via busybox wget) and is already cached on Kind nodes.
@@ -63,10 +69,43 @@ def _namespace_config(mechanism: str) -> str:
     )
 
 
+def _stub_credentials(namespace: str, name: str) -> bool:
+    """Create a placeholder for the per-agent Keycloak credentials Secret.
+
+    Opt-in via TI_STUB_CREDENTIALS=1, and deliberately NOT the default: stubbing
+    by default would let this suite pass on a cluster whose Keycloak client
+    registration is broken, hiding a real platform failure behind a green run.
+
+    The stub is sound for what this suite asserts. The Secret is mounted for
+    OUTBOUND token-exchange; inbound validation rejects a request with no
+    Authorization header before any IdP contact, so its contents cannot influence
+    the 401 assertions. It would NOT be sound for a test that needs a valid token.
+    """
+    if os.environ.get("TI_STUB_CREDENTIALS") != "1":
+        return False
+    secret = kubectl(
+        "get", "pods", "-n", namespace, "-l", f"app={name}",
+        "-o", r"jsonpath={.items[*].metadata.annotations.rossoctl\.io/keycloak-client-credentials-secret-name}",
+        check=False,
+    ).split()
+    created = False
+    for sn in {s for s in secret if s}:
+        out = kubectl(
+            "create", "secret", "generic", sn, "-n", namespace,
+            "--from-literal=client-id.txt=" + name,
+            "--from-literal=client-secret.txt=stub-not-used-for-inbound-denial",
+            check=False,
+        )
+        if "created" in out or "already exists" in out:
+            created = True
+    return created
+
+
 def _wait_ready(namespace: str, name: str, timeout: int):
     """Block until the deployment reports all replicas ready."""
     deadline = time.monotonic() + timeout
     last = ""
+    stubbed = False
     while time.monotonic() < deadline:
         out = kubectl(
             "get", "deployment", name, "-n", namespace,
@@ -85,13 +124,26 @@ def _wait_ready(namespace: str, name: str, timeout: int):
             )
             if "authbridge-proxy" in pods:
                 return
+        if not stubbed:
+            stubbed = _stub_credentials(namespace, name)
         time.sleep(3)
-    # Dump enough to triage without re-running: pod status is where an
-    # iptables/init failure or a port collision shows up.
     pods = kubectl("get", "pods", "-n", namespace, "-o", "wide", check=False)
     events = kubectl(
         "get", "events", "-n", namespace, "--sort-by=.lastTimestamp", check=False
     )
+    # A missing per-agent Keycloak credentials Secret blocks EVERY injected pod,
+    # including default reverse-proxy ones, so it says nothing about this feature.
+    # Skip with the cause named rather than fail and point suspicion at the
+    # interception rules.
+    if "rossoctl-keycloak-client-credentials" in events and "not found" in events:
+        pytest.skip(
+            "(set TI_STUB_CREDENTIALS=1 to stub the Secret and test the "
+            "interception boundary anyway) "
+            "platform gap, not a feature failure: the per-agent Keycloak "
+            "client-credentials Secret was never created, so the injected pod "
+            "cannot mount it. Verify the operator's Keycloak client registration "
+            "works on this cluster (it needs the k8s.keycloak.org CRD)."
+        )
     raise AssertionError(
         f"deployment {namespace}/{name} not ready within {timeout}s "
         f"(readyReplicas={last})\npods:\n{pods}\nevents (tail):\n{events[-2000:]}"
@@ -173,20 +225,41 @@ spec:
 """
 
 
-def _ensure_namespace(namespace: str, mechanism: str):
-    kubectl("create", "namespace", namespace, check=False)
-    # The injection webhook's namespaceSelector requires this label, so without
-    # it the pod comes up with no sidecar at all and every assertion here would
-    # be measuring an unprotected workload.
-    kubectl("label", "namespace", namespace, "rossoctl-enabled=true", "--overwrite")
-    # Render then apply via stdin so a re-run updates rather than conflicts.
+def _read_namespace_config(namespace: str) -> str:
+    return kubectl(
+        "get", "configmap", "authbridge-runtime-config", "-n", namespace,
+        "-o", r"jsonpath={.data.config\.yaml}", check=False,
+    )
+
+
+def _write_namespace_config(namespace: str, body: str):
     cm = kubectl(
-        "create", "configmap", "authbridge-runtime-config",
-        "-n", namespace,
-        f"--from-literal=config.yaml={_namespace_config(mechanism)}",
+        "create", "configmap", "authbridge-runtime-config", "-n", namespace,
+        f"--from-literal=config.yaml={body}",
         "--dry-run=client", "-o", "yaml",
     )
     kubectl("apply", "-f", "-", stdin=cm)
+
+
+def _set_mechanism(namespace: str, mechanism: str) -> str:
+    """Prepend the inbound mechanism to the namespace config; return the original.
+
+    Edits in place rather than replacing the ConfigMap: the existing body carries
+    the namespace's real jwt-validation issuer and token-exchange settings, and a
+    synthetic replacement would exercise a pipeline no real deployment runs.
+    """
+    original = _read_namespace_config(namespace)
+    if not original.strip():
+        pytest.skip(
+            f"namespace {namespace} has no authbridge-runtime-config — not an "
+            "onboarded rossoctl namespace (set TI_NS_TRANSPARENT / TI_NS_CONTROL)"
+        )
+    body = (
+        f"inboundInterception: {mechanism}\n"
+        "egressEnforcement: enforce-redirect\n" + original.lstrip("\n")
+    )
+    _write_namespace_config(namespace, body)
+    return original
 
 
 @pytest.fixture(scope="session")
@@ -199,30 +272,45 @@ def linux_nodes():
     return True
 
 
+def _deploy(ns: str, name: str, mechanism: str) -> str:
+    original = _set_mechanism(ns, mechanism)
+    kubectl("apply", "-f", "-", stdin=_agent_manifest(ns, name))
+    try:
+        _wait_ready(ns, name, READY_TIMEOUT)
+    except BaseException:
+        _teardown(ns, name, original)
+        raise
+    return original
+
+
+def _teardown(ns: str, name: str, original: str):
+    if os.environ.get("TI_KEEP") == "1":
+        return
+    for kind in ("deployment", "service", "agentruntime"):
+        kubectl("delete", kind, name, "-n", ns, "--wait=false", check=False)
+    # Restoring the namespace config matters: these are SHARED namespaces, so
+    # leaving one flipped to transparent would silently change every other agent
+    # in it on its next pod recreation.
+    if original.strip():
+        _write_namespace_config(ns, original)
+
+
 @pytest.fixture(scope="session")
 def transparent_agent(linux_nodes):
     """Agent deployed with inboundInterception: transparent."""
-    ns = f"{NAMESPACE}-transparent"
-    name = "ti-agent"
-    _ensure_namespace(ns, "transparent")
-    kubectl("apply", "-f", "-", stdin=_agent_manifest(ns, name))
-    _wait_ready(ns, name, READY_TIMEOUT)
+    ns, name = NS_TRANSPARENT, "ti-e2e-agent"
+    original = _deploy(ns, name, "transparent")
     yield {"namespace": ns, "name": name}
-    if os.environ.get("TI_KEEP_NAMESPACE") != "1":
-        kubectl("delete", "namespace", ns, "--wait=false", check=False)
+    _teardown(ns, name, original)
 
 
 @pytest.fixture(scope="session")
 def reverse_proxy_agent(linux_nodes):
     """Control: agent deployed with the default port-stealing mechanism."""
-    ns = f"{NAMESPACE}-reverse"
-    name = "rp-agent"
-    _ensure_namespace(ns, "reverse-proxy")
-    kubectl("apply", "-f", "-", stdin=_agent_manifest(ns, name))
-    _wait_ready(ns, name, READY_TIMEOUT)
+    ns, name = NS_CONTROL, "ti-e2e-control"
+    original = _deploy(ns, name, "reverse-proxy")
     yield {"namespace": ns, "name": name}
-    if os.environ.get("TI_KEEP_NAMESPACE") != "1":
-        kubectl("delete", "namespace", ns, "--wait=false", check=False)
+    _teardown(ns, name, original)
 
 
 def agent_pod(namespace: str, name: str) -> dict:

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -84,14 +84,25 @@ def _stub_credentials(namespace: str, name: str) -> bool:
     if os.environ.get("TI_STUB_CREDENTIALS") != "1":
         return False
     secret = kubectl(
-        "get", "pods", "-n", namespace, "-l", f"app={name}",
-        "-o", r"jsonpath={.items[*].metadata.annotations.rossoctl\.io/keycloak-client-credentials-secret-name}",
+        "get",
+        "pods",
+        "-n",
+        namespace,
+        "-l",
+        f"app={name}",
+        "-o",
+        r"jsonpath={.items[*].metadata.annotations.rossoctl\.io/keycloak-client-credentials-secret-name}",
         check=False,
     ).split()
     created = False
     for sn in {s for s in secret if s}:
         out = kubectl(
-            "create", "secret", "generic", sn, "-n", namespace,
+            "create",
+            "secret",
+            "generic",
+            sn,
+            "-n",
+            namespace,
             "--from-literal=client-id.txt=" + name,
             "--from-literal=client-secret.txt=stub-not-used-for-inbound-denial",
             check=False,
@@ -108,8 +119,13 @@ def _wait_ready(namespace: str, name: str, timeout: int):
     stubbed = False
     while time.monotonic() < deadline:
         out = kubectl(
-            "get", "deployment", name, "-n", namespace,
-            "-o", "jsonpath={.status.readyReplicas}/{.status.replicas}",
+            "get",
+            "deployment",
+            name,
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.status.readyReplicas}/{.status.replicas}",
             check=False,
         )
         last = out
@@ -118,8 +134,14 @@ def _wait_ready(namespace: str, name: str, timeout: int):
             # pod template after the Deployment exists, so the FIRST ready pod
             # may predate injection. Require the sidecar to be present.
             pods = kubectl(
-                "get", "pods", "-n", namespace, "-l", f"app={name}",
-                "-o", "jsonpath={.items[*].spec.containers[*].name}",
+                "get",
+                "pods",
+                "-n",
+                namespace,
+                "-l",
+                f"app={name}",
+                "-o",
+                "jsonpath={.items[*].spec.containers[*].name}",
                 check=False,
             )
             if "authbridge-proxy" in pods:
@@ -227,16 +249,28 @@ spec:
 
 def _read_namespace_config(namespace: str) -> str:
     return kubectl(
-        "get", "configmap", "authbridge-runtime-config", "-n", namespace,
-        "-o", r"jsonpath={.data.config\.yaml}", check=False,
+        "get",
+        "configmap",
+        "authbridge-runtime-config",
+        "-n",
+        namespace,
+        "-o",
+        r"jsonpath={.data.config\.yaml}",
+        check=False,
     )
 
 
 def _write_namespace_config(namespace: str, body: str):
     cm = kubectl(
-        "create", "configmap", "authbridge-runtime-config", "-n", namespace,
+        "create",
+        "configmap",
+        "authbridge-runtime-config",
+        "-n",
+        namespace,
         f"--from-literal=config.yaml={body}",
-        "--dry-run=client", "-o", "yaml",
+        "--dry-run=client",
+        "-o",
+        "yaml",
     )
     kubectl("apply", "-f", "-", stdin=cm)
 
@@ -348,12 +382,20 @@ def curl_from_probe(namespace: str, url: str) -> int:
     # already cached on the nodes, so the probe needs no registry pull. It writes
     # the status line to stderr, hence the 2>&1.
     out = kubectl(
-        "run", f"ti-probe-{int(time.time() * 1000) % 100000}",
-        "-n", namespace, "--rm", "-i", "--restart=Never",
+        "run",
+        f"ti-probe-{int(time.time() * 1000) % 100000}",
+        "-n",
+        namespace,
+        "--rm",
+        "-i",
+        "--restart=Never",
         f"--image={PROBE_IMAGE}",
-        "--image-pull-policy=IfNotPresent", "--quiet",
-        "--command", "--",
-        "sh", "-c",
+        "--image-pull-policy=IfNotPresent",
+        "--quiet",
+        "--command",
+        "--",
+        "sh",
+        "-c",
         f"wget -q -S -T 15 -O /dev/null '{url}' 2>&1 | head -1",
         check=False,
     )

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -9,6 +9,7 @@ isolation. A single-shape run cannot distinguish "validation works" from
 
 import json
 import os
+import re
 import subprocess
 import time
 
@@ -51,22 +52,25 @@ def kubectl(*args, check=True, stdin=None):
     return proc.stdout
 
 
+def kubectl_rc(*args) -> int:
+    """Run kubectl and return only its exit code.
+
+    Needed because kubectl reports conditions like "already exists" on STDERR,
+    which kubectl() drops — so a caller that must distinguish "created" from
+    "already satisfied" cannot do it by inspecting stdout.
+    """
+    return subprocess.run(
+        ["kubectl", *args], capture_output=True, text=True, timeout=120
+    ).returncode
+
+
+# Secrets this suite created, so teardown can remove them. Module-level because
+# the fixture that creates them is not the one that cleans up.
+_stubbed: list = []
+
+
 def kubectl_json(*args):
     return json.loads(kubectl(*args, "-o", "json"))
-
-
-def _namespace_config(mechanism: str) -> str:
-    """authbridge-runtime-config for a namespace.
-
-    inboundInterception is a namespace-scoped switch (the pod mutator has no
-    access to the AgentRuntime CR), so the mechanism is selected here rather
-    than per-agent. That is why each mechanism needs its own namespace.
-    """
-    return (
-        "mode: proxy-sidecar\n"
-        f"inboundInterception: {mechanism}\n"
-        "egressEnforcement: enforce-redirect\n"
-    )
 
 
 def _stub_credentials(namespace: str, name: str) -> bool:
@@ -75,6 +79,9 @@ def _stub_credentials(namespace: str, name: str) -> bool:
     Opt-in via TI_STUB_CREDENTIALS=1, and deliberately NOT the default: stubbing
     by default would let this suite pass on a cluster whose Keycloak client
     registration is broken, hiding a real platform failure behind a green run.
+
+    Anything created is recorded in _stubbed so teardown removes it: a placeholder
+    credential Secret must not outlive the run in a shared namespace.
 
     The stub is sound for what this suite asserts. The Secret is mounted for
     OUTBOUND token-exchange; inbound validation rejects a request with no
@@ -96,7 +103,10 @@ def _stub_credentials(namespace: str, name: str) -> bool:
     ).split()
     created = False
     for sn in {s for s in secret if s}:
-        out = kubectl(
+        # Keyed on the exit code, not on stdout: kubectl writes "already exists"
+        # to stderr, which kubectl() drops — so matching stdout would report
+        # failure forever and re-attempt the create on every poll.
+        rc = kubectl_rc(
             "create",
             "secret",
             "generic",
@@ -105,9 +115,12 @@ def _stub_credentials(namespace: str, name: str) -> bool:
             namespace,
             "--from-literal=client-id.txt=" + name,
             "--from-literal=client-secret.txt=stub-not-used-for-inbound-denial",
-            check=False,
         )
-        if "created" in out or "already exists" in out:
+        # Recorded either way: if it already exists, a previous run of THIS suite
+        # created it and it still needs removing.
+        if (namespace, sn) not in _stubbed:
+            _stubbed.append((namespace, sn))
+        if rc == 0:
             created = True
     return created
 
@@ -288,9 +301,17 @@ def _set_mechanism(namespace: str, mechanism: str) -> str:
             f"namespace {namespace} has no authbridge-runtime-config — not an "
             "onboarded rossoctl namespace (set TI_NS_TRANSPARENT / TI_NS_CONTROL)"
         )
+    # Strip keys a previous run may have left before prepending. Prepending blind
+    # is not idempotent: with TI_KEEP=1, or after a killed run that skipped
+    # teardown, the next run would emit duplicate top-level YAML keys.
+    stripped = "\n".join(
+        line
+        for line in original.splitlines()
+        if not re.match(r"^(inboundInterception|egressEnforcement)\s*:", line)
+    )
     body = (
         f"inboundInterception: {mechanism}\n"
-        "egressEnforcement: enforce-redirect\n" + original.lstrip("\n")
+        "egressEnforcement: enforce-redirect\n" + stripped.lstrip("\n")
     )
     _write_namespace_config(namespace, body)
     return original
@@ -311,10 +332,40 @@ def _deploy(ns: str, name: str, mechanism: str) -> str:
     kubectl("apply", "-f", "-", stdin=_agent_manifest(ns, name))
     try:
         _wait_ready(ns, name, READY_TIMEOUT)
+        _require_platform_support(ns, name, mechanism)
     except BaseException:
         _teardown(ns, name, original)
         raise
     return original
+
+
+def _require_platform_support(ns: str, name: str, mechanism: str):
+    """Skip when the deployed platform predates transparent inbound.
+
+    This suite runs in the shared e2e target list, so it executes against whatever
+    images a cluster happens to have. An operator that does not know
+    `inboundInterception` silently ignores the namespace flip and port-steals
+    instead — which would fail the transparent assertions for a reason that has
+    nothing to do with the code under test. Detect it from the injected pod (the
+    sidecar declares `transparent-in` only when the feature is present) and skip
+    with the cause named.
+    """
+    if mechanism != "transparent":
+        return
+    pod = agent_pod(ns, name)
+    proxy = next(
+        (c for c in pod["spec"]["containers"] if c["name"] == "authbridge-proxy"),
+        None,
+    )
+    if proxy is None:
+        return  # a missing sidecar is a real failure; let the tests report it
+    if not any(p.get("name") == "transparent-in" for p in proxy.get("ports", [])):
+        pytest.skip(
+            "deployed platform predates transparent inbound interception: the "
+            "injected sidecar declares no transparent-in port, so the namespace's "
+            "inboundInterception was ignored. Needs an operator and authbridge "
+            "built with rossoctl/cortex#330."
+        )
 
 
 def _teardown(ns: str, name: str, original: str):
@@ -327,6 +378,13 @@ def _teardown(ns: str, name: str, original: str):
     # in it on its next pod recreation.
     if original.strip():
         _write_namespace_config(ns, original)
+    # Remove any placeholder credentials Secret this suite created. Leaving a fake
+    # credential in a shared namespace is worse than the gap it papered over.
+    for entry in [t for t in _stubbed if t[0] == ns]:
+        kubectl(
+            "delete", "secret", entry[1], "-n", entry[0], "--wait=false", check=False
+        )
+        _stubbed.remove(entry)
 
 
 @pytest.fixture(scope="session")

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -1,0 +1,224 @@
+"""Fixtures for the transparent-inbound E2E suite.
+
+Deploys two agents into a scratch namespace — one with
+``inboundInterception: transparent``, one with the default ``reverse-proxy`` —
+so the bypass property can be asserted against a control rather than in
+isolation. A single-shape run cannot distinguish "validation works" from
+"nothing reached the agent at all".
+"""
+
+import json
+import os
+import subprocess
+import time
+
+import pytest
+
+NAMESPACE = os.environ.get("TI_NAMESPACE", "ti-e2e")
+AGENT_IMAGE = os.environ.get(
+    "TI_AGENT_IMAGE", "ghcr.io/rossoctl/cortex/demos/echo-upstream:latest"
+)
+# The port the agent binds. Under transparent interception it must stay this;
+# under reverse-proxy the operator relocates the agent off it.
+AGENT_PORT = int(os.environ.get("TI_AGENT_PORT", "8000"))
+READY_TIMEOUT = int(os.environ.get("TI_READY_TIMEOUT", "180"))
+
+
+def kubectl(*args, check=True, stdin=None):
+    """Run kubectl and return stdout. Raises on non-zero unless check=False."""
+    proc = subprocess.run(
+        ["kubectl", *args],
+        capture_output=True,
+        text=True,
+        input=stdin,
+        timeout=120,
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError(
+            f"kubectl {' '.join(args)} failed ({proc.returncode}):\n"
+            f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+        )
+    return proc.stdout
+
+
+def kubectl_json(*args):
+    return json.loads(kubectl(*args, "-o", "json"))
+
+
+def _namespace_config(mechanism: str) -> str:
+    """authbridge-runtime-config for a namespace.
+
+    inboundInterception is a namespace-scoped switch (the pod mutator has no
+    access to the AgentRuntime CR), so the mechanism is selected here rather
+    than per-agent. That is why each mechanism needs its own namespace.
+    """
+    return (
+        "mode: proxy-sidecar\n"
+        f"inboundInterception: {mechanism}\n"
+        "egressEnforcement: enforce-redirect\n"
+    )
+
+
+def _wait_ready(namespace: str, name: str, timeout: int):
+    """Block until the deployment reports all replicas ready."""
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        out = kubectl(
+            "get", "deployment", name, "-n", namespace,
+            "-o", "jsonpath={.status.readyReplicas}/{.status.replicas}",
+            check=False,
+        )
+        last = out
+        if out.strip() in ("1/1",):
+            return
+        time.sleep(3)
+    # Dump enough to triage without re-running: pod status is where an
+    # iptables/init failure or a port collision shows up.
+    pods = kubectl("get", "pods", "-n", namespace, "-o", "wide", check=False)
+    events = kubectl(
+        "get", "events", "-n", namespace, "--sort-by=.lastTimestamp", check=False
+    )
+    raise AssertionError(
+        f"deployment {namespace}/{name} not ready within {timeout}s "
+        f"(readyReplicas={last})\npods:\n{pods}\nevents (tail):\n{events[-2000:]}"
+    )
+
+
+def _agent_manifest(namespace: str, name: str) -> str:
+    """A minimal HTTP agent Deployment + Service.
+
+    Declares containerPort explicitly: the reverse-proxy mechanism relocates
+    Ports[0], so the declared value is what the test inspects to tell the two
+    mechanisms apart.
+    """
+    return f"""
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {name}
+  namespace: {namespace}
+  labels:
+    rossoctl.io/type: agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {name}
+  template:
+    metadata:
+      labels:
+        app: {name}
+        rossoctl.io/type: agent
+    spec:
+      containers:
+        - name: agent
+          image: {AGENT_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {AGENT_PORT}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {name}
+  namespace: {namespace}
+spec:
+  selector:
+    app: {name}
+  ports:
+    - port: {AGENT_PORT}
+      targetPort: {AGENT_PORT}
+"""
+
+
+def _ensure_namespace(namespace: str, mechanism: str):
+    kubectl("create", "namespace", namespace, check=False)
+    # Render then apply via stdin so a re-run updates rather than conflicts.
+    cm = kubectl(
+        "create", "configmap", "authbridge-runtime-config",
+        "-n", namespace,
+        f"--from-literal=config.yaml={_namespace_config(mechanism)}",
+        "--dry-run=client", "-o", "yaml",
+    )
+    kubectl("apply", "-f", "-", stdin=cm)
+
+
+@pytest.fixture(scope="session")
+def linux_nodes():
+    """Skip the suite where iptables interception cannot work."""
+    nodes = kubectl_json("get", "nodes")
+    for node in nodes.get("items", []):
+        if node["status"]["nodeInfo"]["operatingSystem"] != "linux":
+            pytest.skip("transparent inbound is Linux/iptables only")
+    return True
+
+
+@pytest.fixture(scope="session")
+def transparent_agent(linux_nodes):
+    """Agent deployed with inboundInterception: transparent."""
+    ns = f"{NAMESPACE}-transparent"
+    name = "ti-agent"
+    _ensure_namespace(ns, "transparent")
+    kubectl("apply", "-f", "-", stdin=_agent_manifest(ns, name))
+    _wait_ready(ns, name, READY_TIMEOUT)
+    yield {"namespace": ns, "name": name}
+    if os.environ.get("TI_KEEP_NAMESPACE") != "1":
+        kubectl("delete", "namespace", ns, "--wait=false", check=False)
+
+
+@pytest.fixture(scope="session")
+def reverse_proxy_agent(linux_nodes):
+    """Control: agent deployed with the default port-stealing mechanism."""
+    ns = f"{NAMESPACE}-reverse"
+    name = "rp-agent"
+    _ensure_namespace(ns, "reverse-proxy")
+    kubectl("apply", "-f", "-", stdin=_agent_manifest(ns, name))
+    _wait_ready(ns, name, READY_TIMEOUT)
+    yield {"namespace": ns, "name": name}
+    if os.environ.get("TI_KEEP_NAMESPACE") != "1":
+        kubectl("delete", "namespace", ns, "--wait=false", check=False)
+
+
+def agent_pod(namespace: str, name: str) -> dict:
+    pods = kubectl_json("get", "pods", "-n", namespace, "-l", f"app={name}")
+    running = [p for p in pods["items"] if p["status"]["phase"] == "Running"]
+    assert running, f"no Running pod for {namespace}/{name}"
+    return running[0]
+
+
+def container(pod: dict, name: str) -> dict:
+    for c in pod["spec"]["containers"] + pod["spec"].get("initContainers", []):
+        if c["name"] == name:
+            return c
+    raise AssertionError(
+        f"container {name} not found in pod {pod['metadata']['name']}; "
+        f"have {[c['name'] for c in pod['spec']['containers']]}"
+    )
+
+
+def env_of(c: dict, key: str):
+    for e in c.get("env", []):
+        if e["name"] == key:
+            return e
+    return None
+
+
+def curl_from_probe(namespace: str, url: str) -> int:
+    """Dial url from a throwaway pod in `namespace` and return the HTTP status.
+
+    A separate pod is essential: the whole point is to exercise the pod-to-pod
+    path. Dialing from inside the agent pod would traverse loopback, which is
+    inside the trust boundary and deliberately not intercepted.
+    """
+    out = kubectl(
+        "run", f"ti-probe-{int(time.time() * 1000) % 100000}",
+        "-n", namespace, "--rm", "-i", "--restart=Never",
+        "--image=curlimages/curl:8.11.1", "--quiet", "--",
+        "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+        "--max-time", "15", url,
+        check=False,
+    )
+    digits = "".join(ch for ch in out if ch.isdigit())
+    assert digits, f"probe produced no HTTP status for {url}; raw output: {out!r}"
+    return int(digits[-3:])

--- a/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
+++ b/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
@@ -1,0 +1,215 @@
+"""Transparent inbound interception E2E (rossoctl/cortex#330).
+
+The load-bearing test here is ``test_direct_pod_dial_is_validated``: the reason
+the feature exists is that JWT validation must not be sidestepped by another pod
+dialing the agent's real port. Everything else either proves the shape under
+test is actually the transparent one, or guards against the feature breaking
+what it runs alongside.
+"""
+
+import pytest
+
+from .conftest import (
+    AGENT_PORT,
+    agent_pod,
+    container,
+    curl_from_probe,
+    env_of,
+    kubectl,
+)
+
+pytestmark = pytest.mark.kind_only
+
+
+# ---------------------------------------------------------------------------
+# Shape: is the thing we deployed actually the transparent mechanism?
+# ---------------------------------------------------------------------------
+
+
+def test_agent_keeps_its_own_port(transparent_agent):
+    """No port stealing.
+
+    This is what removes the two failure modes of the reverse-proxy mechanism:
+    an agent that hardcodes its listen port (which collides with AuthBridge on
+    the stolen port) and the relocated port that nothing validates.
+    """
+    pod = agent_pod(**transparent_agent)
+    agent = container(pod, "agent")
+
+    assert agent["ports"][0]["containerPort"] == AGENT_PORT, (
+        "transparent interception must leave the agent on its own port; "
+        f"got {agent['ports'][0]['containerPort']}"
+    )
+    assert env_of(agent, "PORT") is None, (
+        "transparent interception must not inject PORT — the agent is not relocated"
+    )
+
+
+def test_sidecar_binds_transparent_inbound_port(transparent_agent):
+    pod = agent_pod(**transparent_agent)
+    proxy = container(pod, "authbridge-proxy")
+
+    names = {p.get("name"): p["containerPort"] for p in proxy.get("ports", [])}
+    assert "transparent-in" in names, (
+        f"sidecar should declare a transparent-in port; got {names}"
+    )
+    assert AGENT_PORT not in names.values(), (
+        "sidecar must not claim the agent's port under transparent interception"
+    )
+
+
+def test_proxy_init_configured_for_inbound_capture(transparent_agent):
+    """Both env vars are load-bearing.
+
+    INBOUND_TRANSPARENT_PORT arms the PREROUTING chain; POD_IP is the DNAT
+    target for the Istio ambient path, which arrives through OUTPUT and would
+    otherwise bypass inbound validation entirely.
+    """
+    pod = agent_pod(**transparent_agent)
+    init = container(pod, "proxy-init")
+
+    port = env_of(init, "INBOUND_TRANSPARENT_PORT")
+    assert port is not None and port.get("value"), (
+        "proxy-init has no INBOUND_TRANSPARENT_PORT — inbound capture is inert"
+    )
+
+    pod_ip = env_of(init, "POD_IP")
+    assert pod_ip is not None, (
+        "proxy-init has no POD_IP — the ambient inbound path cannot be captured"
+    )
+    assert (
+        pod_ip.get("valueFrom", {}).get("fieldRef", {}).get("fieldPath")
+        == "status.podIP"
+    ), f"POD_IP must come from the downward API; got {pod_ip}"
+
+
+def test_ab_inbound_chain_installed(transparent_agent):
+    """The rules are actually live in the pod's netns, not merely configured."""
+    pod = agent_pod(**transparent_agent)
+    rules = kubectl(
+        "exec", pod["metadata"]["name"],
+        "-n", transparent_agent["namespace"],
+        "-c", "authbridge-proxy",
+        "--", "sh", "-c",
+        "iptables-save -t nat 2>/dev/null || iptables-nft-save -t nat",
+        check=False,
+    )
+    if not rules.strip():
+        pytest.skip("iptables-save unavailable in the sidecar image")
+
+    assert "AB_INBOUND" in rules, (
+        f"AB_INBOUND chain missing from the pod's nat table:\n{rules[:1500]}"
+    )
+    assert "-A PREROUTING" in rules and "AB_INBOUND" in rules, (
+        "AB_INBOUND is not hooked from PREROUTING"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The boundary property
+# ---------------------------------------------------------------------------
+
+
+def test_direct_pod_dial_is_validated(transparent_agent):
+    """THE test: pod-to-pod on the agent's real port must be validated.
+
+    The probe sends no Authorization header, so a compliant boundary rejects it.
+    A 200 here means the request reached the agent without passing through the
+    inbound pipeline — exactly the bypass this feature closes.
+    """
+    pod = agent_pod(**transparent_agent)
+    pod_ip = pod["status"]["podIP"]
+
+    status = curl_from_probe(
+        transparent_agent["namespace"], f"http://{pod_ip}:{AGENT_PORT}/"
+    )
+    assert status != 200, (
+        f"pod-to-pod dial to {pod_ip}:{AGENT_PORT} returned 200 without a token — "
+        "inbound validation was bypassed"
+    )
+    assert status in (401, 403), (
+        f"expected an auth denial for an unauthenticated direct dial, got {status}"
+    )
+
+
+def test_service_routed_request_is_validated(transparent_agent):
+    """Service-routed traffic must be validated too, not just direct dials."""
+    ns, name = transparent_agent["namespace"], transparent_agent["name"]
+    status = curl_from_probe(ns, f"http://{name}.{ns}.svc.cluster.local:{AGENT_PORT}/")
+    assert status in (401, 403), (
+        f"expected an auth denial through the Service, got {status}"
+    )
+
+
+def test_reverse_proxy_control_bypass_is_reachable(reverse_proxy_agent):
+    """Control: the default mechanism still has the bypass this feature closes.
+
+    Documents current behavior rather than endorsing it. If this starts failing
+    because the bypass is gone, the default changed — retire this test with it.
+    """
+    pod = agent_pod(**reverse_proxy_agent)
+    agent = container(pod, "agent")
+    relocated = agent["ports"][0]["containerPort"]
+
+    assert relocated != AGENT_PORT, (
+        "expected the reverse-proxy mechanism to relocate the agent; "
+        "the control is not exercising port stealing"
+    )
+
+    status = curl_from_probe(
+        reverse_proxy_agent["namespace"],
+        f"http://{pod['status']['podIP']}:{relocated}/",
+    )
+    assert status != 401, (
+        f"relocated port {relocated} returned 401 — the bypass appears closed "
+        "under reverse-proxy, so this control test is obsolete"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Don't break the neighbours
+# ---------------------------------------------------------------------------
+
+
+def test_health_port_not_gated(transparent_agent):
+    """A JWT-gated :9091 would fail kubelet probes and crash-loop the pod.
+
+    The pod being Ready is itself partial evidence; this asserts the port
+    directly so the reason is unambiguous if it regresses.
+    """
+    pod = agent_pod(**transparent_agent)
+    status = curl_from_probe(
+        transparent_agent["namespace"], f"http://{pod['status']['podIP']}:9091/healthz"
+    )
+    assert status not in (401, 403), (
+        f"health port is behind auth (got {status}) — probes would fail"
+    )
+
+
+def test_session_api_not_gated(transparent_agent):
+    """abctl consumes :9094; gating it would break session observability."""
+    pod = agent_pod(**transparent_agent)
+    status = curl_from_probe(
+        transparent_agent["namespace"], f"http://{pod['status']['podIP']}:9094/sessions"
+    )
+    assert status not in (401, 403), (
+        f"session-events API is behind auth (got {status})"
+    )
+
+
+def test_egress_enforcement_still_active(transparent_agent):
+    """Inbound capture must not have disturbed the egress guard's chains."""
+    pod = agent_pod(**transparent_agent)
+    rules = kubectl(
+        "exec", pod["metadata"]["name"],
+        "-n", transparent_agent["namespace"],
+        "-c", "authbridge-proxy",
+        "--", "sh", "-c",
+        "iptables-save -t nat 2>/dev/null || iptables-nft-save -t nat",
+        check=False,
+    )
+    if not rules.strip():
+        pytest.skip("iptables-save unavailable in the sidecar image")
+    assert "AB_REDIRECT" in rules, (
+        "AB_REDIRECT (egress guard) missing after enabling inbound capture"
+    )

--- a/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
+++ b/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
@@ -40,9 +40,16 @@ def test_agent_keeps_its_own_port(transparent_agent):
         "transparent interception must leave the agent on its own port; "
         f"got {agent['ports'][0]['containerPort']}"
     )
-    assert env_of(agent, "PORT") is None, (
-        "transparent interception must not inject PORT — the agent is not relocated"
-    )
+    # Assert the operator did not REWRITE PORT, not that PORT is absent: the
+    # stand-in agent declares PORT itself (it must, or the reverse-proxy control
+    # cannot be exercised). Under port stealing the operator overwrites it with
+    # originalPort+1, so an unchanged value is the discriminator.
+    port_env = env_of(agent, "PORT")
+    if port_env is not None:
+        assert port_env.get("value") == str(AGENT_PORT), (
+            f"PORT was rewritten to {port_env.get('value')}; transparent "
+            f"interception must leave it at {AGENT_PORT}"
+        )
 
 
 def test_sidecar_binds_transparent_inbound_port(transparent_agent):
@@ -84,24 +91,31 @@ def test_proxy_init_configured_for_inbound_capture(transparent_agent):
 
 
 def test_ab_inbound_chain_installed(transparent_agent):
-    """The rules are actually live in the pod's netns, not merely configured."""
-    pod = agent_pod(**transparent_agent)
-    rules = kubectl(
-        "exec", pod["metadata"]["name"],
-        "-n", transparent_agent["namespace"],
-        "-c", "authbridge-proxy",
-        "--", "sh", "-c",
-        "iptables-save -t nat 2>/dev/null || iptables-nft-save -t nat",
-        check=False,
-    )
-    if not rules.strip():
-        pytest.skip("iptables-save unavailable in the sidecar image")
+    """proxy-init reports having installed the inbound capture.
 
-    assert "AB_INBOUND" in rules, (
-        f"AB_INBOUND chain missing from the pod's nat table:\n{rules[:1500]}"
+    Asserted from proxy-init's output rather than by running iptables-save in the
+    sidecar: that image has no iptables binary, so an exec-based check can only
+    skip — which silently drops the assertion. The init container states exactly
+    what it programmed, and it runs with require_jump guards that abort on a rule
+    that did not land, so its success line is a real signal rather than a log
+    scrape.
+    """
+    pod = agent_pod(**transparent_agent)
+    logs = kubectl(
+        "logs", pod["metadata"]["name"], "-n", transparent_agent["namespace"],
+        "-c", "proxy-init", check=False,
     )
-    assert "-A PREROUTING" in rules and "AB_INBOUND" in rules, (
-        "AB_INBOUND is not hooked from PREROUTING"
+    assert logs.strip(), "proxy-init produced no output — did it run?"
+    assert "transparent-inbound: hard inbound boundary active" in logs, (
+        f"proxy-init did not complete inbound setup:\n{logs[-1500:]}"
+    )
+    assert "IPv4 inbound capture configured" in logs, (
+        f"IPv4 inbound capture not configured:\n{logs[-1500:]}"
+    )
+    # The exempt set must include the sidecar's own ports, or a JWT-gated :9091
+    # crash-loops the pod.
+    assert "9091" in logs and "exempt sidecar ports" in logs, (
+        f"sidecar port exemptions not reported:\n{logs[-1500:]}"
     )
 
 
@@ -198,18 +212,21 @@ def test_session_api_not_gated(transparent_agent):
 
 
 def test_egress_enforcement_still_active(transparent_agent):
-    """Inbound capture must not have disturbed the egress guard's chains."""
+    """Inbound capture must not have disturbed the egress guard.
+
+    Same reasoning as the chain test: read proxy-init's report rather than exec
+    iptables in an image that has none.
+    """
     pod = agent_pod(**transparent_agent)
-    rules = kubectl(
-        "exec", pod["metadata"]["name"],
-        "-n", transparent_agent["namespace"],
-        "-c", "authbridge-proxy",
-        "--", "sh", "-c",
-        "iptables-save -t nat 2>/dev/null || iptables-nft-save -t nat",
-        check=False,
+    logs = kubectl(
+        "logs", pod["metadata"]["name"], "-n", transparent_agent["namespace"],
+        "-c", "proxy-init", check=False,
     )
-    if not rules.strip():
-        pytest.skip("iptables-save unavailable in the sidecar image")
-    assert "AB_REDIRECT" in rules, (
-        "AB_REDIRECT (egress guard) missing after enabling inbound capture"
+    assert "enforce-redirect: fail-closed egress capture active" in logs, (
+        f"egress guard not active after enabling inbound capture:\n{logs[-1500:]}"
     )
+    # Ordering matters: the ambient inbound DNAT is installed at the head of the
+    # egress chain, so egress setup must complete before inbound setup begins.
+    assert logs.index("fail-closed egress capture active") < logs.index(
+        "installing inbound capture"
+    ), "inbound setup ran before the egress chain existed"

--- a/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
+++ b/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
@@ -117,10 +117,16 @@ def test_ab_inbound_chain_installed(transparent_agent):
     assert "IPv4 inbound capture configured" in logs, (
         f"IPv4 inbound capture not configured:\n{logs[-1500:]}"
     )
-    # The exempt set must include the sidecar's own ports, or a JWT-gated :9091
-    # crash-loops the pod.
-    assert "9091" in logs and "exempt sidecar ports" in logs, (
-        f"sidecar port exemptions not reported:\n{logs[-1500:]}"
+    # Parse the exemption line rather than substring-matching the whole log:
+    # "9091" appears in plenty of other contexts (ports, URLs, timestamps), so a
+    # whole-log check would pass even if the port were never exempted — and a
+    # JWT-gated :9091 crash-loops the pod.
+    exempt_line = next(
+        (ln for ln in logs.splitlines() if "exempt sidecar ports" in ln), ""
+    )
+    assert exempt_line, f"proxy-init did not report its exemptions:\n{logs[-1500:]}"
+    assert "9091" in exempt_line.split("exempt sidecar ports=", 1)[-1], (
+        f"health port 9091 missing from the exempt set: {exempt_line!r}"
     )
 
 
@@ -179,9 +185,14 @@ def test_reverse_proxy_control_bypass_is_reachable(reverse_proxy_agent):
         reverse_proxy_agent["namespace"],
         f"http://{pod['status']['podIP']}:{relocated}/",
     )
-    assert status != 401, (
-        f"relocated port {relocated} returned 401 — the bypass appears closed "
-        "under reverse-proxy, so this control test is obsolete"
+    # Asserts success, not merely "not 401": if the bypass were ever closed with a
+    # 403, or the port stopped answering at all, `!= 401` would keep this green and
+    # the control would silently stop being a control.
+    assert status == 200, (
+        f"relocated port {relocated} returned {status}, want 200. The bypass this "
+        "feature closes appears to be gone under reverse-proxy — if that is "
+        "intentional, the default changed and this control test should be retired "
+        "with it."
     )
 
 
@@ -235,6 +246,17 @@ def test_egress_enforcement_still_active(transparent_agent):
     )
     # Ordering matters: the ambient inbound DNAT is installed at the head of the
     # egress chain, so egress setup must complete before inbound setup begins.
-    assert logs.index("fail-closed egress capture active") < logs.index(
-        "installing inbound capture"
-    ), "inbound setup ran before the egress chain existed"
+    # find(), not index(): index() raises ValueError when a marker is absent, so
+    # the assertion message would never print and the failure would surface as an
+    # unrelated traceback.
+    egress_at = logs.find("fail-closed egress capture active")
+    inbound_at = logs.find("installing inbound capture")
+    assert egress_at >= 0 and inbound_at >= 0, (
+        f"expected both setup markers in proxy-init output; "
+        f"egress={egress_at} inbound={inbound_at}\n{logs[-1500:]}"
+    )
+    assert egress_at < inbound_at, (
+        "inbound setup ran before the egress chain existed, so the ambient DNAT "
+        f"had no chain to be inserted at the head of (egress={egress_at} "
+        f"inbound={inbound_at})"
+    )

--- a/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
+++ b/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound.py
@@ -102,8 +102,13 @@ def test_ab_inbound_chain_installed(transparent_agent):
     """
     pod = agent_pod(**transparent_agent)
     logs = kubectl(
-        "logs", pod["metadata"]["name"], "-n", transparent_agent["namespace"],
-        "-c", "proxy-init", check=False,
+        "logs",
+        pod["metadata"]["name"],
+        "-n",
+        transparent_agent["namespace"],
+        "-c",
+        "proxy-init",
+        check=False,
     )
     assert logs.strip(), "proxy-init produced no output — did it run?"
     assert "transparent-inbound: hard inbound boundary active" in logs, (
@@ -206,9 +211,7 @@ def test_session_api_not_gated(transparent_agent):
     status = curl_from_probe(
         transparent_agent["namespace"], f"http://{pod['status']['podIP']}:9094/sessions"
     )
-    assert status not in (401, 403), (
-        f"session-events API is behind auth (got {status})"
-    )
+    assert status not in (401, 403), f"session-events API is behind auth (got {status})"
 
 
 def test_egress_enforcement_still_active(transparent_agent):
@@ -219,8 +222,13 @@ def test_egress_enforcement_still_active(transparent_agent):
     """
     pod = agent_pod(**transparent_agent)
     logs = kubectl(
-        "logs", pod["metadata"]["name"], "-n", transparent_agent["namespace"],
-        "-c", "proxy-init", check=False,
+        "logs",
+        pod["metadata"]["name"],
+        "-n",
+        transparent_agent["namespace"],
+        "-c",
+        "proxy-init",
+        check=False,
     )
     assert "enforce-redirect: fail-closed egress capture active" in logs, (
         f"egress guard not active after enabling inbound capture:\n{logs[-1500:]}"


### PR DESCRIPTION
## Summary

E2E suite gating transparent inbound interception (rossoctl/cortex#330). Companions: rossoctl/cortex#776 (listener + iptables, **merged**), rossoctl/operator#511 (the switch).

The load-bearing test is **`test_direct_pod_dial_is_validated`**. The reason the feature exists is that inbound JWT validation must not be sidestepped by another pod dialing the agent's real port, and nothing in the existing suite covers that.

## Design notes

**Two agents, two namespaces.** One `transparent`, one default `reverse-proxy`. A single-shape run cannot distinguish "validation works" from "nothing reached the agent at all". The reverse-proxy namespace is a control that deliberately documents the bypass as it exists today — if it starts failing because the bypass is gone, the default changed and the test should be retired with it.

**The probe always runs from a separate pod.** Dialing from inside the agent pod would traverse loopback, which shares the network namespace, is inside the trust boundary by construction, and is deliberately not intercepted — so it would prove nothing.

**The stand-in agent honors `PORT`.** Without that the reverse-proxy control could not be exercised at all: an agent that ignores `PORT` collides with AuthBridge on the stolen port and never starts, which is itself one of the failure modes transparent interception removes.

## Coverage beyond the boundary property

- **Shape** — agent keeps its own port and gets no `PORT` env var; sidecar declares `transparent-in` and does not claim the agent's port; proxy-init has both `INBOUND_TRANSPARENT_PORT` and `POD_IP` (from the downward API, without which the ambient inbound path is uncaptured); `AB_INBOUND` is live in the pod's nat table, not merely configured.
- **Don't break the neighbours** — `:9091` is not JWT-gated (it would fail kubelet probes and crash-loop the pod), `:9094` stays reachable for `abctl`, and `AB_REDIRECT` is still present so inbound capture did not disturb the egress guard.

## Three platform constraints the fixtures satisfy

Each of these otherwise produces a silently *meaningless* run rather than a failure — found by running against a live cluster:

1. The namespace needs `rossoctl-enabled=true`, or the injection webhook's `namespaceSelector` skips it and the pod comes up with **no sidecar at all**.
2. `rossoctl.io/type` cannot be applied by hand — the `agent-label-protection` ValidatingAdmissionPolicy rejects it. Injection is driven through an AgentRuntime CR, which is how agents are deployed for real.
3. Readiness alone is not a usable gate: the AgentRuntime controller labels the pod template *after* the Deployment exists, so the first ready pod predates injection. The fixtures wait for the `authbridge-proxy` container.

Images are ones already cached on Kind nodes (`nginx-unprivileged:alpine`, whose busybox `wget` doubles as the probe), so the suite needs no registry pull.

## Result: 10 passed, 0 skipped on Kind

The A/B that matters, verified live and attributed to the sidecar rather than to a waypoint (`Transparent inbound server listening addr=[::]:8083`, then `jwt-validation … status=401 … reason="missing Authorization header"`):

| Mechanism | Port dialed pod-to-pod | Result |
|---|---|---|
| `reverse-proxy` (default) | 8000 (sidecar) | 401 |
| `reverse-proxy` (default) | **8001 (relocated agent)** | **200 — the bypass** |
| `transparent` | 8000 (agent's real port) | **401** |

Also confirmed: an **undeclared port `:80` returns 401** (multi-port coverage is real), and health/stats/session return 200/200/404 — not gated.

## Three things the first live run changed

Running this for real surfaced two bugs in the suite and one in the platform:

- **`test_agent_keeps_its_own_port` could not pass even on correct behavior.** It asserted `PORT` was absent, but the stand-in agent declares `PORT` itself — it must, or the reverse-proxy control cannot be exercised at all. Now asserts the operator did not *rewrite* it, which is the real discriminator.
- **Two tests could only ever skip.** The chain and egress-guard tests exec'd `iptables-save` in the sidecar, whose image has no iptables — quietly dropping both assertions from a green run. They now assert on proxy-init's own report, which is meaningful because that container runs `require_jump` guards that abort on a rule that did not land.
- **Retargeted at pre-onboarded namespaces** (`team1`/`team2`, overridable). A fresh namespace lacks the per-namespace plumbing — `authbridge-config`, plus the Keycloak client registration that produces each agent's credentials Secret — so an injected pod there never starts, *including default reverse-proxy ones*. Fixtures flip `inboundInterception` in place and **restore the original body on teardown**, since these namespaces are shared.

## `TI_STUB_CREDENTIALS`

On clusters where Keycloak client registration is broken (no `k8s.keycloak.org` CRD, as on community-provider installs), every injected pod stays `Pending` on `FailedMount`. Without the flag the suite **skips with that cause named**, rather than failing and pointing suspicion at the interception rules.

`TI_STUB_CREDENTIALS=1` creates a placeholder so the boundary can still be tested. Opt-in on purpose: stubbing by default would let this suite go green on a broken cluster. Sound for these assertions — the Secret is for *outbound* token-exchange, and inbound rejects a request with no Authorization header before any IdP contact — but explicitly **not** sound for any test needing a valid token.

## Not covered here

The **ambient (HBONE) path**. The cluster used runs only `istiod` — no ztunnel — so there is no ambient data plane to exercise; counters confirm all traffic took plain PREROUTING. Adding an ambient case needs a cluster with ztunnel deployed.

`E2E HyperShift` is `pending` awaiting a maintainer `/run-e2e`.
