### PR TITLE
feat: feature-flagged mesh self-heal CronJob

### DIFF
--- a/charts/rossoctl-deps/files/mesh-recover.sh
+++ b/charts/rossoctl-deps/files/mesh-recover.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# mesh-recover.sh — detect and (optionally) recover from an Istio Ambient
+# mesh outage where ztunnel / waypoint proxies serve EXPIRED mTLS certificates
+# and never re-fetch, so every gateway-routed service returns HTTP 503.
+#
+# This is the classic "long-running / suspended dev Kind cluster" failure
+# (rossoctl/rossoctl#1899): a host suspend expires the istiod-issued workload
+# certs, the Ambient data plane keeps serving them, and all *.localtest.me URLs
+# 503 while every pod still looks Running. The durable fix is upstream
+# (istio/ztunnel#1679); this script is the rossoctl-side detect + recover
+# mitigation for dev/Kind clusters.
+#
+# Read-only by default: it DETECTS and prints the recommended recovery
+# commands. Pass --fix to actually run the rollout restarts.
+#
+# Scope: dev / Kind. Do not wire this to auto-run against production meshes.
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging + command wrapper (self-contained; mirrors scripts/kind/setup-rossoctl.sh
+# so this file can be dropped into a container unchanged by the follow-up
+# CronJob remediator — no external lib sourcing).
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'
+  BLUE=$'\033[0;34m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+FIX=false
+INCLUDE_SPIRE=false
+JSON=false
+# In --json mode all human logs go to stderr so stdout stays pure JSON
+# (the follow-up CronJob remediator parses stdout).
+log_info()    { if $JSON; then echo "→ $1" >&2; else echo "${BLUE}→${NC} $1"; fi; }
+log_success() { if $JSON; then echo "✓ $1" >&2; else echo "${GREEN}✓${NC} $1"; fi; }
+log_warn()    { if $JSON; then echo "⚠ $1" >&2; else echo "${YELLOW}⚠${NC} $1"; fi; }
+log_error()   { echo "${RED}✗${NC} $1" >&2; }
+PROBE_HOST=""
+GATEWAY_URL="${GATEWAY_URL:-http://127.0.0.1:8080}"
+GW_NS="rossoctl-system"
+TIMEOUT=5
+
+usage() {
+  cat <<'EOF'
+mesh-recover.sh — detect / recover an Istio Ambient mesh 503 outage (expired certs)
+
+Usage: mesh-recover.sh [--fix] [--include-spire] [--probe-host HOST]
+                       [--gateway-url URL] [--json] [-h]
+
+  --fix            Perform recovery (rollout restart ztunnel + waypoints + gateway).
+                   Default is DETECT-ONLY: report status and print the commands.
+  --include-spire  Also check (and with --fix, restart) the SPIRE agent. This is a
+                   SEPARATE failure domain (AuthBridge/token-exchange identity), not
+                   the cause of the mesh 503 — off by default.
+  --probe-host H   Host header to probe (e.g. rossoctl-ui.localtest.me). Default:
+                   auto-discovered from the http Gateway's routes.
+  --gateway-url U  Gateway base URL to curl. Default: http://127.0.0.1:8080
+                   (the Kind port-map; env GATEWAY_URL also honored).
+  --json           Emit a machine-readable JSON summary (for the CronJob remediator).
+  -h, --help       This help.
+
+Exit: 0 healthy · 2 degraded (recoverable) · 3 inconclusive (unreachable / not Ambient) · 1 usage error.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix)           FIX=true; shift ;;
+    --include-spire) INCLUDE_SPIRE=true; shift ;;
+    --json)          JSON=true; shift ;;
+    --probe-host)    PROBE_HOST="${2:-}"; shift 2 ;;
+    --gateway-url)   GATEWAY_URL="${2:-}"; shift 2 ;;
+    -h|--help)       usage; exit 0 ;;
+    *) log_error "unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+# run_cmd: gate mutating actions behind --fix (dry-run prints the command).
+run_cmd() {
+  if $FIX; then
+    "$@"
+  else
+    echo "    [would run] $*"
+  fi
+}
+
+command -v kubectl >/dev/null 2>&1 || { log_error "kubectl not found in PATH"; exit 1; }
+HAVE_ISTIOCTL=false
+command -v istioctl >/dev/null 2>&1 && HAVE_ISTIOCTL=true
+
+# Findings accumulate here for the summary / JSON output.
+DEGRADED=false       # a recoverable mesh outage (503 / expired certs) → exit 2, restart helps
+INCONCLUSIVE=false   # can't confirm health (gateway unreachable, no ztunnel) → exit 3, restart won't help
+declare -a CHECKS=()   # "name|status|detail"
+declare -a ACTIONS=()  # recovery commands that were (or would be) run
+record() {
+  CHECKS+=("$1|$2|$3")
+  case "$2" in
+    DEGRADED)     DEGRADED=true ;;
+    INCONCLUSIVE) INCONCLUSIVE=true ;;
+  esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+discover_ztunnel_ns() {
+  # ztunnel namespace is NOT fixed: charts use istio-ztunnel, a plain istioctl
+  # install uses istio-system. Discover by the daemonset's app=ztunnel label.
+  local ns
+  ns=$(kubectl get ds -A -l app=ztunnel -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || true)
+  [[ -z "$ns" ]] && for c in istio-system istio-ztunnel; do
+    kubectl get ds -n "$c" ztunnel >/dev/null 2>&1 && { ns="$c"; break; }
+  done
+  echo "$ns"
+}
+
+discover_probe_host() {
+  # Pick a BACKEND-DEPENDENT route: some routes (e.g. kiali) redirect (302) at the
+  # gateway edge before the ztunnel->backend mTLS hop, so they stay 302 even during
+  # a mesh outage and would give a false-healthy. Prefer the platform UI/API routes
+  # in rossoctl-system, which return a backend response (200) and flip to 503 when the
+  # mesh is broken.
+  [[ -n "$PROBE_HOST" ]] && { echo "$PROBE_HOST"; return; }
+  local h
+  h=$(kubectl get httproute -n "$GW_NS" -o jsonpath='{range .items[*]}{.spec.hostnames[0]}{"\n"}{end}' 2>/dev/null \
+      | grep -m1 -E 'rossoctl-ui|rossoctl-api' || true)
+  [[ -z "$h" ]] && h=$(kubectl get httproute -n "$GW_NS" -o jsonpath='{.items[0].spec.hostnames[0]}' 2>/dev/null || true)
+  [[ -z "$h" ]] && h=$(kubectl get httproute -A -o jsonpath='{range .items[*]}{.spec.hostnames[0]}{"\n"}{end}' 2>/dev/null | grep -m1 'localtest.me' || true)
+  echo "${h:-rossoctl-ui.localtest.me}"
+}
+
+# ---------------------------------------------------------------------------
+# Detectors (read-only)
+# ---------------------------------------------------------------------------
+check_mesh_reachability() {
+  local host code body
+  host=$(discover_probe_host)
+  log_info "Probing gateway ${GATEWAY_URL} (Host: ${host}) ..."
+  code=$(curl -s -o /dev/null -w '%{http_code}' -m "$TIMEOUT" -H "Host: ${host}" "${GATEWAY_URL}/" 2>/dev/null || true)
+  code=${code:-000}
+  if [[ "$code" == "503" ]]; then
+    body=$(curl -s -m "$TIMEOUT" -H "Host: ${host}" "${GATEWAY_URL}/" 2>/dev/null || true)
+    if grep -qi 'connection termination\|upstream connect error' <<<"$body"; then
+      record "mesh-reachability" "DEGRADED" "HTTP 503 (connection termination) for ${host} — Ambient upstream mTLS is failing"
+      log_error "503 with upstream connection termination for ${host} — classic expired-cert mesh outage"
+    else
+      record "mesh-reachability" "DEGRADED" "HTTP 503 for ${host}"
+      log_error "503 for ${host}"
+    fi
+  elif [[ "$code" == "000" ]]; then
+    record "mesh-reachability" "INCONCLUSIVE" "could not connect to ${GATEWAY_URL} — is the Kind port-map / port-forward up?"
+    log_warn "Gateway ${GATEWAY_URL} unreachable (curl 000) — that's a port-map/port-forward issue, not a mesh cert outage; a restart won't help."
+  else
+    record "mesh-reachability" "OK" "HTTP ${code} for ${host}"
+    log_success "Gateway reachable — HTTP ${code} for ${host} (not 503)"
+  fi
+}
+
+check_ztunnel_certs() {
+  local ns pod hits
+  ns=$(discover_ztunnel_ns)
+  if [[ -z "$ns" ]]; then
+    record "ztunnel-certs" "INCONCLUSIVE" "no ztunnel daemonset found (app=ztunnel)"
+    log_warn "No ztunnel daemonset found — is this an Ambient cluster?"
+    return
+  fi
+  log_info "Checking ztunnel certs in namespace ${ns} ..."
+  hits=$(kubectl logs -n "$ns" -l app=ztunnel --tail=300 --since=2h 2>/dev/null \
+         | grep -ciE 'certificate expired|CertificateExpired' || true)
+  if [[ "${hits:-0}" -gt 0 ]]; then
+    record "ztunnel-certs" "DEGRADED" "${hits} expired-certificate errors in ztunnel logs (ns ${ns})"
+    log_error "ztunnel is logging expired-certificate errors (${hits} hits, ns ${ns})"
+  else
+    record "ztunnel-certs" "OK" "no expired-certificate errors in recent ztunnel logs (ns ${ns})"
+    log_success "ztunnel logs clean of expired-cert errors (ns ${ns})"
+  fi
+  if $HAVE_ISTIOCTL; then
+    pod=$(kubectl get pods -n "$ns" -l app=ztunnel -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [[ -n "$pod" ]] && istioctl ztunnel-config certificates "$pod" -n "$ns" 2>/dev/null | grep -qi 'Unavailable'; then
+      record "ztunnel-cert-status" "DEGRADED" "istioctl reports Unavailable certs on ${pod}"
+      log_error "istioctl ztunnel-config certificates: Unavailable certs on ${pod}"
+    fi
+  else
+    log_info "istioctl not found — skipping ztunnel-config certificate inspection (log check still applies)"
+  fi
+}
+
+check_spire_agent() {
+  local ns restarts prev
+  ns=$(kubectl get pods -A -l app=spire-agent -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || true)
+  [[ -z "$ns" ]] && ns="spire-system"
+  if ! kubectl get pods -n "$ns" -l app=spire-agent >/dev/null 2>&1; then
+    record "spire-agent" "INCONCLUSIVE" "no spire-agent pods found"
+    log_warn "No spire-agent pods found (ns ${ns}) — skipping SPIRE check"
+    return
+  fi
+  log_info "Checking SPIRE agent in namespace ${ns} (separate domain: AuthBridge identity) ..."
+  restarts=$(kubectl get pods -n "$ns" -l app=spire-agent \
+             -o jsonpath='{range .items[*]}{.status.containerStatuses[0].restartCount}{"\n"}{end}' 2>/dev/null \
+             | sort -rn | head -1 || echo 0)
+  prev=$(kubectl logs -n "$ns" -l app=spire-agent --previous --tail=40 2>/dev/null \
+         | grep -ciE 'reattest|service account token has expired|Agent crashed' || true)
+  if [[ "${prev:-0}" -gt 0 || "${restarts:-0}" -ge 3 ]]; then
+    record "spire-agent" "DEGRADED" "reattest/expiry signatures or ${restarts} restarts (ns ${ns})"
+    log_error "SPIRE agent shows reattest-deadlock signatures (restarts=${restarts}, ns ${ns})"
+  else
+    record "spire-agent" "OK" "spire-agent healthy (restarts=${restarts}, ns ${ns})"
+    log_success "SPIRE agent healthy (ns ${ns})"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Recovery
+# ---------------------------------------------------------------------------
+recover_mesh() {
+  local ns gw
+  ns=$(discover_ztunnel_ns)
+  echo
+  log_info "Recovery — restart the Ambient data plane so it re-fetches fresh certs:"
+
+  if [[ -n "$ns" ]]; then
+    ACTIONS+=("kubectl rollout restart daemonset/ztunnel -n ${ns}")
+    run_cmd kubectl rollout restart daemonset/ztunnel -n "$ns"
+  fi
+
+  # Waypoints: mesh-managed deployments, any namespace.
+  while IFS=$'\t' read -r wns wname; do
+    [[ -z "$wname" ]] && continue
+    ACTIONS+=("kubectl rollout restart deploy/${wname} -n ${wns}")
+    run_cmd kubectl rollout restart deploy/"$wname" -n "$wns"
+  done < <(kubectl get deploy -A -l gateway.networking.k8s.io/managed-by=istio.io-mesh-controller \
+           -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+  # Gateway deployment (Istio names it <gateway>-istio, selected by gateway-name).
+  gw=$(kubectl get deploy -n "$GW_NS" -l gateway.networking.k8s.io/gateway-name=http \
+       -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  gw="${gw:-http-istio}"
+  ACTIONS+=("kubectl rollout restart deploy/${gw} -n ${GW_NS}")
+  run_cmd kubectl rollout restart deploy/"$gw" -n "$GW_NS"
+
+  if $INCLUDE_SPIRE; then
+    local sns
+    sns=$(kubectl get pods -A -l app=spire-agent -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo spire-system)
+    ACTIONS+=("kubectl rollout restart daemonset/spire-agent -n ${sns}")
+    run_cmd kubectl rollout restart daemonset/spire-agent -n "$sns"
+  fi
+
+  if $FIX; then
+    log_info "Waiting for the data plane to settle ..."
+    [[ -n "$ns" ]] && kubectl rollout status daemonset/ztunnel -n "$ns" --timeout=120s || true
+    kubectl rollout status deploy/"$gw" -n "$GW_NS" --timeout=120s || true
+    log_info "Re-probing to verify recovery ..."
+    DEGRADED=false; INCONCLUSIVE=false; CHECKS=()
+    check_mesh_reachability
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+emit_json() {
+  local first=true
+  printf '{"degraded":%s,"inconclusive":%s,"fixed":%s,"checks":[' "$DEGRADED" "$INCONCLUSIVE" "$FIX"
+  for c in "${CHECKS[@]}"; do
+    IFS='|' read -r n s d <<<"$c"
+    $first || printf ','; first=false
+    printf '{"name":"%s","status":"%s","detail":"%s"}' "$n" "$s" "${d//\"/\'}"
+  done
+  printf '],"actions":['
+  first=true
+  for a in "${ACTIONS[@]:-}"; do
+    [[ -z "$a" ]] && continue
+    $first || printf ','; first=false
+    printf '"%s"' "$a"
+  done
+  printf ']}\n'
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+$JSON || { echo; log_info "Istio Ambient mesh self-heal — $($FIX && echo 'RECOVER (--fix)' || echo 'detect only') · scope: dev/Kind"; echo; }
+
+check_mesh_reachability
+check_ztunnel_certs
+$INCLUDE_SPIRE && check_spire_agent
+
+if $DEGRADED; then
+  recover_mesh
+fi
+
+if $JSON; then
+  emit_json
+else
+  echo
+  if $DEGRADED && ! $FIX; then
+    log_warn "Mesh looks degraded. Re-run with --fix to apply the recovery above, or run those commands manually."
+    log_info "Root cause is upstream (istio/ztunnel#1679); this restart is the dev-cluster mitigation for #1899."
+  elif $DEGRADED && $FIX; then
+    log_success "Recovery applied — see re-probe result above."
+  elif $INCONCLUSIVE; then
+    log_warn "Could not confirm mesh health (gateway unreachable, or no ztunnel found). Check the gateway port-map and that this is an Ambient cluster — no restart attempted."
+  else
+    log_success "Mesh healthy — no action needed."
+  fi
+fi
+
+if $DEGRADED; then exit 2; elif $INCONCLUSIVE; then exit 3; else exit 0; fi

--- a/charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh
+++ b/charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# mesh-selfheal-wrapper.sh — Part B scheduling+safety wrapper around mesh-recover.sh
+# (rossoctl/rossoctl#1899). Run by the mesh-selfheal CronJob on each tick:
+#   1. detect: mesh-recover.sh --json   (exit 0 healthy / 2 degraded / 3 inconclusive)
+#   2. on degraded, apply cooldown + max-restart(window) gating from a state ConfigMap
+#   3. if allowed: mesh-recover.sh --fix   (rollout restart ztunnel + waypoints + gateway)
+#   4. emit k8s Events throughout; persist restart state back to the ConfigMap
+#
+# Env (set by the CronJob):
+#   GATEWAY_URL, PROBE_HOST (optional), INCLUDE_SPIRE (true/false),
+#   COOLDOWN_SECONDS, MAX_RESTARTS, WINDOW_SECONDS, STATE_NS, STATE_CM, CRONJOB_NAME
+set -uo pipefail
+
+NS="${STATE_NS:?STATE_NS required}"
+CM="${STATE_CM:?STATE_CM required}"
+COOLDOWN="${COOLDOWN_SECONDS:-900}"
+MAX_RESTARTS="${MAX_RESTARTS:-5}"
+WINDOW="${WINDOW_SECONDS:-3600}"
+CRONJOB="${CRONJOB_NAME:-mesh-selfheal}"
+now=$(date +%s)
+
+log() { echo "[mesh-selfheal] $*" >&2; }
+
+# Best-effort k8s Event against the CronJob so `kubectl describe cronjob mesh-selfheal` shows history.
+emit_event() {  # $1=type(Normal|Warning) $2=reason $3=message
+  local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  kubectl -n "$NS" create -f - >/dev/null 2>&1 <<EOF || log "event emit failed (non-fatal): $2"
+apiVersion: v1
+kind: Event
+metadata:
+  generateName: mesh-selfheal-
+  namespace: ${NS}
+type: ${1}
+reason: ${2}
+message: ${3}
+firstTimestamp: ${ts}
+lastTimestamp: ${ts}
+count: 1
+source:
+  component: mesh-selfheal
+involvedObject:
+  apiVersion: batch/v1
+  kind: CronJob
+  name: ${CRONJOB}
+  namespace: ${NS}
+EOF
+}
+
+read_state() {  # $1=key ; echoes value or 0
+  local v; v=$(kubectl -n "$NS" get cm "$CM" -o "jsonpath={.data.$1}" 2>/dev/null || true)
+  echo "${v:-0}"
+}
+
+# --- 1. detect (never mutates) ---
+args=(--json --gateway-url "$GATEWAY_URL")
+[ -n "${PROBE_HOST:-}" ] && args+=(--probe-host "$PROBE_HOST")
+[ "${INCLUDE_SPIRE:-false}" = "true" ] && args+=(--include-spire)
+
+summary=$(bash /scripts/mesh-recover.sh "${args[@]}" 2>/dev/null); rc=$?
+log "detect rc=$rc summary=$summary"
+
+case "$rc" in
+  0) emit_event Normal MeshHealthy "gateway reachable, mesh certs OK"; exit 0 ;;
+  3) emit_event Warning MeshInconclusive "cannot confirm mesh health (restart would not help): ${summary}"; exit 0 ;;
+  2) : ;;  # degraded/recoverable — fall through to gating
+  *) log "unexpected rc=$rc; treating as inconclusive"; emit_event Warning MeshInconclusive "mesh-recover.sh rc=$rc"; exit 0 ;;
+esac
+
+# --- 2. gating (cooldown + max-restarts within a rolling window) ---
+last=$(read_state last_restart)
+count=$(read_state restart_count)
+wstart=$(read_state window_start)
+[ "$wstart" = "0" ] && wstart=$now
+# reset the rolling window if it has elapsed
+if [ $((now - wstart)) -ge "$WINDOW" ]; then count=0; wstart=$now; fi
+
+if [ $((now - last)) -lt "$COOLDOWN" ]; then
+  emit_event Warning MeshCooldown "degraded but within ${COOLDOWN}s cooldown since last restart — skipping: ${summary}"
+  log "in cooldown ($((now - last))s < ${COOLDOWN}s); skip"
+  exit 0
+fi
+if [ "$count" -ge "$MAX_RESTARTS" ]; then
+  emit_event Warning MeshRestartCapHit "degraded but restart cap ${MAX_RESTARTS}/${WINDOW}s reached — manual intervention needed: ${summary}"
+  log "restart cap hit ($count >= $MAX_RESTARTS); skip"
+  exit 0
+fi
+
+# --- 3. remediate ---
+emit_event Warning MeshDegraded "recoverable mesh outage detected — issuing rollout restart: ${summary}"
+log "degraded — running --fix"
+bash /scripts/mesh-recover.sh --fix "${args[@]:1}" >&2 2>&1 || log "mesh-recover.sh --fix returned non-zero (continuing)"
+
+# --- 4. persist state + Event ---
+kubectl -n "$NS" patch cm "$CM" --type merge \
+  -p "{\"data\":{\"last_restart\":\"$now\",\"restart_count\":\"$((count + 1))\",\"window_start\":\"$wstart\"}}" \
+  >/dev/null 2>&1 || log "state ConfigMap patch failed (non-fatal)"
+emit_event Normal MeshRecoverAttempted "rollout restart issued (attempt $((count + 1))/${MAX_RESTARTS} in window)"
+log "recover attempted; state updated (count=$((count + 1)))"
+exit 0

--- a/charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh
+++ b/charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh
@@ -24,7 +24,14 @@ log() { echo "[mesh-selfheal] $*" >&2; }
 
 # Best-effort k8s Event against the CronJob so `kubectl describe cronjob mesh-selfheal` shows history.
 emit_event() {  # $1=type(Normal|Warning) $2=reason $3=message
-  local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local ts msg
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  # Flatten to a single line, then emit as a YAML literal block scalar. The
+  # --json summary we pass as the message contains ':' (and other YAML
+  # metacharacters); interpolated into a plain `message: ${3}` scalar it makes
+  # `kubectl create -f -` fail with "mapping values are not allowed here", so
+  # the very Warning Events the design promises would silently never be created.
+  msg=$(printf '%s' "$3" | tr '\n\r' '  ')
   kubectl -n "$NS" create -f - >/dev/null 2>&1 <<EOF || log "event emit failed (non-fatal): $2"
 apiVersion: v1
 kind: Event
@@ -33,7 +40,8 @@ metadata:
   namespace: ${NS}
 type: ${1}
 reason: ${2}
-message: ${3}
+message: |-
+  ${msg}
 firstTimestamp: ${ts}
 lastTimestamp: ${ts}
 count: 1

--- a/charts/rossoctl-deps/templates/mesh-selfheal.yaml
+++ b/charts/rossoctl-deps/templates/mesh-selfheal.yaml
@@ -136,6 +136,13 @@ spec:
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true
+            # Pin an explicit non-root UID/GID. The image defaults to root, and
+            # runAsNonRoot alone would let the kubelet reject the pod at admission
+            # ("container has runAsNonRoot and image will run as root"). fsGroup
+            # makes the HOME emptyDir below writable by this UID.
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
             seccompProfile:
               type: RuntimeDefault
           containers:
@@ -148,6 +155,11 @@ spec:
                 capabilities:
                   drop: ["ALL"]
               env:
+                # readOnlyRootFilesystem is on, so give kubectl a writable HOME
+                # (the emptyDir below) for its discovery/http cache. Without it
+                # every kubectl call warns about an unwritable ~/.kube/cache.
+                - name: HOME
+                  value: /home/nonroot
                 - name: GATEWAY_URL
                   value: {{ .Values.meshSelfHeal.gatewayUrl | quote }}
                 - name: PROBE_HOST
@@ -171,9 +183,13 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
+                - name: home
+                  mountPath: /home/nonroot
           volumes:
             - name: scripts
               configMap:
                 name: mesh-selfheal-scripts
                 defaultMode: 0755
+            - name: home
+              emptyDir: {}
 {{- end }}

--- a/charts/rossoctl-deps/templates/mesh-selfheal.yaml
+++ b/charts/rossoctl-deps/templates/mesh-selfheal.yaml
@@ -1,0 +1,179 @@
+{{- /*
+Mesh self-heal Part B (rossoctl/rossoctl#1899): a feature-flagged CronJob that probes the gateway
+and, on a recoverable mesh-wide 503 (expired ztunnel/waypoint certs after a host suspend), runs
+scripts/k8s/mesh-recover.sh --fix with cooldown / max-restart safety and loud Events.
+OFF by default; Kind/dev-only (the ambient cert-expiry failure mode does not apply on OpenShift).
+Durable fix is upstream (istio/ztunnel#1679); this is a stop-gap remediator.
+*/ -}}
+{{- if and .Values.meshSelfHeal.enabled (not .Values.openshift) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mesh-selfheal-scripts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+data:
+  # mesh-recover.sh is a verbatim copy of scripts/k8s/mesh-recover.sh, kept in sync by
+  # scripts/check-mesh-recover-sync.sh (Helm .Files.Get cannot read outside the chart).
+  mesh-recover.sh: |
+{{ .Files.Get "files/mesh-recover.sh" | indent 4 }}
+  mesh-selfheal-wrapper.sh: |
+{{ .Files.Get "files/mesh-selfheal-wrapper.sh" | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mesh-selfheal-state
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+  annotations:
+    # Preserve cooldown/restart-count state across chart upgrades.
+    helm.sh/resource-policy: keep
+data: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mesh-selfheal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+---
+# Cluster-scoped: the remediator rollout-restarts ztunnel (istio-system / istio-ztunnel),
+# waypoints and the gateway (rossoctl-system) — different namespaces — so restart perms are
+# cluster-wide but limited to read + patch (rollout restart is a patch of the pod template).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}-mesh-selfheal
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-mesh-selfheal
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}-mesh-selfheal
+subjects:
+  - kind: ServiceAccount
+    name: mesh-selfheal
+    namespace: {{ .Release.Namespace }}
+---
+# Namespaced: the state ConfigMap and Events live in the release namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mesh-selfheal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["mesh-selfheal-state"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mesh-selfheal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mesh-selfheal
+subjects:
+  - kind: ServiceAccount
+    name: mesh-selfheal
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mesh-selfheal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rossoctl.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.meshSelfHeal.schedule | quote }}
+  # Never overlap ticks; a stuck rollout shouldn't stack jobs.
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            app: mesh-selfheal
+            # Keep this pod OUT of ambient — its kubectl/curl must not traverse the (possibly
+            # broken) ztunnel it is trying to repair. Same mechanism the gateway pods use.
+            istio.io/dataplane-mode: none
+        spec:
+          serviceAccountName: mesh-selfheal
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: mesh-selfheal
+              image: {{ .Values.meshSelfHeal.image | quote }}
+              command: ["bash", "/scripts/mesh-selfheal-wrapper.sh"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: GATEWAY_URL
+                  value: {{ .Values.meshSelfHeal.gatewayUrl | quote }}
+                - name: PROBE_HOST
+                  value: {{ .Values.meshSelfHeal.probeHost | quote }}
+                - name: INCLUDE_SPIRE
+                  value: {{ .Values.meshSelfHeal.includeSpire | quote }}
+                - name: COOLDOWN_SECONDS
+                  value: {{ .Values.meshSelfHeal.cooldownSeconds | quote }}
+                - name: MAX_RESTARTS
+                  value: {{ .Values.meshSelfHeal.maxRestarts | quote }}
+                - name: WINDOW_SECONDS
+                  value: {{ .Values.meshSelfHeal.windowSeconds | quote }}
+                - name: STATE_NS
+                  value: {{ .Release.Namespace | quote }}
+                - name: STATE_CM
+                  value: "mesh-selfheal-state"
+                - name: CRONJOB_NAME
+                  value: "mesh-selfheal"
+              resources:
+                {{- toYaml .Values.meshSelfHeal.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+          volumes:
+            - name: scripts
+              configMap:
+                name: mesh-selfheal-scripts
+                defaultMode: 0755
+{{- end }}

--- a/charts/rossoctl-deps/values.yaml
+++ b/charts/rossoctl-deps/values.yaml
@@ -441,3 +441,33 @@ mlflow:
     # Set to true in ocp_values.yaml for production deployments
     enabled: false
     secretName: mlflow-oauth-secret
+
+# [MESH SELF-HEAL] Dev/Kind-only CronJob that auto-recovers a mesh-wide 503 caused by expired
+# ztunnel/waypoint mTLS certs after a long host suspend (rossoctl/rossoctl#1899). It periodically
+# probes the gateway and, on a recoverable outage, runs scripts/k8s/mesh-recover.sh --fix with
+# cooldown / max-restart safety and loud Events. OFF by default; only renders on non-OpenShift
+# (the ambient/ztunnel cert-expiry failure mode is Kind/dev-specific — see the issue). The durable
+# fix is upstream (istio/ztunnel#1679); this is a stop-gap remediator.
+meshSelfHeal:
+  enabled: false
+  # Cron schedule for the probe+remediate tick.
+  schedule: "*/5 * * * *"
+  # Stock image with bash + kubectl + curl (no custom image built for this).
+  image: "registry.k8s.io/kubectl:v1.31.0"
+  # In-cluster gateway URL the CronJob probes (the Istio-generated Service for Gateway "http").
+  gatewayUrl: "http://http-istio.rossoctl-system.svc.cluster.local:80"
+  # Host header to probe; empty ⇒ mesh-recover.sh auto-discovers it from HTTPRoutes.
+  probeHost: ""
+  # Also check/restart the SPIRE agent (separate failure domain; off by default).
+  includeSpire: false
+  # Safety gating (enforced by the wrapper via a small state ConfigMap):
+  cooldownSeconds: 900    # minimum gap between restart attempts
+  maxRestarts: 5          # cap on restarts within the rolling window; then Events only
+  windowSeconds: 3600     # rolling window for the restart cap
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi

--- a/charts/rossoctl-deps/values.yaml
+++ b/charts/rossoctl-deps/values.yaml
@@ -452,8 +452,12 @@ meshSelfHeal:
   enabled: false
   # Cron schedule for the probe+remediate tick.
   schedule: "*/5 * * * *"
-  # Stock image with bash + kubectl + curl (no custom image built for this).
-  image: "registry.k8s.io/kubectl:v1.31.0"
+  # Stock image bundling bash + curl + kubectl (all three verified present).
+  # NB: registry.k8s.io/kubectl is kubectl-only — no shell and no curl — so the
+  # ["bash", ...] command can't exec and the curl gateway probe would no-op.
+  # alpine/k8s ships all three; pinned (non-floating) and runs as the non-root
+  # UID set in the CronJob securityContext (see templates/mesh-selfheal.yaml).
+  image: "docker.io/alpine/k8s:1.31.0"
   # In-cluster gateway URL the CronJob probes (the Istio-generated Service for Gateway "http").
   gatewayUrl: "http://http-istio.rossoctl-system.svc.cluster.local:80"
   # Host header to probe; empty ⇒ mesh-recover.sh auto-discovers it from HTTPRoutes.

--- a/scripts/check-mesh-recover-sync.sh
+++ b/scripts/check-mesh-recover-sync.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Guard: charts/rossoctl-deps/files/mesh-recover.sh must be a verbatim copy of
+# scripts/k8s/mesh-recover.sh (Helm .Files.Get cannot read outside the chart, so the mesh
+# self-heal CronJob (rossoctl/rossoctl#1899 Part B) mounts a copy). Re-sync with:
+#   cp scripts/k8s/mesh-recover.sh charts/rossoctl-deps/files/mesh-recover.sh
+set -euo pipefail
+SRC="scripts/k8s/mesh-recover.sh"
+DST="charts/rossoctl-deps/files/mesh-recover.sh"
+if ! diff -q "$SRC" "$DST" >/dev/null 2>&1; then
+  echo "error: $DST is out of sync with $SRC" >&2
+  echo "  re-sync: cp $SRC $DST" >&2
+  exit 1
+fi
+echo "mesh-recover.sh chart copy is in sync ✓"


### PR DESCRIPTION
## Summary

**Part B** of the mesh-wide-503 self-heal (rossoctl/rossoctl#1899). Part A — `scripts/k8s/mesh-recover.sh` + the `k8s:health` / `istio:mesh-selfheal` skills — shipped in 0.7 (#2179). This adds the hands-off remediator: a **feature-flagged CronJob** (in `rossoctl-deps`) that periodically probes the gateway and, on a recoverable mesh outage (expired ztunnel/waypoint mTLS certs after a host suspend → HTTP 503 on all `*.localtest.me` routes), runs `mesh-recover.sh --fix` with cooldown / max-restart safety and loud Events.

**Part of #1899** (not Closes — #1899 stays open as the umbrella; the durable fix is upstream, istio/ztunnel#1679).

## Design

- **OFF by default.** Helm value `meshSelfHeal.enabled` (chart-level flag). Renders only on **non-OpenShift** — the ambient cert-expiry failure mode is Kind/dev-specific.
- **Reuses `mesh-recover.sh` unchanged** (auto-discovers the ztunnel namespace + probe host; exit `0` healthy / `2` degraded / `3` inconclusive). Helm `.Files.Get` can't read outside the chart, so a **verbatim copy** lives in `charts/rossoctl-deps/files/`, kept identical by `scripts/check-mesh-recover-sync.sh`.
- **Wrapper** (`mesh-selfheal-wrapper.sh`) adds only scheduling + safety: detect → cooldown / max-restart(rolling-window) gating (persisted in a small state ConfigMap) → `--fix` → k8s Events. Probes the in-cluster gateway Service `http-istio.rossoctl-system.svc`.
- **Safe by construction:** CronJob pod is kept **out of ambient** (`istio.io/dataplane-mode: none`) so its own `kubectl` calls don't traverse the broken ztunnel it's repairing; `concurrencyPolicy: Forbid`; nonroot / read-only rootfs / drop-ALL; least-privilege RBAC (get/list + **patch** deployments+daemonsets for `rollout restart`; state ConfigMap get/patch; events create).

## Files

- `charts/rossoctl-deps/values.yaml` — `meshSelfHeal` block (flag, schedule, image, gatewayUrl, cooldown/max/window, resources).
- `charts/rossoctl-deps/files/mesh-recover.sh` — verbatim copy of the Part A engine.
- `charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh` — the scheduling/gating/Events wrapper.
- `charts/rossoctl-deps/templates/mesh-selfheal.yaml` — scripts CM + state CM + SA + ClusterRole/Binding + Role/Binding + CronJob, gated `enabled AND not openshift`.
- `scripts/check-mesh-recover-sync.sh` — `diff -q` guard for the chart copy.

## Verification

- `helm template`: **OFF → no objects**, **ON+Kind → full set**, **ON+OpenShift → no objects** (Kind-only gate).
- `helm lint` clean · wrapper **shellcheck-clean** · sync guard passing.

## Follow-ups (not in this PR)

- Wire `scripts/check-mesh-recover-sync.sh` into pre-commit.
- Live Kind test via `scripts/k8s/induce-mesh-outage.sh`.
- File/link the suspend/clock-jump repro to istio/ztunnel#1679 (durable upstream fix).

Refs: Part A #2179 · umbrella #1899 · upstream istio/ztunnel#1679.

Assisted-By: Claude Code
