### PR TITLE
docs: update quickstart install to check out v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ git clone https://github.com/rossoctl/rossoctl.git
 cd rossoctl
 
 # Check out the latest release
-git checkout v0.6.0
+git checkout v0.7.0
 
 # Copy and configure secrets (optional)
 cp charts/rossoctl/.secrets_template.yaml charts/rossoctl/.secrets.yaml


### PR DESCRIPTION
## Summary

The Quickstart **Install** section in `README.md` pinned `git checkout v0.6.0` under a comment reading "Check out the latest release." The latest published release is now [`v0.7.0`](https://github.com/rossoctl/rossoctl/releases/tag/v0.7.0), so this updates the command to match.

```diff
 # Check out the latest release
-git checkout v0.6.0
+git checkout v0.7.0
```

## Testing

Docs-only change; no code paths affected.

Fixes #2461

_Assisted-By: Claude Code_