### PR TITLE
fix: constrain agent route path params to RFC-1123

### DIFF
--- a/rossoctl/backend/app/routers/acp.py
+++ b/rossoctl/backend/app/routers/acp.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
 from app.core.config import settings
 from app.services.acp_bridge import ACPBridge
+from app.utils.naming import K8S_NAME_PATTERN
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/acp", tags=["acp"])
@@ -29,7 +30,7 @@ JSON_RPC_METHOD_NOT_FOUND = -32601
 JSON_RPC_INTERNAL_ERROR = -32603
 JSON_RPC_PARSE_ERROR = -32700
 
-_K8S_NAME = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_K8S_NAME = re.compile(K8S_NAME_PATTERN)
 
 
 @router.websocket("/ws/{namespace}/{agent_name}")

--- a/rossoctl/backend/app/routers/agents_authbridge.py
+++ b/rossoctl/backend/app/routers/agents_authbridge.py
@@ -34,13 +34,14 @@ from app.core.constants import (
 )
 from app.routers.agents_models import OutboundRoute
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.utils.naming import K8S_NAME_PATTERN
 from app.utils.routes import detect_platform, sanitize_log
 
 logger = logging.getLogger(__name__)
 
 authbridge_router = APIRouter()
 
-_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_K8S_NAME_RE = re.compile(K8S_NAME_PATTERN)
 
 
 def _get_authbridge_runtime_yaml() -> str:
@@ -363,7 +364,7 @@ async def _fetch_authbridge_json(url: str) -> dict:
         return data
 
 
-_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_K8S_NAME_RE = re.compile(K8S_NAME_PATTERN)
 
 
 if settings.rossoctl_feature_flag_authbridge_api:

--- a/rossoctl/backend/app/routers/agents_migration.py
+++ b/rossoctl/backend/app/routers/agents_migration.py
@@ -16,7 +16,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from kubernetes.client import ApiException
 
 from app.core.auth import ROLE_OPERATOR, require_roles
@@ -49,6 +49,7 @@ from app.routers.agents_models import (
     MigrateAgentResponse,
 )
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
+from app.utils.naming import K8S_NAME_MAX_LENGTH, K8S_NAME_PATTERN
 
 logger = logging.getLogger(__name__)
 
@@ -147,8 +148,8 @@ async def list_migratable_agents(
     dependencies=[Depends(require_roles(ROLE_OPERATOR))],
 )
 async def migrate_agent(
-    namespace: str,
-    name: str,
+    namespace: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
+    name: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
     request: MigrateAgentRequest = MigrateAgentRequest(),
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> MigrateAgentResponse:

--- a/rossoctl/backend/app/routers/agents_shipwright.py
+++ b/rossoctl/backend/app/routers/agents_shipwright.py
@@ -15,7 +15,7 @@ router by ``agents.py`` -- see the ordering note there.
 import logging
 from typing import Any, Dict, List
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from kubernetes.client import ApiException
 
 from app.core.auth import ROLE_OPERATOR, ROLE_VIEWER, require_roles
@@ -45,6 +45,7 @@ from app.services.shipwright import (
     get_latest_buildrun,
 )
 from app.services.shipwright_builds import collect_rossoctl_shipwright_builds
+from app.utils.naming import K8S_NAME_MAX_LENGTH, K8S_NAME_PATTERN
 
 logger = logging.getLogger(__name__)
 
@@ -140,8 +141,8 @@ async def list_agent_shipwright_builds(
     dependencies=[Depends(require_roles(ROLE_VIEWER))],
 )
 async def get_shipwright_build_status(
-    namespace: str,
-    name: str,
+    namespace: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
+    name: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> ShipwrightBuildStatusResponse:
     """Get the Shipwright Build status for an agent.
@@ -189,8 +190,8 @@ async def get_shipwright_build_status(
     dependencies=[Depends(require_roles(ROLE_VIEWER))],
 )
 async def get_shipwright_buildrun_status(
-    namespace: str,
-    name: str,
+    namespace: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
+    name: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> ShipwrightBuildRunStatusResponse:
     """Get the latest Shipwright BuildRun status for an agent build.
@@ -283,8 +284,8 @@ async def get_shipwright_buildrun_status(
     "/{namespace}/{name}/shipwright-buildrun", dependencies=[Depends(require_roles(ROLE_OPERATOR))]
 )
 async def trigger_shipwright_buildrun(
-    namespace: str,
-    name: str,
+    namespace: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
+    name: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> Dict[str, Any]:
     """Trigger a new Shipwright BuildRun for an existing Build.
@@ -348,8 +349,8 @@ async def trigger_shipwright_buildrun(
     dependencies=[Depends(require_roles(ROLE_VIEWER))],
 )
 async def get_shipwright_build_info(
-    namespace: str,
-    name: str,
+    namespace: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
+    name: str = Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH),
     kube: KubernetesService = Depends(get_kubernetes_service),
 ) -> AgentShipwrightBuildInfoResponse:
     """Get full Shipwright Build information including agent config and BuildRun status.

--- a/rossoctl/backend/app/routers/chat.py
+++ b/rossoctl/backend/app/routers/chat.py
@@ -23,6 +23,7 @@ from app.core.auth import require_roles, get_required_user, ROLE_VIEWER, ROLE_OP
 from app.core.config import settings
 from app.services.kubernetes import KubernetesService, get_kubernetes_service
 from app.utils.routes import resolve_agent_url, sanitize_log
+from app.utils.naming import K8S_NAME_PATTERN
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -32,7 +33,7 @@ A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json"
 A2A_LEGACY_AGENT_CARD_PATH = "/.well-known/agent.json"
 
 # RFC 1123 label: lowercase alphanumeric, may contain hyphens, 1-63 chars.
-_K8S_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_K8S_NAME_RE = re.compile(K8S_NAME_PATTERN)
 
 # Characters permitted in an agent card path (positive allowlist).
 _SAFE_PATH_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-_.")

--- a/rossoctl/backend/app/utils/naming.py
+++ b/rossoctl/backend/app/utils/naming.py
@@ -5,6 +5,15 @@
 Helpers for deriving valid Kubernetes resource names from user-supplied text.
 """
 
+# RFC-1123 DNS label — the shape of a Kubernetes resource / namespace name:
+# lowercase alphanumeric plus '-', starting and ending with an alphanumeric.
+# Use with FastAPI ``Path(pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH)``
+# to constrain user-supplied path params at the boundary, so injection characters
+# (e.g. an encoded newline) can't reach loggers or downstream calls — invalid input
+# is rejected with 422 before any handler code runs. (rossoctl/rossoctl#2395)
+K8S_NAME_PATTERN = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+K8S_NAME_MAX_LENGTH = 63
+
 
 def sanitize_k8s_name(name: str) -> str:
     """Sanitize a name to be valid for Kubernetes resource names.

--- a/rossoctl/backend/app/utils/naming.py
+++ b/rossoctl/backend/app/utils/naming.py
@@ -5,14 +5,22 @@
 Helpers for deriving valid Kubernetes resource names from user-supplied text.
 """
 
+import re
+
 # RFC-1123 DNS label — the shape of a Kubernetes resource / namespace name:
-# lowercase alphanumeric plus '-', starting and ending with an alphanumeric.
-# Use with FastAPI ``Path(pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH)``
-# to constrain user-supplied path params at the boundary, so injection characters
-# (e.g. an encoded newline) can't reach loggers or downstream calls — invalid input
-# is rejected with 422 before any handler code runs. (rossoctl/rossoctl#2395)
-K8S_NAME_PATTERN = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+# lowercase alphanumeric plus '-', starting and ending with an alphanumeric, ≤63 chars.
+# Single source of truth for this pattern across the backend (routers previously each
+# defined their own identical ``re.compile(...)`` — chat.py, acp.py, agents_authbridge.py).
+#
+# Two forms:
+#   * K8S_NAME_PATTERN — regex string, for FastAPI ``Path(pattern=..., max_length=...)`` so
+#     malformed path params are rejected with 422 before any handler/logger runs (#2395).
+#   * K8S_NAME_RE — compiled, for direct ``.fullmatch()`` / ``.match()`` validation.
+# The length bound (``{0,61}`` between the anchors) makes the regex self-sufficient, so it
+# holds standalone as well as behind Path's max_length.
+K8S_NAME_PATTERN = r"^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$"
 K8S_NAME_MAX_LENGTH = 63
+K8S_NAME_RE = re.compile(K8S_NAME_PATTERN)
 
 
 def sanitize_k8s_name(name: str) -> str:

--- a/rossoctl/backend/tests/test_route_name_validation.py
+++ b/rossoctl/backend/tests/test_route_name_validation.py
@@ -1,0 +1,70 @@
+# Copyright 2025 IBM Corp.
+# Licensed under the Apache License, Version 2.0
+
+"""
+Boundary-validation tests for agent route path params (rossoctl/rossoctl#2395).
+
+The `namespace` / `name` path params on the migration + shipwright handlers are
+constrained to an RFC-1123 DNS label via FastAPI ``Path(pattern=..., max_length=63)``,
+so injection characters (e.g. an encoded newline) are rejected with 422 before any
+handler code — and can't reach the loggers CodeQL flagged (py/log-injection).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import agents_migration, agents_shipwright
+from app.services.kubernetes import get_kubernetes_service
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(agents_migration.migration_router, prefix="/api/v1")
+    app.include_router(agents_shipwright.shipwright_router, prefix="/api/v1")
+    # Handlers never run for the invalid cases (422 at validation), but override the
+    # kube dep so the valid-name case doesn't touch a real cluster.
+    app.dependency_overrides[get_kubernetes_service] = lambda: MagicMock()
+    with patch("app.core.auth.settings") as mock_auth:
+        # Disable auth so the only thing that can fail is path-param validation.
+        mock_auth.enable_auth = False
+        yield TestClient(app)
+
+
+# Names that violate the RFC-1123 DNS label (all must be rejected with 422).
+_INVALID = {
+    "newline": "bad%0Aname",  # the log-injection vector (encoded \n)
+    "uppercase": "BadName",
+    "dotted": "a.b",
+    "underscore": "bad_name",
+    "leading-hyphen": "-bad",
+    "too-long": "a" * 64,
+}
+
+
+@pytest.mark.parametrize("label,bad", _INVALID.items(), ids=list(_INVALID))
+def test_migrate_rejects_invalid_name(client, label, bad):
+    r = client.post(f"/api/v1/default/{bad}/migrate")
+    assert r.status_code == 422, f"{label}: expected 422, got {r.status_code}"
+
+
+@pytest.mark.parametrize("label,bad", _INVALID.items(), ids=list(_INVALID))
+def test_migrate_rejects_invalid_namespace(client, label, bad):
+    r = client.post(f"/api/v1/{bad}/my-agent/migrate")
+    assert r.status_code == 422, f"{label}: expected 422, got {r.status_code}"
+
+
+@pytest.mark.parametrize("label,bad", _INVALID.items(), ids=list(_INVALID))
+def test_shipwright_build_info_rejects_invalid_name(client, label, bad):
+    r = client.get(f"/api/v1/default/{bad}/shipwright-build-info")
+    assert r.status_code == 422, f"{label}: expected 422, got {r.status_code}"
+
+
+def test_valid_name_passes_validation(client):
+    # A well-formed RFC-1123 name must NOT be rejected by the pattern (422). It may
+    # succeed or fail downstream on the mocked kube call, but validation must pass.
+    r = client.post("/api/v1/default/my-agent-1/migrate")
+    assert r.status_code != 422, f"valid name wrongly rejected: {r.status_code}"


### PR DESCRIPTION
## Summary

Resolves the CodeQL **`py/log-injection`** findings on the agent migration + shipwright routes: user-provided path params (`name`, `namespace`) were logged unsanitized, so an authenticated `ROLE_OPERATOR` caller could pass an encoded newline (`%0A`) in a path segment and forge/split log lines (log-integrity, not RCE).

**Fix = boundary validation**, not a suppression: constrain the path params to an RFC-1123 DNS label with FastAPI `Path(pattern=…, max_length=63)`, so injection characters are rejected with **422** before any handler code or logger runs.

Closes #2395. Refs #2388 (the move-only split that relocated these pre-existing findings).

## Changes

- `app/utils/naming.py` — shared `K8S_NAME_PATTERN` (`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`) + `K8S_NAME_MAX_LENGTH` (63).
- `app/routers/agents_migration.py` — `migrate_agent` `name`/`namespace` → `Path(..., pattern=K8S_NAME_PATTERN, max_length=K8S_NAME_MAX_LENGTH)`.
- `app/routers/agents_shipwright.py` — same for all four path-param handlers: `get_shipwright_build_status`, `get_shipwright_buildrun_status`, `trigger_shipwright_buildrun`, `get_shipwright_build_info`.
- `tests/test_route_name_validation.py` — new.

## Why this is safe

Agent/namespace names are already RFC-1123 labels (lowercase alphanumeric + `-`, ≤63) — Deployments/Services derived from them can't be dotted or longer — so no legitimate request is affected. k8s would reject invalid names on the actual op anyway; this just moves the rejection to the boundary so the logger never sees the raw value.

## Testing

- New `tests/test_route_name_validation.py`: newline (`%0A`), uppercase, dotted, underscore, leading-hyphen, and >63-char names all return **422** on both `name` and `namespace` across the migration + shipwright routes; a valid RFC-1123 name is **not** rejected. **19 passed.**
- `ruff check` + `ruff format --check` clean.
- No regressions: shipwright route tests **155 passed**.
- Expect CodeQL `py/log-injection` to clear on `agents_migration.py` / `agents_shipwright.py`.

Assisted-By: Claude Code
