### PR TITLE
test(e2e): cover inbound mTLS and the ambient/HBONE path in transparent inbound

### DIFF
--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -69,12 +69,28 @@ feature.
 - `proxy.allowedInboundInterception` must permit `transparent` (the default).
 - Linux nodes: the feature is iptables-based. Skipped elsewhere.
 - **Working Keycloak client registration.** The injected sidecar mounts a
-  per-agent credentials Secret created by the operator. Where that path is broken
-  — e.g. the `k8s.keycloak.org/v2alpha1` CRD is absent, as on a cluster installed
-  with the community Keycloak provider — every injected pod stays `Pending` on
-  `FailedMount`, including default reverse-proxy ones. The suite **skips with that
-  cause named** rather than failing and pointing suspicion at the interception
-  rules.
+  per-agent credentials Secret the operator registers *asynchronously*. Where that
+  path does not complete, every injected pod stays `Pending` on `FailedMount` —
+  including default reverse-proxy ones — so it says nothing about interception. The
+  suite **skips with the cause named** rather than failing and pointing suspicion
+  at the interception rules. Two causes are known and they need distinguishing:
+
+  1. **On Kind, registration is intermittent.** `.github/workflows/e2e-kind.yaml`
+     carries an explicit wait loop for these Secrets and marks the token-exchange
+     suite `continue-on-error` for exactly this reason.
+  2. **The `k8s.keycloak.org/v2alpha1` CRD is absent**, as on community-provider
+     installs. Then *no* agent in the cluster ever gets a Secret.
+
+  Check `kubectl get crd | grep k8s.keycloak.org`, and whether other agents have
+  credentials Secrets, before suspecting this feature.
+
+  > **This suite is currently inert in CI.** All of its tests skip on the shared
+  > Kind e2e run via cause (1) above — verified on the run for #2404. That has
+  > been true since the suite merged, so CI passing is **not** evidence these
+  > tests ran. Until it is resolved, the meaningful signal is a local run with
+  > `TI_STUB_CREDENTIALS=1`. Making it gate in CI means either fixing registration
+  > or setting `TI_STUB_CREDENTIALS=1` in the runner — the latter reverses the
+  > opt-in reasoning below, so it is a deliberate call, not a default.
 
   To test the boundary anyway on such a cluster, set `TI_STUB_CREDENTIALS=1` to
   create a placeholder Secret. This is opt-in on purpose: stubbing by default

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -69,42 +69,47 @@ feature.
 - `proxy.allowedInboundInterception` must permit `transparent` (the default).
 - Linux nodes: the feature is iptables-based. Skipped elsewhere.
 - **Working Keycloak client registration.** The injected sidecar mounts a
-  per-agent credentials Secret the operator registers *asynchronously*. Where that
-  path does not complete, every injected pod stays `Pending` on `FailedMount` —
-  including default reverse-proxy ones — so it says nothing about interception. The
-  suite **skips with the cause named** rather than failing and pointing suspicion
-  at the interception rules. Two causes are known and they need distinguishing:
+  per-agent credentials Secret the operator's ClientRegistration controller creates
+  *asynchronously*. Where that path does not complete, every injected pod stays
+  `Pending` on `FailedMount` — including default reverse-proxy ones — so it says
+  nothing about interception. The suite **skips with the cause named** rather than
+  failing and pointing suspicion at the interception rules.
 
-  1. **On Kind, registration is intermittent.** `.github/workflows/e2e-kind.yaml`
-     carries an explicit wait loop for these Secrets and marks the token-exchange
-     suite `continue-on-error` for exactly this reason.
-  2. **The `k8s.keycloak.org/v2alpha1` CRD is absent**, as on community-provider
-     installs. Then *no* agent in the cluster ever gets a Secret.
+  The controller logs its exact reason and then requeues every 30s, so read the
+  log rather than guessing:
 
-  Check `kubectl get crd | grep k8s.keycloak.org`, and whether other agents have
-  credentials Secrets, before suspecting this feature.
+  ```sh
+  kubectl logs -n rossoctl-system deployment/rossoctl-controller-manager \
+    | grep -E 'cannot resolve|waiting for|registration failed|skipping'
+  ```
 
-  > **This suite is currently inert in CI.** All of its tests skip on the shared
-  > Kind e2e run via cause (1) above — verified on the run for #2404. That has
-  > been true since the suite merged, so CI passing is **not** evidence these
-  > tests ran. Until it is resolved, the meaningful signal is a local run with
-  > `TI_STUB_CREDENTIALS=1`. Making it gate in CI means either fixing registration
-  > or setting `TI_STUB_CREDENTIALS=1` in the runner — the latter reverses the
-  > opt-in reasoning below, so it is a deliberate call, not a default.
+  The reason that bit this suite, and the reason the fixtures create a dedicated
+  ServiceAccount, is documented at the manifest in `conftest.py`: with SPIRE
+  enabled the controller derives the Keycloak client ID from the **Deployment pod
+  template's** `serviceAccountName` and refuses on `default`. The AuthBridge
+  webhook does create a per-agent SA and set it on the **pod**, but never on the
+  template — so the webhook's fixup is invisible to the controller, and the pod
+  ends up mounting a Secret that the controller has already declined to create.
+  That split is a platform defect, tracked separately; setting the SA ourselves is
+  the half we control. Note the `k8s.keycloak.org` CRD is **not** in this path —
+  the controller uses Keycloak's admin REST API directly.
 
-  To test the boundary anyway on such a cluster, set `TI_STUB_CREDENTIALS=1` to
-  create a placeholder Secret. This is opt-in on purpose: stubbing by default
-  would let the suite go green on a cluster whose Keycloak registration is
-  broken. The stub is sound for these assertions — the Secret is for *outbound*
-  token-exchange, and inbound validation rejects a request with no Authorization
-  header before any IdP contact — but it would **not** be sound for any test
-  needing a valid token.
+  `TI_STUB_CREDENTIALS=1` creates a placeholder Secret so the interception
+  boundary can still be tested on a cluster where registration is genuinely
+  broken. It is opt-in on purpose: stubbing by default would let the suite go
+  green on such a cluster. The stub is sound for these assertions — the Secret is
+  for *outbound* token-exchange, and inbound validation rejects a request with no
+  Authorization header before any IdP contact — but it would **not** be sound for
+  any test needing a valid token.
 
-Three platform constraints the fixtures satisfy, each of which otherwise
+Four platform constraints the fixtures satisfy, each of which otherwise
 produces a silently meaningless run:
 
 - The namespace needs `rossoctl-enabled=true`, or the injection webhook's
   `namespaceSelector` skips it and the pod comes up with no sidecar at all.
+- The pod template needs an explicit `serviceAccountName` (a dedicated SA, not
+  `default`), or with SPIRE enabled the credentials Secret is never created and
+  every pod stays `FailedMount` forever. See the requirement above.
 - `rossoctl.io/type` cannot be applied by hand — the `agent-label-protection`
   ValidatingAdmissionPolicy rejects it. Injection is driven through an
   AgentRuntime CR, which is how agents are deployed for real.

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -15,6 +15,30 @@ port answers without validation. If that test ever fails because the bypass is
 gone, the default changed — which is a decision, not a bug, and the test should
 be retired with it.
 
+## Modules
+
+| Module | Covers |
+|---|---|
+| `test_transparent_inbound.py` | The bypass property, injected shape, multi-port capture, sidecar ports, egress |
+| `test_transparent_inbound_mtls.py` | Inbound mTLS through the transparent listener (rossoctl/cortex#780) |
+
+The mTLS module closes a gap the first one could not see. The transparent
+listener reuses the reverse proxy's mTLS posture via `WrapListener`, and the
+startup log said `mtls=true`, but no TLS client had ever been driven at it. The
+untested part is the *combination*: `SO_ORIGINAL_DST` recovery happens on the raw
+connection, before `tlssniff` peeks the first byte — had those interfered, the
+logs would still have looked correct. It asserts plaintext is refused under
+`strict` (so `tlssniff` is provably engaged, since the same request is a 401
+under permissive), that a ClientHello reaches a real server-side handshake, and
+that a valid SVID **completes** the handshake and then still gets a 401 from
+`jwt-validation` — transport authentication is not request authorization.
+
+It is module-scoped rather than session-scoped because it flips the same
+namespace: it sets up and tears down within itself, restoring from a baseline
+captured before the suite touched the namespace, so module order cannot change
+the namespace's final state. It skips when SPIRE supplies no SVIDs, since a
+completed-handshake assertion is not possible there.
+
 ## Namespaces
 
 Runs in **pre-onboarded** namespaces (`team1`/`team2` by default, override with

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -90,9 +90,13 @@ feature.
   webhook does create a per-agent SA and set it on the **pod**, but never on the
   template — so the webhook's fixup is invisible to the controller, and the pod
   ends up mounting a Secret that the controller has already declined to create.
-  That split is a platform defect, tracked separately; setting the SA ourselves is
-  the half we control. Note the `k8s.keycloak.org` CRD is **not** in this path —
-  the controller uses Keycloak's admin REST API directly.
+  That split is latent rather than an active platform defect: every path that
+  creates a workload for real — the backend's agent and tool manifests, and the
+  `7x-deploy-*` scripts — already sets `serviceAccountName`, so only a
+  hand-written Deployment like this fixture ever reaches the refusal. Setting it
+  here is matching what those paths do, not working around a bug. Note the
+  `k8s.keycloak.org` CRD is **not** in this path — the controller uses Keycloak's
+  admin REST API directly.
 
   `TI_STUB_CREDENTIALS=1` creates a placeholder Secret so the interception
   boundary can still be tested on a cluster where registration is genuinely

--- a/rossoctl/tests/e2e/transparent_inbound/README.md
+++ b/rossoctl/tests/e2e/transparent_inbound/README.md
@@ -21,6 +21,7 @@ be retired with it.
 |---|---|
 | `test_transparent_inbound.py` | The bypass property, injected shape, multi-port capture, sidecar ports, egress |
 | `test_transparent_inbound_mtls.py` | Inbound mTLS through the transparent listener (rossoctl/cortex#780) |
+| `test_transparent_inbound_ambient.py` | The same bypass property on the Istio ambient / HBONE path (rossoctl/cortex#780) |
 
 The mTLS module closes a gap the first one could not see. The transparent
 listener reuses the reverse proxy's mTLS posture via `WrapListener`, and the
@@ -38,6 +39,38 @@ namespace: it sets up and tears down within itself, restoring from a baseline
 captured before the suite touched the namespace, so module order cannot change
 the namespace's final state. It skips when SPIRE supplies no SVIDs, since a
 completed-handshake assertion is not possible there.
+
+The ambient module covers a path the other two structurally cannot reach. Without
+a ztunnel, a pod-to-pod dial arrives as ordinary TCP and is captured in
+`nat PREROUTING` by `AB_INBOUND`. Under ambient it never reaches `PREROUTING` at
+all: ztunnel terminates HBONE on `:15008` and re-originates a local connection,
+which surfaces in `nat OUTPUT` and is captured by a separate mark-based DNAT at
+the head of `AB_REDIRECT` — ahead of that chain's ztunnel-mark `RETURN`. Two
+paths, two rules, and the same 401 either way, so no other test can tell which
+one carried the request. Hence `test_hbone_delivered_request_is_validated`
+asserts the **path** as well as the status, from ztunnel's own access log:
+without that, the module silently degrades into a duplicate of
+`test_direct_pod_dial_is_validated` the moment ambient stops being engaged.
+
+Removing that one DNAT rule from a live pod's netns makes the mesh-delivered
+request return **200** — the app answering unvalidated — and the module fails
+with that diagnosis, while the health-port test keeps passing. Rule ordering and
+packet counters are not asserted directly: they are not reachable from a test
+pod, and every way the rule can regress (deleted, ordered after the mark
+`RETURN`, matching too narrowly) ends in that same 200. The counter-level
+evidence for the rules as programmed is recorded on rossoctl/cortex#780.
+
+Unlike the other two modules it is deliberately **not** `kind_only`. The platform
+ships the ambient data plane on OpenShift only — `charts/rossoctl-deps/templates/istio-operand.yaml`
+gates the `Istio`, `IstioCNI` and `ZTunnel` operands on `.Values.openshift`, and
+`deployments/envs/dev_values*.yaml` set it false — so a Kind-only ambient test
+could never run where ambient actually is the shipped configuration. It self-gates
+on a ready ztunnel found by label across all namespaces (the platform chart uses
+`istio-ztunnel`, a community `istio/ztunnel` install defaults to `istio-system`,
+and neither changes the rule under test) plus `istio.io/dataplane-mode=ambient` on
+both namespaces, skipping with whichever is missing named. Being unmarked makes it
+the first module here to run on OpenShift, so its first run there may surface
+pre-existing suite or platform issues rather than ambient ones.
 
 ## Namespaces
 

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -180,15 +180,21 @@ def _wait_ready(namespace: str, name: str, timeout: int):
             "interception boundary anyway) "
             "platform gap, not a feature failure: the per-agent Keycloak "
             "client-credentials Secret was never created, so the injected pod "
-            "cannot mount it. The operator registers the client asynchronously; "
-            "two causes are known, so check which one applies rather than "
-            "assuming: (1) on Kind, client registration is intermittent — "
-            "e2e-kind.yaml carries an explicit wait loop and marks the "
-            "token-exchange suite continue-on-error for exactly this; (2) the "
-            "k8s.keycloak.org CRD is absent, as on community-provider installs, "
-            "in which case no agent in the cluster ever gets a Secret. Check "
-            "`kubectl get crd | grep k8s.keycloak.org` and whether OTHER agents "
-            "have credentials Secrets before suspecting this feature."
+            "cannot mount it. This blocks EVERY injected pod, including default "
+            "reverse-proxy ones, so it says nothing about interception. The "
+            "operator's ClientRegistration controller creates that Secret and "
+            "logs its exact reason for not doing so, then requeues every 30s — "
+            "so read the log rather than guessing:\n"
+            "  kubectl logs -n rossoctl-system deployment/rossoctl-controller-manager "
+            "| grep -E 'cannot resolve|waiting for|registration failed|skipping'\n"
+            "Known reasons, all of which it prints verbatim: the pod template's "
+            "serviceAccountName is 'default' while SPIRE is on (this suite sets a "
+            "dedicated SA precisely to avoid it — check the manifest still does); "
+            "KEYCLOAK_URL/KEYCLOAK_REALM absent from the namespace's "
+            "authbridge-config; the Keycloak admin Secret missing from "
+            "rossoctl-system; or the cluster feature gates disabling "
+            "clientRegistration. Note the k8s.keycloak.org CRD is NOT in this "
+            "path — the controller uses Keycloak's admin REST API directly."
         )
     raise AssertionError(
         f"deployment {namespace}/{name} not ready within {timeout}s "
@@ -204,6 +210,23 @@ def _agent_manifest(namespace: str, name: str) -> str:
     mechanisms apart.
     """
     return f"""
+# A dedicated ServiceAccount, named after the workload, is a hard requirement
+# rather than tidiness. With SPIRE enabled the operator's ClientRegistration
+# controller derives the Keycloak client ID from the pod template's
+# serviceAccountName; on "default" it refuses -- "SPIRE enabled: set
+# spec.template.spec.serviceAccountName to a dedicated ServiceAccount" -- and
+# requeues every 30s forever, so the per-agent credentials Secret is never
+# created and the injected pod never leaves FailedMount. The AuthBridge webhook
+# does create such an SA and sets it on the *pod*, but the controller reads the
+# *Deployment template*, which the webhook never touches, so the webhook's fixup
+# is invisible to it. Creating the SA explicitly is what the platform's own
+# agent deploy scripts do, and it is the only half of that pair we control here.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {name}
+  namespace: {namespace}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -219,6 +242,7 @@ spec:
       labels:
         app: {name}
     spec:
+      serviceAccountName: {name}
       containers:
         - name: agent
           image: {AGENT_IMAGE}
@@ -406,7 +430,12 @@ def _require_platform_support(ns: str, name: str, mechanism: str):
 def _teardown(ns: str, name: str, original: str):
     if os.environ.get("TI_KEEP") == "1":
         return
-    for kind in ("deployment", "service", "agentruntime"):
+    # The ServiceAccount is deleted explicitly because nothing garbage-collects it:
+    # the AuthBridge webhook creates per-agent SAs with no ownerReference, so they
+    # outlive the workload. Ours is in the manifest, but the delete also sweeps one
+    # a pre-fix run of this suite left behind. The credentials Secret needs no entry
+    # here -- the controller owner-references it to the Deployment, so it GCs itself.
+    for kind in ("deployment", "service", "agentruntime", "serviceaccount"):
         kubectl("delete", kind, name, "-n", ns, "--wait=false", check=False)
     # Restoring the namespace config matters: these are SHARED namespaces, so
     # leaving one flipped to transparent would silently change every other agent

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -39,15 +39,25 @@ READY_TIMEOUT = int(os.environ.get("TI_READY_TIMEOUT", "180"))
 SVID_SECRET_NAME = "ti-e2e-mtls-svid"
 
 
-def kubectl(*args, check=True, stdin=None):
-    """Run kubectl and return stdout. Raises on non-zero unless check=False."""
-    proc = subprocess.run(
+def kubectl_run(*args, stdin=None):
+    """Run kubectl and return the CompletedProcess (returncode, stdout, stderr).
+
+    The full result matters to any caller that must tell "the command failed" apart
+    from "the command succeeded and produced nothing" — kubectl() collapses both to
+    an empty string.
+    """
+    return subprocess.run(
         ["kubectl", *args],
         capture_output=True,
         text=True,
         input=stdin,
         timeout=120,
     )
+
+
+def kubectl(*args, check=True, stdin=None):
+    """Run kubectl and return stdout. Raises on non-zero unless check=False."""
+    proc = kubectl_run(*args, stdin=stdin)
     if check and proc.returncode != 0:
         raise RuntimeError(
             f"kubectl {' '.join(args)} failed ({proc.returncode}):\n"
@@ -63,9 +73,7 @@ def kubectl_rc(*args) -> int:
     which kubectl() drops — so a caller that must distinguish "created" from
     "already satisfied" cannot do it by inspecting stdout.
     """
-    return subprocess.run(
-        ["kubectl", *args], capture_output=True, text=True, timeout=120
-    ).returncode
+    return kubectl_run(*args).returncode
 
 
 # Secrets this suite created, so teardown can remove them. Module-level because
@@ -476,6 +484,33 @@ def mtls_strict_agent(linux_nodes):
     _teardown(ns, name, original)
 
 
+def _skip_or_fail_svid(filename: str, pod: str, proc) -> None:
+    """Decide whether an unreadable SVID file is a legitimate skip or a failure.
+
+    Only one cause justifies skipping the completed-handshake test: SPIRE genuinely
+    supplied no SVID, which surfaces as ``cat`` reporting the file does not exist.
+    Everything else — a renamed container, a moved path, a pod mid-restart, a
+    transient API error — is an infrastructure regression, and skipping on it would
+    silently green the one security-critical case in this module. So: skip on
+    proven absence, raise on anything unexplained.
+    """
+    stderr = (proc.stderr or "").strip()
+    # Matches both coreutils ("cat: /opt/x: No such file or directory") and busybox
+    # ("cat: can't open '/opt/x': No such file or directory"). Deliberately not the
+    # broader "not found", which also matches "executable file not found" (no cat in
+    # the image) and "container not found" — neither of which is an absent SVID.
+    if "no such file" in stderr.lower():
+        pytest.skip(
+            f"sidecar has no /opt/{filename}: SPIRE is not supplying SVIDs on this "
+            "cluster, so a completed-handshake test is not possible here"
+        )
+    raise RuntimeError(
+        f"could not read /opt/{filename} from {pod}/authbridge-proxy "
+        f"(exit {proc.returncode}) — refusing to skip the mTLS handshake test on an "
+        f"unexplained failure:\nstdout: {proc.stdout!r}\nstderr: {stderr!r}"
+    )
+
+
 @pytest.fixture(scope="module")
 def svid_secret(mtls_strict_agent):
     """Stage the agent sidecar's own SVID as a Secret a probe pod can mount.
@@ -489,28 +524,29 @@ def svid_secret(mtls_strict_agent):
     ns, name = mtls_strict_agent["namespace"], mtls_strict_agent["name"]
     pod = agent_pod(ns, name)["metadata"]["name"]
     args = ["create", "secret", "generic", SVID_SECRET_NAME, "-n", ns]
-    for f in ("svid.pem", "svid_key.pem", "svid_bundle.pem"):
-        data = kubectl(
-            "exec",
-            pod,
-            "-n",
-            ns,
-            "-c",
-            "authbridge-proxy",
-            "--",
-            "cat",
-            f"/opt/{f}",
-            check=False,
-        )
-        if not data.strip():
-            pytest.skip(
-                f"sidecar has no /opt/{f}: SPIRE is not supplying SVIDs on this "
-                "cluster, so a completed-handshake test is not possible here"
+    # A private 0700 directory, removed on the way out: the SVID *private key*
+    # passes through here, and an SVID being short-lived is not a reason to leave
+    # key material on the runner. The context manager also covers the skip/raise
+    # paths below, which an explicit unlink at the end would not.
+    with tempfile.TemporaryDirectory(prefix=f"{SVID_SECRET_NAME}-") as tmpdir:
+        for f in ("svid.pem", "svid_key.pem", "svid_bundle.pem"):
+            proc = kubectl_run(
+                "exec",
+                pod,
+                "-n",
+                ns,
+                "-c",
+                "authbridge-proxy",
+                "--",
+                "cat",
+                f"/opt/{f}",
             )
-        path = pathlib.Path(tempfile.gettempdir()) / f"{SVID_SECRET_NAME}-{f}"
-        path.write_text(data)
-        args.append(f"--from-file={f}={path}")
-    rendered = kubectl(*args, "--dry-run=client", "-o", "yaml")
+            if proc.returncode != 0 or not proc.stdout.strip():
+                _skip_or_fail_svid(f, pod, proc)
+            path = pathlib.Path(tmpdir) / f
+            path.write_text(proc.stdout)
+            args.append(f"--from-file={f}={path}")
+        rendered = kubectl(*args, "--dry-run=client", "-o", "yaml")
     kubectl("apply", "-f", "-", stdin=rendered)
     yield SVID_SECRET_NAME
     kubectl("delete", "secret", SVID_SECRET_NAME, "-n", ns, "--wait=false", check=False)

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -9,8 +9,10 @@ isolation. A single-shape run cannot distinguish "validation works" from
 
 import json
 import os
+import pathlib
 import re
 import subprocess
+import tempfile
 import time
 
 import pytest
@@ -33,6 +35,8 @@ PROBE_IMAGE = os.environ.get("TI_PROBE_IMAGE", AGENT_IMAGE)
 # under reverse-proxy the operator relocates the agent off it.
 AGENT_PORT = int(os.environ.get("TI_AGENT_PORT", "8000"))
 READY_TIMEOUT = int(os.environ.get("TI_READY_TIMEOUT", "180"))
+# Secret holding a staged SVID for the mTLS module's probe pod.
+SVID_SECRET_NAME = "ti-e2e-mtls-svid"
 
 
 def kubectl(*args, check=True, stdin=None):
@@ -260,6 +264,22 @@ spec:
 """
 
 
+def _strip_top_level(body: str, keys: tuple, with_children: bool = False) -> str:
+    """Drop the given top-level YAML keys, optionally with their indented children."""
+    out, skipping = [], False
+    for line in body.splitlines():
+        if skipping:
+            # A blank line or any non-indented line ends the block.
+            if line.strip() and line[:1].isspace():
+                continue
+            skipping = False
+        if any(re.match(rf"^{k}\s*:", line) for k in keys):
+            skipping = with_children
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
 def _read_namespace_config(namespace: str) -> str:
     return kubectl(
         "get",
@@ -288,7 +308,14 @@ def _write_namespace_config(namespace: str, body: str):
     kubectl("apply", "-f", "-", stdin=cm)
 
 
-def _set_mechanism(namespace: str, mechanism: str) -> str:
+# The namespace config as it was before this suite touched it, captured once per
+# namespace. Fixtures restore from here rather than from whatever they observed,
+# so adding a second module that flips the same namespace cannot make restoration
+# order-dependent.
+_baseline: dict = {}
+
+
+def _set_mechanism(namespace: str, mechanism: str, mtls: str = "") -> str:
     """Prepend the inbound mechanism to the namespace config; return the original.
 
     Edits in place rather than replacing the ConfigMap: the existing body carries
@@ -296,6 +323,7 @@ def _set_mechanism(namespace: str, mechanism: str) -> str:
     synthetic replacement would exercise a pipeline no real deployment runs.
     """
     original = _read_namespace_config(namespace)
+    _baseline.setdefault(namespace, original)
     if not original.strip():
         pytest.skip(
             f"namespace {namespace} has no authbridge-runtime-config — not an "
@@ -304,15 +332,15 @@ def _set_mechanism(namespace: str, mechanism: str) -> str:
     # Strip keys a previous run may have left before prepending. Prepending blind
     # is not idempotent: with TI_KEEP=1, or after a killed run that skipped
     # teardown, the next run would emit duplicate top-level YAML keys.
-    stripped = "\n".join(
-        line
-        for line in original.splitlines()
-        if not re.match(r"^(inboundInterception|egressEnforcement)\s*:", line)
-    )
-    body = (
-        f"inboundInterception: {mechanism}\n"
-        "egressEnforcement: enforce-redirect\n" + stripped.lstrip("\n")
-    )
+    stripped = _strip_top_level(original, ("inboundInterception", "egressEnforcement"))
+    prefix = f"inboundInterception: {mechanism}\negressEnforcement: enforce-redirect\n"
+    if mtls:
+        # mtls is a nested block, so it cannot be prepended as a bare line the way
+        # the scalar keys are — and an existing block has to be removed with its
+        # indented children or the two would merge into one malformed mapping.
+        stripped = _strip_top_level(stripped, ("mtls",), with_children=True)
+        prefix += f"mtls:\n  mode: {mtls}\n"
+    body = prefix + stripped.lstrip("\n")
     _write_namespace_config(namespace, body)
     return original
 
@@ -327,8 +355,8 @@ def linux_nodes():
     return True
 
 
-def _deploy(ns: str, name: str, mechanism: str) -> str:
-    original = _set_mechanism(ns, mechanism)
+def _deploy(ns: str, name: str, mechanism: str, mtls: str = "") -> str:
+    original = _set_mechanism(ns, mechanism, mtls)
     kubectl("apply", "-f", "-", stdin=_agent_manifest(ns, name))
     try:
         _wait_ready(ns, name, READY_TIMEOUT)
@@ -376,8 +404,9 @@ def _teardown(ns: str, name: str, original: str):
     # Restoring the namespace config matters: these are SHARED namespaces, so
     # leaving one flipped to transparent would silently change every other agent
     # in it on its next pod recreation.
-    if original.strip():
-        _write_namespace_config(ns, original)
+    restore = _baseline.get(ns, original)
+    if restore.strip():
+        _write_namespace_config(ns, restore)
     # Remove any placeholder credentials Secret this suite created. Leaving a fake
     # credential in a shared namespace is worse than the gap it papered over.
     for entry in [t for t in _stubbed if t[0] == ns]:
@@ -394,6 +423,61 @@ def transparent_agent(linux_nodes):
     original = _deploy(ns, name, "transparent")
     yield {"namespace": ns, "name": name}
     _teardown(ns, name, original)
+
+
+@pytest.fixture(scope="module")
+def mtls_strict_agent(linux_nodes):
+    """Transparent agent with mTLS strict.
+
+    Module-scoped, not session-scoped: it flips the same namespace the permissive
+    fixture uses, so it must set up and tear down within its own module rather
+    than persisting for the session. Restoration comes from _baseline, so the
+    order the two modules run in cannot change the namespace's final state.
+    """
+    ns, name = NS_TRANSPARENT, "ti-e2e-mtls"
+    original = _deploy(ns, name, "transparent", mtls="strict")
+    yield {"namespace": ns, "name": name}
+    _teardown(ns, name, original)
+
+
+@pytest.fixture(scope="module")
+def svid_secret(mtls_strict_agent):
+    """Stage the agent sidecar's own SVID as a Secret a probe pod can mount.
+
+    Reuses the workload's real SVID rather than minting one: any identity in the
+    trust domain satisfies RequireAndVerifyClientCert, and borrowing the existing
+    one avoids standing up a second SPIRE registration just to hold a certificate.
+    The point of the test is that the handshake completes at all, not which
+    identity completes it.
+    """
+    ns, name = mtls_strict_agent["namespace"], mtls_strict_agent["name"]
+    pod = agent_pod(ns, name)["metadata"]["name"]
+    args = ["create", "secret", "generic", SVID_SECRET_NAME, "-n", ns]
+    for f in ("svid.pem", "svid_key.pem", "svid_bundle.pem"):
+        data = kubectl(
+            "exec",
+            pod,
+            "-n",
+            ns,
+            "-c",
+            "authbridge-proxy",
+            "--",
+            "cat",
+            f"/opt/{f}",
+            check=False,
+        )
+        if not data.strip():
+            pytest.skip(
+                f"sidecar has no /opt/{f}: SPIRE is not supplying SVIDs on this "
+                "cluster, so a completed-handshake test is not possible here"
+            )
+        path = pathlib.Path(tempfile.gettempdir()) / f"{SVID_SECRET_NAME}-{f}"
+        path.write_text(data)
+        args.append(f"--from-file={f}={path}")
+    rendered = kubectl(*args, "--dry-run=client", "-o", "yaml")
+    kubectl("apply", "-f", "-", stdin=rendered)
+    yield SVID_SECRET_NAME
+    kubectl("delete", "secret", SVID_SECRET_NAME, "-n", ns, "--wait=false", check=False)
 
 
 @pytest.fixture(scope="session")

--- a/rossoctl/tests/e2e/transparent_inbound/conftest.py
+++ b/rossoctl/tests/e2e/transparent_inbound/conftest.py
@@ -180,8 +180,15 @@ def _wait_ready(namespace: str, name: str, timeout: int):
             "interception boundary anyway) "
             "platform gap, not a feature failure: the per-agent Keycloak "
             "client-credentials Secret was never created, so the injected pod "
-            "cannot mount it. Verify the operator's Keycloak client registration "
-            "works on this cluster (it needs the k8s.keycloak.org CRD)."
+            "cannot mount it. The operator registers the client asynchronously; "
+            "two causes are known, so check which one applies rather than "
+            "assuming: (1) on Kind, client registration is intermittent — "
+            "e2e-kind.yaml carries an explicit wait loop and marks the "
+            "token-exchange suite continue-on-error for exactly this; (2) the "
+            "k8s.keycloak.org CRD is absent, as on community-provider installs, "
+            "in which case no agent in the cluster ever gets a Secret. Check "
+            "`kubectl get crd | grep k8s.keycloak.org` and whether OTHER agents "
+            "have credentials Secrets before suspecting this feature."
         )
     raise AssertionError(
         f"deployment {namespace}/{name} not ready within {timeout}s "

--- a/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound_ambient.py
+++ b/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound_ambient.py
@@ -1,0 +1,199 @@
+"""Inbound validation on the Istio ambient / HBONE path (rossoctl/cortex#780, part 3).
+
+The other modules dial the agent from another pod and assert a denial. On a
+cluster with no ztunnel that request reaches the pod as ordinary TCP and is
+captured in `nat PREROUTING` by `AB_INBOUND`. Under ambient it does not: ztunnel
+terminates HBONE on `:15008` and **re-originates** a local connection to the
+workload, which never traverses `PREROUTING` at all. It surfaces in `nat OUTPUT`
+instead, and is captured by a separate mark-based DNAT at the head of
+`AB_REDIRECT` — ahead of that chain's ztunnel-mark `RETURN`, which would
+otherwise wave it straight through to the app.
+
+So the two paths are captured by two different rules, and the hazard #780 names
+is that a `PREROUTING`-only implementation looks entirely correct while passing
+every mesh-delivered request to the app unvalidated. Nothing in the other modules
+can tell the difference: both paths end in the same 401.
+
+That is why `test_hbone_delivered_request_is_validated` asserts the *path* as
+well as the outcome. Without the path assertion this module silently degrades
+into a duplicate of `test_direct_pod_dial_is_validated` the moment ambient is
+absent or stops being engaged — green, and testing nothing new.
+
+Rule ordering and packet counters are not asserted here; they are not reachable
+from a test pod, and they do not need to be. Every way the ambient DNAT can
+regress — deleted, placed after the mark `RETURN`, or matching too narrowly —
+ends with the app answering the mesh-delivered request itself, so the status code
+catches it. The counter-level evidence for the rules as programmed is recorded on
+rossoctl/cortex#780.
+
+Deliberately **not** marked `kind_only`, unlike the rest of this suite: the
+platform ships the ambient data plane on OpenShift only
+(`charts/rossoctl-deps/templates/istio-operand.yaml` gates the `Istio`,
+`IstioCNI` and `ZTunnel` operands on `.Values.openshift`), so a Kind-only ambient
+test could never run where ambient actually is the shipped configuration. It
+self-gates on a running ztunnel instead, which skips on Kind today and becomes a
+real gate on OpenShift and on any Kind cluster with ambient installed by hand.
+"""
+
+import pytest
+
+from .conftest import (
+    AGENT_PORT,
+    NS_CONTROL,
+    NS_TRANSPARENT,
+    agent_pod,
+    curl_from_probe,
+    kubectl,
+    kubectl_json,
+)
+
+# AuthBridge's own health port, exempt from capture on both paths so kubelet
+# probes are not gated. Same value the other module asserts against.
+HEALTH_PORT = 9091
+
+AMBIENT_LABEL = "istio.io/dataplane-mode"
+
+# ztunnel is one DaemonSet pod per node and logs the inbound side of every HBONE
+# connection it terminates. Read enough lines to survive an unrelated busy
+# cluster between the request and the read.
+ZTUNNEL_LOG_TAIL = "1000"
+
+
+@pytest.fixture(scope="module")
+def ztunnel_namespace():
+    """Skip unless an ambient data plane is actually carrying traffic here.
+
+    Two separate things have to hold, and they fail for different reasons worth
+    naming separately: a ztunnel must be running (absent on a cluster installed
+    without the ambient profile), and the namespaces this suite uses must be
+    enrolled into it (present but not applied to these namespaces). Either way
+    the request under test would arrive as plain TCP, so the module has nothing
+    to say and says so rather than passing.
+
+    Found by label across all namespaces on purpose: the platform chart puts
+    ztunnel in `istio-ztunnel` while a community `istio/ztunnel` install defaults
+    to `istio-system`, and which one is in front of the workload does not change
+    the rule under test.
+    """
+    pods = kubectl_json("get", "pods", "-A", "-l", "app=ztunnel")
+    ready = [
+        p
+        for p in pods.get("items", [])
+        if p["status"].get("phase") == "Running"
+        and all(c.get("ready") for c in p["status"].get("containerStatuses", []))
+    ]
+    if not ready:
+        pytest.skip(
+            "no ready ztunnel pod: this cluster has no ambient data plane, so "
+            "inbound cannot arrive over HBONE and the ambient capture rule is "
+            "unreachable. The platform enables ambient on OpenShift only "
+            "(charts/rossoctl-deps/templates/istio-operand.yaml gates the Istio, "
+            "IstioCNI and ZTunnel operands on .Values.openshift)."
+        )
+
+    for ns in (NS_TRANSPARENT, NS_CONTROL):
+        labels = kubectl_json("get", "ns", ns)["metadata"].get("labels", {})
+        if labels.get(AMBIENT_LABEL) != "ambient":
+            pytest.skip(
+                f"namespace {ns} is not ambient-enrolled "
+                f"({AMBIENT_LABEL}={labels.get(AMBIENT_LABEL)!r}): traffic would "
+                "arrive as plain TCP and be captured by AB_INBOUND, which the "
+                "other modules already cover"
+            )
+
+    return ready[0]["metadata"]["namespace"]
+
+
+def _ztunnel_log(ztunnel_ns: str) -> str:
+    return kubectl(
+        "logs", "-n", ztunnel_ns, "-l", "app=ztunnel", "--tail=" + ZTUNNEL_LOG_TAIL
+    )
+
+
+def _hbone_inbound_lines(log: str, pod_ip: str, port: int) -> int:
+    """Count ztunnel access lines for HBONE *terminated at* pod_ip:port.
+
+    `dst.hbone_addr` is only written for a connection ztunnel took off `:15008`
+    and re-originated locally — precisely the path this module exists for. The
+    direction filter keeps the destination ztunnel's own entry and drops the
+    source side's view of the same connection, so a count difference of one
+    request is one line.
+    """
+    needle = f"dst.hbone_addr={pod_ip}:{port}"
+    return sum(
+        1
+        for line in log.splitlines()
+        if needle in line and 'direction="inbound"' in line
+    )
+
+
+def _assert_arrived_over_hbone(ztunnel_ns: str, pod_ip: str, port: int, before: int):
+    """Fail if the request did not reach pod_ip:port as terminated HBONE."""
+    log = _ztunnel_log(ztunnel_ns)
+    if _hbone_inbound_lines(log, pod_ip, port) > before:
+        return
+    # Distinguish "no HBONE" from "no evidence of HBONE": if ztunnel is not
+    # writing access logs at all, this module cannot see the path either way, and
+    # failing would name the wrong cause. Any hbone_addr line for any workload
+    # proves the signal exists and its absence for ours is the real answer.
+    if "dst.hbone_addr=" not in log:
+        pytest.skip(
+            f"ztunnel in {ztunnel_ns} is logging no HBONE connections for any "
+            "workload, so the delivery path cannot be confirmed from here; "
+            "refusing to claim ambient coverage on unverified traffic"
+        )
+    raise AssertionError(
+        f"no terminated-HBONE line for {pod_ip}:{port} — the request did not "
+        "arrive through ztunnel, so it exercised AB_INBOUND in nat PREROUTING "
+        "and this module is duplicating test_direct_pod_dial_is_validated "
+        "rather than covering the ambient DNAT. Check that the probe's namespace "
+        f"({NS_CONTROL}) is still ambient-enrolled."
+    )
+
+
+def test_hbone_delivered_request_is_validated(ztunnel_namespace, transparent_agent):
+    """A mesh-delivered request must be validated, not handed to the app.
+
+    The assertion that closes #780's ambient half. Traffic crosses from an
+    ambient namespace, so ztunnel terminates HBONE and re-originates locally,
+    bypassing `PREROUTING` entirely — and the 401 can then only have come from
+    the ambient DNAT having captured it in `nat OUTPUT`.
+    """
+    pod_ip = agent_pod(**transparent_agent)["status"]["podIP"]
+    before = _hbone_inbound_lines(_ztunnel_log(ztunnel_namespace), pod_ip, AGENT_PORT)
+
+    status = curl_from_probe(NS_CONTROL, f"http://{pod_ip}:{AGENT_PORT}/")
+
+    _assert_arrived_over_hbone(ztunnel_namespace, pod_ip, AGENT_PORT, before)
+    assert status in (401, 403), (
+        f"mesh-delivered request to :{AGENT_PORT} returned {status}, want an auth "
+        "denial. It reached the pod over HBONE and was answered without "
+        "validation, which is the ambient bypass #780 tracks: the ambient DNAT at "
+        "the head of AB_REDIRECT is missing, ordered after that chain's "
+        "ztunnel-mark RETURN, or matching too narrowly."
+    )
+
+
+def test_health_port_exempt_on_the_hbone_path(ztunnel_namespace, transparent_agent):
+    """The port exemptions have to hold on the ambient path too.
+
+    They are a separate set of rules from the ones the other module exercises —
+    same ports, but re-stated with the ztunnel-mark match in `AB_REDIRECT`. If
+    they were dropped there, or ordered after the DNAT, `:9091` would go through
+    the pipeline and kubelet probes on a meshed pod would start failing.
+
+    Asserts reachable-and-unauthenticated, not merely "not 401": a health port
+    that stopped answering entirely would also stop failing probes' auth check.
+    """
+    pod_ip = agent_pod(**transparent_agent)["status"]["podIP"]
+    before = _hbone_inbound_lines(_ztunnel_log(ztunnel_namespace), pod_ip, HEALTH_PORT)
+
+    status = curl_from_probe(NS_CONTROL, f"http://{pod_ip}:{HEALTH_PORT}/healthz")
+
+    _assert_arrived_over_hbone(ztunnel_namespace, pod_ip, HEALTH_PORT, before)
+    assert status == 200, (
+        f"health port {HEALTH_PORT} returned {status} on the ambient path, want "
+        "200. Under ambient the exemptions are re-stated in AB_REDIRECT with the "
+        "ztunnel-mark match; a 401 means they are missing or ordered after the "
+        "DNAT, and probes on a meshed pod would fail."
+    )

--- a/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound_mtls.py
+++ b/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound_mtls.py
@@ -123,7 +123,13 @@ def test_strict_terminates_tls_on_the_recovered_connection(mtls_strict_agent):
         f'curl -sS -k -o /dev/null -w "code=%{{http_code}}" --max-time 15 '
         f"https://{ip}:{AGENT_PORT}/ 2>&1 | tail -3",
     )
-    assert "certificate required" in out.lower() or "alert" in out.lower(), (
+    # Specifically a *missing client certificate* alert, not any alert at all: this
+    # case is C's control, so accepting e.g. a handshake_failure would let it pass
+    # for reasons unrelated to client-cert verification. Go's tls.Server sends
+    # certificate_required under TLS 1.3 and bad_certificate under 1.2 when a
+    # caller presents no certificate, so both spellings are legitimate here.
+    lowered = out.lower()
+    assert "certificate required" in lowered or "bad certificate" in lowered, (
         "expected a TLS alert demanding a client certificate, which is what proves "
         f"server-side TLS terminated here:\n{out}"
     )

--- a/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound_mtls.py
+++ b/rossoctl/tests/e2e/transparent_inbound/test_transparent_inbound_mtls.py
@@ -1,0 +1,159 @@
+"""Inbound mTLS through the transparent listener (rossoctl/cortex#780, part 2).
+
+The transparent listener reuses the reverse proxy's mTLS posture via
+`WrapListener`, so `tlssniff` handles permissive/strict identically for both
+inbound shapes. Startup logs confirmed the wrap was active, but nothing had ever
+driven TLS at it — and the untested part is specifically the *combination*:
+`SO_ORIGINAL_DST` recovery happens on the raw connection, before `tlssniff`
+peeks the first byte. If those two interfered, the logs would still look correct.
+
+Three cases, in increasing strength:
+
+  A. strict + plaintext        -> connection closed, no HTTP (tlssniff is engaged)
+  B. strict + TLS, no cert     -> TLS alert (server-side TLS really terminates)
+  C. strict + TLS, valid SVID  -> handshake COMPLETES, pipeline runs (401)
+
+C is the one that matters: it proves the whole chain — REDIRECT, destination
+recovery, TLS termination, client-cert verification, then the inbound pipeline.
+B doubles as C's control: the same endpoint refuses a caller that presents no
+certificate, so C's 401 cannot be explained by verification being lax.
+"""
+
+import json
+
+import pytest
+
+from .conftest import AGENT_PORT, PROBE_IMAGE, agent_pod, kubectl
+from .conftest import SVID_SECRET_NAME as SVID_SECRET
+
+pytestmark = pytest.mark.kind_only
+
+
+def _curl(namespace: str, name: str, script: str, svid: bool = False) -> str:
+    """Run a shell snippet in a throwaway pod and return its combined output.
+
+    With svid=True the staged SVID Secret is mounted at /svid. That needs
+    ``--overrides``, which is a JSON *merge* patch: it replaces the generated
+    container list wholesale rather than merging into it, so the override has to
+    restate command/image/stdin itself. Omitting the command leaves the probe
+    running the image's default entrypoint, which never exits — the pod hangs
+    until kubectl's timeout instead of failing an assertion.
+    """
+    args = [
+        "run",
+        name,
+        "-n",
+        namespace,
+        "--rm",
+        "-i",
+        "--restart=Never",
+        "--image=" + PROBE_IMAGE,
+        "--image-pull-policy=IfNotPresent",
+        "--quiet",
+    ]
+    if svid:
+        args.append("--overrides=" + _svid_overrides(name, script))
+    args += ["--command", "--", "sh", "-c", script]
+    return kubectl(*args, check=False)
+
+
+def _svid_overrides(name: str, script: str) -> str:
+    """Pod overrides mounting the staged SVID at /svid."""
+    return json.dumps(
+        {
+            "spec": {
+                "volumes": [{"name": "svid", "secret": {"secretName": SVID_SECRET}}],
+                "containers": [
+                    {
+                        "name": name,
+                        "image": PROBE_IMAGE,
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["sh", "-c", script],
+                        "stdin": True,
+                        "stdinOnce": True,
+                        "volumeMounts": [
+                            {"name": "svid", "mountPath": "/svid", "readOnly": True}
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+
+
+def test_strict_rejects_plaintext(mtls_strict_agent):
+    """A: strict must refuse a non-TLS caller on the transparent listener.
+
+    This is the cheapest proof that `tlssniff` is actually in the path: the same
+    request returns 401 under permissive (see the main module), so a closed
+    connection here can only come from the sniffer rejecting the first byte.
+    """
+    pod = agent_pod(**mtls_strict_agent)
+    ip = pod["status"]["podIP"]
+    out = _curl(
+        mtls_strict_agent["namespace"],
+        "ti-mtls-plain",
+        f'curl -sS -o /dev/null -w "code=%{{http_code}}" --max-time 15 '
+        f"http://{ip}:{AGENT_PORT}/ 2>&1 | tail -2",
+    )
+    assert "code=200" not in out, (
+        f"strict mTLS served a plaintext caller — tlssniff is not in the "
+        f"transparent path:\n{out}"
+    )
+    assert "code=401" not in out, (
+        f"strict mTLS ran the pipeline for a plaintext caller instead of "
+        f"rejecting the connection:\n{out}"
+    )
+    # curl reports a closed connection as (52) Empty reply, or a reset.
+    assert "code=000" in out, f"expected no HTTP response at all, got:\n{out}"
+
+
+def test_strict_terminates_tls_on_the_recovered_connection(mtls_strict_agent):
+    """B: a TLS ClientHello must reach a real server-side handshake.
+
+    The alert is the evidence: to demand a client certificate the server had to
+    send its own certificate first, which means TLS terminated on the connection
+    the transparent listener recovered via SO_ORIGINAL_DST.
+    """
+    pod = agent_pod(**mtls_strict_agent)
+    ip = pod["status"]["podIP"]
+    out = _curl(
+        mtls_strict_agent["namespace"],
+        "ti-mtls-nocert",
+        f'curl -sS -k -o /dev/null -w "code=%{{http_code}}" --max-time 15 '
+        f"https://{ip}:{AGENT_PORT}/ 2>&1 | tail -3",
+    )
+    assert "certificate required" in out.lower() or "alert" in out.lower(), (
+        "expected a TLS alert demanding a client certificate, which is what proves "
+        f"server-side TLS terminated here:\n{out}"
+    )
+
+
+def test_strict_completes_mtls_and_still_enforces(mtls_strict_agent, svid_secret):
+    """C: a valid SVID completes the handshake, and the pipeline still runs.
+
+    401, not 200: authentication of the *transport* must not be mistaken for
+    authorization of the *request*. Reaching 401 means the request traversed
+    REDIRECT -> SO_ORIGINAL_DST -> tlssniff -> tls.Server (client cert verified)
+    -> jwt-validation.
+    """
+    pod = agent_pod(**mtls_strict_agent)
+    ip = pod["status"]["podIP"]
+    ns = mtls_strict_agent["namespace"]
+    name = mtls_strict_agent["name"]
+    host = f"{name}.{ns}.svc.cluster.local"
+    # --resolve so SNI/Host match the SVID's DNS SANs while still dialing the pod
+    # IP directly: via the Service the request would be indistinguishable from the
+    # Service-routed case this module is not testing.
+    script = (
+        f'curl -sS -o /dev/null -w "code=%{{http_code}}" --max-time 20 '
+        f"--cert /svid/svid.pem --key /svid/svid_key.pem "
+        f"--cacert /svid/svid_bundle.pem "
+        f'--resolve "{host}:{AGENT_PORT}:{ip}" '
+        f"https://{host}:{AGENT_PORT}/ 2>&1 | tail -3"
+    )
+    out = _curl(ns, "ti-mtls-svid", script, svid=True)
+    assert "code=401" in out, (
+        "expected 401: a completed mTLS handshake followed by the inbound pipeline "
+        f"rejecting a request with no bearer token. Got:\n{out}"
+    )


### PR DESCRIPTION
## What

Adds two modules to the transparent-inbound e2e suite, closing **both open halves
of rossoctl/cortex#780**: `test_transparent_inbound_mtls.py` for inbound mTLS, and
`test_transparent_inbound_ambient.py` for the Istio ambient / HBONE delivery path.
Suite goes from 13 tests to 15, 0 skipped locally.

## Why

#330 shipped the transparent inbound listener reusing the reverse proxy's mTLS
posture via `WrapListener`, and the sidecar logged `mtls=true` — but no TLS
client had ever been driven at `:8083`. The path was exercised only by its own
startup message.

The untested part is specifically the **combination**: `SO_ORIGINAL_DST` recovery
happens on the raw connection, *before* `tlssniff` peeks the first byte. Had
those two interfered, the logs would still have looked correct.

## The three cases

| # | Case | Expected | What it proves |
|---|---|---|---|
| A | `strict` + plaintext | connection closed, `http_code=000` | `tlssniff` is genuinely in the transparent path — the same request is a **401** under permissive, so a closed connection can only come from the sniffer |
| B | `strict` + TLS, no client cert | TLS alert `certificate required` | server-side TLS really terminates on the recovered connection (to demand a client cert it had to send its own first) |
| C | `strict` + TLS, **valid SVID** | **`http_code=401`** | the whole chain in one request: REDIRECT → `SO_ORIGINAL_DST` → `tlssniff` → `tls.Server` (client cert verified) → `jwt-validation` |

**C is the one that matters.** It lands on 401 rather than 200 deliberately:
authentication of the *transport* must not be mistaken for authorization of the
*request*. **B doubles as C's control** — the same endpoint refuses a caller with
no certificate, so C cannot be explained by verification being lax.

## Notes on approach

- **Borrows the agent sidecar's own SVID** rather than minting a second SPIRE
  registration. Any identity in the trust domain satisfies
  `RequireAndVerifyClientCert`, and the assertion is that the handshake completes
  at all, not which identity completes it. Skips when SPIRE supplies no SVIDs.
- `--resolve` so SNI/Host match the SVID's DNS SANs while still dialing the **pod
  IP** directly — via the Service the request would be indistinguishable from the
  Service-routed case this module is not testing.
- **`conftest` gains a `_baseline` registry.** Fixtures now restore the namespace
  to what it looked like *before the suite touched it*, not to whatever they
  happened to observe. Without this, a second module flipping the same shared
  namespace makes restoration order-dependent.
- Module-scoped, not session-scoped: it flips the same namespace the permissive
  fixture uses, so it must set up and tear down within its own module.

## Verification

Run on kind `rossoctl` against operator + authbridge + proxy-init images built
from **merged main** (so the shipped code was under test):

```
13 passed in 89.56s   # 10 existing + 3 new, 0 skipped
```

Both namespaces confirmed restored afterwards (no `inboundInterception`/`mtls`
keys left behind, no leftover test objects).

### The suite was inert in CI — root-caused and fixed

Worth stating plainly, because the green checkmark on the first two commits should
not be over-read: **all 13 tests were skipping on the shared Kind e2e run**,
including the 10 that merged in #2393. Signature was three 3-minute fixture stalls
(exactly `READY_TIMEOUT`), each followed by an instant batch of skips, because the
per-agent Keycloak client-credentials Secret was never created.

My first read of that was wrong. I called it the "intermittent Kind client
registration" that `e2e-kind.yaml` works around, and the earlier skip message
blamed a missing `k8s.keycloak.org` CRD. **Neither is the cause.** It is
deterministic, and the CRD is not in this code path at all — the controller uses
Keycloak's admin REST API directly.

The actual cause: with SPIRE enabled, the operator's ClientRegistration controller
derives the Keycloak client ID from the **Deployment pod template's**
`serviceAccountName`, and refuses on `default`:

```
"msg":"cannot resolve Keycloak client id yet"
"reason":"SPIRE enabled: set spec.template.spec.serviceAccountName to a dedicated
          ServiceAccount (not default) on the workload for a stable SPIFFE client ID"
```

It then requeues every 30s forever at `Info` level. The fixtures' Deployment set no
`serviceAccountName`, so they hit this every single run. The platform's own
`74-deploy-weather-agent.sh` creates a dedicated SA for exactly this reason, which
is why weather-service works in CI and these agents did not.

Proven both directions on Kind: fixture shape → `cannot resolve` + zero Secrets +
pod `Pending`; add `serviceAccountName` → Secret appears in 20s **with the exact
hash the webhook had already pre-populated**, pod Ready 10s later.

The third commit adds the SA to the manifest and rewrites the skip message and
README to point at the controller log, which prints the real reason verbatim.

**This resolves the gating question** — better than either option I floated
earlier. No stubbing, no waiting on a platform fix:

```
13 passed, 0 skipped, no TI_STUB_CREDENTIALS   # real controller-issued credentials
```

### A latent platform inconsistency this surfaced (not a defect, not fixed here)

The AuthBridge webhook creates a per-agent ServiceAccount, sets it on the **pod**,
and pre-populates the annotation naming the credentials Secret — but never touches
the **Deployment template** the controller reads, so the webhook's fixup is
invisible to it.

That is latent rather than broken. Every path that creates a workload for real
already sets `serviceAccountName` — the backend's agent manifests
(`agents_manifests.py:379,581,723,832`), tools (`tools.py:1330,1492`),
`simulation_manifests.py:253`, `agents_migration.py:487` (comment: *"Ensure
serviceAccountName is set so the webhook's SPIFFE identity…"*), and the
`7x-deploy-*` scripts. Only a hand-written Deployment reaches the refusal, which
is why this fixture did and nothing else does. Nor is anything regressed: the
refusal has been present since the commit introducing that controller
(`9637c03`, 2026-03-26) and `spire.enabled` has defaulted true since 2025-11-06.

I initially filed this as operator#513 and generalized it to "any workload";
that was wrong and the issue is closed with a retraction.

One thing there does still seem worth fixing upstream, unrelated to the SA: those
failures surface only as `logger.Info` plus `RequeueAfter: 30s` forever — no Event,
no status condition — while the pod sits on `FailedMount`. That applies to every
reason client-ID resolution can fail, not just this one.

Second, minor: webhook-created SAs carry no `ownerReference`, so nothing
garbage-collects them. Eight had accumulated across `team1`/`team2` during
development. Teardown now deletes ours.

## The ambient / HBONE half

The suite could only ever exercise one of the two capture rules. Without a
ztunnel a pod-to-pod dial arrives as ordinary TCP and is caught in
`nat PREROUTING` by `AB_INBOUND`. Under ambient it never reaches `PREROUTING`:
ztunnel terminates HBONE on `:15008` and re-originates a local connection, caught
instead by a mark-based DNAT at the head of `AB_REDIRECT`, ahead of that chain's
ztunnel-mark `RETURN`. Two paths, two rules, **and the same 401 either way** —
which is the hazard #780 names, since a PREROUTING-only implementation looks
correct while passing every mesh-delivered request through unvalidated.

So the new module asserts the **delivery path** as well as the status, read from
ztunnel's own access log. Without that it silently becomes a duplicate of
`test_direct_pod_dial_is_validated` the moment ambient stops being engaged.

That the DNAT counter previously read 0 was a config gate, not missing
infrastructure: `charts/rossoctl-deps/templates/istio-operand.yaml` wraps the
`Istio`, `IstioCNI` and `ZTunnel` operands in
`{{- if and .Values.components.istio.enabled .Values.openshift }}`, and
`deployments/envs/dev_values*.yaml` set `openshift: false`. Kind has no ambient
data plane by construction.

### Verified

Ambient installed by hand on Kind (istiod 1.28.0 `profile=ambient` with
`PILOT_ENABLE_AMBIENT=true`, istio-cni, ztunnel), agent in `team1`, probe in
`team2`, both `istio.io/dataplane-mode=ambient`:

| Request from `team2` | Result | `AB_INBOUND` REDIRECT | ambient DNAT | `:9091` RETURN |
|---|---|---|---|---|
| baseline | — | `[2:120]` | `[0:0]` | `[1:60]` |
| Service `:8000` | **401** | unchanged | **+1** | — |
| direct pod dial `:8000` | **401** | unchanged | **+1** | — |
| `:9091/healthz` | **200** | unchanged | unchanged | **+1** |

The ambient DNAT carried every mesh-delivered request; `AB_INBOUND` never fired
for one. The exemption is confirmed *positively* — the dport-9091 rule's own
counter incremented — not by absence. The plain `--mark 0x539 -j RETURN` stayed
flat having taken 6 *outbound* HBONE packets earlier, live confirmation that
`--dst-type LOCAL` on the DNAT is load-bearing. Corroborated at three layers in
the same millisecond: ztunnel logged `dst.hbone_addr=<podIP>:8000` with SPIFFE
identities both ends, and authbridge logged
`plugin=jwt-validation status=401 reason="missing Authorization header"`.

**Negative control**, since a test that cannot fail proves nothing: deleting that
one DNAT rule from the live pod's netns makes the mesh-delivered request return
**200** — the app answering unvalidated — and the module fails naming that cause,
while the health-port test keeps passing. Recreating the pod reprograms the rule
from proxy-init and both pass again.

Rule ordering and counters are not asserted in the test: not reachable from a test
pod, and unnecessary — every way the rule can regress (deleted, ordered after the
mark `RETURN`, matching too narrowly) ends in that same 200. The counter evidence
is recorded on #780.

### One thing to flag

The ambient module is deliberately **not** `kind_only`, unlike the rest of this
suite. Ambient ships on OpenShift only, so a Kind-only ambient test could never
run where ambient is the shipped configuration; it self-gates instead on a ready
ztunnel (found by label across namespaces — the chart uses `istio-ztunnel`, a
community install defaults to `istio-system`) plus `dataplane-mode=ambient` on
both namespaces, naming whichever is missing.

Consequence: **this becomes the first module in the suite to run on OpenShift**,
so its first run there may surface pre-existing suite or platform issues rather
than ambient ones. Narrowing it to `kind_only` would make it skip everywhere the
feature actually ships, which is why it is not — but that is a call worth making
explicitly rather than by default.

Also worth noting the data plane used here is community Helm charts, not the
sail-operator operands the platform ships. The ztunnel namespace does not enter
the iptables tuple under test, but confirming on OpenShift is what the unmarked
test now does automatically.

## Follow-up, not in this PR

The mTLS coverage lives in this repo while the code under test lives in cortex, so
a cortex regression would not fail cortex CI. The narrow gap there is a Go test
for the assembled `NewInboundListener` → `WrapListener` with mTLS **on** — the two
weaker cases here already duplicate existing `tlssniff` and `origdst` unit tests.

Assisted-By: Claude Code
