### PR TITLE
CI: gate floating image tags in rendered subcharts (#2389)

### DIFF
--- a/.github/workflows/ci-release-pins.yaml
+++ b/.github/workflows/ci-release-pins.yaml
@@ -21,6 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      # Needed by the --render gate below (helm dependency build + helm template).
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
+
       - name: Capture pin-validation results
         run: bash scripts/check-release-pins.sh --json > pin-results.json || true
 
@@ -60,4 +64,4 @@ jobs:
         if: >-
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/'))
-        run: bash scripts/check-release-pins.sh
+        run: bash scripts/check-release-pins.sh --render

--- a/scripts/check-release-pins.sh
+++ b/scripts/check-release-pins.sh
@@ -29,6 +29,7 @@ DEPS_VALUES_FILE="$DEPS_CHARTS_DIR/values.yaml"
 
 JSON_MODE=false
 VERIFY_IMAGES=false
+RENDER=false
 
 usage() {
     cat <<EOF
@@ -39,6 +40,10 @@ Validate that all image tags and chart dependencies are pinned for release.
 Options:
   --json            Output results as JSON (for CI summary consumption)
   --verify-images   Check that pinned GHCR images exist via docker manifest inspect
+  --render          Render the chart (helm template, incl. subcharts) and fail on any
+                    floating image tag (:latest/:main/:master). Catches tags inside
+                    dependency subcharts that the values/template greps cannot see
+                    (rossoctl/rossoctl#2389). Requires helm.
   -h, --help        Show this help message
 EOF
     exit 0
@@ -48,6 +53,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --json)           JSON_MODE=true;     shift ;;
         --verify-images)  VERIFY_IMAGES=true; shift ;;
+        --render)         RENDER=true;        shift ;;
         -h|--help)        usage ;;
         *)                echo "Unknown option: $1"; usage ;;
     esac
@@ -451,6 +457,54 @@ if [[ -f "$DEPS_VALUES_FILE" ]]; then
             else
                 add_ok "charts/rossoctl-deps/values.yaml" \
                     "spiffeIdp.image.tag ($spiffe_tag) consistent with platform"
+            fi
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 6c (opt-in, --render): No floating image tags in the RENDERED chart
+#
+# Checks 1-2 only see rossoctl's own values.yaml/templates. They cannot see a
+# floating tag inside a dependency subchart (e.g. operator-chart's AuthBridge
+# images), which is how a :latest shipped invisibly at an earlier rc
+# (rossoctl/rossoctl#2389). Rendering the full chart (subcharts included) and
+# grepping the output for any registry ref ending in :latest/:main/:master
+# closes that gap. Opt-in because it needs helm + fetching OCI dependencies.
+# ---------------------------------------------------------------------------
+
+if [[ "$RENDER" == "true" ]]; then
+    render_label="charts/rossoctl (rendered)"
+    if ! command -v helm >/dev/null 2>&1; then
+        add_error "$render_label" 0 "--render requires helm, which is not installed"
+    else
+        # Build dependencies so subcharts are rendered too. Public OCI, no auth.
+        if ! helm dependency build "$CHARTS_DIR" >/tmp/crp-helm-dep.log 2>&1; then
+            add_error "$render_label" 0 "helm dependency build failed (cannot render subcharts) — see output"
+            cat /tmp/crp-helm-dep.log >&2 || true
+        else
+            # openshift=false avoids the OpenShift-only required-value guards;
+            # image references (incl. subcharts) render regardless.
+            if ! helm template rossoctl "$CHARTS_DIR" --set openshift=false \
+                    > /tmp/crp-render.yaml 2>/tmp/crp-render.err; then
+                add_error "$render_label" 0 "helm template failed — see output"
+                cat /tmp/crp-render.err >&2 || true
+            else
+                # Match a container-registry ref ending in a floating tag, in any
+                # field (image:, or a subchart ConfigMap value like authbridge:).
+                # Excludes version-pinned (:vX.Y.Z) and digest (@sha256:) refs.
+                float_re='(ghcr\.io|quay\.io|docker\.io|registry\.[a-z.]+)[^[:space:]"'\'']*:(latest|main|master)([^0-9A-Za-z._-]|$)'
+                matches=$(grep -nE "$float_re" /tmp/crp-render.yaml || true)
+                if [[ -z "$matches" ]]; then
+                    add_ok "$render_label" "no floating image tags in rendered manifests (subcharts included)"
+                else
+                    while IFS= read -r m; do
+                        [[ -z "$m" ]] && continue
+                        ln="${m%%:*}"
+                        ref=$(printf '%s' "$m" | grep -oE "$float_re" | head -1)
+                        add_error "$render_label" "$ln" "floating image tag in rendered output: ${ref}"
+                    done <<< "$matches"
+                fi
             fi
         fi
     fi

--- a/scripts/check-release-pins.sh
+++ b/scripts/check-release-pins.sh
@@ -478,30 +478,46 @@ if [[ "$RENDER" == "true" ]]; then
     if ! command -v helm >/dev/null 2>&1; then
         add_error "$render_label" 0 "--render requires helm, which is not installed"
     else
+        # Isolate render artifacts in a private temp dir: --render is documented
+        # for local use too, where fixed /tmp names let concurrent runs clobber
+        # each other and leave a rendered manifest lingering on a shared host.
+        crp_tmp=$(mktemp -d)
+        trap 'rm -rf "$crp_tmp"' EXIT
         # Build dependencies so subcharts are rendered too. Public OCI, no auth.
-        if ! helm dependency build "$CHARTS_DIR" >/tmp/crp-helm-dep.log 2>&1; then
+        if ! helm dependency build "$CHARTS_DIR" >"$crp_tmp/helm-dep.log" 2>&1; then
             add_error "$render_label" 0 "helm dependency build failed (cannot render subcharts) — see output"
-            cat /tmp/crp-helm-dep.log >&2 || true
+            cat "$crp_tmp/helm-dep.log" >&2 || true
         else
             # openshift=false avoids the OpenShift-only required-value guards;
             # image references (incl. subcharts) render regardless.
             if ! helm template rossoctl "$CHARTS_DIR" --set openshift=false \
-                    > /tmp/crp-render.yaml 2>/tmp/crp-render.err; then
+                    > "$crp_tmp/render.yaml" 2>"$crp_tmp/render.err"; then
                 add_error "$render_label" 0 "helm template failed — see output"
-                cat /tmp/crp-render.err >&2 || true
+                cat "$crp_tmp/render.err" >&2 || true
             else
                 # Match a container-registry ref ending in a floating tag, in any
                 # field (image:, or a subchart ConfigMap value like authbridge:).
-                # Excludes version-pinned (:vX.Y.Z) and digest (@sha256:) refs.
-                float_re='(ghcr\.io|quay\.io|docker\.io|registry\.[a-z.]+)[^[:space:]"'\'']*:(latest|main|master)([^0-9A-Za-z._-]|$)'
-                matches=$(grep -nE "$float_re" /tmp/crp-render.yaml || true)
+                # The host is a generic "<name>.<tld>[:port]/..." pattern rather
+                # than an allowlist, so a future subchart pulling from gcr.io, ECR
+                # (*.dkr.ecr.*.amazonaws.com), or mcr.microsoft.com is covered too
+                # — that "image source the check can't see" class is what #2389 was.
+                # Matched case-insensitively (-i) so :LATEST is caught as well.
+                # The trailing [^0-9A-Za-z._-] boundary is deliberate: it excludes
+                # suffixed tags like :latest-arm64 / :main-abc123, which are
+                # effectively pinned. Version-pinned (:vX.Y.Z) and digest
+                # (@sha256:) refs never match the alternation.
+                float_re='[a-z0-9.-]+\.[a-z]{2,}(:[0-9]+)?/[^[:space:]"'\'']*:(latest|main|master)([^0-9A-Za-z._-]|$)'
+                matches=$(grep -niE "$float_re" "$crp_tmp/render.yaml" || true)
                 if [[ -z "$matches" ]]; then
                     add_ok "$render_label" "no floating image tags in rendered manifests (subcharts included)"
                 else
                     while IFS= read -r m; do
                         [[ -z "$m" ]] && continue
                         ln="${m%%:*}"
-                        ref=$(printf '%s' "$m" | grep -oE "$float_re" | head -1)
+                        ref=$(printf '%s' "$m" | grep -oiE "$float_re" | head -1)
+                        # Drop the trailing delimiter the boundary group captured
+                        # (e.g. a closing quote) so the reported ref reads clean.
+                        ref="${ref%[!0-9A-Za-z._-]}"
                         add_error "$render_label" "$ln" "floating image tag in rendered output: ${ref}"
                     done <<< "$matches"
                 fi


### PR DESCRIPTION
## Summary

`check-release-pins.sh` only inspected rossoctl's own `charts/rossoctl/values.yaml` and `templates/`, so a floating image tag inside a **dependency subchart** (e.g. `operator-chart`'s AuthBridge images) was **invisible** — how a `:latest` shipped at an earlier rc while the pin check stayed green.

Adds an opt-in **`--render`** gate:
- `helm dependency build` + `helm template rossoctl charts/rossoctl --set openshift=false` (subcharts included; `openshift=false` clears the OpenShift-only required-value guards so it renders in CI),
- greps the **rendered** output for any container-registry ref ending in `:latest`/`:main`/`:master` — matches both `image:` fields and subchart ConfigMap-embedded refs (the AuthBridge case); ignores version-pinned (`:vX.Y.Z`) and digest (`@sha256:`) refs,
- fails **loudly** if helm is missing or the render fails (no silent skip).

Wired into `ci-release-pins.yaml`: a `Set up Helm` step + `--render` on the release-gate run (release/* PRs + manual dispatch). `helm dependency build` fetches the OCI subchart **without auth** (public), so it runs in CI.

## Validation

- Clean run → render check **passes** (0 floating tags today — operator #512 pinned operator-chart's images).
- **Negative test**: injecting a floating tag is caught end-to-end — `floating image tag in rendered output: …/backend:latest`, exit 1 — then reverted.
- Grep pattern verified positive/negative: pinned, digest, and bare `tag: latest` (non-registry) refs are correctly ignored.

This is defense-in-depth complementing operator #512 (which fixed the source): even if a *future* dependency ships a floating tag, the release check now catches it.

Closes #2389.

_Assisted-By: Claude Code_