### PR TITLE
CI: gate broken relative links in changed docs (#2412)

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -36,8 +36,39 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0  # need the merge-base to diff changed files against the PR base
 
-      - name: Run lychee link checker
+      # Gate only on links in the files THIS PR changes, so a docs reorg can't
+      # introduce a broken relative link (rossoctl/rossoctl#2412) without failing
+      # review — without forcing an up-front cleanup of the repo's pre-existing
+      # relative-link debt (tracked separately).
+      - name: Determine changed markdown files
+        id: changed
+        run: |
+          base='${{ github.event.pull_request.base.sha }}'
+          files="$(git diff --name-only --diff-filter=d "${base}...HEAD" -- '*.md' | sort -u | tr '\n' ' ')"
+          echo "files=${files}" >> "$GITHUB_OUTPUT"
+          [ -n "${files}" ] && echo "any=true" >> "$GITHUB_OUTPUT" || echo "any=false" >> "$GITHUB_OUTPUT"
+          echo "Changed markdown: ${files:-<none>}"
+
+      # Gating pass: --offline checks only local/relative links (no network), so it
+      # is deterministic and free of external-URL flakiness. Fails the job on a
+      # broken relative link in a changed doc.
+      - name: Link check — changed files, relative links (gating)
+        if: steps.changed.outputs.any == 'true'
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
+        with:
+          args: >-
+            --offline
+            --config .lychee.toml
+            ${{ steps.changed.outputs.files }}
+          fail: true
+
+      # Advisory pass: full check (external URLs + all docs). External links are
+      # flake-prone (rate limits, transient 5xx), so this stays non-gating —
+      # preserving today's behavior for everything the gating pass doesn't cover.
+      - name: Link check — full, external + all docs (advisory)
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
         with:
           args: >-

--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -39,15 +39,24 @@ jobs:
         with:
           fetch-depth: 0  # need the merge-base to diff changed files against the PR base
 
-      # Gate only on links in the files THIS PR changes, so a docs reorg can't
-      # introduce a broken relative link (rossoctl/rossoctl#2412) without failing
-      # review — without forcing an up-front cleanup of the repo's pre-existing
-      # relative-link debt (tracked separately).
+      # Gate on broken relative links in the .md files THIS PR changes
+      # (rossoctl/rossoctl#2412), without forcing an up-front cleanup of the repo's
+      # pre-existing relative-link debt (~74 links; tracked in #2449).
+      #
+      # Scope note: this catches a broken relative link in an *edited* file. It does
+      # NOT catch a rename that moves a link target while leaving its (unedited)
+      # referrers stale — e.g. #2398 broke README.md (edited in the reorg PR, would
+      # be caught here) *and* CLAUDE.md (not edited, would slip through). That
+      # move-the-target class is only surfaced by the advisory full pass today.
       - name: Determine changed markdown files
         id: changed
         run: |
           base='${{ github.event.pull_request.base.sha }}'
-          files="$(git diff --name-only --diff-filter=d "${base}...HEAD" -- '*.md' | sort -u | tr '\n' ' ')"
+          # Prefix each path with ./ so a name can never be parsed as a lychee flag.
+          # (A pathological name with a space still can't inject: lychee errors on a
+          # nonexistent input path and fails the job, rather than passing silently.)
+          files="$(git diff --name-only --diff-filter=d "${base}...HEAD" -- '*.md' \
+                   | sort -u | sed 's,^,./,' | tr '\n' ' ')"
           echo "files=${files}" >> "$GITHUB_OUTPUT"
           [ -n "${files}" ] && echo "any=true" >> "$GITHUB_OUTPUT" || echo "any=false" >> "$GITHUB_OUTPUT"
           echo "Changed markdown: ${files:-<none>}"


### PR DESCRIPTION
## Summary

`docs-ci.yaml` ran lychee with `fail: false`, so broken **relative** links passed the Link Check job — how #2398 reached `main` with a green check.

Splits the single advisory pass into two:

- **Gating pass** (`fail: true`) — `lychee --offline` over only the `.md` files the PR changes. `--offline` checks local/relative links only, so it is deterministic and free of external-URL flakiness. Verified locally (lychee 0.24.2 + repo `.lychee.toml`): a broken relative link exits non-zero (job red), a clean one exits 0.
- **Advisory pass** (`fail: false`) — the existing full check (external URLs + all docs) preserved unchanged; external links are flake-prone, so they stay non-gating.

`fetch-depth: 0` makes the PR base merge-base reachable for the changed-files diff; changed paths are `./`-prefixed so a filename can't be parsed as a lychee flag (and lychee fails **closed** on a bad input path, so a mangled path reds the job rather than passing silently).

## Coverage (and its limit)

This catches a broken relative link in an **edited** `.md`. It does **not** catch a rename that moves a link target while leaving its *unedited* referrers stale — e.g. #2398 broke `README.md` (edited in the reorg PR → **would be caught**) *and* `CLAUDE.md` (not edited → **would slip through**). That move-the-target class stays with the advisory full pass and the cleanup issue.

## Why changed-files-scoped, not repo-wide

`main` still has **~74 broken relative links** (lychee's count under `.lychee.toml`'s `exclude_path`): in-repo doc breakage, cross-repo `../cortex/…` refs that can't resolve locally, and a few placeholders. A repo-wide `fail: true` would block on all of them. This PR fixes **recurrence** (the issue's intent) without that cleanup. Pre-existing debt is tracked in #2449; note the OpenClaw link-health agent (#1178) only auto-files **external** broken-link issues, so relative-link debt is otherwise untracked.

Closes #2412.

_Assisted-By: Claude Code_