### PR TITLE
Feat: report attached contexts in agent detail responses

### DIFF
--- a/rossoctl/backend/README.md
+++ b/rossoctl/backend/README.md
@@ -77,7 +77,9 @@ Once running, access the OpenAPI documentation:
 
 ### Agents
 - `GET /api/v1/agents` - List all agents across namespaces
-- `GET /api/v1/agents/{namespace}/{name}` - Get specific agent details
+- `GET /api/v1/agents/{namespace}/{name}` - Get specific agent details. When present,
+  `contexts` reports the attachments declared when Rosso created the workload; it is a
+  metadata snapshot and is not continuously reconciled with manual Kubernetes changes.
 - `GET /api/v1/agents/{namespace}/{name}/route-status` - Check HTTPRoute/Route status for agent
 - `DELETE /api/v1/agents/{namespace}/{name}` - Delete agent
 - `POST /api/v1/agents` - Create new agent (supports deployment from image or source code via Shipwright)

--- a/rossoctl/backend/app/routers/agents.py
+++ b/rossoctl/backend/app/routers/agents.py
@@ -22,6 +22,7 @@ Names those submodules define are re-exported here (see ``__all__``) because
 other modules and the test suite import them from ``app.routers.agents``.
 """
 
+import json
 import logging
 from typing import Any
 
@@ -90,6 +91,7 @@ from app.routers.agents_env import (
 # the patch effective -- do not promote it to a module-level import there.
 from app.routers.agents_finalize import finalize_router, finalize_shipwright_build
 from app.routers.agents_manifests import (
+    CONTEXTS_ANNOTATION,
     build_container_resources,
     _agentruntime_supported_workload,
     _build_agentruntime_manifest,
@@ -547,6 +549,13 @@ async def get_agent(
         "workloadType": labels.get(ROSSOCTL_WORKLOAD_TYPE_LABEL, workload_type),
         "readyStatus": ready_status,  # Computed ready status for frontend
     }
+
+    stored_contexts = annotations.get(CONTEXTS_ANNOTATION)
+    if stored_contexts:
+        try:
+            response["contexts"] = json.loads(stored_contexts)
+        except (TypeError, json.JSONDecodeError):
+            logger.warning("Ignoring invalid context attachment annotation on agent")
 
     # Add service info if available
     if service:

--- a/rossoctl/backend/app/routers/agents_create.py
+++ b/rossoctl/backend/app/routers/agents_create.py
@@ -46,6 +46,7 @@ from app.routers.agents_manifests import (
     _build_statefulset_manifest,
     _create_or_replace_service,
     _ensure_agentruntime,
+    _record_contexts,
     _resolve_context_mounts,
 )
 from app.routers.agents_models import CreateAgentRequest, CreateAgentResponse
@@ -121,7 +122,7 @@ async def create_agent(
             s for s in request.skills if s and not _is_skill_external(kube, request.namespace, s)
         ]
 
-    context_volumes, context_mounts = await _resolve_context_mounts(
+    context_volumes, context_mounts, resolved_contexts = await _resolve_context_mounts(
         request.namespace, request.contexts, request.workloadType
     )
     ext_volumes.extend(context_volumes)
@@ -201,6 +202,7 @@ async def create_agent(
                     ext_volume_mounts=ext_volume_mounts,
                     ext_skill_paths=ext_skill_paths,
                 )
+                _record_contexts(workload_manifest, resolved_contexts)
                 kube.create_deployment(
                     namespace=request.namespace,
                     body=workload_manifest,
@@ -219,6 +221,7 @@ async def create_agent(
                     ext_volume_mounts=ext_volume_mounts,
                     ext_skill_paths=ext_skill_paths,
                 )
+                _record_contexts(workload_manifest, resolved_contexts)
                 kube.create_statefulset(
                     namespace=request.namespace,
                     body=workload_manifest,
@@ -237,6 +240,7 @@ async def create_agent(
                     ext_volume_mounts=ext_volume_mounts,
                     ext_skill_paths=ext_skill_paths,
                 )
+                _record_contexts(workload_manifest, resolved_contexts)
                 kube.create_job(
                     namespace=request.namespace,
                     body=workload_manifest,
@@ -253,6 +257,7 @@ async def create_agent(
                     ext_volume_mounts=ext_volume_mounts,
                     ext_skill_paths=ext_skill_paths,
                 )
+                _record_contexts(sandbox_manifest, resolved_contexts)
                 kube.create_sandbox(
                     namespace=request.namespace,
                     body=sandbox_manifest,

--- a/rossoctl/backend/app/routers/agents_finalize.py
+++ b/rossoctl/backend/app/routers/agents_finalize.py
@@ -53,6 +53,7 @@ from app.routers.agents_manifests import (
     _build_statefulset_manifest,
     _create_or_replace_service,
     _ensure_agentruntime,
+    _record_contexts,
     _resolve_context_mounts,
 )
 from app.routers.agents_models import (
@@ -444,7 +445,7 @@ async def finalize_shipwright_build(
             k8sResourceRequests=final_k8s_resource_requests,
         )
         agent_request = apply_agent_import_defaults(agent_request, kube)
-        context_volumes, context_mounts = await _resolve_context_mounts(
+        context_volumes, context_mounts, resolved_contexts = await _resolve_context_mounts(
             namespace, final_contexts, final_workload_type
         )
         build_ext_volumes.extend(context_volumes)
@@ -499,6 +500,7 @@ async def finalize_shipwright_build(
                 ext_volume_mounts=build_ext_volume_mounts,
                 ext_skill_paths=build_ext_skill_paths,
             )
+            _record_contexts(workload_manifest, resolved_contexts)
             # Add additional labels from Build
             workload_manifest["metadata"]["labels"].update(
                 {k: v for k, v in build_labels.items() if k.startswith("rossoctl.io/")}
@@ -522,6 +524,7 @@ async def finalize_shipwright_build(
                 ext_volume_mounts=build_ext_volume_mounts,
                 ext_skill_paths=build_ext_skill_paths,
             )
+            _record_contexts(workload_manifest, resolved_contexts)
             # Add additional labels from Build
             workload_manifest["metadata"]["labels"].update(
                 {k: v for k, v in build_labels.items() if k.startswith("rossoctl.io/")}
@@ -545,6 +548,7 @@ async def finalize_shipwright_build(
                 ext_volume_mounts=build_ext_volume_mounts,
                 ext_skill_paths=build_ext_skill_paths,
             )
+            _record_contexts(workload_manifest, resolved_contexts)
             # Add additional labels from Build
             workload_manifest["metadata"]["labels"].update(
                 {k: v for k, v in build_labels.items() if k.startswith("rossoctl.io/")}
@@ -568,6 +572,7 @@ async def finalize_shipwright_build(
                 ext_volume_mounts=build_ext_volume_mounts,
                 ext_skill_paths=build_ext_skill_paths,
             )
+            _record_contexts(sandbox_manifest, resolved_contexts)
             rossoctl_build_labels = {
                 k: v
                 for k, v in build_labels.items()

--- a/rossoctl/backend/app/routers/agents_manifests.py
+++ b/rossoctl/backend/app/routers/agents_manifests.py
@@ -63,6 +63,7 @@ from app.routers.agents_models import (
 )
 from app.routers.agents_skills import _get_linked_skill_mounts
 from app.services.kubernetes import KubernetesService
+from app.utils.routes import get_agent_url
 
 CONTEXTS_ANNOTATION = "rossoctl.io/contexts"
 
@@ -74,8 +75,6 @@ def _record_contexts(manifest: Dict[str, Any], contexts: List[Dict[str, Any]]) -
             json.dumps(contexts, separators=(",", ":"))
         )
 
-
-from app.utils.routes import get_agent_url
 
 logger = logging.getLogger(__name__)
 

--- a/rossoctl/backend/app/routers/agents_manifests.py
+++ b/rossoctl/backend/app/routers/agents_manifests.py
@@ -63,6 +63,18 @@ from app.routers.agents_models import (
 )
 from app.routers.agents_skills import _get_linked_skill_mounts
 from app.services.kubernetes import KubernetesService
+
+CONTEXTS_ANNOTATION = "rossoctl.io/contexts"
+
+
+def _record_contexts(manifest: Dict[str, Any], contexts: List[Dict[str, Any]]) -> None:
+    """Persist declared attachments for GET; this snapshot is not live reconciliation."""
+    if contexts:
+        manifest.setdefault("metadata", {}).setdefault("annotations", {})[CONTEXTS_ANNOTATION] = (
+            json.dumps(contexts, separators=(",", ":"))
+        )
+
+
 from app.utils.routes import get_agent_url
 
 logger = logging.getLogger(__name__)
@@ -901,10 +913,10 @@ async def _resolve_context_mounts(
     namespace: str,
     attachments: Optional[List[ContextAttachment]],
     workload_type: str,
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Resolve named contexts into Kubernetes PVC volumes and mounts."""
     if not attachments:
-        return [], []
+        return [], [], []
     if workload_type not in {WORKLOAD_TYPE_STATEFULSET, WORKLOAD_TYPE_SANDBOX}:
         raise HTTPException(
             status_code=400,
@@ -917,6 +929,7 @@ async def _resolve_context_mounts(
 
     volumes: List[Dict[str, Any]] = []
     mounts: List[Dict[str, Any]] = []
+    resolved: List[Dict[str, Any]] = []
     seen_paths: set[str] = set()
     for index, attachment in enumerate(attachments):
         if not attachment.mountPath.startswith("/"):
@@ -933,6 +946,9 @@ async def _resolve_context_mounts(
         claim_name = resource_attachment.get("claimName")
         if not claim_name:
             raise HTTPException(status_code=502, detail="Context Service returned no PVC claim")
+        context_type = resource.get("type")
+        if not context_type:
+            raise HTTPException(status_code=502, detail="Context Service returned no type")
         volume_name = f"context-{index}"
         volumes.append(
             {
@@ -950,4 +966,13 @@ async def _resolve_context_mounts(
                 "readOnly": attachment.readOnly,
             }
         )
-    return volumes, mounts
+        resolved.append(
+            {
+                "name": attachment.name,
+                "type": context_type,
+                "mountPath": attachment.mountPath,
+                "readOnly": attachment.readOnly,
+                "claimName": claim_name,
+            }
+        )
+    return volumes, mounts, resolved

--- a/rossoctl/backend/tests/test_contexts.py
+++ b/rossoctl/backend/tests/test_contexts.py
@@ -1,10 +1,12 @@
 """Tests for optional Context Service resources and agent attachments."""
 
-from unittest.mock import AsyncMock, patch
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 from fastapi import HTTPException
+from kubernetes.client import ApiException
 
 from app.routers import contexts
 from app.routers.agents import (
@@ -13,6 +15,7 @@ from app.routers.agents import (
     _build_sandbox_manifest,
     _build_statefulset_manifest,
     _resolve_context_mounts,
+    get_agent,
 )
 
 
@@ -102,6 +105,24 @@ async def test_context_attachments_require_service_url() -> None:
 
 
 @pytest.mark.asyncio
+async def test_context_attachments_reject_missing_context() -> None:
+    with (
+        patch("app.routers.agents.settings.context_service_url", "http://context-service:8080"),
+        patch(
+            "app.routers.contexts.resolve_context",
+            new=AsyncMock(side_effect=HTTPException(status_code=404, detail="context not found")),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _resolve_context_mounts(
+            "team1", [ContextAttachment(name="does-not-exist")], "sandbox"
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "context not found"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("context_type", ["workspace", "memory", "knowledge", "artifacts"])
 async def test_context_attachments_resolve_pvc_for_sandbox_and_statefulset(
     context_type: str,
@@ -120,7 +141,9 @@ async def test_context_attachments_resolve_pvc_for_sandbox_and_statefulset(
             ("sandbox", _build_sandbox_manifest),
             ("statefulset", _build_statefulset_manifest),
         ):
-            volumes, mounts = await _resolve_context_mounts("team1", [attachment], workload_type)
+            volumes, mounts, resolved = await _resolve_context_mounts(
+                "team1", [attachment], workload_type
+            )
             agent_request = CreateAgentRequest(
                 name="research-agent",
                 namespace="team1",
@@ -144,6 +167,15 @@ async def test_context_attachments_resolve_pvc_for_sandbox_and_statefulset(
             assert pod_spec["containers"][0]["volumeMounts"][-1]["mountPath"] == "/workspace"
             context_volume = next(v for v in pod_spec["volumes"] if v["name"] == "context-0")
             assert context_volume["persistentVolumeClaim"]["claimName"] == "context-research"
+            assert resolved == [
+                {
+                    "name": "research",
+                    "type": context_type,
+                    "mountPath": "/workspace",
+                    "readOnly": False,
+                    "claimName": "context-research",
+                }
+            ]
 
 
 @pytest.mark.asyncio
@@ -163,6 +195,67 @@ async def test_context_attachments_reject_non_pvc_attachment() -> None:
 
 
 @pytest.mark.asyncio
+async def test_context_attachments_reject_missing_type() -> None:
+    resource = {
+        "attachment": {"kind": "pvc", "claimName": "context-research"},
+    }
+    with (
+        patch("app.routers.agents.settings.context_service_url", "http://context-service:8080"),
+        patch("app.routers.contexts.resolve_context", new=AsyncMock(return_value=resource)),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _resolve_context_mounts("team1", [ContextAttachment(name="research")], "sandbox")
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "Context Service returned no type"
+
+
+@pytest.mark.asyncio
 async def test_context_attachments_reject_deployment() -> None:
     with pytest.raises(HTTPException, match="statefulset or sandbox"):
         await _resolve_context_mounts("team1", [ContextAttachment(name="research")], "deployment")
+
+
+@pytest.mark.asyncio
+async def test_get_statefulset_agent_reports_context_attachments() -> None:
+    attachments = [
+        {
+            "name": "research",
+            "type": "workspace",
+            "mountPath": "/workspace",
+            "readOnly": False,
+            "claimName": "context-research",
+        }
+    ]
+    kube = MagicMock()
+    kube.get_deployment.side_effect = ApiException(status=404)
+    kube.get_statefulset.return_value = {
+        "metadata": {
+            "name": "research-agent",
+            "namespace": "team1",
+            "labels": {},
+            "annotations": {"rossoctl.io/contexts": json.dumps(attachments)},
+        },
+        "spec": {},
+        "status": {},
+    }
+    kube.get_service.side_effect = ApiException(status=404)
+
+    result = await get_agent("team1", "research-agent", kube)
+
+    assert result["contexts"] == attachments
+
+
+@pytest.mark.asyncio
+async def test_get_agent_without_contexts_omits_field() -> None:
+    kube = MagicMock()
+    kube.get_deployment.return_value = {
+        "metadata": {"name": "plain-agent", "namespace": "team1", "labels": {}},
+        "spec": {},
+        "status": {},
+    }
+    kube.get_service.side_effect = ApiException(status=404)
+
+    result = await get_agent("team1", "plain-agent", kube)
+
+    assert "contexts" not in result

--- a/rossoctl/backend/tests/test_contexts.py
+++ b/rossoctl/backend/tests/test_contexts.py
@@ -17,6 +17,7 @@ from app.routers.agents import (
     _resolve_context_mounts,
     get_agent,
 )
+from app.routers.agents_manifests import CONTEXTS_ANNOTATION, _record_contexts
 
 
 @pytest.mark.asyncio
@@ -158,6 +159,7 @@ async def test_context_attachments_resolve_pvc_for_sandbox_and_statefulset(
                 ext_volumes=volumes,
                 ext_volume_mounts=mounts,
             )
+            _record_contexts(manifest, resolved)
             pod_spec = (
                 manifest["spec"]["podTemplate"]["spec"]
                 if workload_type == "sandbox"
@@ -167,6 +169,7 @@ async def test_context_attachments_resolve_pvc_for_sandbox_and_statefulset(
             assert pod_spec["containers"][0]["volumeMounts"][-1]["mountPath"] == "/workspace"
             context_volume = next(v for v in pod_spec["volumes"] if v["name"] == "context-0")
             assert context_volume["persistentVolumeClaim"]["claimName"] == "context-research"
+            assert json.loads(manifest["metadata"]["annotations"][CONTEXTS_ANNOTATION]) == resolved
             assert resolved == [
                 {
                     "name": "research",
@@ -234,7 +237,7 @@ async def test_get_statefulset_agent_reports_context_attachments() -> None:
             "name": "research-agent",
             "namespace": "team1",
             "labels": {},
-            "annotations": {"rossoctl.io/contexts": json.dumps(attachments)},
+            "annotations": {CONTEXTS_ANNOTATION: json.dumps(attachments)},
         },
         "spec": {},
         "status": {},
@@ -244,6 +247,60 @@ async def test_get_statefulset_agent_reports_context_attachments() -> None:
     result = await get_agent("team1", "research-agent", kube)
 
     assert result["contexts"] == attachments
+
+
+@pytest.mark.asyncio
+async def test_get_sandbox_agent_reports_context_attachments() -> None:
+    attachments = [
+        {
+            "name": "research",
+            "type": "workspace",
+            "mountPath": "/workspace",
+            "readOnly": False,
+            "claimName": "context-research",
+        }
+    ]
+    kube = MagicMock()
+    kube.get_deployment.side_effect = ApiException(status=404)
+    kube.get_statefulset.side_effect = ApiException(status=404)
+    kube.get_job.side_effect = ApiException(status=404)
+    kube.get_sandbox.return_value = {
+        "metadata": {
+            "name": "research-sandbox",
+            "namespace": "team1",
+            "labels": {},
+            "annotations": {CONTEXTS_ANNOTATION: json.dumps(attachments)},
+        },
+        "spec": {},
+        "status": {},
+    }
+    kube.get_service.side_effect = ApiException(status=404)
+
+    with patch("app.routers.agents.settings.rossoctl_feature_flag_agent_sandbox", True):
+        result = await get_agent("team1", "research-sandbox", kube)
+
+    assert result["workloadType"] == "sandbox"
+    assert result["contexts"] == attachments
+
+
+@pytest.mark.asyncio
+async def test_get_agent_with_malformed_contexts_omits_field() -> None:
+    kube = MagicMock()
+    kube.get_deployment.return_value = {
+        "metadata": {
+            "name": "legacy-agent",
+            "namespace": "team1",
+            "labels": {},
+            "annotations": {CONTEXTS_ANNOTATION: "not-json"},
+        },
+        "spec": {},
+        "status": {},
+    }
+    kube.get_service.side_effect = ApiException(status=404)
+
+    result = await get_agent("team1", "legacy-agent", kube)
+
+    assert "contexts" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Expose context attachments through `GET /api/v1/agents/{namespace}/{name}`.

When Rosso creates a StatefulSet or Sandbox agent with context attachments, it now preserves the resolved attachment metadata on the workload and returns it as part of the agent detail response.

```json
"contexts": [
  {
    "name": "research",
    "type": "workspace",
    "mountPath": "/workspace",
    "readOnly": false,
    "claimName": "context-research"
  }
]
```

## Why

Agent creation already accepts context attachments, but callers could not subsequently determine which named contexts were attached to an agent or where they were mounted.

## Behavior

- Supports StatefulSet and Sandbox workloads.
- Covers direct-image and source-build/finalization paths.
- Omits `contexts` for agents created without context attachments.
- Safely ignores missing or malformed legacy attachment metadata.
- Rejects incomplete Context Service responses that omit the PVC claim or context type.
- Returns the attachment declaration recorded when Rosso created the workload; it is not continuously reconciled with manual Kubernetes changes.

Existing agents are not automatically backfilled.

## Validation

- 21 focused backend tests pass.
- Live-tested StatefulSet and Sandbox creation in `team2`.
- Verified context name, type, claim, mount path, and access in agent GET responses.
- Verified agents without contexts remain compatible.
- Verified nonexistent contexts fail creation cleanly.
- Verified temporary test resources were removed.
