### PR TITLE
fix(mesh): proactive SVID near-expiry detection + SPIRE TTL right-sizing + 503 docs (Part of #1899)

### DIFF
--- a/.claude/skills/k8s:health/SKILL.md
+++ b/.claude/skills/k8s:health/SKILL.md
@@ -247,10 +247,13 @@ kubectl get destinationrule -A
 > (`scripts/k8s/mesh-recover.sh`) to detect and recover.
 >
 > **Proactively** (before the 503): run `scripts/k8s/mesh-recover.sh` in detect
-> mode from a machine with `openssl`. Exit code **4** / a `cert-expiry: WARN`
-> finding means the SPIRE trust-bundle CA is nearing expiry — plan a data-plane
-> restart or cluster recreate before the outage. Tune the window with
+> mode from a machine with `kubectl` exec access and `jq`. It reads the soonest-
+> expiring ztunnel **workload SVID** (via ztunnel's admin `config_dump`); exit code
+> **4** / a `cert-expiry: WARN` finding means an SVID is nearing expiry — plan a
+> data-plane restart or cluster recreate before the outage. Tune the window with
 > `CERT_WARN_SECONDS` (default 6h). This is advisory: it never restarts anything.
+> (The automated CronJob's ServiceAccount has no `pods/exec`, so it skips this
+> check — proactive warning is a manual / `k8s:health` capability.)
 
 #### SPIRE (Workload Identity)
 

--- a/.claude/skills/k8s:health/SKILL.md
+++ b/.claude/skills/k8s:health/SKILL.md
@@ -245,6 +245,12 @@ kubectl get destinationrule -A
 > **All `*.localtest.me` routes returning HTTP 503 while pods look healthy?** That's the Ambient
 > expired-cert outage on long-running/suspended dev clusters — use **`istio:mesh-selfheal`**
 > (`scripts/k8s/mesh-recover.sh`) to detect and recover.
+>
+> **Proactively** (before the 503): run `scripts/k8s/mesh-recover.sh` in detect
+> mode from a machine with `openssl`. Exit code **4** / a `cert-expiry: WARN`
+> finding means the SPIRE trust-bundle CA is nearing expiry — plan a data-plane
+> restart or cluster recreate before the outage. Tune the window with
+> `CERT_WARN_SECONDS` (default 6h). This is advisory: it never restarts anything.
 
 #### SPIRE (Workload Identity)
 

--- a/charts/rossoctl-deps/files/mesh-recover.sh
+++ b/charts/rossoctl-deps/files/mesh-recover.sh
@@ -62,7 +62,7 @@ Usage: mesh-recover.sh [--fix] [--include-spire] [--probe-host HOST]
   --json           Emit a machine-readable JSON summary (for the CronJob remediator).
   -h, --help       This help.
 
-Exit: 0 healthy · 2 degraded (recoverable) · 3 inconclusive (unreachable / not Ambient) · 1 usage error.
+Exit: 0 healthy · 2 degraded (recoverable) · 3 inconclusive (unreachable / not Ambient) · 4 near-expiry (advisory) · 1 usage error.
 EOF
 }
 
@@ -90,10 +90,13 @@ run_cmd() {
 command -v kubectl >/dev/null 2>&1 || { log_error "kubectl not found in PATH"; exit 1; }
 HAVE_ISTIOCTL=false
 command -v istioctl >/dev/null 2>&1 && HAVE_ISTIOCTL=true
+HAVE_OPENSSL=false
+command -v openssl >/dev/null 2>&1 && HAVE_OPENSSL=true
 
 # Findings accumulate here for the summary / JSON output.
 DEGRADED=false       # a recoverable mesh outage (503 / expired certs) → exit 2, restart helps
 INCONCLUSIVE=false   # can't confirm health (gateway unreachable, no ztunnel) → exit 3, restart won't help
+NEAR_EXPIRY=false    # a cert is close to expiry but not yet expired → exit 4, ADVISORY (no restart)
 declare -a CHECKS=()   # "name|status|detail"
 declare -a ACTIONS=()  # recovery commands that were (or would be) run
 record() {
@@ -101,6 +104,7 @@ record() {
   case "$2" in
     DEGRADED)     DEGRADED=true ;;
     INCONCLUSIVE) INCONCLUSIVE=true ;;
+    WARN)         NEAR_EXPIRY=true ;;
   esac
   return 0
 }
@@ -190,6 +194,39 @@ check_ztunnel_certs() {
   fi
 }
 
+check_cert_expiry() {
+  # PROACTIVE: warn when the SPIRE trust-bundle CA is close to expiry, BEFORE
+  # ztunnel starts serving expired certs (the reactive check_ztunnel_certs case).
+  # The CA is the credential whose expiry drives the #1899 post-suspend deadlock.
+  # Needs openssl; on the tool-less CronJob image this degrades to a skipped
+  # INCONCLUSIVE finding (matching the istioctl-optional pattern above).
+  if ! $HAVE_OPENSSL; then
+    record "cert-expiry" "INCONCLUSIVE" "openssl not available — skipped proactive near-expiry check"
+    log_info "openssl not found — skipping proactive cert-expiry check (reactive checks still apply)"
+    return
+  fi
+  local ca warn_secs enddate
+  warn_secs="${CERT_WARN_SECONDS:-21600}"   # 6h default
+  # Trust bundle: spire-bundle (spire-system) or istio-ca-root-cert (ztwim ns).
+  ca=$(kubectl get cm spire-bundle -n spire-system -o jsonpath='{.data.bundle\.crt}' 2>/dev/null || true)
+  [[ -z "$ca" ]] && ca=$(kubectl get cm istio-ca-root-cert -n zero-trust-workload-identity-manager \
+        -o jsonpath='{.data.root-cert\.pem}' 2>/dev/null || true)
+  if [[ -z "$ca" ]]; then
+    record "cert-expiry" "INCONCLUSIVE" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
+    log_info "trust bundle not found — skipping proactive cert-expiry check"
+    return
+  fi
+  enddate=$(printf '%s' "$ca" | openssl x509 -enddate -noout 2>/dev/null | cut -d= -f2 || true)
+  log_info "Checking trust-bundle CA expiry (warn window ${warn_secs}s) ..."
+  if printf '%s' "$ca" | openssl x509 -checkend "$warn_secs" -noout >/dev/null 2>&1; then
+    record "cert-expiry" "OK" "trust-bundle CA not near expiry (notAfter ${enddate})"
+    log_success "trust-bundle CA not near expiry (notAfter ${enddate})"
+  else
+    record "cert-expiry" "WARN" "trust-bundle CA expires within ${warn_secs}s (notAfter ${enddate}) — plan a data-plane restart / cluster recreate before the mesh 503s"
+    log_warn "trust-bundle CA nearing expiry (notAfter ${enddate}) — advisory, no restart"
+  fi
+}
+
 check_spire_agent() {
   local ns restarts prev
   ns=$(kubectl get pods -A -l app=spire-agent -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || true)
@@ -265,7 +302,7 @@ recover_mesh() {
 # ---------------------------------------------------------------------------
 emit_json() {
   local first=true
-  printf '{"degraded":%s,"inconclusive":%s,"fixed":%s,"checks":[' "$DEGRADED" "$INCONCLUSIVE" "$FIX"
+  printf '{"degraded":%s,"inconclusive":%s,"warn":%s,"fixed":%s,"checks":[' "$DEGRADED" "$INCONCLUSIVE" "$NEAR_EXPIRY" "$FIX"
   for c in "${CHECKS[@]}"; do
     IFS='|' read -r n s d <<<"$c"
     $first || printf ','; first=false
@@ -288,6 +325,7 @@ $JSON || { echo; log_info "Istio Ambient mesh self-heal — $($FIX && echo 'RECO
 
 check_mesh_reachability
 check_ztunnel_certs
+check_cert_expiry
 $INCLUDE_SPIRE && check_spire_agent
 
 if $DEGRADED; then
@@ -305,9 +343,11 @@ else
     log_success "Recovery applied — see re-probe result above."
   elif $INCONCLUSIVE; then
     log_warn "Could not confirm mesh health (gateway unreachable, or no ztunnel found). Check the gateway port-map and that this is an Ambient cluster — no restart attempted."
+  elif $NEAR_EXPIRY; then
+    log_warn "Mesh reachable, but the trust-bundle CA is nearing expiry (see cert-expiry above). Plan a data-plane restart or cluster recreate before it 503s. Root cause is upstream (istio/ztunnel#1679)."
   else
     log_success "Mesh healthy — no action needed."
   fi
 fi
 
-if $DEGRADED; then exit 2; elif $INCONCLUSIVE; then exit 3; else exit 0; fi
+if $DEGRADED; then exit 2; elif $INCONCLUSIVE; then exit 3; elif $NEAR_EXPIRY; then exit 4; else exit 0; fi

--- a/charts/rossoctl-deps/files/mesh-recover.sh
+++ b/charts/rossoctl-deps/files/mesh-recover.sh
@@ -90,8 +90,6 @@ run_cmd() {
 command -v kubectl >/dev/null 2>&1 || { log_error "kubectl not found in PATH"; exit 1; }
 HAVE_ISTIOCTL=false
 command -v istioctl >/dev/null 2>&1 && HAVE_ISTIOCTL=true
-HAVE_OPENSSL=false
-command -v openssl >/dev/null 2>&1 && HAVE_OPENSSL=true
 
 # Findings accumulate here for the summary / JSON output.
 DEGRADED=false       # a recoverable mesh outage (503 / expired certs) → exit 2, restart helps
@@ -102,7 +100,7 @@ declare -a ACTIONS=()  # recovery commands that were (or would be) run
 record() {
   CHECKS+=("$1|$2|$3")
   # OK and SKIP intentionally set no flag: SKIP is a non-fatal "couldn't check"
-  # (e.g. openssl missing, trust bundle not found) and must never flip a
+  # (e.g. jq missing, or ztunnel exec denied/unreachable) and must never flip a
   # healthy mesh to a degraded/inconclusive exit code.
   case "$2" in
     DEGRADED)     DEGRADED=true ;;
@@ -198,36 +196,66 @@ check_ztunnel_certs() {
 }
 
 check_cert_expiry() {
-  # PROACTIVE: warn when the SPIRE trust-bundle CA is close to expiry, BEFORE
-  # ztunnel starts serving expired certs (the reactive check_ztunnel_certs case).
-  # The CA is the credential whose expiry drives the #1899 post-suspend deadlock.
-  # Needs openssl; on the tool-less CronJob image this degrades to a skipped
-  # INCONCLUSIVE finding (matching the istioctl-optional pattern above).
-  if ! $HAVE_OPENSSL; then
-    record "cert-expiry" "SKIP" "openssl not available — skipped proactive near-expiry check"
-    log_info "openssl not found — skipping proactive cert-expiry check (reactive checks still apply)"
-    return
-  fi
-  local ca warn_secs enddate
+  # PROACTIVE: warn when a ztunnel-served workload SVID is close to expiry, BEFORE
+  # it actually expires and the data plane starts 503ing (the reactive
+  # check_ztunnel_certs case). These short-lived SVIDs — not the long-lived
+  # trust-domain root CA — are what lapse during a host suspend (#1899), so we
+  # read the real per-workload certChain expiry from ztunnel's admin config_dump
+  # (the same data `istioctl ztunnel-config certificates` surfaces).
+  #
+  # Needs `kubectl exec` into ztunnel + jq. On the CronJob ServiceAccount (which
+  # deliberately lacks pods/exec) or without jq, this degrades to a non-fatal
+  # SKIP finding — proactive warning is a manual / k8s:health-path capability
+  # (design decision for #1899), while the CronJob stays reactive-only.
+  local ns pod warn_secs dump result status detail
   warn_secs="${CERT_WARN_SECONDS:-21600}"   # 6h default
-  # Trust bundle: spire-bundle (spire-system) or istio-ca-root-cert (ztwim ns).
-  ca=$(kubectl get cm spire-bundle -n spire-system -o jsonpath='{.data.bundle\.crt}' 2>/dev/null || true)
-  [[ -z "$ca" ]] && ca=$(kubectl get cm istio-ca-root-cert -n zero-trust-workload-identity-manager \
-        -o jsonpath='{.data.root-cert\.pem}' 2>/dev/null || true)
-  if [[ -z "$ca" ]]; then
-    record "cert-expiry" "SKIP" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
-    log_info "trust bundle not found — skipping proactive cert-expiry check"
+  if ! command -v jq >/dev/null 2>&1; then
+    record "cert-expiry" "SKIP" "jq not available — skipped proactive SVID near-expiry check"
+    log_info "jq not found — skipping proactive SVID expiry check (reactive checks still apply)"
     return
   fi
-  enddate=$(printf '%s' "$ca" | openssl x509 -enddate -noout 2>/dev/null | cut -d= -f2 || true)
-  log_info "Checking trust-bundle CA expiry (warn window ${warn_secs}s) ..."
-  if printf '%s' "$ca" | openssl x509 -checkend "$warn_secs" -noout >/dev/null 2>&1; then
-    record "cert-expiry" "OK" "trust-bundle CA not near expiry (notAfter ${enddate})"
-    log_success "trust-bundle CA not near expiry (notAfter ${enddate})"
-  else
-    record "cert-expiry" "WARN" "trust-bundle CA expires within ${warn_secs}s (notAfter ${enddate}) — plan a data-plane restart / cluster recreate before the mesh 503s"
-    log_warn "trust-bundle CA nearing expiry (notAfter ${enddate}) — advisory, no restart"
+  ns=$(discover_ztunnel_ns)
+  pod=$(kubectl get pods -n "$ns" -l app=ztunnel -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [[ -z "$ns" || -z "$pod" ]]; then
+    record "cert-expiry" "SKIP" "no ztunnel pod found — skipped proactive SVID near-expiry check"
+    log_info "no ztunnel pod — skipping proactive SVID expiry check"
+    return
   fi
+  log_info "Checking ztunnel workload SVID expiry (warn window ${warn_secs}s) ..."
+  # ztunnel exposes each workload SVID's certChain in its admin config_dump.
+  # --request-timeout bounds the exec/API round-trip so a stalled node can't hang
+  # the run; --max-time bounds the in-pod curl. Either failure → empty dump → SKIP.
+  dump=$(kubectl exec --request-timeout=10s -n "$ns" "$pod" -- curl -s --max-time "$TIMEOUT" localhost:15000/config_dump 2>/dev/null || true)
+  if [[ -z "$dump" ]]; then
+    record "cert-expiry" "SKIP" "could not read ztunnel admin config_dump (exec denied or unreachable) — skipped near-expiry check"
+    log_info "ztunnel config_dump unavailable (needs pods/exec) — skipping proactive SVID expiry check"
+    return
+  fi
+  # Pick the soonest-expiring SVID and classify against the warn window. All time
+  # math is done in jq (fromdateiso8601/now) to avoid GNU-vs-BSD date(1) portability issues.
+  # Note: fromdateiso8601 expects the strict %Y-%m-%dT%H:%M:%SZ form ztunnel emits; a
+  # future fractional-seconds timestamp would fail the parse and degrade to SKIP (non-fatal).
+  result=$(printf '%s' "$dump" | jq -r --argjson warn "$warn_secs" '
+    [ .certificates[]?.certChain[]?.expirationTime | fromdateiso8601 ] as $exp
+    | if ($exp | length) == 0 then "SKIP|no workload SVID certs found in ztunnel config_dump"
+      else ($exp | min) as $soonest
+        | (($soonest - now) | floor) as $rem
+        | ($soonest | todateiso8601) as $when
+        | if $rem < $warn
+          then "WARN|soonest workload SVID expires in \($rem)s (\($when)) — the data plane will 503 if it is not rotated (e.g. after a host suspend)"
+          else "OK|soonest workload SVID valid for \($rem)s (\($when))" end
+      end' 2>/dev/null || true)
+  if [[ -z "$result" ]]; then
+    record "cert-expiry" "SKIP" "could not parse ztunnel config_dump — skipped near-expiry check"
+    log_info "could not parse ztunnel config_dump — skipping proactive SVID expiry check"
+    return
+  fi
+  status="${result%%|*}"; detail="${result#*|}"
+  case "$status" in
+    WARN) record "cert-expiry" "WARN" "$detail"; log_warn "$detail — advisory, no restart" ;;
+    OK)   record "cert-expiry" "OK"   "$detail"; log_success "$detail" ;;
+    *)    record "cert-expiry" "SKIP" "$detail"; log_info "$detail" ;;
+  esac
 }
 
 check_spire_agent() {
@@ -347,7 +375,7 @@ else
   elif $INCONCLUSIVE; then
     log_warn "Could not confirm mesh health (gateway unreachable, or no ztunnel found). Check the gateway port-map and that this is an Ambient cluster — no restart attempted."
   elif $NEAR_EXPIRY; then
-    log_warn "Mesh reachable, but the trust-bundle CA is nearing expiry (see cert-expiry above). Plan a data-plane restart or cluster recreate before it 503s. Root cause is upstream (istio/ztunnel#1679)."
+    log_warn "Mesh reachable, but a workload SVID is nearing expiry (see cert-expiry above). Plan a data-plane restart or cluster recreate before it 503s. Root cause is upstream (istio/ztunnel#1679)."
   else
     log_success "Mesh healthy — no action needed."
   fi

--- a/charts/rossoctl-deps/files/mesh-recover.sh
+++ b/charts/rossoctl-deps/files/mesh-recover.sh
@@ -101,6 +101,9 @@ declare -a CHECKS=()   # "name|status|detail"
 declare -a ACTIONS=()  # recovery commands that were (or would be) run
 record() {
   CHECKS+=("$1|$2|$3")
+  # OK and SKIP intentionally set no flag: SKIP is a non-fatal "couldn't check"
+  # (e.g. openssl missing, trust bundle not found) and must never flip a
+  # healthy mesh to a degraded/inconclusive exit code.
   case "$2" in
     DEGRADED)     DEGRADED=true ;;
     INCONCLUSIVE) INCONCLUSIVE=true ;;
@@ -201,7 +204,7 @@ check_cert_expiry() {
   # Needs openssl; on the tool-less CronJob image this degrades to a skipped
   # INCONCLUSIVE finding (matching the istioctl-optional pattern above).
   if ! $HAVE_OPENSSL; then
-    record "cert-expiry" "INCONCLUSIVE" "openssl not available — skipped proactive near-expiry check"
+    record "cert-expiry" "SKIP" "openssl not available — skipped proactive near-expiry check"
     log_info "openssl not found — skipping proactive cert-expiry check (reactive checks still apply)"
     return
   fi
@@ -212,7 +215,7 @@ check_cert_expiry() {
   [[ -z "$ca" ]] && ca=$(kubectl get cm istio-ca-root-cert -n zero-trust-workload-identity-manager \
         -o jsonpath='{.data.root-cert\.pem}' 2>/dev/null || true)
   if [[ -z "$ca" ]]; then
-    record "cert-expiry" "INCONCLUSIVE" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
+    record "cert-expiry" "SKIP" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
     log_info "trust bundle not found — skipping proactive cert-expiry check"
     return
   fi
@@ -292,7 +295,7 @@ recover_mesh() {
     [[ -n "$ns" ]] && kubectl rollout status daemonset/ztunnel -n "$ns" --timeout=120s || true
     kubectl rollout status deploy/"$gw" -n "$GW_NS" --timeout=120s || true
     log_info "Re-probing to verify recovery ..."
-    DEGRADED=false; INCONCLUSIVE=false; CHECKS=()
+    DEGRADED=false; INCONCLUSIVE=false; NEAR_EXPIRY=false; CHECKS=()
     check_mesh_reachability
   fi
 }

--- a/charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh
+++ b/charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh
@@ -72,6 +72,7 @@ case "$rc" in
   0) emit_event Normal MeshHealthy "gateway reachable, mesh certs OK"; exit 0 ;;
   3) emit_event Warning MeshInconclusive "cannot confirm mesh health (restart would not help): ${summary}"; exit 0 ;;
   2) : ;;  # degraded/recoverable — fall through to gating
+  4) emit_event Warning MeshNearExpiry "trust-bundle CA nearing expiry (advisory; no restart): ${summary}"; exit 0 ;;
   *) log "unexpected rc=$rc; treating as inconclusive"; emit_event Warning MeshInconclusive "mesh-recover.sh rc=$rc"; exit 0 ;;
 esac
 

--- a/docs/superpowers/specs/2026-08-24-mesh-selfheal-detection-ttl-design.md
+++ b/docs/superpowers/specs/2026-08-24-mesh-selfheal-detection-ttl-design.md
@@ -31,8 +31,8 @@ make the outage likely, nor documents the failure for users.
 **Out of scope (upstream):** the root-cause SPIRE agent re-attest deadlock and
 ztunnel not re-fetching fresh SVIDs are tracked upstream
 ([ztunnel#1679](https://github.com/istio/ztunnel/issues/1679)). This work does
-**not** `Close #1899`; it advances the issue's remediation points #4 (docs),
-#5 (TTL right-sizing), and #6 (proactive detection).
+**not** `Close #1899`; it advances the issue's remediation points #4 (docs), #5
+(TTL right-sizing), and #6 (proactive detection).
 
 ## Goals
 

--- a/docs/superpowers/specs/2026-08-24-mesh-selfheal-detection-ttl-design.md
+++ b/docs/superpowers/specs/2026-08-24-mesh-selfheal-detection-ttl-design.md
@@ -1,0 +1,182 @@
+# Design: Proactive SVID near-expiry detection, SPIRE TTL right-sizing, and 503 troubleshooting docs
+
+**Issue:** [rossoctl/rossoctl#1899](https://github.com/rossoctl/rossoctl/issues/1899) — Mesh-wide 503 from expired SPIRE workload SVIDs on long-running/suspended Kind clusters.
+
+**Date:** 2026-08-24
+**Status:** Approved (brainstorming) — pending implementation plan
+**Author:** cwiklik (Assisted-By: Claude Code)
+
+## Background
+
+On a long-running Kind cluster whose host is suspended longer than the SPIRE
+credential lifetimes (SVID/CA/SA-token), every gateway-routed service returns
+HTTP 503: the Ambient data plane (ztunnel + waypoints) keeps serving expired
+mTLS certs and never re-fetches fresh ones. The cluster looks healthy to
+`kubectl get pods`; the failure is only visible in ztunnel logs.
+
+Two parts of the response are **already merged**:
+
+- **Part A — [#2179](https://github.com/rossoctl/rossoctl/pull/2179)**:
+  `scripts/k8s/mesh-recover.sh` — reactive detect + recover (rollout-restart
+  ztunnel/waypoints/gateway). Exit codes `0=OK`, `2=DEGRADED` (restart helps),
+  `3=INCONCLUSIVE`.
+- **Part B — [#2452](https://github.com/rossoctl/rossoctl/pull/2452)**:
+  a feature-flagged, Kind-only CronJob (`charts/rossoctl-deps/templates/mesh-selfheal.yaml`)
+  that wraps Part A to auto-remediate on a schedule. Off by default.
+
+Both are **reactive** — they act only once certs have already expired (503s,
+"expired" log lines). Neither warns *before* the outage, tunes the TTLs that
+make the outage likely, nor documents the failure for users.
+
+**Out of scope (upstream):** the root-cause SPIRE agent re-attest deadlock and
+ztunnel not re-fetching fresh SVIDs are tracked upstream
+([ztunnel#1679](https://github.com/istio/ztunnel/issues/1679)). This work does
+**not** `Close #1899`; it advances the issue's remediation points #4 (docs),
+#5 (TTL right-sizing), and #6 (proactive detection).
+
+## Goals
+
+1. **Proactive detection** — warn on *near-expiry* (not-yet-expired) SVIDs/CA
+   before the 503, surfaced on the manual `k8s:health` / preflight path.
+2. **TTL right-sizing (Kind-dev-only)** — lengthen SPIRE CA and x509 SVID TTLs
+   so a normal overnight suspend no longer expires everything at once.
+3. **Troubleshooting docs** — document the post-suspend 503, diagnosis, and
+   recovery for users.
+
+## Non-goals
+
+- Fixing the upstream re-attest deadlock / ztunnel re-fetch (ztunnel#1679).
+- Changing OpenShift SPIRE TTLs (suspend is not a production concern; the OCP
+  path is separate and gated on `.Values.openshift`).
+- Adding proactive detection to the automated CronJob image (see Decision D3).
+- Auto-restarting on near-expiry (see Decision D2).
+
+## Design
+
+### Unit 1 — `check_cert_expiry()` in `scripts/k8s/mesh-recover.sh`
+
+A new `check_*` function feeding the existing `record()` accumulator, adding a
+new **`WARN`** status (advisory) alongside `OK`/`DEGRADED`/`INCONCLUSIVE`.
+
+**Detection mechanism (graceful degradation, mirroring the existing
+`istioctl`-optional pattern):**
+
+1. If `istioctl` is present → `istioctl ztunnel-config certificates <ztunnel-pod>`;
+   parse each SVID's expiry.
+2. Else if `openssl` is present → read the trust-bundle CA cert from the
+   `spire-bundle` (ns `spire-system`) or `istio-ca-root-cert` (ns
+   `zero-trust-workload-identity-manager`) ConfigMap and run
+   `openssl x509 -enddate`.
+3. Else → `record` an `INCONCLUSIVE` finding
+   ("cert-expiry tooling (istioctl/openssl) unavailable"). Non-fatal. This is
+   the tool-less CronJob-image case, so the automated path simply skips the
+   check rather than false-alarming.
+
+**Threshold:** warn when remaining validity `< 25%` of the cert's total
+lifetime (computed from `notBefore`/`notAfter`), so it adapts across the long
+CA and the short SVIDs. Overridable via env `CERT_WARN_PCT` (default `25`) with
+an absolute floor `CERT_WARN_SECONDS` (default `600`).
+
+**Exit / behavior:** near-expiry maps to a **new exit code `4`** (advisory).
+Precedence for the process exit code: `DEGRADED(2) > INCONCLUSIVE(3) > WARN(4) > OK(0)`
+— i.e. an actual outage still wins and still triggers recovery; near-expiry only
+sets the exit code when nothing worse is present. The `--json` output gains
+`WARN`-status entries in its `checks` array.
+
+### Unit 2 — CronJob wrapper mapping (`mesh-selfheal-wrapper.sh`)
+
+The wrapper (`charts/rossoctl-deps/files/mesh-selfheal-wrapper.sh`) currently
+maps rc `0→MeshHealthy`, `2→remediate`, `3→MeshInconclusive`. Add:
+
+- `rc=4` → emit a `MeshNearExpiry` **Warning** Event with the summary; **no
+  restart, no gating**; exit 0.
+
+In practice the CronJob image (alpine/k8s, no openssl/istioctl) records the
+check as INCONCLUSIVE, so rc=4 is primarily produced on the manual path. The
+mapping is added for completeness and forward-compatibility.
+
+### Unit 3 — `k8s:health` skill surfacing
+
+Update `.claude/skills/k8s:health/SKILL.md` to run `mesh-recover.sh` (detect
+mode) and surface the near-expiry `WARN`, replacing its current
+"defer to `istio:mesh-selfheal`" note for the **proactive** case (the reactive
+503 case still defers to recovery). `.github/scripts/common/90-preflight-checks.sh`
+is intentionally **not** touched — it runs on fresh CI clusters where certs are
+never near expiry.
+
+### Unit 4 — SPIRE TTL right-sizing (Kind)
+
+Kind installs SPIRE from the upstream SPIFFE hardened Helm charts
+(`spiffe.github.io/helm-charts-hardened`: `spire-crds` 0.5.0 + `spire` 0.27.0),
+configured entirely via `--set` flags in `scripts/kind/setup-rossoctl.sh`
+(~lines 698–725). Today only `...clusterSPIFFEIDs.default.jwtTTL=5m` is set;
+`ca_ttl` and the x509 SVID TTL are unset → chart defaults.
+
+Add TTL `--set` flags next to the existing `jwtTTL`:
+
+- **CA TTL: 24h → 168h (7d)**
+- **x509 SVID TTL (ClusterSPIFFEID `ttl`): default → 24h**
+
+**Rationale:** a 7d CA + 24h SVID lets a developer suspend overnight (~16h)
+without the CA/SVIDs expiring at once, shrinking the #1899 vulnerability window,
+while keeping dev credentials reasonably short. Honors SPIRE's constraint that
+the x509 SVID TTL be well under the CA TTL (rotation at half-life). Kind-dev-only.
+
+**To confirm during planning:** the exact upstream value keys and any
+chart-version-specific naming in helm-charts-hardened `spire` 0.27.0 (e.g.
+`spire-server.caTTL` vs `spire-server.ca_ttl`, and the ClusterSPIFFEID `ttl`
+key), plus that the resulting SVIDs actually mint at the new TTL. The proposed
+values are tunable.
+
+### Unit 5 — Troubleshooting docs
+
+Add a section to `docs/users-guides/troubleshooting.md`:
+**"Mesh-wide 503 after laptop suspend (expired SPIRE SVIDs)"** covering:
+
+- Symptom: all `*.localtest.me:8080` return 503 while pods/gateway look healthy.
+- Diagnosis: the issue's one-liners (ztunnel `certificate expired`; spire-agent
+  `reattest`/`token has expired`; SVID/CA TTLs; agent restart reason).
+- Recovery: `scripts/k8s/mesh-recover.sh --fix` (or the manual rollout restart);
+  pointer to the optional mesh-selfheal CronJob.
+- Expectation: suspend longer than the CA TTL requires a data-plane restart or
+  cluster recreate.
+
+Cross-link from the `k8s:health` and `ui-debug` (502/503) skills.
+
+## Decisions (from brainstorming)
+
+- **D1 — Scope:** all three of detection + TTL + docs (not verification-only).
+- **D2 — Near-expiry behavior:** advisory `WARN` only; no auto-restart.
+- **D3 — Detection home:** the preflight / `k8s:health` path (tools present on a
+  dev machine); the tool-less CronJob degrades to a skipped/INCONCLUSIVE check.
+  No CronJob image change, no new RBAC.
+- **D4 — TTL scope:** Kind-dev-only (`setup-rossoctl.sh`); OCP untouched.
+
+## Gating / feature-flag posture
+
+Per repo policy, new *features* are feature-flagged off by default. Here:
+
+- Detection lives in a **script** (`mesh-recover.sh`) and inherits its callers'
+  gating — manual `k8s:health` is opt-in; the CronJob is already flag-off. No
+  new backend/frontend feature flag applies.
+- TTL is a **dev-install config change** in the Kind setup script, not a runtime
+  feature.
+
+## Testing strategy
+
+- **Detection (Unit 1/2):**
+  - Live on `kind-rossoctl` with a deliberately high `CERT_WARN_PCT` (or low
+    threshold) to force a `WARN` against current certs; confirm exit code 4 and
+    the `WARN` JSON entry.
+  - Run the detect path in the tool-less `alpine/k8s` image and confirm graceful
+    `INCONCLUSIVE`/skip (no false alarm, non-fatal).
+  - Confirm precedence: with an actual outage present, `DEGRADED(2)` still wins.
+- **TTL (Unit 4):** run the modified `setup-rossoctl.sh` on Kind; confirm the
+  SPIRE server CA TTL and minted x509 SVID TTL reflect the new values
+  (`istioctl ztunnel-config certificates` validity window / SPIRE server config).
+- **Docs (Unit 5):** link check; verify commands against a live cluster.
+
+## Delivery
+
+Single PR to `main`. Advances #1899 points #4/#5/#6; references "Part of #1899"
+(does not close it — root cause is upstream ztunnel#1679).

--- a/docs/users-guides/troubleshooting.md
+++ b/docs/users-guides/troubleshooting.md
@@ -124,11 +124,12 @@ scripts/k8s/mesh-recover.sh --fix        # detect + restart ztunnel/waypoints/ga
 `scripts/k8s/mesh-recover.sh` (no flags) detects and prints the commands without
 acting. An optional, feature-flagged, Kind-only CronJob (`meshSelfHeal.enabled`)
 can automate this. To catch it **before** the outage, run the script in detect
-mode periodically — exit code 4 warns on a near-expiry CA (see the `k8s:health`
-skill).
+mode periodically — exit code 4 warns when the soonest-expiring ztunnel workload
+SVID is within `CERT_WARN_SECONDS` (default 6h) of expiry (see the `k8s:health`
+skill). This proactive check needs `kubectl` exec access and `jq`.
 
-**Expectation for dev clusters:** suspending the host longer than the SPIRE CA
-TTL requires a data-plane restart (above) or a cluster recreate. The root-cause
+**Expectation for dev clusters:** suspending the host longer than the SPIRE SVID
+lifetime requires a data-plane restart (above) or a cluster recreate. The root-cause
 fix is upstream ([istio/ztunnel#1679](https://github.com/istio/ztunnel/issues/1679)).
 
 ### Need to edit ENV values

--- a/docs/users-guides/troubleshooting.md
+++ b/docs/users-guides/troubleshooting.md
@@ -98,6 +98,39 @@ kubectl rollout restart daemonset -n istio-system  ztunnel
 kubectl rollout restart -n rossoctl-system deployment http-istio
 ```
 
+### Mesh-wide 503 after host suspend (expired SPIRE SVIDs)
+
+**Symptom:** every `*.localtest.me:8080` route returns `HTTP 503` (`upstream
+connect error ... connection termination`) while all pods are `Running`, the
+gateway is `1/1`, and `HTTPRoute`/`Gateway` status is `Accepted`. Common after a
+laptop/host suspend longer than the SPIRE credential lifetime: the Ambient data
+plane (ztunnel + waypoints) keeps serving expired mTLS certs and never re-fetches.
+
+**Diagnose:**
+
+```bash
+# Expired-cert errors in ztunnel?
+kubectl logs -n istio-system -l app=ztunnel --tail=100 | grep -iE "certificate expired|CertificateExpired"
+# SPIRE agent stuck re-attesting?
+kubectl logs -n spire-system -l app.kubernetes.io/name=agent --tail=100 | grep -iE "reattest|service account token has expired"
+```
+
+**Recover:** rollout-restart the Ambient data plane so it re-fetches fresh certs:
+
+```bash
+scripts/k8s/mesh-recover.sh --fix        # detect + restart ztunnel/waypoints/gateway
+```
+
+`scripts/k8s/mesh-recover.sh` (no flags) detects and prints the commands without
+acting. An optional, feature-flagged, Kind-only CronJob (`meshSelfHeal.enabled`)
+can automate this. To catch it **before** the outage, run the script in detect
+mode periodically — exit code 4 warns on a near-expiry CA (see the `k8s:health`
+skill).
+
+**Expectation for dev clusters:** suspending the host longer than the SPIRE CA
+TTL requires a data-plane restart (above) or a cluster recreate. The root-cause
+fix is upstream ([istio/ztunnel#1679](https://github.com/istio/ztunnel/issues/1679)).
+
 ### Need to edit ENV values
 
 If you need to update the values in `charts/rossoctl/.secrets.yaml` file, e.g., `githubToken`,

--- a/scripts/k8s/mesh-recover.sh
+++ b/scripts/k8s/mesh-recover.sh
@@ -62,7 +62,7 @@ Usage: mesh-recover.sh [--fix] [--include-spire] [--probe-host HOST]
   --json           Emit a machine-readable JSON summary (for the CronJob remediator).
   -h, --help       This help.
 
-Exit: 0 healthy · 2 degraded (recoverable) · 3 inconclusive (unreachable / not Ambient) · 1 usage error.
+Exit: 0 healthy · 2 degraded (recoverable) · 3 inconclusive (unreachable / not Ambient) · 4 near-expiry (advisory) · 1 usage error.
 EOF
 }
 
@@ -90,10 +90,13 @@ run_cmd() {
 command -v kubectl >/dev/null 2>&1 || { log_error "kubectl not found in PATH"; exit 1; }
 HAVE_ISTIOCTL=false
 command -v istioctl >/dev/null 2>&1 && HAVE_ISTIOCTL=true
+HAVE_OPENSSL=false
+command -v openssl >/dev/null 2>&1 && HAVE_OPENSSL=true
 
 # Findings accumulate here for the summary / JSON output.
 DEGRADED=false       # a recoverable mesh outage (503 / expired certs) → exit 2, restart helps
 INCONCLUSIVE=false   # can't confirm health (gateway unreachable, no ztunnel) → exit 3, restart won't help
+NEAR_EXPIRY=false    # a cert is close to expiry but not yet expired → exit 4, ADVISORY (no restart)
 declare -a CHECKS=()   # "name|status|detail"
 declare -a ACTIONS=()  # recovery commands that were (or would be) run
 record() {
@@ -101,6 +104,7 @@ record() {
   case "$2" in
     DEGRADED)     DEGRADED=true ;;
     INCONCLUSIVE) INCONCLUSIVE=true ;;
+    WARN)         NEAR_EXPIRY=true ;;
   esac
   return 0
 }
@@ -190,6 +194,39 @@ check_ztunnel_certs() {
   fi
 }
 
+check_cert_expiry() {
+  # PROACTIVE: warn when the SPIRE trust-bundle CA is close to expiry, BEFORE
+  # ztunnel starts serving expired certs (the reactive check_ztunnel_certs case).
+  # The CA is the credential whose expiry drives the #1899 post-suspend deadlock.
+  # Needs openssl; on the tool-less CronJob image this degrades to a skipped
+  # INCONCLUSIVE finding (matching the istioctl-optional pattern above).
+  if ! $HAVE_OPENSSL; then
+    record "cert-expiry" "INCONCLUSIVE" "openssl not available — skipped proactive near-expiry check"
+    log_info "openssl not found — skipping proactive cert-expiry check (reactive checks still apply)"
+    return
+  fi
+  local ca warn_secs enddate
+  warn_secs="${CERT_WARN_SECONDS:-21600}"   # 6h default
+  # Trust bundle: spire-bundle (spire-system) or istio-ca-root-cert (ztwim ns).
+  ca=$(kubectl get cm spire-bundle -n spire-system -o jsonpath='{.data.bundle\.crt}' 2>/dev/null || true)
+  [[ -z "$ca" ]] && ca=$(kubectl get cm istio-ca-root-cert -n zero-trust-workload-identity-manager \
+        -o jsonpath='{.data.root-cert\.pem}' 2>/dev/null || true)
+  if [[ -z "$ca" ]]; then
+    record "cert-expiry" "INCONCLUSIVE" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
+    log_info "trust bundle not found — skipping proactive cert-expiry check"
+    return
+  fi
+  enddate=$(printf '%s' "$ca" | openssl x509 -enddate -noout 2>/dev/null | cut -d= -f2 || true)
+  log_info "Checking trust-bundle CA expiry (warn window ${warn_secs}s) ..."
+  if printf '%s' "$ca" | openssl x509 -checkend "$warn_secs" -noout >/dev/null 2>&1; then
+    record "cert-expiry" "OK" "trust-bundle CA not near expiry (notAfter ${enddate})"
+    log_success "trust-bundle CA not near expiry (notAfter ${enddate})"
+  else
+    record "cert-expiry" "WARN" "trust-bundle CA expires within ${warn_secs}s (notAfter ${enddate}) — plan a data-plane restart / cluster recreate before the mesh 503s"
+    log_warn "trust-bundle CA nearing expiry (notAfter ${enddate}) — advisory, no restart"
+  fi
+}
+
 check_spire_agent() {
   local ns restarts prev
   ns=$(kubectl get pods -A -l app=spire-agent -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || true)
@@ -265,7 +302,7 @@ recover_mesh() {
 # ---------------------------------------------------------------------------
 emit_json() {
   local first=true
-  printf '{"degraded":%s,"inconclusive":%s,"fixed":%s,"checks":[' "$DEGRADED" "$INCONCLUSIVE" "$FIX"
+  printf '{"degraded":%s,"inconclusive":%s,"warn":%s,"fixed":%s,"checks":[' "$DEGRADED" "$INCONCLUSIVE" "$NEAR_EXPIRY" "$FIX"
   for c in "${CHECKS[@]}"; do
     IFS='|' read -r n s d <<<"$c"
     $first || printf ','; first=false
@@ -288,6 +325,7 @@ $JSON || { echo; log_info "Istio Ambient mesh self-heal — $($FIX && echo 'RECO
 
 check_mesh_reachability
 check_ztunnel_certs
+check_cert_expiry
 $INCLUDE_SPIRE && check_spire_agent
 
 if $DEGRADED; then
@@ -305,9 +343,11 @@ else
     log_success "Recovery applied — see re-probe result above."
   elif $INCONCLUSIVE; then
     log_warn "Could not confirm mesh health (gateway unreachable, or no ztunnel found). Check the gateway port-map and that this is an Ambient cluster — no restart attempted."
+  elif $NEAR_EXPIRY; then
+    log_warn "Mesh reachable, but the trust-bundle CA is nearing expiry (see cert-expiry above). Plan a data-plane restart or cluster recreate before it 503s. Root cause is upstream (istio/ztunnel#1679)."
   else
     log_success "Mesh healthy — no action needed."
   fi
 fi
 
-if $DEGRADED; then exit 2; elif $INCONCLUSIVE; then exit 3; else exit 0; fi
+if $DEGRADED; then exit 2; elif $INCONCLUSIVE; then exit 3; elif $NEAR_EXPIRY; then exit 4; else exit 0; fi

--- a/scripts/k8s/mesh-recover.sh
+++ b/scripts/k8s/mesh-recover.sh
@@ -90,8 +90,6 @@ run_cmd() {
 command -v kubectl >/dev/null 2>&1 || { log_error "kubectl not found in PATH"; exit 1; }
 HAVE_ISTIOCTL=false
 command -v istioctl >/dev/null 2>&1 && HAVE_ISTIOCTL=true
-HAVE_OPENSSL=false
-command -v openssl >/dev/null 2>&1 && HAVE_OPENSSL=true
 
 # Findings accumulate here for the summary / JSON output.
 DEGRADED=false       # a recoverable mesh outage (503 / expired certs) → exit 2, restart helps
@@ -102,7 +100,7 @@ declare -a ACTIONS=()  # recovery commands that were (or would be) run
 record() {
   CHECKS+=("$1|$2|$3")
   # OK and SKIP intentionally set no flag: SKIP is a non-fatal "couldn't check"
-  # (e.g. openssl missing, trust bundle not found) and must never flip a
+  # (e.g. jq missing, or ztunnel exec denied/unreachable) and must never flip a
   # healthy mesh to a degraded/inconclusive exit code.
   case "$2" in
     DEGRADED)     DEGRADED=true ;;
@@ -198,36 +196,66 @@ check_ztunnel_certs() {
 }
 
 check_cert_expiry() {
-  # PROACTIVE: warn when the SPIRE trust-bundle CA is close to expiry, BEFORE
-  # ztunnel starts serving expired certs (the reactive check_ztunnel_certs case).
-  # The CA is the credential whose expiry drives the #1899 post-suspend deadlock.
-  # Needs openssl; on the tool-less CronJob image this degrades to a skipped
-  # INCONCLUSIVE finding (matching the istioctl-optional pattern above).
-  if ! $HAVE_OPENSSL; then
-    record "cert-expiry" "SKIP" "openssl not available — skipped proactive near-expiry check"
-    log_info "openssl not found — skipping proactive cert-expiry check (reactive checks still apply)"
-    return
-  fi
-  local ca warn_secs enddate
+  # PROACTIVE: warn when a ztunnel-served workload SVID is close to expiry, BEFORE
+  # it actually expires and the data plane starts 503ing (the reactive
+  # check_ztunnel_certs case). These short-lived SVIDs — not the long-lived
+  # trust-domain root CA — are what lapse during a host suspend (#1899), so we
+  # read the real per-workload certChain expiry from ztunnel's admin config_dump
+  # (the same data `istioctl ztunnel-config certificates` surfaces).
+  #
+  # Needs `kubectl exec` into ztunnel + jq. On the CronJob ServiceAccount (which
+  # deliberately lacks pods/exec) or without jq, this degrades to a non-fatal
+  # SKIP finding — proactive warning is a manual / k8s:health-path capability
+  # (design decision for #1899), while the CronJob stays reactive-only.
+  local ns pod warn_secs dump result status detail
   warn_secs="${CERT_WARN_SECONDS:-21600}"   # 6h default
-  # Trust bundle: spire-bundle (spire-system) or istio-ca-root-cert (ztwim ns).
-  ca=$(kubectl get cm spire-bundle -n spire-system -o jsonpath='{.data.bundle\.crt}' 2>/dev/null || true)
-  [[ -z "$ca" ]] && ca=$(kubectl get cm istio-ca-root-cert -n zero-trust-workload-identity-manager \
-        -o jsonpath='{.data.root-cert\.pem}' 2>/dev/null || true)
-  if [[ -z "$ca" ]]; then
-    record "cert-expiry" "SKIP" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
-    log_info "trust bundle not found — skipping proactive cert-expiry check"
+  if ! command -v jq >/dev/null 2>&1; then
+    record "cert-expiry" "SKIP" "jq not available — skipped proactive SVID near-expiry check"
+    log_info "jq not found — skipping proactive SVID expiry check (reactive checks still apply)"
     return
   fi
-  enddate=$(printf '%s' "$ca" | openssl x509 -enddate -noout 2>/dev/null | cut -d= -f2 || true)
-  log_info "Checking trust-bundle CA expiry (warn window ${warn_secs}s) ..."
-  if printf '%s' "$ca" | openssl x509 -checkend "$warn_secs" -noout >/dev/null 2>&1; then
-    record "cert-expiry" "OK" "trust-bundle CA not near expiry (notAfter ${enddate})"
-    log_success "trust-bundle CA not near expiry (notAfter ${enddate})"
-  else
-    record "cert-expiry" "WARN" "trust-bundle CA expires within ${warn_secs}s (notAfter ${enddate}) — plan a data-plane restart / cluster recreate before the mesh 503s"
-    log_warn "trust-bundle CA nearing expiry (notAfter ${enddate}) — advisory, no restart"
+  ns=$(discover_ztunnel_ns)
+  pod=$(kubectl get pods -n "$ns" -l app=ztunnel -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [[ -z "$ns" || -z "$pod" ]]; then
+    record "cert-expiry" "SKIP" "no ztunnel pod found — skipped proactive SVID near-expiry check"
+    log_info "no ztunnel pod — skipping proactive SVID expiry check"
+    return
   fi
+  log_info "Checking ztunnel workload SVID expiry (warn window ${warn_secs}s) ..."
+  # ztunnel exposes each workload SVID's certChain in its admin config_dump.
+  # --request-timeout bounds the exec/API round-trip so a stalled node can't hang
+  # the run; --max-time bounds the in-pod curl. Either failure → empty dump → SKIP.
+  dump=$(kubectl exec --request-timeout=10s -n "$ns" "$pod" -- curl -s --max-time "$TIMEOUT" localhost:15000/config_dump 2>/dev/null || true)
+  if [[ -z "$dump" ]]; then
+    record "cert-expiry" "SKIP" "could not read ztunnel admin config_dump (exec denied or unreachable) — skipped near-expiry check"
+    log_info "ztunnel config_dump unavailable (needs pods/exec) — skipping proactive SVID expiry check"
+    return
+  fi
+  # Pick the soonest-expiring SVID and classify against the warn window. All time
+  # math is done in jq (fromdateiso8601/now) to avoid GNU-vs-BSD date(1) portability issues.
+  # Note: fromdateiso8601 expects the strict %Y-%m-%dT%H:%M:%SZ form ztunnel emits; a
+  # future fractional-seconds timestamp would fail the parse and degrade to SKIP (non-fatal).
+  result=$(printf '%s' "$dump" | jq -r --argjson warn "$warn_secs" '
+    [ .certificates[]?.certChain[]?.expirationTime | fromdateiso8601 ] as $exp
+    | if ($exp | length) == 0 then "SKIP|no workload SVID certs found in ztunnel config_dump"
+      else ($exp | min) as $soonest
+        | (($soonest - now) | floor) as $rem
+        | ($soonest | todateiso8601) as $when
+        | if $rem < $warn
+          then "WARN|soonest workload SVID expires in \($rem)s (\($when)) — the data plane will 503 if it is not rotated (e.g. after a host suspend)"
+          else "OK|soonest workload SVID valid for \($rem)s (\($when))" end
+      end' 2>/dev/null || true)
+  if [[ -z "$result" ]]; then
+    record "cert-expiry" "SKIP" "could not parse ztunnel config_dump — skipped near-expiry check"
+    log_info "could not parse ztunnel config_dump — skipping proactive SVID expiry check"
+    return
+  fi
+  status="${result%%|*}"; detail="${result#*|}"
+  case "$status" in
+    WARN) record "cert-expiry" "WARN" "$detail"; log_warn "$detail — advisory, no restart" ;;
+    OK)   record "cert-expiry" "OK"   "$detail"; log_success "$detail" ;;
+    *)    record "cert-expiry" "SKIP" "$detail"; log_info "$detail" ;;
+  esac
 }
 
 check_spire_agent() {
@@ -347,7 +375,7 @@ else
   elif $INCONCLUSIVE; then
     log_warn "Could not confirm mesh health (gateway unreachable, or no ztunnel found). Check the gateway port-map and that this is an Ambient cluster — no restart attempted."
   elif $NEAR_EXPIRY; then
-    log_warn "Mesh reachable, but the trust-bundle CA is nearing expiry (see cert-expiry above). Plan a data-plane restart or cluster recreate before it 503s. Root cause is upstream (istio/ztunnel#1679)."
+    log_warn "Mesh reachable, but a workload SVID is nearing expiry (see cert-expiry above). Plan a data-plane restart or cluster recreate before it 503s. Root cause is upstream (istio/ztunnel#1679)."
   else
     log_success "Mesh healthy — no action needed."
   fi

--- a/scripts/k8s/mesh-recover.sh
+++ b/scripts/k8s/mesh-recover.sh
@@ -101,6 +101,9 @@ declare -a CHECKS=()   # "name|status|detail"
 declare -a ACTIONS=()  # recovery commands that were (or would be) run
 record() {
   CHECKS+=("$1|$2|$3")
+  # OK and SKIP intentionally set no flag: SKIP is a non-fatal "couldn't check"
+  # (e.g. openssl missing, trust bundle not found) and must never flip a
+  # healthy mesh to a degraded/inconclusive exit code.
   case "$2" in
     DEGRADED)     DEGRADED=true ;;
     INCONCLUSIVE) INCONCLUSIVE=true ;;
@@ -201,7 +204,7 @@ check_cert_expiry() {
   # Needs openssl; on the tool-less CronJob image this degrades to a skipped
   # INCONCLUSIVE finding (matching the istioctl-optional pattern above).
   if ! $HAVE_OPENSSL; then
-    record "cert-expiry" "INCONCLUSIVE" "openssl not available — skipped proactive near-expiry check"
+    record "cert-expiry" "SKIP" "openssl not available — skipped proactive near-expiry check"
     log_info "openssl not found — skipping proactive cert-expiry check (reactive checks still apply)"
     return
   fi
@@ -212,7 +215,7 @@ check_cert_expiry() {
   [[ -z "$ca" ]] && ca=$(kubectl get cm istio-ca-root-cert -n zero-trust-workload-identity-manager \
         -o jsonpath='{.data.root-cert\.pem}' 2>/dev/null || true)
   if [[ -z "$ca" ]]; then
-    record "cert-expiry" "INCONCLUSIVE" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
+    record "cert-expiry" "SKIP" "trust-bundle ConfigMap not found (spire-bundle / istio-ca-root-cert)"
     log_info "trust bundle not found — skipping proactive cert-expiry check"
     return
   fi
@@ -292,7 +295,7 @@ recover_mesh() {
     [[ -n "$ns" ]] && kubectl rollout status daemonset/ztunnel -n "$ns" --timeout=120s || true
     kubectl rollout status deploy/"$gw" -n "$GW_NS" --timeout=120s || true
     log_info "Re-probing to verify recovery ..."
-    DEGRADED=false; INCONCLUSIVE=false; CHECKS=()
+    DEGRADED=false; INCONCLUSIVE=false; NEAR_EXPIRY=false; CHECKS=()
     check_mesh_reachability
   fi
 }

--- a/scripts/kind/setup-rossoctl.sh
+++ b/scripts/kind/setup-rossoctl.sh
@@ -714,6 +714,8 @@ if $WITH_SPIRE; then
     --set "spire-server.controllerManager.ignoreNamespaces={kube-system,kube-public}" \
     --set spire-server.controllerManager.identities.clusterSPIFFEIDs.default.autoPopulateDNSNames=true \
     --set spire-server.controllerManager.identities.clusterSPIFFEIDs.default.jwtTTL=5m \
+    --set spire-server.controllerManager.identities.clusterSPIFFEIDs.default.ttl=24h \
+    --set spire-server.caTTL=168h \
     --set spiffe-oidc-discovery-provider.enabled=true \
     --set spiffe-oidc-discovery-provider.config.set_key_use=true \
     --set spiffe-oidc-discovery-provider.tls.spire.enabled=false \


### PR DESCRIPTION
## Summary

Advances #1899 (mesh-wide 503 from expired SPIRE SVIDs after a long host suspend) beyond the merged reactive self-heal (Part A #2179 / Part B #2452) with three additions. **This is "Part of #1899", not a close** — the root cause (SPIRE re-attest deadlock / ztunnel not re-fetching) is upstream [istio/ztunnel#1679](https://github.com/istio/ztunnel/issues/1679).

## What & why

1. **Proactive near-expiry detection** (`scripts/k8s/mesh-recover.sh`) — a new `check_cert_expiry()` reads the **soonest-expiring ztunnel workload SVID** from ztunnel's admin `config_dump` (the data `istioctl ztunnel-config certificates` surfaces), via `kubectl exec` + `jq`. It emits a new advisory `WARN` status → **exit code 4** → the CronJob wrapper emits a `MeshNearExpiry` Warning Event. **Advisory only — never restarts.** Degrades to a non-fatal `SKIP` when `jq` is absent or `kubectl exec` is denied (the CronJob ServiceAccount has no `pods/exec`), so proactive warning is a manual / `k8s:health`-path capability and the CronJob stays reactive-only — **no new RBAC**.

2. **SPIRE TTL right-sizing (Kind-dev-only)** (`scripts/kind/setup-rossoctl.sh`) — CA TTL `24h → 168h (7d)`, x509 SVID TTL `→ 24h`, so a normal overnight suspend no longer expires every mesh credential at once. OpenShift path untouched.

3. **Troubleshooting docs** — a "503 after host suspend" section in `docs/users-guides/troubleshooting.md` and a proactive-detection note in the `k8s:health` skill.

## Exit-code semantics

`DEGRADED(2) > INCONCLUSIVE(3) > WARN/near-expiry(4) > OK(0)`. A skipped near-expiry check is **neutral** (does not flip a healthy mesh off `OK`).

## Validation (live, `kind-rossoctl`)

- Detection WARN reports the **real ~24h SVID** expiry → exit 4; OK → exit 0; healthy CronJob run (exec denied) → `cert-expiry: SKIP` → `MeshHealthy` (not a false `MeshInconclusive`).
- `rc=4` → `MeshNearExpiry` Warning Event with the full JSON summary, **no rollout restart** (ztunnel restart count unchanged).
- shellcheck clean on all edited scripts; `mesh-recover.sh` chart-copy sync guard passes.

## Caveats / notes for reviewers

- **TTL change is render-verified, not live-reinstalled.** `helm template` confirms `ca_ttl: 168h` and ClusterSPIFFEID `ttl: 24h` render correctly; a live SPIRE reinstall was intentionally skipped to avoid disrupting a running cluster, so it takes effect on the next fresh Kind install.
- **Design pivot vs. the committed spec.** The spec doc (`docs/superpowers/specs/2026-08-24-…`) describes an `openssl`-on-trust-bundle-CA approach. Live testing showed that only ever reads the 10-year Istio root CA (the SPIRE bundle is JWKS, not PEM), so it would never warn before a real outage; the implementation was reworked to read the actual short-lived workload SVID instead. The spec is left as the historical record.
- **Pre-existing follow-up (not fixed here):** `mesh-recover.sh check_spire_agent` uses `-l app=spire-agent`, which matches no pods (real label `app.kubernetes.io/name=agent`); it only runs under `--include-spire`. Worth a separate fix.

Assisted-By: Claude Code
