### PR TITLE
feat: Report backend version from GET /auth/config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ build-load-ui-backend:
 		echo "Info: Podman backend detected. Using --load flag for build."; \
 	fi
 	@echo ""
-	docker build -t $(UI_BACKEND_REPO):$(UI_BACKEND_TAG) -f $(UI_BACKEND_DIR)/Dockerfile $(DOCKER_BUILD_CONTEXT) $(DOCKER_BUILD_FLAGS)
+	docker build -t $(UI_BACKEND_REPO):$(UI_BACKEND_TAG) -f $(UI_BACKEND_DIR)/Dockerfile $(DOCKER_BUILD_CONTEXT) $(DOCKER_BUILD_FLAGS) --build-arg RELEASE_TAG=$(RELEASE_TAG)
 	@echo ""
 	@echo "Loading backend image into kind cluster $(KIND_CLUSTER_NAME)..."
 	kind load docker-image $(UI_BACKEND_REPO):$(UI_BACKEND_TAG) --name $(KIND_CLUSTER_NAME)

--- a/rossoctl/backend/Dockerfile
+++ b/rossoctl/backend/Dockerfile
@@ -41,6 +41,13 @@ COPY --from=builder /app/.venv /app/.venv
 # Copy application code
 COPY backend/app/ ./app/
 
+# Bake the release tag in as the reported backend version. Mirrors what
+# ui-v2/Dockerfile does to package.json, so the backend's GET /auth/config and the
+# UI's version badge report the same string from the same source. CI passes
+# RELEASE_TAG for every image in the build matrix (.github/workflows/build.yaml).
+ARG RELEASE_TAG=unknown
+ENV ROSSOCTL_BACKEND_VERSION=${RELEASE_TAG}
+
 # Set environment variables
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1

--- a/rossoctl/backend/app/core/config.py
+++ b/rossoctl/backend/app/core/config.py
@@ -26,6 +26,12 @@ class Settings(BaseSettings):
     debug: bool = False
     domain_name: str = "localtest.me"
 
+    # Version reported by GET /auth/config. backend/Dockerfile bakes this in from
+    # the RELEASE_TAG build arg — the same source ui-v2/Dockerfile substitutes into
+    # package.json for the UI version badge — so both report the same string.
+    # Empty (local dev/tests) falls back to rossoctl-backend package metadata.
+    rossoctl_backend_version: str = ""
+
     @property
     def is_running_in_cluster(self) -> bool:
         """Check if the backend is running inside a Kubernetes cluster."""

--- a/rossoctl/backend/app/routers/auth.py
+++ b/rossoctl/backend/app/routers/auth.py
@@ -5,6 +5,7 @@
 Authentication API endpoints.
 """
 
+from importlib.metadata import PackageNotFoundError, version as package_version
 from typing import Optional, List
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -43,10 +44,33 @@ class AuthConfigResponse(BaseModel):
     """
 
     enabled: bool
+    version: str
     keycloak_url: Optional[str] = None
     realm: Optional[str] = None
     client_id: Optional[str] = None
     redirect_uri: Optional[str] = None
+
+
+def _backend_version() -> str:
+    """Resolve the rossoctl-backend version.
+
+    Prefers ROSSOCTL_BACKEND_VERSION, which backend/Dockerfile bakes in from the
+    RELEASE_TAG build arg. That is the same source ui-v2/Dockerfile substitutes
+    into package.json for the UI's version badge, so both report an identical
+    string for a given build.
+
+    Outside a built image (local dev, tests) that env var is unset, so fall back
+    to the installed package metadata -- i.e. backend/pyproject.toml's version.
+    Returns "unknown" if neither is available; note the runtime image installs
+    dependencies only, so package metadata is genuinely absent there and the env
+    var is the only source.
+    """
+    if settings.rossoctl_backend_version:
+        return settings.rossoctl_backend_version
+    try:
+        return package_version("rossoctl-backend")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 @router.get("/config", response_model=AuthConfigResponse)
@@ -58,10 +82,11 @@ async def get_auth_config() -> AuthConfigResponse:
     the frontend to initialize keycloak-js without build-time env vars.
     """
     if not settings.enable_auth:
-        return AuthConfigResponse(enabled=False)
+        return AuthConfigResponse(enabled=False, version=_backend_version())
 
     return AuthConfigResponse(
         enabled=True,
+        version=_backend_version(),
         keycloak_url=settings.effective_keycloak_url,
         realm=settings.effective_keycloak_realm,
         client_id=settings.effective_client_id,

--- a/rossoctl/backend/tests/test_auth.py
+++ b/rossoctl/backend/tests/test_auth.py
@@ -5,6 +5,7 @@
 Tests for authentication and authorization utilities.
 """
 
+import asyncio
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
@@ -434,3 +435,69 @@ class TestValidateTokenRoleMapping:
         with mock_jwt_decode(realm_roles=[]):
             token_data = await validate_token("fake-token")
             assert ROLE_VIEWER in token_data.roles
+
+
+class TestAuthConfigVersion:
+    """Tests for the version reported by GET /auth/config."""
+
+    def test_version_present_when_auth_disabled(self):
+        """The early auth-disabled return path still reports a version."""
+        from app.routers.auth import get_auth_config
+
+        with patch("app.routers.auth.settings") as mock_settings:
+            mock_settings.enable_auth = False
+            mock_settings.rossoctl_backend_version = ""
+            result = asyncio.run(get_auth_config())
+
+        assert result.enabled is False
+        assert result.version
+
+    def test_version_present_when_auth_enabled(self):
+        """The authenticated config path reports the same version."""
+        from app.routers.auth import get_auth_config
+
+        with patch("app.routers.auth.settings") as mock_settings:
+            mock_settings.enable_auth = True
+            mock_settings.rossoctl_backend_version = ""
+            mock_settings.effective_keycloak_url = "http://keycloak"
+            mock_settings.effective_keycloak_realm = "rossoctl"
+            mock_settings.effective_client_id = "rossoctl-ui"
+            mock_settings.effective_redirect_uri = "http://ui"
+            result = asyncio.run(get_auth_config())
+
+        assert result.enabled is True
+        assert result.version
+
+    def test_version_matches_backend_package_metadata(self):
+        """Falling back to package metadata reports backend/pyproject.toml's version."""
+        from importlib.metadata import version as package_version
+
+        from app.routers.auth import _backend_version
+
+        with patch("app.routers.auth.settings") as mock_settings:
+            mock_settings.rossoctl_backend_version = ""
+            assert _backend_version() == package_version("rossoctl-backend")
+
+    def test_setting_overrides_package_metadata(self):
+        """ROSSOCTL_BACKEND_VERSION wins so a deployment can report its image version."""
+        from app.routers.auth import _backend_version
+
+        with patch("app.routers.auth.settings") as mock_settings:
+            mock_settings.rossoctl_backend_version = "0.7.0-alpha.6"
+            assert _backend_version() == "0.7.0-alpha.6"
+
+    def test_version_falls_back_to_unknown_without_metadata(self):
+        """The container installs dependencies only, so metadata may be absent."""
+        from importlib.metadata import PackageNotFoundError
+
+        from app.routers.auth import _backend_version
+
+        with (
+            patch("app.routers.auth.settings") as mock_settings,
+            patch(
+                "app.routers.auth.package_version",
+                side_effect=PackageNotFoundError("rossoctl-backend"),
+            ),
+        ):
+            mock_settings.rossoctl_backend_version = ""
+            assert _backend_version() == "unknown"


### PR DESCRIPTION
## Summary

Adds a `version` key to `GET /api/v1/auth/config`, reporting the same string the UI shows in its `rossoctl-brand-version` badge.

```json
{"enabled": false, "version": "v0.7.0-alpha.6", "keycloak_url": null, ...}
```

Key changes:

- `app/routers/auth.py` — `version: str` on `AuthConfigResponse`, resolved by `_backend_version()`. Set on **both** return paths, including the early return when auth is disabled.
- `app/core/config.py` — new `rossoctl_backend_version` setting (`ROSSOCTL_BACKEND_VERSION`).
- `backend/Dockerfile` — `ARG RELEASE_TAG` baked in as `ROSSOCTL_BACKEND_VERSION`, mirroring what `ui-v2/Dockerfile` does to `package.json`. This is what makes both images report the same version from the same source.
- `Makefile` — the backend build now passes `--build-arg RELEASE_TAG`, matching the frontend build.
- `tests/test_auth.py` — 5 tests.

Resolution order: `ROSSOCTL_BACKEND_VERSION` → `rossoctl-backend` package metadata → `"unknown"`.

## Notes for reviewers

**The Makefile change is a fix, not cosmetic.** CI already passes `RELEASE_TAG` to every image in the build matrix, but the Makefile passed it only to the frontend (line 76) and not the backend (line 93). Without it, `make build-load-ui` produced a UI showing the release tag next to a backend reporting `unknown`.

**Why the env var rather than package metadata alone**: `backend/Dockerfile` deliberately installs dependencies only, not the app package, so `importlib.metadata` raises `PackageNotFoundError` in the runtime image. Metadata is the local-dev/test fallback (`backend/pyproject.toml`); the env var is the only source inside a built image.

**Verified**: 752 tests pass; `ROSSOCTL_BACKEND_VERSION=v0.7.0-alpha.6` returns that string over HTTP; the `ARG` sits in the runtime stage (an `ARG` in the builder stage would silently yield `unknown`). The Dockerfile line itself is not exercised by the unit tests — worth a `docker build --build-arg RELEASE_TAG=test` on review.

Note `RELEASE_TAG` carries the `v` prefix (`v0.7.0-alpha.6`) since it comes from `git describe`/`github.ref_name`, unlike `Chart.yaml`'s `appVersion`.

## Related issue(s)

Fixes #