### PR TITLE
chore(release): pin image tags for v0.8.0-alpha.1

### DIFF
--- a/charts/rossoctl-deps/values.yaml
+++ b/charts/rossoctl-deps/values.yaml
@@ -118,7 +118,7 @@ spiffeIdp:
   # - Standalone Helm users must create job manually (see docs)
   image:
     repository: ghcr.io/rossoctl/rossoctl/spiffe-idp-setup
-    tag: v0.7.0-alpha.6
+    tag: v0.8.0-alpha.1
     pullPolicy: IfNotPresent
 
 

--- a/charts/rossoctl/Chart.lock
+++ b/charts/rossoctl/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: operator-chart
   repository: oci://ghcr.io/rossoctl/operator
-  version: 0.3.0-alpha.10
-digest: sha256:527e41cf2e45fd9c2c4a47258035b87269728637e795d6d078adc5f2220a11ac
-generated: "2026-07-22T10:41:42.889752-04:00"
+  version: 0.3.1-alpha.1
+digest: sha256:d1128a983972051b812d2614085b0fa2b4b90a0594d273f55bfc623abb18f260
+generated: "2026-08-19T14:10:34.130254-04:00"

--- a/charts/rossoctl/Chart.yaml
+++ b/charts/rossoctl/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: rossoctl
 description: A Helm chart for deploying the rossoctl platform
 type: application
-version: 0.7.0-alpha.6
-appVersion: "0.7.0-alpha.6"
+version: 0.8.0-alpha.1
+appVersion: "0.8.0-alpha.1"
 
 dependencies:
 - name: operator-chart
-  version: 0.3.0-alpha.10
+  version: 0.3.1-alpha.1
   repository: oci://ghcr.io/rossoctl/operator
   condition: components.agentOperator.enabled

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -400,25 +400,11 @@ operator-chart:
   # the explicit value is required because neither ZTWIM nor spire-bundle exist at startup.
   signatureVerification:
     spireTrustDomain: localtest.me
-  # Pin sidecar image tags injected by the AuthBridge webhook.
-  #
-  # After cortex#411 there are three combined images:
-  #   * authbridge      — proxy-sidecar mode (default), full plugin set
-  #                       including the a2a/mcp/inference parsers.
-  #   * authbridge-envoy — envoy-sidecar mode, full plugin set, expects
-  #                       proxyInit's iptables setup.
-  #   * authbridge-lite  — proxy-sidecar shape, auth-only plugins
-  #                       (parsers dropped). For size-constrained deployments;
-  #                       not selected by default.
-  # Spiffe-helper is bundled inside each combined image and gated per
-  # workload by the SPIRE_ENABLED env var; it is no longer a separate
-  # sidecar. Client registration is operator-managed.
-  defaults:
-    images:
-      authbridge: ghcr.io/rossoctl/cortex/authbridge:v0.7.0-alpha.3
-      envoyProxy: ghcr.io/rossoctl/cortex/authbridge-envoy:v0.7.0-alpha.3
-      authbridgeLite: ghcr.io/rossoctl/cortex/authbridge-lite:v0.7.0-alpha.3
-      proxyInit: ghcr.io/rossoctl/cortex/proxy-init:v0.7.0-alpha.3
+  # AuthBridge sidecar image tags (authbridge / -envoy / -lite / proxy-init) are
+  # NOT overridden here — they come from the operator subchart's own defaults,
+  # pinned via the operator-chart dependency version in Chart.yaml. Keeping a
+  # single source of truth avoids the silent drift we hit when this override
+  # block sat stale behind the subchart default (rossoctl/rossoctl#2399).
 
 # ------------------------------------------------------------------
 #  SPIFFE Configuration

--- a/charts/rossoctl/values.yaml
+++ b/charts/rossoctl/values.yaml
@@ -194,7 +194,7 @@ ui:
   frontend:
     enabled: true
     image: ghcr.io/rossoctl/rossoctl/ui-v2
-    tag: v0.7.0-alpha.6
+    tag: v0.8.0-alpha.1
     resources:
       limits:
         cpu: 100m
@@ -211,7 +211,7 @@ ui:
   # Backend configuration
   backend:
     image: ghcr.io/rossoctl/rossoctl/backend
-    tag: v0.7.0-alpha.6
+    tag: v0.8.0-alpha.1
     # Optional Context Service API URL. Empty disables context resource APIs and
     # agent context attachments. Example:
     # http://context-service.serverless-harness.svc.cluster.local:8080
@@ -241,7 +241,7 @@ ui:
 # ------------------------------------------------------------------
 uiOAuthSecret:
   image: ghcr.io/rossoctl/rossoctl/ui-oauth-secret
-  tag: v0.7.0-alpha.6
+  tag: v0.8.0-alpha.1
   # When true, mount the in-cluster serviceaccount CA
   # into the ui-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -253,7 +253,7 @@ uiOAuthSecret:
 # ------------------------------------------------------------------
 agentOAuthSecret:
   image: ghcr.io/rossoctl/rossoctl/agent-oauth-secret
-  tag: v0.7.0-alpha.6
+  tag: v0.8.0-alpha.1
   # When true, mount the in-cluster serviceaccount CA
   # into the agent-oauth-secret job via the SSL_CERT_FILE environment variable.
   # When false, the serviceaccount CA is only for the API server
@@ -271,7 +271,7 @@ agentOAuthSecret:
 apiOAuthSecret:
   enabled: false
   image: ghcr.io/rossoctl/rossoctl/api-oauth-secret
-  tag: v0.7.0-alpha.6
+  tag: v0.8.0-alpha.1
   # Client ID for the API service account
   clientId: rossoctl-api
   # Name of the K8s secret to store credentials
@@ -289,7 +289,7 @@ apiOAuthSecret:
 # ------------------------------------------------------------------
 operatorSpiffeBootstrap:
   image: ghcr.io/rossoctl/rossoctl/operator-spiffe-bootstrap
-  tag: latest
+  tag: v0.8.0-alpha.1
 
 # ------------------------------------------------------------------
 #  Keycloak Configuration
@@ -368,7 +368,7 @@ authBridge:
 spiffeIdp:
   image:
     repository: ghcr.io/rossoctl/rossoctl/spiffe-idp-setup
-    tag: v0.7.0-alpha.6
+    tag: v0.8.0-alpha.1
     pullPolicy: IfNotPresent
 
 # ------------------------------------------------------------------
@@ -379,7 +379,7 @@ operator-chart:
     container:
       cmd: /manager
       image:
-        tag: 0.3.0-alpha.10
+        tag: 0.3.1-alpha.1
       args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -415,10 +415,10 @@ operator-chart:
   # sidecar. Client registration is operator-managed.
   defaults:
     images:
-      authbridge: ghcr.io/rossoctl/cortex/authbridge:v0.6.0-alpha.12
-      envoyProxy: ghcr.io/rossoctl/cortex/authbridge-envoy:v0.6.0-alpha.12
-      authbridgeLite: ghcr.io/rossoctl/cortex/authbridge-lite:v0.6.0-alpha.12
-      proxyInit: ghcr.io/rossoctl/cortex/proxy-init:v0.6.0-alpha.12
+      authbridge: ghcr.io/rossoctl/cortex/authbridge:v0.7.0-alpha.3
+      envoyProxy: ghcr.io/rossoctl/cortex/authbridge-envoy:v0.7.0-alpha.3
+      authbridgeLite: ghcr.io/rossoctl/cortex/authbridge-lite:v0.7.0-alpha.3
+      proxyInit: ghcr.io/rossoctl/cortex/proxy-init:v0.7.0-alpha.3
 
 # ------------------------------------------------------------------
 #  SPIFFE Configuration
@@ -466,7 +466,7 @@ phoenix:
 # ------------------------------------------------------------------
 phoenixOAuthSecret:
   image: ghcr.io/rossoctl/rossoctl/phoenix-oauth-secret
-  tag: v0.7.0-alpha.6
+  tag: v0.8.0-alpha.1
   # Keycloak client ID for Phoenix
   clientId: phoenix
   # Kubernetes secret name to store OAuth credentials
@@ -494,7 +494,7 @@ mlflow:
 # ------------------------------------------------------------------
 mlflowOAuthSecret:
   image: ghcr.io/rossoctl/rossoctl/mlflow-oauth-secret
-  tag: v0.7.0-alpha.6
+  tag: v0.8.0-alpha.1
   # Keycloak client ID for MLflow
   clientId: mlflow
   # Kubernetes secret name to store OAuth credentials

--- a/docs/overview/5-quickstart.md
+++ b/docs/overview/5-quickstart.md
@@ -34,7 +34,7 @@ cd rossoctl
 Check out the latest stable release (recommended). Find the current version at https://github.com/rossoctl/rossoctl/releases/latest.
 
 ```bash
-git checkout v0.7.0-alpha.6
+git checkout v0.7.0
 ```
 
 Copy and configure secrets (optional). Edit `deployments/envs/.secret_values.yaml` with your values.


### PR DESCRIPTION
## Summary

Cut **`v0.8.0-alpha.1`** — the first alpha off `main` since the `0.7.0` GA — so people can install pinned, reproducible artifacts to test features in `main`.

Pins all rossoctl-built images and aligns core dependency versions:

| Component | Version |
|-----------|---------|
| platform (this repo) | `0.8.0-alpha.1` |
| operator-chart | `0.3.1-alpha.1` |
| cortex / AuthBridge injection images | `v0.7.0-alpha.3` |
| examples | `v0.2.0` (unchanged — no cut warranted) |

### Changes
- `Chart.yaml` version/appVersion `0.7.0-alpha.6 → 0.8.0-alpha.1`; operator-chart dep `0.3.0-alpha.10 → 0.3.1-alpha.1` (`Chart.lock` regenerated).
- rossoctl images (ui-v2, backend, ui/agent/api/phoenix/mlflow-oauth-secret, operator-spiffe-bootstrap, spiffe-idp-setup) `→ v0.8.0-alpha.1`.
- **`operator-spiffe-bootstrap: latest → v0.8.0-alpha.1`** — no floating tags, even for alphas.
- operator image tag `→ 0.3.1-alpha.1`.
- AuthBridge injection overrides `v0.6.0-alpha.12 → v0.7.0-alpha.3` (match cortex alpha.3, and the operator chart's own pinned defaults).
- rossoctl-deps spiffe-idp-setup `→ v0.8.0-alpha.1`.

### Verification
- `scripts/check-release-pins.sh` → **PASS**
- Full-render `:latest` gate (`helm template` incl. operator subchart) → **PASS**, all injected images pinned.

### Notes
Two `pin-release-tags.sh` gaps worked around here (filed separately): yq write path broken on yq v4.45.1, and the managed-image list misses `phoenix-oauth-secret` + the rossoctl-chart `spiffe-idp-setup` copy.

Assisted-By: Claude Code
